### PR TITLE
Fix health check logic for zookeeper and redis to make it work on CentOS

### DIFF
--- a/ansible/roles/kafka/tasks/deploy.yml
+++ b/ansible/roles/kafka/tasks/deploy.yml
@@ -15,7 +15,7 @@
       - "{{ zookeeper.port }}:2181"
 
 - name: wait until the Zookeeper in this host is up and running
-  action: shell echo ruok | nc -w 3 -i 1 {{ inventory_hostname }} {{ zookeeper.port }}
+  action: shell (echo ruok; sleep 1) | nc {{ inventory_hostname }} {{ zookeeper.port }}
   register: result
   until: (result.rc == 0) and (result.stdout == 'imok')
   retries: 36

--- a/ansible/roles/redis/tasks/deploy.yml
+++ b/ansible/roles/redis/tasks/deploy.yml
@@ -15,7 +15,7 @@
       - "{{ redis.port }}:6379"
 
 - name: wait until redis is up and running
-  action: shell echo PING | nc -w 3 -i 1 {{ inventory_hostname }} {{ redis.port }}
+  action: shell (echo PING; sleep 1) | nc {{ inventory_hostname }} {{ redis.port }}
   register: result
   until: (result.rc == 0) and (result.stdout == '+PONG')
   retries: 12

--- a/tools/health/isAlive
+++ b/tools/health/isAlive
@@ -98,9 +98,9 @@ def isConsulAlive() :
 
 def isZookeeperAlive() :
     host_port = getHostAndPort('zookeeper').split(':')
-    cmd = ['nc', '-w', '3', host_port[0], host_port[1]]
+    cmd = '(echo ruok; sleep 1) | nc '+ host_port[0] + ' '+ host_port[1]
     okString = 'imok'
-    (rc, output) = monitorUtil.run(cmd, 'ruok')
+    (rc, output) = monitorUtil.run(cmd, 'ruok', True)
     if (rc != 0):
         print('isZooKeeperAlive: still waiting for zookeeper (nc failed with '
               '%d: %s)' % (rc, output))

--- a/tools/health/monitorUtil.py
+++ b/tools/health/monitorUtil.py
@@ -44,15 +44,17 @@ def checkLoop(name, checker, delay):
 # Runs the given command with optional input.
 # The command is run in a blocking fashion and the return code
 # and output (both stdout/stderr combined) returned as a pair.
-def run(cmd, inData=""):
+def run(cmd, inData="", isShell=False):
     try:
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                             shell=isShell,
                              stdin=subprocess.PIPE,
                              stderr=subprocess.STDOUT)
         if (inData != ""):
             p.stdin.write(inData)
-        p.wait()
-        output = p.stdout.read()
+        (output, err) = p.communicate()
+        if (err != None):
+            return (-1, str(err))
         rc = p.returncode
     except Exception as e:
         print("exec: died with exception ", end="")


### PR DESCRIPTION
This is to make health check logic for zookeeper and redis work on Cent OS.

It has been tested on following OSs:
* CentOS 7.3
* OSX 10.11
* Ubuntu 16.04

Ansible deployment worked as expected.

Closes: #1997