### PR TITLE
expose and run GC for nodejs to avoid memory intensive actions to run…

### DIFF
--- a/core/nodejs6Action/Dockerfile
+++ b/core/nodejs6Action/Dockerfile
@@ -75,4 +75,4 @@ xmlhttprequest@1.8.0 \
 yauzl@2.7.0
 
 # See app.js
-CMD node app.js
+CMD node --expose-gc app.js

--- a/tests/dat/actions/memoryWithGC.js
+++ b/tests/dat/actions/memoryWithGC.js
@@ -1,0 +1,13 @@
+function eat(memoryMB) {
+    var bytes = 1*1024*1024*memoryMB;
+    var buffer = new Buffer.alloc(bytes, 'a');
+    buffer = null;
+    console.log('done.');
+}
+
+function main(msg) {
+    console.log('helloEatMemory', 'memory ' + msg.payload + 'MB');
+    global.gc();
+    eat(msg.payload);
+    return {msg: 'OK, buffer of size ' + msg.payload + ' MB has been filled.'};
+}

--- a/tests/src/test/scala/whisk/core/limits/ActionLimitsTests.scala
+++ b/tests/src/test/scala/whisk/core/limits/ActionLimitsTests.scala
@@ -234,4 +234,24 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers {
                     }.length shouldBe 1
             }
     }
+
+    it should "be able to run memory intensive actions multiple times by running the GC in the action" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "TestNodeJsMemoryActionAbleToRunOften"
+            assetHelper.withCleaner(wsk.action, name, confirmDelete = true) {
+                val allowedMemory = 512 megabytes
+                val actionName = TestUtils.getTestActionFilename("memoryWithGC.js")
+                (action, _) => action.create(name, Some(actionName), memory = Some(allowedMemory))
+            }
+
+            for( a <- 1 to 10){
+                val run = wsk.action.invoke(name, Map("payload" -> "128".toJson))
+                withActivation(wsk.activation, run) { response =>
+                    response.response.status shouldBe "success"
+                    response.response.result shouldBe Some(JsObject(
+                        "msg" -> "OK, buffer of size 128 MB has been filled.".toJson))
+                }
+            }
+    }
+
 }


### PR DESCRIPTION
… in memory limit

# Problem Statement

During debugging the system I found an issue with memory intensive nodejs actions that got killed because they are running in the memory limit even when the memory got freed up in the action code. Since the action containers are running a very short period of time (ms) I suspect the nodejs garbage collector had no chance to free up the memory resources because it's running in "idle" time that does not exist by definition. To reproduce choose a 512MB action limit and allocating a buffer of 128MB. (disclaimer: the action is a very synthetic action doing nothing else which might reduce the time for the GC to jump in, like downloading a video/image, ...)

action code:
```
function eat(memoryMB) {
  var bytes = 1*1024*1024*memoryMB;
  var buffer = new Buffer.alloc(bytes, 'a');
  buffer = null;
  console.log('done.');
}

function main(msg) {
    console.log('helloEatMemory', 'memory ' + msg.payload + 'MB');
    eat(msg.payload);
    return {msg: 'OK, buffer of size ' + msg.payload + ' MB has been filled.'};
}
```

result:

```
> while (true); do wsk action invoke eatMemory -p payload 128 -rb; echo ""; sleep 2; done
{
    "msg": "OK, buffer of size 128 MB has been filled."
}

{
    "msg": "OK, buffer of size 128 MB has been filled."
}

{
    "msg": "OK, buffer of size 128 MB has been filled."
}

{
    "msg": "OK, buffer of size 128 MB has been filled."
}

{
    "error": "The action did not produce a valid response and exited unexpectedly."
}
```

# Expected
A user would expect that the memory is either freed up automatically or the user is able to free up the memory by enforcing the gc.

# Resulting behaviour
As a result the GC is cleaning up the memory and the issue is gone away. 

# Drawbacks
* garbage collector is blocking the node process. no other request is executed
* `global.gc()` is running in the user's action time

# Impact on performance
Testing locally a node process for 100 iterations allocating 128MB vs 0MB of memory and forcing/not-forcing the garbage collector. It seems like that the `global.gc()` results in a constant overhead of 30ms, even if there is no or a lot of memory to free-up.

```
function eat(memoryMB) {
  var bytes = 1*1024*1024*memoryMB;
  var buffer = new Buffer.alloc(bytes, 'a');
  buffer = null;
  console.log('eat ' + memoryMB + ' memory.');
}

function recEat(mb, timeout, count) {
  eat(mb);
  global.gc();
  setTimeout(function() {
    if (count > 0) {
        recEat(mb, timeout, count-1)
    }
  }, timeout);
}

recEat(128, 0, 100);
```

results:

allocate 128MB and force global.gc();
```
node --expose-gc ~/playground/dosEatMemoryLocal.js  
2.95s user 4.45s system 96% cpu 7.642 total
```

allocate 128MB and do not force global.gc();
```
node --expose-gc ~/playground/dosEatMemoryLocal.js  
2.69s user 4.41s system 96% cpu 7.323 total
```

allocate 0 MB and force global.gc()
```
node --expose-gc ~/playground/dosEatMemoryLocal.js  
0.30s user 0.03s system 82% cpu 0.404 total
```

allocate 0 MB and do not force global.gc()
```
node --expose-gc ~/playground/dosEatMemoryLocal.js 
0.06s user 0.02s system 39% cpu 0.199 total
```

# Implemented MVP
This PR exposes the garbage collector in our nodejs runtime containers by starting the `node` process with `--expose-gc`. The user would be able to run the GC by its own. This should be either documented in a blog or in our documentation as a "hint"/"side-mark"

# Advanced proposal 1
We could run the garbage collector anytime after the user code run `global.gc()` which would result in a significant overhead (see above) but would make it transparent for the user.

# Advanced proposal 2
We could run the garbage collector automatically if we notice that the node process is consuming a lot of memory. 

# Advanced proposal 3
Provide a switch in the CLI that allows the user to decide whether the garbage collector should run for that action