### PR TITLE
Force registrator and invokers containers recreation

### DIFF
--- a/ansible/roles/consul/tasks/deploy.yml
+++ b/ansible/roles/consul/tasks/deploy.yml
@@ -77,6 +77,7 @@
 
 - name: start registrator using docker cli
   shell: >
+        docker rm -f registrator;
         docker run -d
         --name registrator
         --hostname registrator

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -34,6 +34,7 @@
 
 - name: start invoker using docker cli
   shell: >
+        docker rm -f invoker{{play_hosts.index(inventory_hostname)}};
         docker run -d
         --userns=host
         --pid=host


### PR DESCRIPTION
I've been playing around with Ansible playbooks (awesome way to get started quickly !), and found myself replaying the top-level openwhisk.yml playbook many times to set up my environment properly.

This commit prevents the openwhisk.yml playbook from failing if
registrator and invokers containers already exist.

To do that we force recreation of the containers (rm then run),
in the same spirit as the "recreate: true" option set for other
containers using the docker_container ansible module.