### PR TITLE
Implement a new ContainerPool based on reactive patterns

### DIFF
--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -39,3 +39,4 @@ apigw_host_v2: "http://{{ groups['apigateway']|first }}:{{apigateway.port.api}}/
 
 # RunC enablement
 invoker_use_runc: true
+invoker_use_reactive_pool: true

--- a/ansible/environments/mac/group_vars/all
+++ b/ansible/environments/mac/group_vars/all
@@ -44,3 +44,4 @@ apigw_host_v2: "http://{{ groups['apigateway']|first }}:{{apigateway.port.api}}/
 
 # RunC enablement
 invoker_use_runc: true
+invoker_use_reactive_pool: true

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -97,6 +97,7 @@ invoker:
   serializeDockerOp: true
   serializeDockerPull: true
   useRunc: false
+  useReactivePool: false
 
 nginx:
   version: 1.11

--- a/ansible/templates/whisk.properties.j2
+++ b/ansible/templates/whisk.properties.j2
@@ -72,6 +72,7 @@ invoker.coreshare={{ invoker.coreshare }}
 invoker.serializeDockerOp={{ invoker.serializeDockerOp }}
 invoker.serializeDockerPull={{ invoker.serializeDockerPull }}
 invoker.useRunc={{ invoker_use_runc | default(invoker.useRunc) }}
+invoker.useReactivePool={{ invoker_use_reactive_pool | default(invoker.useReactivePool) }}
 
 consulserver.docker.endpoint={{ groups["consul_servers"]|first }}:{{ docker.port }}
 edge.docker.endpoint={{ groups["edge"]|first }}:{{ docker.port }}

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -76,6 +76,7 @@ class WhiskConfig(
     val invokerSerializeDockerOp = this(WhiskConfig.invokerSerializeDockerOp)
     val invokerSerializeDockerPull = this(WhiskConfig.invokerSerializeDockerPull)
     val invokerUseRunc = this(WhiskConfig.invokerUseRunc)
+    val invokerUseReactivePool = this(WhiskConfig.invokerUseReactivePool)
 
     val wskApiHost = this(WhiskConfig.wskApiProtocol) + "://" + this(WhiskConfig.wskApiHostname) + ":" + this(WhiskConfig.wskApiPort)
     val controllerHost = this(WhiskConfig.controllerHostName) + ":" + this(WhiskConfig.controllerHostPort)
@@ -232,6 +233,7 @@ object WhiskConfig {
     val invokerSerializeDockerOp = "invoker.serializeDockerOp"
     val invokerSerializeDockerPull = "invoker.serializeDockerPull"
     val invokerUseRunc = "invoker.useRunc"
+    val invokerUseReactivePool = "invoker.useReactivePool"
 
     val wskApiProtocol = "whisk.api.host.proto"
     val wskApiPort = "whisk.api.host.port"

--- a/common/scala/src/main/scala/whisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Exec.scala
@@ -57,7 +57,7 @@ sealed abstract class Exec extends ByteSizeable {
  * A common super class for all action exec types that contain their executable
  * code explicitly (i.e., any action other than a sequence).
  */
-sealed abstract class CodeExec[T <% SizeConversion] extends Exec {
+sealed abstract class CodeExec[+T <% SizeConversion] extends Exec {
     /** An entrypoint (typically name of 'main' function). 'None' means a default value will be used. */
     val entryPoint: Option[String]
 

--- a/common/scala/src/main/scala/whisk/core/entity/ExecManifest.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ExecManifest.scala
@@ -89,7 +89,7 @@ protected[core] object ExecManifest {
      * @param sentinelledLogs true iff the runtime generates stdout/stderr log sentinels after an activation
      * @param image optional image name, otherwise inferred via fixed mapping (remove colons and append 'action')
      */
-    protected[entity] case class RuntimeManifest(
+    protected[core] case class RuntimeManifest(
         kind: String,
         deprecated: Option[Boolean] = None,
         default: Option[Boolean] = None,

--- a/core/invoker/src/main/scala/whisk/core/container/HttpUtils.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/HttpUtils.scala
@@ -50,7 +50,7 @@ import whisk.core.entity.size.SizeLong
  * @param timeoutMsec the timeout in msecs to wait for a response
  * @param maxResponse the maximum size in bytes the connection will accept
  */
-class HttpUtils(
+protected[core] class HttpUtils(
     hostname: String,
     timeout: FiniteDuration,
     maxResponse: ByteSize) {

--- a/core/invoker/src/main/scala/whisk/core/container/HttpUtils.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/HttpUtils.scala
@@ -50,7 +50,7 @@ import whisk.core.entity.size.SizeLong
  * @param timeoutMsec the timeout in msecs to wait for a response
  * @param maxResponse the maximum size in bytes the connection will accept
  */
-protected[container] class HttpUtils(
+class HttpUtils(
     hostname: String,
     timeout: FiniteDuration,
     maxResponse: ByteSize) {

--- a/core/invoker/src/main/scala/whisk/core/container/package.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/package.scala
@@ -53,6 +53,13 @@ package object container {
         def duration = Duration.create(end.toEpochMilli() - start.toEpochMilli(), MILLISECONDS)
     }
 
+    object Interval {
+        def zero = {
+            val now = Instant.now
+            Interval(now, now)
+        }
+    }
+
     /**
      * Represents the result of accessing an endpoint in a container:
      * Start time, End time, Some(response) from container consisting of status code and payload
@@ -128,7 +135,7 @@ package object container {
         def apply(content: String) = new DockerOutput(Some(content))
         def unavailable = new DockerOutput(None)
 
-        def isSuccessful(output : DockerOutput) : Boolean =
+        def isSuccessful(output: DockerOutput): Boolean =
             output match {
                 case output if output == DockerOutput.unavailable => false
                 case _ => true

--- a/core/invoker/src/main/scala/whisk/core/containerpool/Container.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/Container.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool
+
+import scala.concurrent.Future
+import spray.json.JsObject
+import whisk.common.TransactionId
+import scala.concurrent.duration.FiniteDuration
+import whisk.core.entity.ByteSize
+import whisk.core.container.Interval
+import whisk.core.entity.ActivationResponse
+
+trait Container {
+    /**
+     * Stops the container from consuming CPU cycles.
+     */
+    def halt()(implicit transid: TransactionId): Future[Unit]
+
+    /**
+     * Dual of pause.
+     */
+    def resume()(implicit transid: TransactionId): Future[Unit]
+
+    /**
+     * Completely destroys this instance of the container.
+     */
+    def destroy()(implicit transid: TransactionId): Future[Unit]
+
+    /**
+     * Initializes code in the container.
+     */
+    def initialize(initializer: Option[JsObject], timeout: FiniteDuration)(implicit transid: TransactionId): Future[Interval]
+
+    /**
+     * Runs code in the container.
+     */
+    def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[(Interval, ActivationResponse)]
+
+    def logs(limit: ByteSize, waitForSentinel: Boolean)(implicit transid: TransactionId): Future[List[String]]
+}
+
+sealed abstract class ContainerError(msg: String) extends Exception(msg)
+sealed abstract class ContainerStartupError(msg: String) extends ContainerError(msg)
+case class WhiskContainerStartupError(msg: String) extends ContainerStartupError(msg)
+case class BlackboxStartupError(msg: String) extends ContainerStartupError(msg)
+case class InitializationError(response: ActivationResponse, interval: Interval) extends Exception(response.toString)

--- a/core/invoker/src/main/scala/whisk/core/containerpool/Container.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/Container.scala
@@ -50,7 +50,7 @@ trait Container {
      */
     def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[(Interval, ActivationResponse)]
 
-    def logs(limit: ByteSize, waitForSentinel: Boolean)(implicit transid: TransactionId): Future[List[String]]
+    def logs(limit: ByteSize, waitForSentinel: Boolean)(implicit transid: TransactionId): Future[Vector[String]]
 }
 
 sealed abstract class ContainerError(msg: String) extends Exception(msg)

--- a/core/invoker/src/main/scala/whisk/core/containerpool/Container.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/Container.scala
@@ -43,7 +43,7 @@ trait Container {
     /**
      * Initializes code in the container.
      */
-    def initialize(initializer: Option[JsObject], timeout: FiniteDuration)(implicit transid: TransactionId): Future[Interval]
+    def initialize(initializer: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[Interval]
 
     /**
      * Runs code in the container.

--- a/core/invoker/src/main/scala/whisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/ContainerPool.scala
@@ -23,10 +23,10 @@ import akka.actor.Props
 import whisk.core.dispatcher.ActivationFeed.FreeWilly
 import whisk.common.AkkaLogging
 import akka.actor.ActorRefFactory
-import whisk.core.entity.WhiskAction
 import whisk.core.entity.EntityName
 import whisk.core.entity.ExecManifest
 import whisk.core.entity.CodeExecAsString
+import whisk.core.entity.ExecutableWhiskAction
 
 sealed trait WorkerState
 case object Busy extends WorkerState
@@ -159,7 +159,7 @@ object ContainerPool {
      * @param idles a map of idle containers, awaiting work
      * @return a container if one found
      */
-    def schedule[A](action: WhiskAction, namespace: EntityName, idles: Map[A, WorkerData]): Option[A] = {
+    def schedule[A](action: ExecutableWhiskAction, namespace: EntityName, idles: Map[A, WorkerData]): Option[A] = {
         idles.find {
             case (_, WorkerData(WarmedData(_, `namespace`, `action`, _), Free)) => true
             case _ => false

--- a/core/invoker/src/main/scala/whisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/ContainerPool.scala
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool
+
+import akka.actor.Actor
+import scala.collection.mutable
+import akka.actor.ActorRef
+import akka.actor.Props
+import akka.actor.FSM
+import akka.actor.FSM.Transition
+import whisk.core.dispatcher.ActivationFeed.FreeWilly
+import whisk.common.AkkaLogging
+import akka.actor.ActorRefFactory
+import java.time.Instant
+import whisk.core.entity.WhiskAction
+import whisk.core.entity.EntityName
+import whisk.core.entity.ExecManifest
+import whisk.core.entity.CodeExecAsString
+
+sealed trait WorkerState
+case object Busy extends WorkerState
+case object Free extends WorkerState
+
+case class WorkerData(data: ContainerData, state: WorkerState)
+
+/**
+ * A pool managing containers to run actions on.
+ *
+ * @param childFactory method to create new containers
+ * @param poolSize maximum size of containers allowed in the pool
+ * @param feed actor to request more work from
+ */
+class ContainerPool(
+    childFactory: ActorRefFactory => ActorRef,
+    poolSize: Int,
+    feed: ActorRef) extends Actor {
+    val logging = new AkkaLogging(context.system.log)
+
+    val pool = new mutable.HashMap[ActorRef, WorkerData]
+    val prewarmedPool = new mutable.HashMap[ActorRef, WorkerData]
+
+    val prewarmKind = "nodejs:6"
+    val prewarmCount = 2
+    val prewarmExec = ExecManifest.runtimesManifest.resolveDefaultRuntime(prewarmKind).map { manifest =>
+        new CodeExecAsString(manifest, "", None)
+    }
+
+    logging.info(this, s"pre-warming $prewarmCount $prewarmKind containers")
+    (1 to prewarmCount).foreach { _ =>
+        prewarmContainer()
+    }
+
+    def receive: Receive = {
+        // A job to run on a container
+        case r: Run =>
+            // Schedule a job to a warm container
+            ContainerPool.schedule(r.action, r.msg.user.namespace, pool.toMap).orElse {
+                // Create a cold container iff there's space in the pool
+                if (pool.size < poolSize) {
+                    takePrewarmContainer(r.action.exec.kind).orElse {
+                        Some(createContainer())
+                    }
+                } else None
+            }.orElse {
+                // Remove a container and create a new one for the given job
+                ContainerPool.remove(r.msg.user.namespace, pool.toMap).map { toDelete =>
+                    removeContainer(toDelete)
+                    createContainer()
+                }
+            } match {
+                case Some(actor) =>
+                    pool.get(actor) match {
+                        case Some(w) =>
+                            pool.update(actor, WorkerData(w.data, Busy))
+                            actor ! r
+                        case None =>
+                            logging.error(this, "actor data not found")
+                            self ! r
+                    }
+                case None =>
+                    // "reenqueue" the request to find a container at a later point in time
+                    self ! r
+            }
+
+        // Container tells us it is free to take more work
+        case NeedWork(data: WarmedData) =>
+            pool.update(sender(), WorkerData(data, Free))
+            feed ! FreeWilly
+
+        case NeedWork(data: PreWarmedData) =>
+            prewarmedPool.update(sender(), WorkerData(data, Free))
+
+        // Container got removed
+        case Transition(actorRef, _, Removing) =>
+            pool.remove(actorRef)
+    }
+
+    /**
+     * Creates a new container and updates state accordingly.
+     */
+    def createContainer() = {
+        val ref = childFactory(context)
+        pool.update(ref, WorkerData(NoData(Instant.EPOCH), Free))
+        ref ! FSM.SubscribeTransitionCallBack(self)
+        ref
+    }
+
+    def prewarmContainer() = prewarmExec match {
+        case Some(exec) =>
+            val ref = childFactory(context)
+            ref ! FSM.SubscribeTransitionCallBack(self)
+            ref ! Start(exec)
+        case None =>
+            logging.error(this, "could not pre-warm containers because the manifest is missing")
+    }
+
+    def takePrewarmContainer(kind: String) =
+        if (kind == prewarmKind) {
+            prewarmedPool.headOption.map {
+                case (ref, data) =>
+                    // Move the container to the usual pool
+                    pool.update(ref, data)
+                    prewarmedPool.remove(ref)
+                    // Create a new prewarm container
+                    prewarmContainer()
+
+                    ref
+            }
+        } else None
+
+    /**
+     * Removes a container and updates state accordingly.
+     */
+    def removeContainer(toDelete: ActorRef) = {
+        toDelete ! Remove
+        pool.remove(toDelete)
+    }
+}
+
+object ContainerPool {
+    /**
+     * Finds the best container for a given job to run on.
+     *
+     * Selects an arbitrary warm container from the passed pool of idle containers
+     * that matches the action and the invocation namespace. The implementation uses
+     * matching such that structural equality of action and the invocation namespace
+     * is required.
+     * Returns None iff no matching container is in the idle pool.
+     * Does not consider pre-warmed containers.
+     *
+     * @param action the action to run
+     * @param namespace the namespace, that wants to run the action
+     * @param idles a map of idle containers, awaiting work
+     * @return a container if one found
+     */
+    def schedule[A](action: WhiskAction, namespace: EntityName, idles: Map[A, WorkerData]): Option[A] = {
+        idles.find {
+            case (_, WorkerData(WarmedData(_, `namespace`, `action`, _), Free)) => true
+            case _ => false
+        }.map(_._1)
+    }
+
+    /**
+     * Finds the best container to remove to make space for the job passed to run.
+     *
+     * Determines which namespace consumes most resources in the current pool and
+     * takes away one of their containers iff the namespace placing the new job is
+     * not already the most consuming one.
+     *
+     * @param namespace the namespace that wants to get a container
+     * @param pool a map of all containers in the pool
+     * @return a container to be removed iff found
+     */
+    def remove[A](namespace: EntityName, pool: Map[A, WorkerData]): Option[A] = {
+        val grouped = pool.collect {
+            case (ref, WorkerData(w: WarmedData, Free)) => ref -> w
+        }.groupBy {
+            case (ref, data) => data.namespace
+        }
+
+        if (!grouped.isEmpty) {
+            val (maxConsumer, containersToDelete) = grouped.maxBy(_._2.size)
+            val (ref, _) = containersToDelete.minBy(_._2.lastUsed)
+            Some(ref)
+        } else None
+    }
+
+    def props(factory: ActorRefFactory => ActorRef,
+              size: Int,
+              feed: ActorRef) = Props(new ContainerPool(factory, size, feed))
+}

--- a/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
@@ -296,9 +296,7 @@ class ContainerProxy(
         }
 
         val activation: Future[WhiskActivation] = initialize.flatMap { initInterval =>
-            val passedParameters = job.msg.content getOrElse JsObject()
-            val boundParameters = job.action.parameters.toJsObject
-            val parameters = JsObject(boundParameters.fields ++ passedParameters.fields)
+            val parameters = job.msg.content getOrElse JsObject()
 
             val environment = JsObject(
                 "api_key" -> job.msg.user.authkey.compact.toJson,

--- a/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
@@ -324,7 +324,7 @@ class ContainerProxy(
         }.flatMap { activation =>
             val exec = job.action.exec.asInstanceOf[CodeExec[_]]
             container.logs(job.action.limits.logs.asMegaBytes, exec.sentinelledLogs).map { logs =>
-                activation.withLogs(ActivationLogs(logs.toVector))
+                activation.withLogs(ActivationLogs(logs))
             }
         }.andThen {
             case Success(activation) => storeActivation(tid, activation)

--- a/core/invoker/src/main/scala/whisk/core/containerpool/WhiskContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/WhiskContainer.scala
@@ -1,0 +1,358 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool
+
+import akka.actor.FSM
+import akka.actor.Props
+import akka.pattern.pipe
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import akka.actor.Stash
+import whisk.core.entity.WhiskAction
+import whisk.core.connector.ActivationMessage
+import whisk.core.entity.WhiskActivation
+import whisk.core.connector.CompletionMessage
+import whisk.core.connector.MessageProducer
+import scala.util.Success
+import whisk.core.entity.ActivationResponse
+import akka.actor.Status.{ Failure => FailureMessage }
+import whisk.core.entity.ActivationLogs
+import whisk.core.entity.types.ActivationStore
+import whisk.common.TransactionId
+import whisk.common.AkkaLogging
+import scala.util.Failure
+import whisk.core.entity.ByteSize
+import whisk.core.entity.size._
+import whisk.core.entity.Exec
+import whisk.core.entity.EntityName
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+import whisk.core.entity.CodeExec
+import whisk.core.entity.Parameters
+
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+import whisk.core.container.Interval
+
+// States
+sealed trait ContainerState
+case object Uninitialized extends ContainerState
+case object Starting extends ContainerState
+case object Started extends ContainerState
+case object Running extends ContainerState
+case object Ready extends ContainerState
+case object Pausing extends ContainerState
+case object Paused extends ContainerState
+case object Unpausing extends ContainerState
+case object Removing extends ContainerState
+
+// Data
+sealed abstract class ContainerData(val lastUsed: Instant)
+case class NoData(override val lastUsed: Instant) extends ContainerData(lastUsed)
+
+sealed abstract class ContainerDataWithContainer(val container: Container, override val lastUsed: Instant) extends ContainerData(lastUsed)
+case class PreWarmedData(
+    override val container: Container,
+    kind: String,
+    override val lastUsed: Instant) extends ContainerDataWithContainer(container, lastUsed)
+case class WarmedData(
+    override val container: Container,
+    namespace: EntityName,
+    action: WhiskAction,
+    override val lastUsed: Instant) extends ContainerDataWithContainer(container, lastUsed)
+
+// Events
+sealed trait Job
+case class Start(exec: Exec) extends Job
+case class Run(action: WhiskAction, msg: ActivationMessage) extends Job
+case object Remove
+
+case class NeedWork(data: ContainerData)
+
+// Container events
+case class ContainerCreated(container: Container, kind: Exec)
+case object ActivationCompleted
+case object ContainerPaused
+case object ContainerUnpaused
+case object ContainerRemoved
+
+class WhiskContainer(
+    factory: (TransactionId, String, Exec, ByteSize) => Future[Container],
+    activeAckProducer: MessageProducer,
+    store: ActivationStore) extends FSM[ContainerState, ContainerData] with Stash {
+    implicit val ec = context.system.dispatcher
+    val logging = new AkkaLogging(context.system.log)
+
+    val unusedTimeout = 30.seconds
+    val pauseGrace = 1.second
+
+    startWith(Uninitialized, NoData(Instant.EPOCH))
+
+    when(Uninitialized) {
+        case Event(job: Start, _) =>
+            factory(
+                TransactionId.invokerWarmup,
+                WhiskContainer.containerName("prewarm", job.exec.kind),
+                job.exec,
+                256.MB).andThen {
+                    case Success(c) =>
+                        self ! ContainerCreated(c, job.exec)
+                        self ! job
+                    case Failure(t) =>
+                        self ! FailureMessage(t)
+                }
+
+            goto(Starting)
+
+        case Event(job: Run, _) =>
+            factory(
+                job.msg.transid,
+                WhiskContainer.containerName(job.msg.user.namespace.name, job.action.name.name),
+                job.action.exec,
+                job.action.limits.memory.megabytes.MB).andThen {
+                    case Success(c) =>
+                        self ! ContainerCreated(c, job.action.exec)
+                        self ! job
+                    case Failure(t) =>
+                        val response = t match {
+                            case WhiskContainerStartupError(msg) => ActivationResponse.whiskError(msg)
+                            case BlackboxStartupError(msg)       => ActivationResponse.applicationError(msg)
+                            case _                               => ActivationResponse.whiskError(t.getMessage)
+                        }
+                        val now = Instant.now
+                        val interval = Interval(now, now)
+                        val activation = WhiskContainer.constructWhiskActivation(job, interval, response)
+                        sendActiveAck(activation)(job.msg.transid)
+                        storeActivation(activation)(job.msg.transid)
+
+                        self ! FailureMessage(t)
+                }
+
+            goto(Starting)
+    }
+
+    when(Starting) {
+        case Event(ContainerCreated(c, exec), _) => goto(Started) using PreWarmedData(c, exec.kind, Instant.EPOCH)
+        case Event(FailureMessage(err), _) =>
+            self ! ContainerRemoved
+            goto(Removing)
+        case _ => delay
+    }
+
+    when(Started) {
+        case Event(job: Start, data: ContainerData) =>
+            context.parent ! NeedWork(data)
+            stay
+
+        case Event(job: Run, data: ContainerDataWithContainer) =>
+            implicit val transid = job.msg.transid
+
+            val actionTimeout = job.action.limits.timeout.duration
+            val initialize = data match {
+                case p: PreWarmedData => p.container.initialize(job.action.containerInitializer, actionTimeout)
+                case _                => Future.successful(Interval(Instant.EPOCH, Instant.EPOCH))
+            }
+
+            val activation: Future[WhiskActivation] = initialize.flatMap { initInterval =>
+                val passedParameters = job.msg.content getOrElse JsObject()
+                val boundParameters = job.action.parameters.toJsObject
+                val parameters = JsObject(boundParameters.fields ++ passedParameters.fields)
+
+                val environment = JsObject(
+                    "api_key" -> job.msg.user.authkey.compact.toJson,
+                    "namespace" -> job.msg.user.namespace.toJson,
+                    "action_name" -> job.msg.action.qualifiedNameWithLeadingSlash.toJson,
+                    "activation_id" -> job.msg.activationId.toString.toJson,
+                    // compute deadline on invoker side avoids discrepancies inside container
+                    // but potentially under-estimates actual deadline
+                    "deadline" -> (Instant.now.toEpochMilli + actionTimeout.toMillis).toString.toJson)
+
+                data.container.run(parameters, environment, actionTimeout)(job.msg.transid).map {
+                    case (runInterval, response) =>
+                        if (!response.isSuccess) {
+                            self ! Remove
+                        }
+                        val initRunInterval = Interval(runInterval.start.minusMillis(initInterval.duration.toMillis), runInterval.end)
+                        WhiskContainer.constructWhiskActivation(job, initRunInterval, response)
+                }
+            }.recover {
+                case InitializationError(response, interval) =>
+                    self ! Remove
+                    WhiskContainer.constructWhiskActivation(job, interval, response)
+            }
+
+            activation.andThen {
+                case Success(activation) => sendActiveAck(activation)
+            }.flatMap { activation =>
+                val exec = job.action.exec.asInstanceOf[CodeExec[_]]
+                data.container.logs(job.action.limits.logs.asMegaBytes, exec.sentinelledLogs).map { logs =>
+                    activation.withLogs(ActivationLogs(logs.toVector))
+                }
+            }.andThen {
+                case Success(activation) =>
+                    self ! ActivationCompleted
+                    storeActivation(activation)
+            }
+
+            goto(Running) using WarmedData(data.container, job.msg.user.namespace, job.action, Instant.now)
+
+        case Event(Remove, data: ContainerDataWithContainer) => destroyContainer(data.container)
+    }
+
+    when(Running) {
+        case Event(ActivationCompleted, _) => goto(Ready)
+        case _                             => delay
+    }
+
+    when(Ready, stateTimeout = pauseGrace) {
+        case Event(run: Run, data: WarmedData) =>
+            self ! run
+            goto(Started)
+
+        case Event(StateTimeout, data: WarmedData) =>
+            data.container.halt()(TransactionId.invokerNanny).map(_ => ContainerPaused).pipeTo(self)
+            goto(Pausing)
+
+        case Event(Remove, data: WarmedData) => destroyContainer(data.container)
+    }
+
+    when(Pausing) {
+        case Event(ContainerPaused, _) => goto(Paused)
+        case Event(FailureMessage(_), data: WarmedData) => destroyContainer(data.container)
+        case _ => delay
+    }
+
+    when(Paused, stateTimeout = unusedTimeout) {
+        case Event(run: Run, data: WarmedData) =>
+            data.container.resume()(run.msg.transid)
+                .map(_ => ContainerUnpaused).pipeTo(self)
+                .map(_ => run).pipeTo(self)
+
+            goto(Unpausing)
+
+        case Event(StateTimeout | Remove, data: WarmedData) => destroyContainer(data.container)
+    }
+
+    when(Unpausing) {
+        case Event(ContainerUnpaused, _) => goto(Started)
+        case Event(FailureMessage(_), data: WarmedData) => destroyContainer(data.container)
+        case _ => delay
+    }
+
+    when(Removing) {
+        case Event(job: Run, _)         => stay
+        case Event(ContainerRemoved, _) => stop()
+    }
+
+    onTransition {
+        case _ -> Ready  => context.parent ! NeedWork(stateData)
+        case _ -> Paused => context.parent ! NeedWork(stateData)
+    }
+
+    // Unstash all messages stashed while in intermediate state
+    onTransition {
+        case _ -> Started => unstashAll()
+        case _ -> Ready   => unstashAll()
+        case _ -> Paused  => unstashAll()
+    }
+
+    /*onTransition {
+        case oldState -> newState => println(s"container went from $oldState to $newState")
+    }*/
+
+    initialize()
+
+    /** Delays all incoming messages until unstashAll() is called */
+    def delay = {
+        stash()
+        stay
+    }
+
+    /**
+     * Destroys the container after unpausing it if needed
+     *
+     * @param container the container to destroy
+     */
+    def destroyContainer(container: Container) = {
+        context.parent ! ContainerRemoved
+
+        val unpause = stateName match {
+            case Paused => container.resume()(TransactionId.invokerNanny)
+            case _      => Future.successful(())
+        }
+
+        unpause
+            .flatMap(_ => container.destroy()(TransactionId.invokerNanny))
+            .map(_ => ContainerRemoved).pipeTo(self)
+
+        goto(Removing)
+    }
+
+    /**
+     * Sends an active ack to exit a blocking invocation as early as possible.
+     *
+     * @param activation the activation that contains run responses etc. but no logs
+     */
+    def sendActiveAck(activation: WhiskActivation)(implicit transid: TransactionId) = {
+        val completion = CompletionMessage(transid, activation)
+        activeAckProducer.send("completed", completion).andThen {
+            case Success(_) => logging.info(this, s"posted completion of activation ${activation.activationId}")
+        }
+    }
+
+    /**
+     * Stores the activation in the datastore for persistence.
+     *
+     * @param activation that contains full information, including logs
+     */
+    def storeActivation(activation: WhiskActivation)(implicit transid: TransactionId) = {
+        logging.info(this, "recording the activation result to the data store")
+        WhiskActivation.put(store, activation) andThen {
+            case Success(id) => logging.info(this, s"recorded activation")
+            case Failure(t)  => logging.error(this, s"failed to record activation")
+        }
+    }
+}
+
+object WhiskContainer {
+    def props(factory: (TransactionId, String, Exec, ByteSize) => Future[Container], prod: MessageProducer, store: ActivationStore) = Props(new WhiskContainer(factory, prod, store))
+
+    private val count = new AtomicInteger(0)
+    def containerNumber() = count.incrementAndGet()
+
+    def containerName(namespace: String, actionName: String) =
+        s"wsk_${containerNumber()}_${namespace}_${actionName}".replaceAll("[^a-zA-Z0-9_]", "")
+
+    def constructWhiskActivation(job: Run, interval: Interval, response: ActivationResponse) = {
+        val causedBy = if (job.msg.causedBySequence) Parameters("causedBy", "sequence".toJson) else Parameters()
+        WhiskActivation(
+            activationId = job.msg.activationId,
+            namespace = job.msg.activationNamespace,
+            subject = job.msg.user.subject,
+            cause = job.msg.cause,
+            name = job.action.name,
+            version = job.action.version,
+            start = interval.start,
+            end = interval.end,
+            duration = Some(interval.duration.toMillis),
+            response = response,
+            annotations = {
+                Parameters("limits", job.action.limits.toJson) ++
+                    Parameters("path", job.action.fullyQualifiedName(false).toString.toJson) ++ causedBy
+            })
+    }
+}

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClient.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClient.scala
@@ -59,8 +59,13 @@ class DockerClient(dockerHost: Option[String] = None)(executionContext: Executio
     def run(image: String, args: Seq[String] = Seq.empty[String])(implicit transid: TransactionId): Future[ContainerId] =
         runCmd((Seq("run", "-d") ++ args ++ Seq(image)): _*).map(ContainerId.apply)
 
-    def inspectIPAddress(id: ContainerId)(implicit transid: TransactionId): Future[ContainerIp] =
-        runCmd("inspect", "--format", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", id.asString).map(ContainerIp.apply)
+    def inspectIPAddress(id: ContainerId, network: String)(implicit transid: TransactionId): Future[ContainerIp] =
+        runCmd("inspect", "--format", s"{{.NetworkSettings.Networks.${network}.IPAddress}}", id.asString).flatMap {
+            _ match {
+                case "<no value>" => Future.failed(new NoSuchElementException)
+                case stdout       => Future.successful(ContainerIp(stdout))
+            }
+        }
 
     def pause(id: ContainerId)(implicit transid: TransactionId): Future[Unit] =
         runCmd("pause", id.asString).map(_ => ())
@@ -109,12 +114,17 @@ trait DockerApi {
     def run(image: String, args: Seq[String] = Seq.empty[String])(implicit transid: TransactionId): Future[ContainerId]
 
     /**
-     * Gets the IP adress of a given container.
+     * Gets the IP address of a given container.
+     *
+     * A container may have more than one network. The container has an
+     * IP address in each of these networks such that the network name
+     * is needed.
      *
      * @param id the id of the container to get the IP address from
+     * @param network name of the network to get the IP address from
      * @return ip of the container
      */
-    def inspectIPAddress(id: ContainerId)(implicit transid: TransactionId): Future[ContainerIp]
+    def inspectIPAddress(id: ContainerId, network: String)(implicit transid: TransactionId): Future[ContainerIp]
 
     /**
      * Pauses the container with the given id.

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClientWithFileAccess.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClientWithFileAccess.scala
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool.docker
+
+import java.io.File
+import java.io.FileInputStream
+import java.io.IOException
+import java.nio.ByteBuffer
+import java.nio.file.Paths
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.blocking
+
+import spray.json.DefaultJsonProtocol._
+import spray.json._
+import whisk.common.Logging
+import whisk.common.TransactionId
+
+class DockerClientWithFileAccess(
+    dockerHost: Option[String] = None,
+    containersDirectory: File = Paths.get("containers").toFile)(executionContext: ExecutionContext)(implicit log: Logging)
+    extends DockerClient(dockerHost)(executionContext)(log) with DockerApiWithFileAccess {
+
+    implicit private val ec = executionContext
+
+    /**
+     * Provides the home directory of the specified Docker container.
+     *
+     * Assumes that property "containersDirectory" holds the location of the
+     * home directory of all Docker containers. Default: directory "containers"
+     * in the current working directory.
+     *
+     * Does not verify that the returned directory actually exists.
+     *
+     * @param containerId Id of the desired Docker container
+     * @return canonical location of the container's home directory
+     */
+    protected def containerDirectory(containerId: ContainerId) =
+        new File(containersDirectory, containerId.asString).getCanonicalFile()
+
+    /**
+     * Provides the configuration file of the specified Docker container.
+     *
+     * Assumes that the file has the well-known location and name.
+     *
+     * Does not verify that the returned file actually exists.
+     *
+     * @param containerId Id of the desired Docker container
+     * @return canonical location of the container's configuration file
+     */
+    protected def containerConfigFile(containerId: ContainerId) = {
+        new File(containerDirectory(containerId), "config.v2.json").getCanonicalFile()
+    }
+
+    /**
+     * Provides the log file of the specified Docker container written by
+     * Docker's JSON log driver.
+     *
+     * Assumes that the file has the well-known location and name.
+     *
+     * Does not verify that the returned file actually exists.
+     *
+     * @param containerId Id of the desired Docker container
+     * @return canonical location of the container's log file
+     */
+    protected def containerLogFile(containerId: ContainerId) =
+        new File(containerDirectory(containerId), s"${containerId.asString}-json.log").getCanonicalFile()
+
+    /**
+     * Provides the contents of the specified Docker container's configuration
+     * file as JSON object.
+     *
+     * @param configFile the container's configuration file in JSON format
+     * @return contents of configuration file as JSON object
+     */
+    protected def configFileContents(configFile: File): Future[JsObject] = Future {
+        blocking { // Needed due to synchronous file operations
+            val source = scala.io.Source.fromFile(configFile)
+            val config = try source.mkString finally source.close()
+            config.parseJson.asJsObject
+        }
+    }
+
+    /**
+     * Extracts the IP of the container from the local config file of the docker daemon.
+     *
+     * A container may have more than one network. The container has an
+     * IP address in each of these networks such that the network name
+     * is needed.
+     *
+     * @param id the id of the container to get the IP address from
+     * @param network name of the network to get the IP address from
+     * @return the ip address of the container
+     */
+    protected def ipAddressFromFile(id: ContainerId, network: String): Future[ContainerIp] = {
+        configFileContents(containerConfigFile(id)).map { json =>
+            val networks = json.fields("NetworkSettings").asJsObject.fields("Networks").asJsObject
+            val specifiedNetwork = networks.fields(network).asJsObject
+            val ipAddr = specifiedNetwork.fields("IPAddress")
+            ContainerIp(ipAddr.convertTo[String])
+        }
+    }
+
+    // See implemented trait for description
+    override def inspectIPAddress(id: ContainerId, network: String)(implicit transid: TransactionId): Future[ContainerIp] = {
+        ipAddressFromFile(id, network).recoverWith {
+            case _ => super.inspectIPAddress(id, network)
+        }
+    }
+
+    // See implemented trait for description
+    def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = Future {
+        blocking { // Needed due to synchronous file operations
+            var fis: FileInputStream = null
+            try {
+                val file = containerLogFile(containerId)
+                val size = file.length
+
+                fis = new FileInputStream(file)
+                val channel = fis.getChannel().position(fromPos)
+
+                // Buffer allocation may fail if the log file is too large to hold in memory or
+                // too few space is left on the heap, respectively.
+                var remainingBytes = (size - fromPos).toInt
+                val readBuffer = ByteBuffer.allocate(remainingBytes)
+
+                while (remainingBytes > 0) {
+                    val readBytes = channel.read(readBuffer)
+                    if (readBytes > 0) {
+                        remainingBytes -= readBytes
+                    } else if (readBytes < 0) {
+                        remainingBytes = 0
+                    }
+                }
+
+                readBuffer
+            } catch {
+                case e: Exception =>
+                    throw new IOException(s"rawContainerLogs failed on ${containerId}", e)
+
+            } finally {
+                if (fis != null) fis.close()
+            }
+        }
+    }
+}
+
+trait DockerApiWithFileAccess extends DockerApi {
+
+    /**
+     * Obtains the container's stdout and stderr by reading the internal docker log file
+     * for the container. Said file is written by docker's JSON log driver and has
+     * a "well-known" location and name.
+     *
+     * Reads the log file from the specified position to its end. The returned ByteBuffer
+     * indicates how many bytes were actually read from the file.
+     *
+     * For warm containers, the container log file already holds output from
+     * previous activations that have to be skipped. For this reason, a starting position can be specified.
+     *
+     * Attention: a ByteBuffer is allocated to keep the file from the specified position to its end
+     * fully in memory. At the moment, there is no size limit checking which can lead to
+     * out-of-memory exceptions for very large files.
+     *
+     * Deals with incomplete reads and premature end of file situations. Behavior is undefined
+     * if the log file is changed or truncated while reading.
+     *
+     * @param containerId the container for which to provide logs
+     * @param fromPos position where to start reading the container's log file
+     * @return a ByteBuffer holding the read log file contents
+     */
+    def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer]
+}

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
@@ -168,7 +168,7 @@ class DockerContainer(id: ContainerId, ip: ContainerIp)(
                 transid.failed(this, start, s"initializiation failed with $t")
         }.recoverWith {
             case t =>
-                Future.failed(InitializationError(ActivationResponse.whiskError("action failed to initialize"), Interval(Instant.EPOCH, Instant.EPOCH)))
+                Future.failed(InitializationError(ActivationResponse.whiskError("action failed to initialize"), Interval.zero))
         }.flatMap { result =>
             if (result.ok) {
                 Future.successful(result.interval)

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
@@ -1,0 +1,357 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool.docker
+
+import scala.concurrent.Future
+import spray.json.JsObject
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext
+import whisk.core.container.HttpUtils
+import whisk.core.entity.size._
+import scala.util.Success
+import scala.util.Failure
+import java.time.Instant
+import whisk.core.container.RunResult
+import whisk.core.container.Interval
+import java.nio.file.Paths
+import java.io.File
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+import scala.util.Try
+import whisk.common.TransactionId
+import whisk.common.Logging
+import whisk.common.LoggingMarkers
+import whisk.core.entity.ByteSize
+import java.nio.charset.StandardCharsets
+import scala.collection.mutable.Buffer
+import whisk.http.Messages
+import whisk.core.entity.ActivationResponse
+import whisk.core.containerpool.BlackboxStartupError
+import whisk.core.containerpool.WhiskContainerStartupError
+import whisk.core.containerpool.InitializationError
+import whisk.core.containerpool.Container
+
+object DockerContainer {
+    /**
+     * Creates a container running on a docker daemon.
+     *
+     * @param transid transaction creating the container
+     * @param image image to create the container from
+     * @param userProvidedImage whether the image is provided by the user
+     * or an OpenWhisk provided image
+     * @param memory memorylimit of the container
+     * @param cpuShares sharefactor for the container
+     * @param environment environment variables to set on the container
+     * @param network network to launch the container in
+     * @param name optional name for the container
+     * @return a container
+     */
+    def create(transid: TransactionId,
+               image: String,
+               userProvidedImage: Boolean = false,
+               memory: ByteSize = 256.MB,
+               cpuShares: Int = 0,
+               environment: Map[String, String] = Map(),
+               network: String = "bridge",
+               name: Option[String] = None)(
+                   implicit docker: DockerApi, runc: RuncApi, ec: ExecutionContext, log: Logging) = {
+
+        val environmentArgs = (environment + ("SERVICE_IGNORE" -> true.toString)).map {
+            case (key, value) => Seq("-e", s"$key=$value")
+        }.flatten
+
+        val args = Seq(
+            "--cap-drop", "NET_RAW",
+            "--cap-drop", "NET_ADMIN",
+            "--ulimit", "nofile=1024:1024",
+            "--pids-limit", "64",
+            "--cpu-shares", cpuShares.toString,
+            "--memory", s"${memory.toMB}m",
+            "--memory-swap", s"${memory.toMB}m",
+            "--network", network) ++
+            environmentArgs ++
+            name.map(n => Seq("--name", n)).getOrElse(Seq.empty)
+
+        val pulled = if (userProvidedImage) {
+            docker.pull(image)(transid).recoverWith {
+                case _ => Future.failed(BlackboxStartupError(s"Failed to pull container image '$image'."))
+            }
+        } else Future.successful(())
+
+        val container = for {
+            _ <- pulled
+            id <- docker.run(image, args)(transid)
+            ip <- DockerContainer.ipFromFile(id, network).recoverWith {
+                case _ => docker.inspectIPAddress(id)(transid)
+            }.andThen {
+                case Failure(_) => docker.rm(id)(transid)
+            }
+        } yield new DockerContainer(id, ip)
+
+        container.recoverWith {
+            case t => if (userProvidedImage) {
+                Future.failed(BlackboxStartupError(t.getMessage))
+            } else {
+                Future.failed(WhiskContainerStartupError(t.getMessage))
+            }
+        }
+    }
+
+    /** Directory to look for containers */
+    val containersDirectory = Paths.get("containers").toFile
+
+    /**
+     * Extracts the ip of the container from the local config file of the docker daemon.
+     *
+     * @param id id of the container to get the ip from
+     * @param network the network the container is running in
+     * @return the ip address of the container
+     */
+    def ipFromFile(id: ContainerId, network: String)(implicit ec: ExecutionContext) = Future {
+        val containerDirectory = new File(DockerContainer.containersDirectory, id.asString)
+        val configFile = new File(containerDirectory, "config.v2.json")
+        val source = scala.io.Source.fromFile(configFile)
+        val contents = source.mkString
+        source.close()
+
+        val networks = contents.parseJson.asJsObject.fields("NetworkSettings").asJsObject.fields("Networks").asJsObject
+        val userland = networks.fields(network).asJsObject
+        val ipAddr = userland.fields("IPAddress")
+        ContainerIp(ipAddr.convertTo[String])
+    }
+}
+
+/**
+ * Represents a container as run by docker.
+ *
+ * This class contains OpenWhisk specific behavior and as such does not necessarily
+ * use docker commands to achieve the effects needed.
+ *
+ * @constructor
+ * @param id the id of the container
+ * @param ip the ip of the container
+ */
+class DockerContainer(id: ContainerId, ip: ContainerIp)(
+    implicit docker: DockerApi, runc: RuncApi, ec: ExecutionContext, log: Logging) extends Container with DockerFileLogs {
+    val containerDirectory = new File(DockerContainer.containersDirectory, id.asString)
+    val logFile = new File(containerDirectory, s"${id.asString}-json.log")
+    var logPointer = 0L
+
+    var httpConnection: Option[HttpUtils] = None
+
+    def halt()(implicit transid: TransactionId): Future[Unit] = runc.pause(id)
+    def resume()(implicit transid: TransactionId): Future[Unit] = runc.resume(id)
+    def destroy()(implicit transid: TransactionId): Future[Unit] = docker.rm(id)
+
+    def initialize(initializer: Option[JsObject], timeout: FiniteDuration)(implicit transid: TransactionId): Future[Interval] = {
+        val start = transid.started(this, LoggingMarkers.INVOKER_ACTIVATION_INIT, s"sending initialization to $id $ip")
+
+        val body = initializer.map(init => JsObject("value" -> init)).getOrElse(JsObject())
+        callContainer("/init", body, timeout, retry = true).andThen {
+            case Success(r: RunResult) =>
+                transid.finished(this, start.copy(start = r.interval.start), s"initialization result: ${r.toBriefString}", endTime = r.interval.end)
+            case Failure(t) =>
+                transid.failed(this, start, s"initializiation failed with $t")
+        }.recoverWith {
+            case t =>
+                Future.failed(InitializationError(ActivationResponse.whiskError("action failed to initialize"), Interval(Instant.EPOCH, Instant.EPOCH)))
+        }.flatMap { result =>
+            if (result.ok) {
+                Future.successful(result.interval)
+            } else if (result.interval.duration >= timeout) {
+                Future.failed(InitializationError(ActivationResponse.applicationError(Messages.timedoutActivation(timeout, true)), result.interval))
+            } else {
+                Future.failed(InitializationError(ActivationResponse.processInitResponseContent(result.response, log), result.interval))
+            }
+        }
+    }
+
+    def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
+        val actionName = environment.fields.get("action_name").map(_.convertTo[String]).getOrElse("")
+        val start = transid.started(this, LoggingMarkers.INVOKER_ACTIVATION_RUN, s"sending arguments to $actionName at $id $ip")
+
+        val parameterWrapper = JsObject("value" -> parameters)
+        val body = JsObject(parameterWrapper.fields ++ environment.fields)
+        callContainer("/run", body, timeout, retry = false).andThen {
+            case Success(r: RunResult) =>
+                transid.finished(this, start.copy(start = r.interval.start), s"running result: ${r.toBriefString}", endTime = r.interval.end)
+            case Failure(t) =>
+                transid.failed(this, start, s"initializiation failed with $t")
+        }.map { result =>
+            val response = if (result.interval.duration >= timeout) {
+                ActivationResponse.applicationError(Messages.timedoutActivation(timeout, false))
+            } else {
+                ActivationResponse.processRunResponseContent(result.response, log)
+            }
+
+            (result.interval, response)
+        }
+    }
+
+    def logs(limit: ByteSize, waitForSentinel: Boolean)(implicit transid: TransactionId): Future[List[String]] = {
+        val from = logPointer
+        def readLogs(retries: Int): List[String] = {
+            val to = logFile.length
+
+            val lines = linesFromFile(logFile, from, to)
+            val (isComplete, isTruncated, logs) = processJsonDriverLogContents(lines, waitForSentinel, limit)
+
+            if (retries > 0 && !isComplete && !isTruncated) {
+                log.info(this, s"log cursor advanced but missing sentinel, trying $retries more times")
+                Thread.sleep(100)
+                readLogs(retries - 1)
+            } else {
+                logPointer = to
+
+                val formattedLogs = logs.map(_.toFormattedString)
+                val finishedLogs = if (isTruncated) {
+                    formattedLogs :+ Messages.truncateLogs(limit)
+                } else formattedLogs
+
+                finishedLogs.toList
+            }
+        }
+
+        Future(readLogs(15))
+    }
+
+    protected def callContainer(path: String, body: JsObject, timeout: FiniteDuration, retry: Boolean = false): Future[RunResult] = {
+        val started = Instant.now()
+        val http = httpConnection.getOrElse {
+            val conn = new HttpUtils(s"${ip.asString}:8080", timeout, 1.MB)
+            httpConnection = Some(conn)
+            conn
+        }
+        Future {
+            http.post(path, body, retry)
+        }.map { response =>
+            val finished = Instant.now()
+            RunResult(Interval(started, finished), response)
+        }
+    }
+}
+
+case class LogLine(time: String, stream: String, log: String) {
+    def toFormattedString = f"$time%-30s $stream: ${log.trim}"
+    def dropRight(maxBytes: ByteSize) = {
+        val bytes = log.getBytes(StandardCharsets.UTF_8).dropRight(maxBytes.toBytes.toInt)
+        LogLine(time, stream, new String(bytes, StandardCharsets.UTF_8))
+    }
+}
+
+object LogLine extends DefaultJsonProtocol {
+    implicit val serdes = jsonFormat3(LogLine.apply)
+}
+
+trait DockerFileLogs {
+    // The action proxies inserts this line in the logs at the end of each activation for stdout/stderr
+    protected val LOG_ACTIVATION_SENTINEL = "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX"
+
+    /**
+     * Given the JSON driver's raw output of a docker container, convert it into our own
+     * JSON format. If asked, check for sentinel markers (which are not included in the output).
+     *
+     * Only parses and returns so much logs to fit into the LogLimit passed.
+     *
+     * @param logMsgs raw String read from a JSON log-driver written file
+     * @param requireSentinel determines if the processor should wait for a sentinel to appear
+     * @param limit the limit to apply to the log size
+     *
+     * @return Tuple containing (isComplete, isTruncated, logs)
+     */
+    def processJsonDriverLogContents(lines: Iterator[String], requireSentinel: Boolean, limit: ByteSize)(
+        implicit transid: TransactionId, logging: Logging): (Boolean, Boolean, Vector[LogLine]) = {
+
+        var hasOut = false
+        var hasErr = false
+        var truncated = false
+        var bytesSoFar = 0.B
+        val logLines = Buffer[LogLine]()
+
+        // read whiles bytesSoFar <= limit when requireSentinel to try and grab sentinel if they exist to indicate completion
+        while (lines.hasNext && ((requireSentinel && bytesSoFar <= limit) || bytesSoFar < limit)) {
+            // if line does not parse, there's an error in the container log driver
+            Try(lines.next().parseJson.convertTo[LogLine]) match {
+                case Success(t) =>
+                    // if sentinels are expected, do not account for their size, otherwise, all bytes are accounted for
+                    if (requireSentinel && t.log.trim != LOG_ACTIVATION_SENTINEL || !requireSentinel) {
+                        // ignore empty log lines
+                        if (t.log.nonEmpty) {
+                            bytesSoFar += t.log.sizeInBytes
+                            if (bytesSoFar <= limit) {
+                                logLines.append(t)
+                            } else {
+                                // chop off the right most bytes that overflow
+                                val chopped = t.dropRight(bytesSoFar - limit)
+                                if (chopped.log.nonEmpty) {
+                                    logLines.append(chopped)
+                                }
+                                truncated = true
+                            }
+                        }
+                    } else if (requireSentinel) {
+                        // there may be more than one sentinel in stdout/stderr (as logs may leak across activations
+                        // if for example there log limit was exceeded in one activation and the container was reused
+                        // to run the same action again (this is considered a feature - otherwise, must drain the logs
+                        // or destroy the container as if it errored)
+                        if (t.stream == "stdout") {
+                            hasOut = true
+                        } else if (t.stream == "stderr") {
+                            hasErr = true
+                        }
+                    }
+
+                case Failure(t) =>
+                    // Drop lines that did not parse to JSON objects.
+                    // However, should not happen since we are using the json log driver.
+                    logging.error(this, s"log line skipped/did not parse: $t")
+            }
+        }
+
+        ((hasOut && hasErr) || !requireSentinel, truncated || lines.hasNext, logLines.toVector)
+    }
+
+    /**
+     * Reads lines from a given file in a specified byte-range.
+     *
+     * @param file the file to read from
+     * @param from byteoffset to start
+     * @param to byteoffset to stop
+     * @return individual lines from the file
+     */
+    def linesFromFile(file: File, from: Long, to: Long): Iterator[String] = {
+        var fis: java.io.FileInputStream = null
+        try {
+            fis = new java.io.FileInputStream(file)
+            val channel = fis.getChannel().position(from)
+            var remain = (to - from).toInt
+            val buffer = java.nio.ByteBuffer.allocate(remain)
+            while (remain > 0) {
+                val read = channel.read(buffer)
+                if (read > 0)
+                    remain = read - read.toInt
+            }
+            new String(buffer.array, StandardCharsets.UTF_8).lines
+        } catch {
+            case e: Exception =>
+                print(e)
+                Iterator.empty
+        } finally {
+            if (fis != null) fis.close()
+        }
+    }
+}

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
@@ -157,10 +157,10 @@ class DockerContainer(id: ContainerId, ip: ContainerIp)(
     def resume()(implicit transid: TransactionId): Future[Unit] = runc.resume(id)
     def destroy()(implicit transid: TransactionId): Future[Unit] = docker.rm(id)
 
-    def initialize(initializer: Option[JsObject], timeout: FiniteDuration)(implicit transid: TransactionId): Future[Interval] = {
+    def initialize(initializer: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[Interval] = {
         val start = transid.started(this, LoggingMarkers.INVOKER_ACTIVATION_INIT, s"sending initialization to $id $ip")
 
-        val body = initializer.map(init => JsObject("value" -> init)).getOrElse(JsObject())
+        val body = JsObject("value" -> initializer)
         callContainer("/init", body, timeout, retry = true).andThen {
             case Success(r: RunResult) =>
                 transid.finished(this, start.copy(start = r.interval.start), s"initialization result: ${r.toBriefString}", endTime = r.interval.end)

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
@@ -191,8 +191,9 @@ class DockerContainer(id: ContainerId, ip: ContainerIp)(
      * the result returned from this method.
      *
      * Only parses and returns as much logs as fit in the passed log limit.
-     * Even if the log limit is exceeded, read until all output is consumed / sentinel
-     * marker is found such that subsequent invocations only provide new output.
+     * Even if the log limit is exceeded, advance the starting position for the next invocation
+     * behind the bytes most recently read - but don't actively read any more until sentinel
+     * markers have been found.
      *
      * @param limit the limit to apply to the log size
      * @param waitForSentinel determines if the processor should wait for a sentinel to appear

--- a/core/invoker/src/main/scala/whisk/core/dispatcher/ActivationFeed.scala
+++ b/core/invoker/src/main/scala/whisk/core/dispatcher/ActivationFeed.scala
@@ -28,10 +28,12 @@ import whisk.common.TransactionId
 import whisk.core.connector.MessageConsumer
 
 object ActivationFeed {
-    sealed class ActivationNotification
+    sealed trait ActivationNotification
 
     /** Pulls new messages from the message bus. */
     case class FillQueueWithMessages()
+
+    case object FreeWilly extends ActivationNotification
 
     /** Indicates resources are available because transaction completed, may cause pipeline fill. */
     case class ContainerReleased(tid: TransactionId) extends ActivationNotification

--- a/core/invoker/src/main/scala/whisk/core/invoker/ActionLogDriver.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/ActionLogDriver.scala
@@ -32,7 +32,7 @@ import whisk.http.Messages
 /**
  * Represents a single log line as read from a docker log
  */
-protected[invoker] case class LogLine(time: String, stream: String, log: String) {
+protected[core] case class LogLine(time: String, stream: String, log: String) {
     def toFormattedString = f"$time%-30s $stream: ${log.trim}"
     def dropRight(maxBytes: ByteSize) = {
         val bytes = log.getBytes(StandardCharsets.UTF_8).dropRight(maxBytes.toBytes.toInt)
@@ -40,11 +40,11 @@ protected[invoker] case class LogLine(time: String, stream: String, log: String)
     }
 }
 
-protected[invoker] object LogLine extends DefaultJsonProtocol {
+protected[core] object LogLine extends DefaultJsonProtocol {
     implicit val serdes = jsonFormat3(LogLine.apply)
 }
 
-protected[invoker] trait ActionLogDriver {
+protected[core] trait ActionLogDriver {
 
     // The action proxies inserts this line in the logs at the end of each activation for stdout/stderr
     protected val LOG_ACTIVATION_SENTINEL = "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX"

--- a/core/invoker/src/main/scala/whisk/core/invoker/ActionLogDriver.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/ActionLogDriver.scala
@@ -44,10 +44,12 @@ protected[core] object LogLine extends DefaultJsonProtocol {
     implicit val serdes = jsonFormat3(LogLine.apply)
 }
 
-protected[core] trait ActionLogDriver {
-
+protected[core] object ActionLogDriver {
     // The action proxies inserts this line in the logs at the end of each activation for stdout/stderr
-    protected val LOG_ACTIVATION_SENTINEL = "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX"
+    val LOG_ACTIVATION_SENTINEL = "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX"
+}
+
+protected[core] trait ActionLogDriver {
 
     /**
      * Given the JSON driver's raw output of a docker container, convert it into our own
@@ -77,7 +79,7 @@ protected[core] trait ActionLogDriver {
             Try(lines.next().parseJson.convertTo[LogLine]) match {
                 case Success(t) =>
                     // if sentinels are expected, do not account for their size, otherwise, all bytes are accounted for
-                    if (requireSentinel && t.log.trim != LOG_ACTIVATION_SENTINEL || !requireSentinel) {
+                    if (requireSentinel && t.log.trim != ActionLogDriver.LOG_ACTIVATION_SENTINEL || !requireSentinel) {
                         // ignore empty log lines
                         if (t.log.nonEmpty) {
                             bytesSoFar += t.log.sizeInBytes

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
@@ -27,7 +27,7 @@ import scala.concurrent.Future
 import whisk.common.LoggingMarkers
 import whisk.core.entity._
 import whisk.core.containerpool.docker.DockerContainer
-import whisk.core.containerpool.docker.DockerClient
+import whisk.core.containerpool.docker.DockerClientWithFileAccess
 import whisk.core.containerpool.docker.RuncClient
 import whisk.core.container.{ ContainerPool => OldContainerPool }
 import whisk.core.containerpool.Run
@@ -55,8 +55,8 @@ class InvokerReactive(
     private val entityStore = WhiskEntityStore.datastore(config)
     private val activationStore = WhiskActivationStore.datastore(config)
 
-    implicit val docker: DockerApi = new DockerClient()(ec)
-    implicit val runc: RuncApi = new RuncClient(ec)
+    implicit val docker = new DockerClientWithFileAccess()(ec)
+    implicit val runc = new RuncClient(ec)
 
     /** Cleans up all running wsk_ containers */
     def cleanup() = {

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
@@ -33,7 +33,7 @@ import whisk.core.container.{ ContainerPool => OldContainerPool }
 import whisk.core.containerpool.Run
 import whisk.core.connector.MessageProducer
 import akka.actor.ActorRefFactory
-import whisk.core.containerpool.WhiskContainer
+import whisk.core.containerpool.ContainerProxy
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import whisk.core.containerpool.docker.DockerApi
@@ -105,7 +105,7 @@ class InvokerReactive(
         }
     }
 
-    val childFactory = (f: ActorRefFactory) => f.actorOf(WhiskContainer.props(containerFactory, ack, store))
+    val childFactory = (f: ActorRefFactory) => f.actorOf(ContainerProxy.props(containerFactory, ack, store))
     val pool = actorSystem.actorOf(whisk.core.containerpool.ContainerPool.props(
         childFactory,
         OldContainerPool.getDefaultMaxActive(config),

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.invoker
+
+import whisk.core.WhiskConfig
+import akka.actor.ActorRef
+import whisk.core.dispatcher.MessageHandler
+import akka.actor.ActorSystem
+import whisk.common.Logging
+import whisk.core.connector.ActivationMessage
+import whisk.common.TransactionId
+import scala.concurrent.Future
+import whisk.common.LoggingMarkers
+import whisk.core.entity._
+import whisk.core.containerpool.docker.DockerContainer
+import whisk.core.containerpool.docker.DockerClient
+import whisk.core.containerpool.docker.RuncClient
+import whisk.core.container.{ ContainerPool => OldContainerPool }
+import whisk.core.containerpool.Run
+import whisk.core.connector.MessageProducer
+import akka.actor.ActorRefFactory
+import whisk.core.containerpool.WhiskContainer
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import whisk.core.containerpool.docker.DockerApi
+import whisk.core.containerpool.docker.RuncApi
+
+class InvokerReactive(
+    config: WhiskConfig,
+    instance: Int,
+    activationFeed: ActorRef,
+    producer: MessageProducer)(implicit actorSystem: ActorSystem, logging: Logging)
+    extends MessageHandler(s"invoker$instance") {
+
+    implicit val ec = actorSystem.dispatcher
+
+    private val entityStore = WhiskEntityStore.datastore(config)
+    private val activationStore = WhiskActivationStore.datastore(config)
+
+    implicit val docker: DockerApi = new DockerClient()(ec)
+    implicit val runc: RuncApi = new RuncClient(ec)
+
+    /** Cleans up all running wsk_ containers */
+    def cleanup() = {
+        val cleaning = docker.ps(Seq("name" -> "wsk_"))(TransactionId.invokerNanny).flatMap { containers =>
+            val removals = containers.map { id =>
+                runc.resume(id)(TransactionId.invokerNanny).recoverWith {
+                    case _ => Future.successful(())
+                }.flatMap {
+                    _ => docker.rm(id)(TransactionId.invokerNanny)
+                }
+            }
+            Future.sequence(removals)
+        }
+
+        Await.ready(cleaning, 30.seconds)
+    }
+    cleanup()
+    sys.addShutdownHook(cleanup())
+
+    val containerFactory = (tid: TransactionId, name: String, exec: Exec, memory: ByteSize) => {
+        val codeExec = exec.asInstanceOf[CodeExec[_]]
+        val image = ExecImageName.containerImageName(config.dockerRegistry, config.dockerImagePrefix, codeExec, config.dockerImageTag)
+        DockerContainer.create(
+            tid,
+            image = image,
+            userProvidedImage = codeExec.pull,
+            memory = memory,
+            cpuShares = OldContainerPool.cpuShare(config),
+            environment = Map("__OW_API_HOST" -> config.wskApiHost),
+            network = config.invokerContainerNetwork,
+            name = Some(name))
+    }
+
+    val childFactory = (f: ActorRefFactory) => f.actorOf(WhiskContainer.props(containerFactory, producer, activationStore))
+    val pool = actorSystem.actorOf(whisk.core.containerpool.ContainerPool.props(
+        childFactory,
+        OldContainerPool.getDefaultMaxActive(config),
+        activationFeed))
+
+    override def onMessage(msg: ActivationMessage)(implicit transid: TransactionId): Future[Unit] = {
+        require(msg != null, "message undefined")
+        require(msg.action.version.isDefined, "action version undefined")
+
+        val start = transid.started(this, LoggingMarkers.INVOKER_ACTIVATION)
+        val namespace = msg.action.path
+        val name = msg.action.name
+        val actionid = FullyQualifiedEntityName(namespace, name).toDocId.asDocInfo(msg.revision)
+        val tran = Transaction(msg)
+        val subject = msg.user.subject
+
+        logging.info(this, s"${actionid.id} $subject ${msg.activationId}")
+
+        // caching is enabled since actions have revision id and an updated
+        // action will not hit in the cache due to change in the revision id;
+        // if the doc revision is missing, then bypass cache
+        if (actionid.rev == DocRevision()) {
+            logging.error(this, s"revision was not provided for ${actionid.id}")
+        }
+        WhiskAction.get(entityStore, actionid.id, actionid.rev, fromCache = actionid.rev != DocRevision()).map { action =>
+            // only Exec instances that are subtypes of CodeExec reach the invoker
+            assume(action.exec.isInstanceOf[CodeExec[_]])
+            pool ! Run(action, msg)
+        }
+    }
+
+}

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
@@ -36,8 +36,6 @@ import akka.actor.ActorRefFactory
 import whisk.core.containerpool.ContainerProxy
 import scala.concurrent.Await
 import scala.concurrent.duration._
-import whisk.core.containerpool.docker.DockerApi
-import whisk.core.containerpool.docker.RuncApi
 import whisk.core.connector.CompletionMessage
 import scala.util.Success
 import scala.util.Failure

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     compile 'com.jayway.restassured:rest-assured:2.6.0'
     compile 'org.scalatest:scalatest_2.11:3.0.1'
     compile 'io.spray:spray-testkit_2.11:1.3.3'
+    compile 'com.typesafe.akka:akka-testkit_2.11:2.4.16'
     compile 'com.google.code.gson:gson:2.3.1'
     compile 'org.scalamock:scalamock-scalatest-support_2.11:3.4.2'
 

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerClientTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerClientTests.scala
@@ -49,9 +49,9 @@ class DockerClientTests extends FlatSpec with Matchers with StreamLogging with B
     val dockerCommand = "docker"
 
     /** Returns a DockerClient with a mocked result for 'executeProcess' */
-    def dockerClient(result: Future[String]) = new DockerClient()(global) {
+    def dockerClient(execResult: Future[String]) = new DockerClient()(global) {
         override val dockerCmd = Seq(dockerCommand)
-        override def executeProcess(args: String*)(implicit ec: ExecutionContext) = result
+        override def executeProcess(args: String*)(implicit ec: ExecutionContext) = execResult
     }
 
     behavior of "DockerClient"
@@ -71,6 +71,12 @@ class DockerClientTests extends FlatSpec with Matchers with StreamLogging with B
         filters.foreach {
             case (k, v) => firstLine should include(s"--filter $k=$v")
         }
+    }
+
+    it should "throw NoSuchElementException if specified network does not exist when using 'inspectIPAddress'" in {
+        val dc = dockerClient { Future.successful("<no value>") }
+
+        a[NoSuchElementException] should be thrownBy await(dc.inspectIPAddress(id, "foo network"))
     }
 
     it should "write proper log markers on a successful command" in {
@@ -100,8 +106,9 @@ class DockerClientTests extends FlatSpec with Matchers with StreamLogging with B
         runAndVerify(dc.rm(id), "rm", Seq("-f", id.asString))
         runAndVerify(dc.ps(), "ps")
 
-        val inspectArgs = Seq("--format", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", id.asString)
-        runAndVerify(dc.inspectIPAddress(id), "inspect", inspectArgs) shouldBe ContainerIp(stdout)
+        val network = "userland"
+        val inspectArgs = Seq("--format", s"{{.NetworkSettings.Networks.${network}.IPAddress}}", id.asString)
+        runAndVerify(dc.inspectIPAddress(id, network), "inspect", inspectArgs) shouldBe ContainerIp(stdout)
 
         val image = "image"
         val runArgs = Seq("--memory", "256m", "--cpushares", "1024")
@@ -129,7 +136,7 @@ class DockerClientTests extends FlatSpec with Matchers with StreamLogging with B
         runAndVerify(dc.unpause(id), "unpause")
         runAndVerify(dc.rm(id), "rm")
         runAndVerify(dc.ps(), "ps")
-        runAndVerify(dc.inspectIPAddress(id), "inspect")
+        runAndVerify(dc.inspectIPAddress(id, "network"), "inspect")
         runAndVerify(dc.run("image"), "run")
         runAndVerify(dc.pull("image"), "pull")
     }

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerClientWithFileAccessTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerClientWithFileAccessTests.scala
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool.docker.test
+
+import scala.concurrent.Future
+
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.fixture.{ FlatSpec => FixtureFlatSpec }
+import org.scalatest.junit.JUnitRunner
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.concurrent.Await
+import org.scalatest.Matchers
+import common.StreamLogging
+import whisk.core.containerpool.docker.ContainerId
+import whisk.common.TransactionId
+import org.scalatest.BeforeAndAfterEach
+import whisk.core.containerpool.docker.ContainerIp
+import whisk.core.containerpool.docker.DockerClientWithFileAccess
+import spray.json._
+import java.nio.charset.StandardCharsets
+import java.io.File
+import java.io.FileWriter
+import java.io.IOException
+import scala.language.reflectiveCalls // Needed to invoke publicIpAddressFromFile() method of structural dockerClientForIp extension
+
+@RunWith(classOf[JUnitRunner])
+class DockerClientWithFileAccessTestsIp extends FlatSpec with Matchers with StreamLogging with BeforeAndAfterEach {
+
+    override def beforeEach = stream.reset()
+
+    implicit val transid = TransactionId.testing
+    val id = ContainerId("Id")
+
+    def await[A](f: Future[A], timeout: FiniteDuration = 500.milliseconds) = Await.result(f, timeout)
+
+    val dockerCommand = "docker"
+    val networkInConfigFile = "networkConfig"
+    val networkInDockerInspect = "networkInspect"
+    val ipInConfigFile = ContainerIp("10.0.0.1")
+    val ipInDockerInspect = ContainerIp("10.0.0.2")
+    val dockerConfig =
+        JsObject("NetworkSettings" ->
+            JsObject("Networks" ->
+                JsObject(s"${networkInConfigFile}" ->
+                    JsObject("IPAddress" -> JsString(s"${ipInConfigFile.asString}")))))
+
+    /** Returns a DockerClient with mocked results */
+    def dockerClient(
+        execResult: Future[String] = Future.successful(ipInDockerInspect.asString),
+        readResult: Future[JsObject] = Future.successful(dockerConfig)) =
+        new DockerClientWithFileAccess()(global) {
+            override val dockerCmd = Seq(dockerCommand)
+            override def executeProcess(args: String*)(implicit ec: ExecutionContext) = execResult
+            override def configFileContents(configFile: File) = readResult
+            // Make protected ipAddressFromFile available for testing - requires reflectiveCalls
+            def publicIpAddressFromFile(id: ContainerId, network: String): Future[ContainerIp] = ipAddressFromFile(id, network)
+        }
+
+    behavior of "DockerClientWithFileAccess - ipAddressFromFile"
+
+    it should "throw NoSuchElementException if specified network is not in configuration file" in {
+        val dc = dockerClient()
+
+        a[NoSuchElementException] should be thrownBy await(dc.publicIpAddressFromFile(id, "foo network"))
+    }
+
+    behavior of "DockerClientWithFileAccess - inspectIPAddress"
+
+    it should "read from config file" in {
+        val dc = dockerClient()
+
+        await(dc.inspectIPAddress(id, networkInConfigFile)) shouldBe ipInConfigFile
+        logLines.foreach { _ should not include (s"${dockerCommand} inspect") }
+    }
+
+    it should "fall back to 'docker inspect' if config file cannot be read" in {
+        val dc = dockerClient(readResult = Future.failed(new RuntimeException()))
+
+        await(dc.inspectIPAddress(id, networkInDockerInspect)) shouldBe ipInDockerInspect
+        logLines.head should include(s"${dockerCommand} inspect")
+    }
+
+    it should "throw NoSuchElementException if specified network does not exist" in {
+        val dc = dockerClient(execResult = Future.successful("<no value>"))
+
+        a[NoSuchElementException] should be thrownBy await(dc.inspectIPAddress(id, "foo network"))
+    }
+}
+
+@RunWith(classOf[JUnitRunner])
+class DockerClientWithFileAccessTestsLogs extends FixtureFlatSpec with Matchers with StreamLogging with BeforeAndAfterEach {
+
+    override def beforeEach = stream.reset()
+
+    implicit val transid = TransactionId.testing
+
+    behavior of "DockerClientWithFileAccess - rawContainerLogs"
+
+    /** Returns a DockerClient with mocked results */
+    def dockerClient(logFile: File) = new DockerClientWithFileAccess()(global) {
+        override def containerLogFile(containerId: ContainerId) = logFile
+    }
+
+    def await[A](f: Future[A], timeout: FiniteDuration = 500.milliseconds) = Await.result(f, timeout)
+
+    case class FixtureParam(file: File, writer: FileWriter, dc: DockerClientWithFileAccess)
+
+    def withFixture(test: OneArgTest) = {
+        val file = File.createTempFile(this.getClass.getName, test.name.replaceAll("[^a-zA-Z0-9.-]", "_"))
+        val writer = new FileWriter(file)
+        val dc = dockerClient(file)
+
+        val fixture = FixtureParam(file, writer, dc)
+
+        try {
+            withFixture(test.toNoArgTest(fixture))
+        } finally {
+            writer.close()
+            file.delete()
+        }
+    }
+
+    def writeLogFile(fixture: FixtureParam, content: String) = {
+        fixture.writer.write(content)
+        fixture.writer.flush()
+    }
+
+    val containerId = ContainerId("Id")
+
+    it should "tolerate an empty log file" in { fixture =>
+        val logText = ""
+        writeLogFile(fixture, logText)
+
+        val buffer = await(fixture.dc.rawContainerLogs(containerId, fromPos = 0))
+
+        val logContent = new String(buffer.array, buffer.arrayOffset, buffer.position, StandardCharsets.UTF_8)
+
+        logContent shouldBe logText
+        stream should have size 0
+    }
+
+    it should "read a full log file" in { fixture =>
+        val logText = "text"
+        writeLogFile(fixture, logText)
+
+        val buffer = await(fixture.dc.rawContainerLogs(containerId, fromPos = 0))
+        val logContent = new String(buffer.array, buffer.arrayOffset, buffer.position, StandardCharsets.UTF_8)
+
+        logContent shouldBe logText
+        stream should have size 0
+    }
+
+    it should "read a log file portion" in { fixture =>
+        val logText =
+            """Hey, dude-it'z true not sad
+              |Take a thrash song and make it better
+              |Admit it! Beatallica'z under your skin!
+              |So now begin to be a shredder""".stripMargin
+        val from = 66 // start at third line...
+        val expectedText = logText.substring(from)
+
+        writeLogFile(fixture, logText)
+
+        val buffer = await(fixture.dc.rawContainerLogs(containerId, fromPos = from))
+        val logContent = new String(buffer.array, buffer.arrayOffset, buffer.position, StandardCharsets.UTF_8)
+
+        logContent shouldBe expectedText
+        stream should have size 0
+    }
+
+    it should "provide an empty result on failure" in { fixture =>
+        fixture.writer.close()
+        fixture.file.delete()
+
+        an[IOException] should be thrownBy await(fixture.dc.rawContainerLogs(containerId, fromPos = 0))
+        stream should have size 0
+    }
+}

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerClientWithFileAccessTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerClientWithFileAccessTests.scala
@@ -68,7 +68,7 @@ class DockerClientWithFileAccessTestsIp extends FlatSpec with Matchers with Stre
         readResult: Future[JsObject] = Future.successful(dockerConfig)) =
         new DockerClientWithFileAccess()(global) {
             override val dockerCmd = Seq(dockerCommand)
-            override def executeProcess(args: String*)(implicit ec: ExecutionContext) = execResult
+            override def executeProcess(args: Seq[String], timeout: Duration)(implicit ec: ExecutionContext) = execResult
             override def configFileContents(configFile: File) = readResult
             // Make protected ipAddressFromFile available for testing - requires reflectiveCalls
             def publicIpAddressFromFile(id: ContainerId, network: String): Future[ContainerIp] = ipAddressFromFile(id, network)

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool.docker.test
+
+import org.scalatest.FlatSpec
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.Matchers
+import org.scalamock.scalatest.MockFactory
+import scala.concurrent.ExecutionContext.Implicits.global
+import common.StreamLogging
+import whisk.common.TransactionId
+import whisk.core.containerpool.docker.RuncApi
+import whisk.core.containerpool.docker.DockerApi
+import whisk.core.containerpool.docker.DockerContainer
+import whisk.core.containerpool.docker.ContainerId
+import whisk.core.containerpool.docker.ContainerIp
+import spray.json.JsObject
+import scala.concurrent.Future
+import whisk.core.container.RunResult
+import whisk.core.entity.ActivationResponse.ContainerResponse
+import whisk.core.container.Interval
+import java.time.Instant
+import scala.concurrent.duration._
+import org.scalatest.concurrent.ScalaFutures
+import whisk.common.LoggingMarkers._
+import whisk.common.LogMarker
+import whisk.core.containerpool.InitializationError
+import whisk.core.entity.ActivationResponse
+import org.scalatest.BeforeAndAfterEach
+import scala.concurrent.Await
+import whisk.core.entity.ActivationResponse.Timeout
+
+/**
+ * Unit tests for ContainerPool schedule
+ */
+@RunWith(classOf[JUnitRunner])
+class DockerContainerTests extends FlatSpec
+    with Matchers
+    with MockFactory
+    with StreamLogging
+    with ScalaFutures
+    with BeforeAndAfterEach {
+
+    override def beforeEach() = {
+        stream.reset()
+    }
+
+    /** Awaits the given future, throws the exception enclosed in Failure. */
+    def await[A](f: Future[A], timeout: FiniteDuration = 100.millisecond) = Await.result[A](f, timeout)
+
+    def dockerContainer(id: ContainerId = ContainerId("id"), ip: ContainerIp = ContainerIp("ip"))(ccRes: Future[RunResult])(
+        implicit docker: DockerApi, runc: RuncApi): DockerContainer = {
+
+        new DockerContainer(id, ip) {
+            override protected def callContainer(path: String, body: JsObject, timeout: FiniteDuration, retry: Boolean = false): Future[RunResult] = {
+                ccRes
+            }
+        }
+    }
+
+    def intervalOf(duration: FiniteDuration) = Interval(Instant.EPOCH, Instant.ofEpochMilli(duration.toMillis))
+
+    behavior of "DockerContainer"
+
+    implicit val transid = TransactionId.testing
+
+    ignore should "create a new instance" in {
+        implicit val docker = stub[DockerApi]
+        implicit val runc = stub[RuncApi]
+
+        val container = DockerContainer.create(transid = TransactionId.testing, image = "image")
+    }
+
+    it should "halt and resume container via runc" in {
+        implicit val docker = stub[DockerApi]
+        implicit val runc = stub[RuncApi]
+
+        val id = ContainerId("id")
+        val container = new DockerContainer(id, ContainerIp("ip"))
+
+        container.halt()
+        container.resume()
+
+        (runc.pause(_: ContainerId)(_: TransactionId)).verify(id, transid)
+        (runc.resume(_: ContainerId)(_: TransactionId)).verify(id, transid)
+    }
+
+    it should "destroy a container via Docker" in {
+        implicit val docker = stub[DockerApi]
+        implicit val runc = stub[RuncApi]
+
+        val id = ContainerId("id")
+        val container = new DockerContainer(id, ContainerIp("ip"))
+
+        container.destroy()
+
+        (docker.rm(_: ContainerId)(_: TransactionId)).verify(id, transid)
+    }
+
+    it should "initialize a container" in {
+        implicit val docker = stub[DockerApi]
+        implicit val runc = stub[RuncApi]
+
+        val interval = intervalOf(1.millisecond)
+        val container = dockerContainer() {
+            Future.successful(RunResult(interval, Right(ContainerResponse(true, "", None))))
+        }
+
+        val initInterval = container.initialize(Some(JsObject()), 1.second)
+        initInterval.futureValue shouldBe interval
+
+        // assert the starting log is there
+        val start = LogMarker.parse(logLines.head)
+        start.token shouldBe INVOKER_ACTIVATION_INIT
+
+        // assert the end log is there
+        val end = LogMarker.parse(logLines.last)
+        end.token shouldBe INVOKER_ACTIVATION_INIT.asFinish
+        end.deltaToMarkerStart shouldBe Some(interval.duration.toMillis)
+    }
+
+    it should "properly deal with terminal initialization failures" in {
+        implicit val docker = stub[DockerApi]
+        implicit val runc = stub[RuncApi]
+
+        val container = dockerContainer() {
+            Future.failed(new RuntimeException())
+        }
+
+        val init = container.initialize(Some(JsObject()), 1.second)
+
+        val error = the[InitializationError] thrownBy await(init)
+        error.interval shouldBe Interval(Instant.EPOCH, Instant.EPOCH)
+        error.response.statusCode shouldBe ActivationResponse.WhiskError
+
+        // assert the error log is there
+        val end = LogMarker.parse(logLines.last)
+        end.token shouldBe INVOKER_ACTIVATION_INIT.asError
+    }
+
+    it should "properly deal with a timeout during initialization" in {
+        implicit val docker = stub[DockerApi]
+        implicit val runc = stub[RuncApi]
+
+        val initTimeout = 1.second
+        val interval = intervalOf(initTimeout + 1.nanoseconds)
+
+        val container = dockerContainer() {
+            Future.successful(RunResult(interval, Left(Timeout())))
+        }
+
+        val init = container.initialize(Some(JsObject()), initTimeout)
+
+        val error = the[InitializationError] thrownBy await(init)
+        error.interval shouldBe interval
+        error.response.statusCode shouldBe ActivationResponse.ApplicationError
+
+        // assert the finish log is there
+        val end = LogMarker.parse(logLines.last)
+        end.token shouldBe INVOKER_ACTIVATION_INIT.asFinish
+    }
+}
+

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
@@ -145,7 +145,7 @@ class DockerContainerTests extends FlatSpec
         val init = container.initialize(Some(JsObject()), 1.second)
 
         val error = the[InitializationError] thrownBy await(init)
-        error.interval shouldBe Interval(Instant.EPOCH, Instant.EPOCH)
+        error.interval.duration shouldBe Duration.Zero
         error.response.statusCode shouldBe ActivationResponse.WhiskError
 
         // assert the error log is there

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
@@ -121,7 +121,7 @@ class DockerContainerTests extends FlatSpec
             Future.successful(RunResult(interval, Right(ContainerResponse(true, "", None))))
         }
 
-        val initInterval = container.initialize(Some(JsObject()), 1.second)
+        val initInterval = container.initialize(JsObject(), 1.second)
         initInterval.futureValue shouldBe interval
 
         // assert the starting log is there
@@ -142,7 +142,7 @@ class DockerContainerTests extends FlatSpec
             Future.failed(new RuntimeException())
         }
 
-        val init = container.initialize(Some(JsObject()), 1.second)
+        val init = container.initialize(JsObject(), 1.second)
 
         val error = the[InitializationError] thrownBy await(init)
         error.interval.duration shouldBe Duration.Zero
@@ -164,7 +164,7 @@ class DockerContainerTests extends FlatSpec
             Future.successful(RunResult(interval, Left(Timeout())))
         }
 
-        val init = container.initialize(Some(JsObject()), initTimeout)
+        val init = container.initialize(JsObject(), initTimeout)
 
         val error = the[InitializationError] thrownBy await(init)
         error.interval shouldBe interval

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
@@ -16,34 +16,35 @@
 
 package whisk.core.containerpool.docker.test
 
-import org.scalatest.FlatSpec
+import java.time.Instant
+
+import scala.collection.mutable
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+import common.StreamLogging
 import org.junit.runner.RunWith
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.Matchers
-import org.scalamock.scalatest.MockFactory
-import scala.concurrent.ExecutionContext.Implicits.global
-import common.StreamLogging
-import whisk.common.TransactionId
-import whisk.core.containerpool.docker.RuncApi
-import whisk.core.containerpool.docker.DockerApi
-import whisk.core.containerpool.docker.DockerContainer
-import whisk.core.containerpool.docker.ContainerId
-import whisk.core.containerpool.docker.ContainerIp
 import spray.json.JsObject
-import scala.concurrent.Future
-import whisk.core.container.RunResult
-import whisk.core.entity.ActivationResponse.ContainerResponse
-import whisk.core.container.Interval
-import java.time.Instant
-import scala.concurrent.duration._
-import org.scalatest.concurrent.ScalaFutures
 import whisk.common.LoggingMarkers._
 import whisk.common.LogMarker
-import whisk.core.containerpool.InitializationError
+import whisk.common.TransactionId
+import whisk.core.container.Interval
+import whisk.core.container.RunResult
+import whisk.core.containerpool._
+import whisk.core.containerpool.docker._
 import whisk.core.entity.ActivationResponse
-import org.scalatest.BeforeAndAfterEach
-import scala.concurrent.Await
+import whisk.core.entity.ActivationResponse.ContainerResponse
 import whisk.core.entity.ActivationResponse.Timeout
+import whisk.core.entity.size._
+import whisk.http.Messages
 
 /**
  * Unit tests for ContainerPool schedule
@@ -63,6 +64,10 @@ class DockerContainerTests extends FlatSpec
     /** Awaits the given future, throws the exception enclosed in Failure. */
     def await[A](f: Future[A], timeout: FiniteDuration = 100.millisecond) = Await.result[A](f, timeout)
 
+    /**
+     * Constructs a testcontainer with overridden IO methods. Results of the override can be provided
+     * as parameters.
+     */
     def dockerContainer(id: ContainerId = ContainerId("id"), ip: ContainerIp = ContainerIp("ip"))(ccRes: Future[RunResult])(
         implicit docker: DockerApi, runc: RuncApi): DockerContainer = {
 
@@ -73,19 +78,129 @@ class DockerContainerTests extends FlatSpec
         }
     }
 
+    /** Creates an interval starting at EPOCH with the given duration. */
     def intervalOf(duration: FiniteDuration) = Interval(Instant.EPOCH, Instant.ofEpochMilli(duration.toMillis))
 
     behavior of "DockerContainer"
 
     implicit val transid = TransactionId.testing
 
-    ignore should "create a new instance" in {
-        implicit val docker = stub[DockerApi]
+    /*
+     * CONTAINER CREATION
+     */
+    it should "create a new instance" in {
+        implicit val docker = new TestDockerClient
         implicit val runc = stub[RuncApi]
 
-        val container = DockerContainer.create(transid = TransactionId.testing, image = "image")
+        val image = "image"
+        val memory = 128.MB
+        val cpuShares = 1
+        val environment = Map("test" -> "hi")
+        val network = "testwork"
+        val name = "myContainer"
+
+        val container = DockerContainer.create(
+            transid = transid,
+            image = image,
+            memory = memory,
+            cpuShares = cpuShares,
+            environment = environment,
+            network = network,
+            name = Some(name))
+
+        await(container)
+
+        docker.runs should have size 1
+        docker.pulls should have size 0
+        docker.rms should have size 0
+
+        val (testImage, args) = docker.runs.head
+        testImage shouldBe "image"
+
+        // Assert fixed values are passed as well
+        args should contain allOf ("--cap-drop", "NET_RAW", "NET_ADMIN")
+        args should contain inOrder ("--ulimit", "nofile=1024:1024")
+        args should contain inOrder ("--pids-limit", "64")
+
+        // Assert proper parameter translation
+        args should contain inOrder ("--memory", s"${memory.toMB}m")
+        args should contain inOrder ("--memory-swap", s"${memory.toMB}m")
+        args should contain inOrder ("--cpu-shares", cpuShares.toString)
+        args should contain inOrder ("--network", network)
+        args should contain inOrder ("--name", name)
+
+        // Assert proper environment passing
+        args should contain allOf ("-e", "test=hi", "SERVICE_IGNORE=true")
     }
 
+    it should "pull a user provided image before creating the container" in {
+        implicit val docker = new TestDockerClient
+        implicit val runc = stub[RuncApi]
+
+        val container = DockerContainer.create(transid = transid, image = "image", userProvidedImage = true)
+        await(container)
+
+        docker.runs should have size 1
+        docker.pulls should have size 1
+        docker.rms should have size 0
+    }
+
+    it should "remove the container if inspect fails" in {
+        implicit val docker = new TestDockerClient {
+            override def inspectIPAddress(id: ContainerId)(implicit transid: TransactionId): Future[ContainerIp] = {
+                inspects += id
+                Future.failed(new RuntimeException())
+            }
+        }
+        implicit val runc = stub[RuncApi]
+
+        val container = DockerContainer.create(transid = transid, image = "image")
+        a[WhiskContainerStartupError] should be thrownBy await(container)
+
+        docker.runs should have size 1
+        docker.inspects should have size 1
+        docker.rms should have size 1
+    }
+
+    it should "disambiguate errors if user images are provided" in {
+        implicit val docker = new TestDockerClient {
+            override def inspectIPAddress(id: ContainerId)(implicit transid: TransactionId): Future[ContainerIp] = {
+                inspects += id
+                Future.failed(new RuntimeException())
+            }
+        }
+        implicit val runc = stub[RuncApi]
+
+        val container = DockerContainer.create(transid = transid, image = "image", userProvidedImage = true)
+        a[BlackboxStartupError] should be thrownBy await(container)
+
+        docker.pulls should have size 1
+        docker.runs should have size 1
+        docker.inspects should have size 1
+        docker.rms should have size 1
+    }
+
+    it should "return a specific error if pulling a user provided image failed" in {
+        implicit val docker = new TestDockerClient {
+            override def pull(image: String)(implicit transid: TransactionId): Future[Unit] = {
+                pulls += image
+                Future.failed(new RuntimeException())
+            }
+        }
+        implicit val runc = stub[RuncApi]
+
+        val container = DockerContainer.create(transid = transid, image = "image", userProvidedImage = true)
+        a[BlackboxStartupError] should be thrownBy await(container)
+
+        docker.pulls should have size 1
+        docker.runs should have size 0
+        docker.inspects should have size 0
+        docker.rms should have size 0
+    }
+
+    /*
+     * DOCKER COMMANDS
+     */
     it should "halt and resume container via runc" in {
         implicit val docker = stub[DockerApi]
         implicit val runc = stub[RuncApi]
@@ -112,6 +227,12 @@ class DockerContainerTests extends FlatSpec
         (docker.rm(_: ContainerId)(_: TransactionId)).verify(id, transid)
     }
 
+    /*
+     * INITIALIZE
+     *
+     * Only tests for quite simple cases. Disambiguation of errors is delegated to ActivationResponse
+     * and so are the tests for those.
+     */
     it should "initialize a container" in {
         implicit val docker = stub[DockerApi]
         implicit val runc = stub[RuncApi]
@@ -134,25 +255,6 @@ class DockerContainerTests extends FlatSpec
         end.deltaToMarkerStart shouldBe Some(interval.duration.toMillis)
     }
 
-    it should "properly deal with terminal initialization failures" in {
-        implicit val docker = stub[DockerApi]
-        implicit val runc = stub[RuncApi]
-
-        val container = dockerContainer() {
-            Future.failed(new RuntimeException())
-        }
-
-        val init = container.initialize(JsObject(), 1.second)
-
-        val error = the[InitializationError] thrownBy await(init)
-        error.interval.duration shouldBe Duration.Zero
-        error.response.statusCode shouldBe ActivationResponse.WhiskError
-
-        // assert the error log is there
-        val end = LogMarker.parse(logLines.last)
-        end.token shouldBe INVOKER_ACTIVATION_INIT.asError
-    }
-
     it should "properly deal with a timeout during initialization" in {
         implicit val docker = stub[DockerApi]
         implicit val runc = stub[RuncApi]
@@ -173,6 +275,100 @@ class DockerContainerTests extends FlatSpec
         // assert the finish log is there
         val end = LogMarker.parse(logLines.last)
         end.token shouldBe INVOKER_ACTIVATION_INIT.asFinish
+    }
+
+    /*
+     * RUN
+     *
+     * Only tests for quite simple cases. Disambiguation of errors is delegated to ActivationResponse
+     * and so are the tests for those.
+     */
+    it should "run a container" in {
+        implicit val docker = stub[DockerApi]
+        implicit val runc = stub[RuncApi]
+
+        val interval = intervalOf(1.millisecond)
+        val result = JsObject()
+        val container = dockerContainer() {
+            Future.successful(RunResult(interval, Right(ContainerResponse(true, result.compactPrint, None))))
+        }
+
+        val runResult = container.run(JsObject(), JsObject(), 1.second)
+        runResult.futureValue shouldBe (interval, ActivationResponse.success(Some(result)))
+
+        // assert the starting log is there
+        val start = LogMarker.parse(logLines.head)
+        start.token shouldBe INVOKER_ACTIVATION_RUN
+
+        // assert the end log is there
+        val end = LogMarker.parse(logLines.last)
+        end.token shouldBe INVOKER_ACTIVATION_RUN.asFinish
+        end.deltaToMarkerStart shouldBe Some(interval.duration.toMillis)
+    }
+
+    it should "properly deal with a timeout during run" in {
+        implicit val docker = stub[DockerApi]
+        implicit val runc = stub[RuncApi]
+
+        val runTimeout = 1.second
+        val interval = intervalOf(runTimeout + 1.nanoseconds)
+
+        val container = dockerContainer() {
+            Future.successful(RunResult(interval, Left(Timeout())))
+        }
+
+        val runResult = container.run(JsObject(), JsObject(), runTimeout)
+
+        runResult.futureValue shouldBe (interval, ActivationResponse.applicationError(Messages.timedoutActivation(runTimeout, false)))
+
+        // assert the finish log is there
+        val end = LogMarker.parse(logLines.last)
+        end.token shouldBe INVOKER_ACTIVATION_RUN.asFinish
+    }
+
+    /*
+     * LOGS
+     */
+
+    class TestDockerClient extends DockerApi {
+        var runs = mutable.Buffer.empty[(String, Seq[String])]
+        var inspects = mutable.Buffer.empty[ContainerId]
+        var pauses = mutable.Buffer.empty[ContainerId]
+        var unpauses = mutable.Buffer.empty[ContainerId]
+        var rms = mutable.Buffer.empty[ContainerId]
+        var pulls = mutable.Buffer.empty[String]
+
+        def run(image: String, args: Seq[String] = Seq.empty[String])(implicit transid: TransactionId): Future[ContainerId] = {
+            runs += ((image, args))
+            Future.successful(ContainerId("testId"))
+        }
+
+        def inspectIPAddress(id: ContainerId)(implicit transid: TransactionId): Future[ContainerIp] = {
+            inspects += id
+            Future.successful(ContainerIp("testIp"))
+        }
+
+        def pause(id: ContainerId)(implicit transid: TransactionId): Future[Unit] = {
+            pauses += id
+            Future.successful(())
+        }
+
+        def unpause(id: ContainerId)(implicit transid: TransactionId): Future[Unit] = {
+            unpauses += id
+            Future.successful(())
+        }
+
+        def rm(id: ContainerId)(implicit transid: TransactionId): Future[Unit] = {
+            rms += id
+            Future.successful(())
+        }
+
+        def ps(filters: Seq[(String, String)] = Seq(), all: Boolean = false)(implicit transid: TransactionId): Future[Seq[ContainerId]] = ???
+
+        def pull(image: String)(implicit transid: TransactionId): Future[Unit] = {
+            pulls += image
+            Future.successful(())
+        }
     }
 }
 

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerPoolTests.scala
@@ -50,11 +50,8 @@ class ContainerPoolScheduleTests extends FlatSpec with Matchers with MockFactory
     def warmedData(action: WhiskAction = createAction(), namespace: String = "anyNamespace", lastUsed: Instant = Instant.now) =
         WarmedData(stub[Container], EntityName(namespace), action, lastUsed)
 
-    def preWarmedData(kind: String = "anyKind", lastUsed: Instant = Instant.EPOCH) =
-        PreWarmedData(stub[Container], kind, lastUsed)
-
-    def noData(lastUsed: Instant = Instant.EPOCH) =
-        NoData(lastUsed)
+    def preWarmedData(kind: String = "anyKind") = PreWarmedData(stub[Container], kind)
+    def noData() = NoData()
 
     def freeWorker(data: ContainerData) = WorkerData(data, Free)
 

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerPoolTests.scala
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool.docker.test
+
+import org.scalatest.FlatSpec
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import whisk.core.containerpool.ContainerPool
+import whisk.core.entity.WhiskAction
+import whisk.core.entity.CodeExecAsString
+import whisk.core.entity.ExecManifest.RuntimeManifest
+import whisk.core.entity.EntityPath
+import whisk.core.entity.EntityName
+import whisk.core.containerpool.Container
+import java.time.Instant
+import whisk.core.containerpool.WarmedData
+import org.scalatest.Matchers
+import org.scalamock.scalatest.MockFactory
+import whisk.core.containerpool.NoData
+import whisk.core.containerpool.PreWarmedData
+import whisk.core.containerpool.WorkerData
+import whisk.core.containerpool.Free
+import whisk.core.containerpool.ContainerData
+
+/**
+ * Unit tests for ContainerPool schedule
+ */
+@RunWith(classOf[JUnitRunner])
+class ContainerPoolScheduleTests extends FlatSpec with Matchers with MockFactory {
+
+    val actionExec = CodeExecAsString(RuntimeManifest("actionKind"), "testCode", None)
+
+    def createAction(namespace: String = "actionNS", name: String = "actionName") =
+        WhiskAction(EntityPath(namespace), EntityName(name), actionExec)
+
+    def warmedData(action: WhiskAction = createAction(), namespace: String = "anyNamespace", lastUsed: Instant = Instant.now) =
+        WarmedData(stub[Container], EntityName(namespace), action, lastUsed)
+
+    def preWarmedData(kind: String = "anyKind", lastUsed: Instant = Instant.EPOCH) =
+        PreWarmedData(stub[Container], kind, lastUsed)
+
+    def noData(lastUsed: Instant = Instant.EPOCH) =
+        NoData(lastUsed)
+
+    def freeWorker(data: ContainerData) = WorkerData(data, Free)
+
+    behavior of "ContainerPool schedule()"
+
+    it should "not provide a container if idle pool is empty" in {
+        ContainerPool.schedule(createAction(), EntityName("anyNamespace"), Map()) shouldBe None
+    }
+
+    it should "reuse an applicable warm container from idle pool with one container" in {
+        val data = warmedData()
+        val pool = Map('name -> freeWorker(data))
+
+        // copy to make sure, referencial equality doesn't suffice
+        ContainerPool.schedule(data.action.copy(), data.namespace, pool) shouldBe Some('name)
+    }
+
+    it should "reuse an applicable warm container from idle pool with several applicable containers" in {
+        val data = warmedData()
+        val pool = Map(
+            'first -> freeWorker(data),
+            'second -> freeWorker(data))
+
+        ContainerPool.schedule(data.action.copy(), data.namespace, pool) should contain oneOf ('first, 'second)
+    }
+
+    it should "reuse an applicable warm container from idle pool with several different containers" in {
+        val matchingData = warmedData()
+        val pool = Map(
+            'none -> freeWorker(noData()),
+            'pre -> freeWorker(preWarmedData()),
+            'warm -> freeWorker(matchingData))
+
+        ContainerPool.schedule(matchingData.action.copy(), matchingData.namespace, pool) shouldBe Some('warm)
+    }
+
+    it should "not reuse a container from idle pool with non-warm containers" in {
+        val data = warmedData()
+        // data is **not** in the pool!
+        val pool = Map(
+            'none -> freeWorker(noData()),
+            'pre -> freeWorker(preWarmedData()))
+
+        ContainerPool.schedule(data.action.copy(), data.namespace, pool) shouldBe None
+    }
+
+    it should "not reuse a warm container with different invocation namespace" in {
+        val data = warmedData()
+        val pool = Map('warm -> freeWorker(data))
+        val differentNamespace = EntityName(data.namespace.asString + "butDifferent")
+
+        data.namespace should not be differentNamespace
+        ContainerPool.schedule(data.action.copy(), differentNamespace, pool) shouldBe None
+    }
+
+    it should "not reuse a warm container with different action name" in {
+        val data = warmedData()
+        val differentAction = data.action.copy(name = EntityName(data.action.name.asString + "butDifferent"))
+        val pool = Map(
+            'warm -> freeWorker(data))
+
+        data.action.name should not be differentAction.name
+        ContainerPool.schedule(differentAction, data.namespace, pool) shouldBe None
+    }
+
+    it should "not reuse a warm container with different action version" in {
+        val data = warmedData()
+        val differentAction = data.action.copy(version = data.action.version.upMajor)
+        val pool = Map(
+            'warm -> freeWorker(data))
+
+        data.action.version should not be differentAction.version
+        ContainerPool.schedule(differentAction, data.namespace, pool) shouldBe None
+    }
+
+    behavior of "ContainerPool remove()"
+
+    it should "not provide a container if pool is empty" in {
+        ContainerPool.remove(EntityName("anyNamespace"), Map()) shouldBe None
+    }
+
+    it should "not provide a container from busy pool with non-warm containers" in {
+        val pool = Map(
+            'none -> freeWorker(noData()),
+            'pre -> freeWorker(preWarmedData()))
+
+        ContainerPool.remove(EntityName("anyNamespace"), pool) shouldBe None
+    }
+
+    it should "provide a container from pool with one single container regardless of invocation namespace" in {
+        val data = warmedData()
+        val pool = Map('warm -> freeWorker(data))
+
+        ContainerPool.remove(data.namespace, pool) shouldBe Some('warm)
+        ContainerPool.remove(EntityName(data.namespace.asString + "butDifferent"), pool) shouldBe Some('warm)
+    }
+
+    it should "provide oldest container from busy pool with multiple containers" in {
+        val commonNamespace = "commonNamespace"
+        val first = warmedData(namespace = commonNamespace, lastUsed = Instant.ofEpochMilli(1))
+        val second = warmedData(namespace = commonNamespace, lastUsed = Instant.ofEpochMilli(2))
+        val oldest = warmedData(namespace = commonNamespace, lastUsed = Instant.ofEpochMilli(0))
+
+        val pool = Map(
+            'first -> freeWorker(first),
+            'second -> freeWorker(second),
+            'oldest -> freeWorker(oldest))
+
+        ContainerPool.remove(EntityName(commonNamespace), pool) shouldBe Some('oldest)
+    }
+
+    it should "provide oldest container of largest namespace group from busy pool with multiple containers" in {
+        val smallNamespace = "smallNamespace"
+        val mediumNamespace = "mediumNamespace"
+        val largeNamespace = "largeNamespace"
+
+        // Note: We choose the oldest from the **largest** pool, although all other containers are even older.
+        val myData = warmedData(namespace = smallNamespace, lastUsed = Instant.ofEpochMilli(0))
+        val pool = Map(
+            'my -> freeWorker(myData),
+            'other -> freeWorker(warmedData(namespace = mediumNamespace, lastUsed = Instant.ofEpochMilli(1))),
+            'largeYoung -> freeWorker(warmedData(namespace = largeNamespace, lastUsed = Instant.ofEpochMilli(3))),
+            'largeOld -> freeWorker(warmedData(namespace = largeNamespace, lastUsed = Instant.ofEpochMilli(2))))
+
+        ContainerPool.remove(myData.namespace, pool) shouldBe Some('largeOld)
+    }
+}

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerPoolTests.scala
@@ -35,6 +35,7 @@ import whisk.core.containerpool.PreWarmedData
 import whisk.core.containerpool.WorkerData
 import whisk.core.containerpool.Free
 import whisk.core.containerpool.ContainerData
+import whisk.core.entity.ExecutableWhiskAction
 
 /**
  * Unit tests for ContainerPool schedule
@@ -45,9 +46,9 @@ class ContainerPoolScheduleTests extends FlatSpec with Matchers with MockFactory
     val actionExec = CodeExecAsString(RuntimeManifest("actionKind"), "testCode", None)
 
     def createAction(namespace: String = "actionNS", name: String = "actionName") =
-        WhiskAction(EntityPath(namespace), EntityName(name), actionExec)
+        WhiskAction(EntityPath(namespace), EntityName(name), actionExec).toExecutableWhiskAction
 
-    def warmedData(action: WhiskAction = createAction(), namespace: String = "anyNamespace", lastUsed: Instant = Instant.now) =
+    def warmedData(action: ExecutableWhiskAction = createAction(), namespace: String = "anyNamespace", lastUsed: Instant = Instant.now) =
         WarmedData(stub[Container], EntityName(namespace), action, lastUsed)
 
     def preWarmedData(kind: String = "anyKind") = PreWarmedData(stub[Container], kind)

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
@@ -454,9 +454,9 @@ class ContainerProxyTests extends TestKit(ActorSystem("ContainerProxys"))
 
             Future.successful((Interval.zero, ActivationResponse.success()))
         }
-        def logs(limit: ByteSize, waitForSentinel: Boolean)(implicit transid: TransactionId): Future[List[String]] = {
+        def logs(limit: ByteSize, waitForSentinel: Boolean)(implicit transid: TransactionId): Future[Vector[String]] = {
             logsCount += 1
-            Future.successful(List("helloTest"))
+            Future.successful(Vector("helloTest"))
         }
     }
 }

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
@@ -51,7 +51,7 @@ import whisk.core.entity.ExecManifest.RuntimeManifest
 import whisk.core.entity.size._
 
 @RunWith(classOf[JUnitRunner])
-class WhiskContainerTests extends TestKit(ActorSystem("WhiskContainers"))
+class ContainerProxyTests extends TestKit(ActorSystem("ContainerProxys"))
     with ImplicitSender
     with FlatSpecLike
     with Matchers
@@ -130,7 +130,7 @@ class WhiskContainerTests extends TestKit(ActorSystem("WhiskContainers"))
     val ack = stubFunction[TransactionId, WhiskActivation, Future[Any]]
     val store = stubFunction[TransactionId, WhiskActivation, Future[Any]]
 
-    behavior of "WhiskContainer"
+    behavior of "ContainerProxy"
 
     /*
      * SUCCESSFUL CASES
@@ -145,7 +145,7 @@ class WhiskContainerTests extends TestKit(ActorSystem("WhiskContainers"))
             Future.successful(container)
         }
 
-        val machine = pool.childActorOf(WhiskContainer.props(factory, ack, store))
+        val machine = pool.childActorOf(ContainerProxy.props(factory, ack, store))
         within(timeout.duration) {
             pool.registerCallback(machine)
             pool.preWarm(machine)
@@ -156,7 +156,7 @@ class WhiskContainerTests extends TestKit(ActorSystem("WhiskContainers"))
         val container = new TestContainer
         def factory(tid: TransactionId, name: String, exec: Exec, memoryLimit: ByteSize) = Future.successful(container)
 
-        val machine = pool.childActorOf(WhiskContainer.props(factory, ack, store))
+        val machine = pool.childActorOf(ContainerProxy.props(factory, ack, store))
         within(timeout.duration) {
             pool.registerCallback(machine)
 
@@ -186,7 +186,7 @@ class WhiskContainerTests extends TestKit(ActorSystem("WhiskContainers"))
         val container = new TestContainer
         def factory(tid: TransactionId, name: String, exec: Exec, memoryLimit: ByteSize) = Future.successful(container)
 
-        val machine = pool.childActorOf(WhiskContainer.props(factory, ack, store))
+        val machine = pool.childActorOf(ContainerProxy.props(factory, ack, store))
         within(timeout.duration) {
             pool.registerCallback(machine)
             pool.preWarm(machine)
@@ -208,7 +208,7 @@ class WhiskContainerTests extends TestKit(ActorSystem("WhiskContainers"))
         val container = new TestContainer
         def factory(tid: TransactionId, name: String, exec: Exec, memoryLimit: ByteSize) = Future.successful(container)
 
-        val machine = pool.childActorOf(WhiskContainer.props(factory, ack, store))
+        val machine = pool.childActorOf(ContainerProxy.props(factory, ack, store))
         within(timeout.duration) {
             pool.registerCallback(machine)
             pool.preWarm(machine)
@@ -232,7 +232,7 @@ class WhiskContainerTests extends TestKit(ActorSystem("WhiskContainers"))
         val container = new TestContainer
         def factory(tid: TransactionId, name: String, exec: Exec, memoryLimit: ByteSize) = Future.successful(container)
 
-        val machine = pool.childActorOf(WhiskContainer.props(factory, ack, store))
+        val machine = pool.childActorOf(ContainerProxy.props(factory, ack, store))
         within(timeout.duration) {
             pool.registerCallback(machine)
             pool.run(machine, Uninitialized)
@@ -252,7 +252,7 @@ class WhiskContainerTests extends TestKit(ActorSystem("WhiskContainers"))
         val container = new TestContainer
         def factory(tid: TransactionId, name: String, exec: Exec, memoryLimit: ByteSize) = Future.failed(new Exception())
 
-        val machine = pool.childActorOf(WhiskContainer.props(factory, ack, store))
+        val machine = pool.childActorOf(ContainerProxy.props(factory, ack, store))
         within(timeout.duration) {
             pool.registerCallback(machine)
             pool.send(machine, Run(action, message))
@@ -277,7 +277,7 @@ class WhiskContainerTests extends TestKit(ActorSystem("WhiskContainers"))
         }
         def factory(tid: TransactionId, name: String, exec: Exec, memoryLimit: ByteSize) = Future.successful(container)
 
-        val machine = pool.childActorOf(WhiskContainer.props(factory, ack, store))
+        val machine = pool.childActorOf(ContainerProxy.props(factory, ack, store))
         within(timeout.duration) {
             pool.registerCallback(machine)
             pool.send(machine, Run(action, message))
@@ -303,7 +303,7 @@ class WhiskContainerTests extends TestKit(ActorSystem("WhiskContainers"))
         }
         def factory(tid: TransactionId, name: String, exec: Exec, memoryLimit: ByteSize) = Future.successful(container)
 
-        val machine = pool.childActorOf(WhiskContainer.props(factory, ack, store))
+        val machine = pool.childActorOf(ContainerProxy.props(factory, ack, store))
         within(timeout.duration) {
             pool.registerCallback(machine)
             pool.send(machine, Run(action, message))
@@ -335,7 +335,7 @@ class WhiskContainerTests extends TestKit(ActorSystem("WhiskContainers"))
         }
         def factory(tid: TransactionId, name: String, exec: Exec, memoryLimit: ByteSize) = Future.successful(container)
 
-        val machine = pool.childActorOf(WhiskContainer.props(factory, ack, store))
+        val machine = pool.childActorOf(ContainerProxy.props(factory, ack, store))
         within(timeout.duration) {
             pool.registerCallback(machine)
 
@@ -380,7 +380,7 @@ class WhiskContainerTests extends TestKit(ActorSystem("WhiskContainers"))
         }
         def factory(tid: TransactionId, name: String, exec: Exec, memoryLimit: ByteSize) = Future.successful(container)
 
-        val machine = pool.childActorOf(WhiskContainer.props(factory, ack, store))
+        val machine = pool.childActorOf(ContainerProxy.props(factory, ack, store))
         within(timeout.duration) {
             pool.registerCallback(machine)
             pool.run(machine, Uninitialized)

--- a/tests/src/test/scala/whisk/core/containerpool/test/WhiskContainerTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/WhiskContainerTests.scala
@@ -1,0 +1,461 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool.test
+
+import java.time.Instant
+
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.concurrent.duration._
+import scala.language.reflectiveCalls
+
+import org.junit.runner.RunWith
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.FlatSpecLike
+import org.scalatest.Matchers
+import org.scalatest.junit.JUnitRunner
+
+import akka.actor.ActorRef
+import akka.actor.ActorSystem
+import akka.actor.FSM
+import akka.actor.FSM.CurrentState
+import akka.actor.FSM.SubscribeTransitionCallBack
+import akka.actor.FSM.Transition
+import akka.testkit.ImplicitSender
+import akka.testkit.TestKit
+import akka.testkit.TestProbe
+import akka.util.Timeout
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+import whisk.common.TransactionId
+import whisk.core.connector.ActivationMessage
+import whisk.core.container.Interval
+import whisk.core.containerpool._
+import whisk.core.entity._
+import whisk.core.entity.ExecManifest.RuntimeManifest
+import whisk.core.entity.size._
+
+@RunWith(classOf[JUnitRunner])
+class WhiskContainerTests extends TestKit(ActorSystem("WhiskContainers"))
+    with ImplicitSender
+    with FlatSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    //with OneInstancePerTest
+    with MockFactory {
+
+    override def afterAll = TestKit.shutdownActorSystem(system)
+
+    implicit val timeout = Timeout(5.seconds)
+
+    // Common entities to pass to the tests. We don't really care what's inside
+    // those for the behavior testing here, as none of the contents will really
+    // reach a container anyway. We merely assert that passing and extraction of
+    // the values is done properly.
+    val exec = CodeExecAsString(RuntimeManifest("actionKind"), "testCode", None)
+    val invocationNamespace = EntityName("invocationSpace")
+    val action = WhiskAction(EntityPath("actionSpace"), EntityName("actionName"), exec)
+
+    val message = ActivationMessage(
+        TransactionId.testing,
+        action.fullyQualifiedName(true),
+        action.rev,
+        Identity(Subject(), invocationNamespace, AuthKey(), Set()),
+        ActivationId(),
+        invocationNamespace.toPath,
+        None)
+
+    /** Imitates a StateTimeout in the FSM */
+    def timeout(actor: ActorRef) = actor ! FSM.StateTimeout
+
+    /** Common fixtures for all of the tests */
+    val pool = new TestProbe(system) {
+        /** Registers the transition callback and expects the first message */
+        def registerCallback(c: ActorRef) = {
+            send(c, SubscribeTransitionCallBack(this.ref))
+            expectMsg(CurrentState(c, Uninitialized))
+        }
+
+        /** Pre-warms the given state-machine, assumes good cases */
+        def preWarm(machine: ActorRef) = {
+            send(machine, Start(exec))
+            expectMsg(Transition(machine, Uninitialized, Starting))
+            expectPreWarmed(exec.kind)
+            expectMsg(Transition(machine, Starting, Started))
+        }
+
+        /** Run the common action on the state-machine, assumes good cases */
+        def run(machine: ActorRef, currentState: ContainerState) = {
+            send(machine, Run(action, message))
+            expectMsg(Transition(machine, currentState, Running))
+            expectWarmed(invocationNamespace.name, action)
+            expectMsg(Transition(machine, Running, Ready))
+        }
+
+        /** Expect a NeedWork message with prewarmed data */
+        def expectPreWarmed(kind: String) = expectMsgPF() {
+            case NeedWork(PreWarmedData(_, kind)) => true
+        }
+
+        /** Expect a NeedWork message with warmed data */
+        def expectWarmed(namespace: String, action: WhiskAction) = {
+            val test = EntityName(namespace)
+            expectMsgPF() {
+                case NeedWork(WarmedData(_, `test`, `action`, _)) => true
+            }
+        }
+
+        /** Expect the container to pause successfully */
+        def expectPause(machine: ActorRef) = {
+            expectMsg(Transition(machine, Ready, Pausing))
+            expectWarmed(invocationNamespace.name, action)
+            expectMsg(Transition(machine, Pausing, Paused))
+        }
+    }
+    val ack = stubFunction[TransactionId, WhiskActivation, Future[Any]]
+    val store = stubFunction[TransactionId, WhiskActivation, Future[Any]]
+
+    behavior of "WhiskContainer"
+
+    /*
+     * SUCCESSFUL CASES
+     */
+    it should "create a container given a Start message" in {
+        val container = new TestContainer
+        def factory(tid: TransactionId, name: String, exec: Exec, memoryLimit: ByteSize) = {
+            tid shouldBe TransactionId.invokerWarmup
+            name should fullyMatch regex """wsk_\d+_prewarm_actionKind"""
+            memoryLimit shouldBe 256.MB
+
+            Future.successful(container)
+        }
+
+        val machine = pool.childActorOf(WhiskContainer.props(factory, ack, store))
+        within(timeout.duration) {
+            pool.registerCallback(machine)
+            pool.preWarm(machine)
+        }
+    }
+
+    it should "run a container which has been started before, write an active ack, write to the store, pause and remove the container" in {
+        val container = new TestContainer
+        def factory(tid: TransactionId, name: String, exec: Exec, memoryLimit: ByteSize) = Future.successful(container)
+
+        val machine = pool.childActorOf(WhiskContainer.props(factory, ack, store))
+        within(timeout.duration) {
+            pool.registerCallback(machine)
+
+            pool.preWarm(machine)
+            pool.run(machine, Started)
+
+            // Timeout causes the container to pause
+            timeout(machine)
+            pool.expectPause(machine)
+
+            // Another pause causes the container to be removed
+            timeout(machine)
+            pool.expectMsg(ContainerRemoved)
+            pool.expectMsg(Transition(machine, Paused, Removing))
+        }
+
+        container.initializeCount shouldBe 1
+        container.runCount shouldBe 1
+        container.logsCount shouldBe 1
+        container.haltCount shouldBe 1
+        container.destroyCount shouldBe 1
+        ack.verify(message.transid, *)
+        store.verify(message.transid, *)
+    }
+
+    it should "run an action and continue with a next run without pausing the container" in {
+        val container = new TestContainer
+        def factory(tid: TransactionId, name: String, exec: Exec, memoryLimit: ByteSize) = Future.successful(container)
+
+        val machine = pool.childActorOf(WhiskContainer.props(factory, ack, store))
+        within(timeout.duration) {
+            pool.registerCallback(machine)
+            pool.preWarm(machine)
+
+            pool.run(machine, Started)
+            // Note that there are no intermediate state changes
+            pool.run(machine, Ready)
+        }
+
+        container.initializeCount shouldBe 1
+        container.runCount shouldBe 2
+        container.logsCount shouldBe 2
+        container.haltCount shouldBe 0
+        ack.verify(message.transid, *).repeat(2)
+        store.verify(message.transid, *).repeat(2)
+    }
+
+    it should "run an action after pausing the container" in {
+        val container = new TestContainer
+        def factory(tid: TransactionId, name: String, exec: Exec, memoryLimit: ByteSize) = Future.successful(container)
+
+        val machine = pool.childActorOf(WhiskContainer.props(factory, ack, store))
+        within(timeout.duration) {
+            pool.registerCallback(machine)
+            pool.preWarm(machine)
+
+            pool.run(machine, Started)
+            timeout(machine)
+            pool.expectPause(machine)
+            pool.run(machine, Paused)
+        }
+
+        container.initializeCount shouldBe 1
+        container.runCount shouldBe 2
+        container.logsCount shouldBe 2
+        container.haltCount shouldBe 1
+        container.resumeCount shouldBe 1
+        ack.verify(message.transid, *).repeat(2)
+        store.verify(message.transid, *).repeat(2)
+    }
+
+    it should "successfully run on an uninitialized container" in {
+        val container = new TestContainer
+        def factory(tid: TransactionId, name: String, exec: Exec, memoryLimit: ByteSize) = Future.successful(container)
+
+        val machine = pool.childActorOf(WhiskContainer.props(factory, ack, store))
+        within(timeout.duration) {
+            pool.registerCallback(machine)
+            pool.run(machine, Uninitialized)
+        }
+
+        container.initializeCount shouldBe 1
+        container.runCount shouldBe 1
+        container.logsCount shouldBe 1
+        ack.verify(message.transid, *).repeat(1)
+        store.verify(message.transid, *).repeat(1)
+    }
+
+    /*
+     * ERROR CASES
+     */
+    it should "complete the transaction and abort if container creation fails" in {
+        val container = new TestContainer
+        def factory(tid: TransactionId, name: String, exec: Exec, memoryLimit: ByteSize) = Future.failed(new Exception())
+
+        val machine = pool.childActorOf(WhiskContainer.props(factory, ack, store))
+        within(timeout.duration) {
+            pool.registerCallback(machine)
+            pool.send(machine, Run(action, message))
+            pool.expectMsg(Transition(machine, Uninitialized, Running))
+            pool.expectMsg(ContainerRemoved)
+        }
+
+        container.initializeCount shouldBe 0
+        container.runCount shouldBe 0
+        container.logsCount shouldBe 0 // gather no logs
+        container.destroyCount shouldBe 0 // no destroying possible as no container could be obtained
+        ack.verify(message.transid, *).repeat(1)
+        store.verify(message.transid, *).repeat(1)
+    }
+
+    it should "complete the transaction and destroy the container on a failed init" in {
+        val container = new TestContainer {
+            override def initialize(initializer: Option[JsObject], timeout: FiniteDuration)(implicit transid: TransactionId): Future[Interval] = {
+                initializeCount += 1
+                Future.failed(InitializationError(ActivationResponse.applicationError("boom"), Interval.zero))
+            }
+        }
+        def factory(tid: TransactionId, name: String, exec: Exec, memoryLimit: ByteSize) = Future.successful(container)
+
+        val machine = pool.childActorOf(WhiskContainer.props(factory, ack, store))
+        within(timeout.duration) {
+            pool.registerCallback(machine)
+            pool.send(machine, Run(action, message))
+            pool.expectMsg(Transition(machine, Uninitialized, Running))
+            pool.expectMsg(ContainerRemoved)
+            pool.expectMsg(Transition(machine, Running, Removing))
+        }
+
+        container.initializeCount shouldBe 1
+        container.runCount shouldBe 0 // should not run the action
+        container.logsCount shouldBe 1
+        container.destroyCount shouldBe 1
+        ack.verify(message.transid, *).repeat(1)
+        store.verify(message.transid, *).repeat(1)
+    }
+
+    it should "complete the transaction and destroy the container on a failed run" in {
+        val container = new TestContainer {
+            override def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
+                runCount += 1
+                Future.successful((Interval.zero, ActivationResponse.applicationError("boom")))
+            }
+        }
+        def factory(tid: TransactionId, name: String, exec: Exec, memoryLimit: ByteSize) = Future.successful(container)
+
+        val machine = pool.childActorOf(WhiskContainer.props(factory, ack, store))
+        within(timeout.duration) {
+            pool.registerCallback(machine)
+            pool.send(machine, Run(action, message))
+            pool.expectMsg(Transition(machine, Uninitialized, Running))
+            pool.expectMsg(ContainerRemoved)
+            pool.expectMsg(Transition(machine, Running, Removing))
+        }
+
+        container.initializeCount shouldBe 1
+        container.runCount shouldBe 1
+        container.logsCount shouldBe 1
+        container.destroyCount shouldBe 1
+        ack.verify(message.transid, *).repeat(1)
+        store.verify(message.transid, *).repeat(1)
+    }
+
+    /*
+     * DELAYED DELETION CASES
+     */
+    // this test represents a Remove message whenever you are in the "Running" state. Therefore, testing
+    // a Remove while /init should suffice to guarantee testcoverage here.
+    it should "delay a deletion message until the transaction is completed successfully" in {
+        val initPromise = Promise[Interval]
+        val container = new TestContainer {
+            override def initialize(initializer: Option[JsObject], timeout: FiniteDuration)(implicit transid: TransactionId): Future[Interval] = {
+                initializeCount += 1
+                initPromise.future
+            }
+        }
+        def factory(tid: TransactionId, name: String, exec: Exec, memoryLimit: ByteSize) = Future.successful(container)
+
+        val machine = pool.childActorOf(WhiskContainer.props(factory, ack, store))
+        within(timeout.duration) {
+            pool.registerCallback(machine)
+
+            // Start running the action
+            pool.send(machine, Run(action, message))
+            pool.expectMsg(Transition(machine, Uninitialized, Running))
+
+            // Schedule the container to be removed
+            pool.send(machine, Remove)
+
+            // Finish /init, note that /run and log-collecting happens nonetheless
+            initPromise.success(Interval.zero)
+            pool.expectWarmed(invocationNamespace.name, action)
+            pool.expectMsg(Transition(machine, Running, Ready))
+
+            // Remove the container after the transaction finished
+            pool.expectMsg(ContainerRemoved)
+            pool.expectMsg(Transition(machine, Ready, Removing))
+        }
+
+        container.initializeCount shouldBe 1
+        container.runCount shouldBe 1
+        container.logsCount shouldBe 1
+        container.haltCount shouldBe 0 // skips pausing the container
+        container.destroyCount shouldBe 1
+        ack.verify(message.transid, *).repeat(1)
+        store.verify(message.transid, *).repeat(1)
+    }
+
+    // this tests a Run message in the "Removing" state. The contract between the pool and state-machine
+    // is, that only one Run is to be sent until a "NeedWork" comes back. If we sent a NeedWork but no work is
+    // there, we might run into the final timeout which will schedule a removal of the container. There is a
+    // time window though, in which the pool doesn't know of that desicion yet. We handle the collision by
+    // sending the Run back to the pool so it can reschedule.
+    it should "send back a Run message which got sent before the container decided to remove itself" in {
+        val destroyPromise = Promise[Unit]
+        val container = new TestContainer {
+            override def destroy()(implicit transid: TransactionId): Future[Unit] = {
+                destroyCount += 1
+                destroyPromise.future
+            }
+        }
+        def factory(tid: TransactionId, name: String, exec: Exec, memoryLimit: ByteSize) = Future.successful(container)
+
+        val machine = pool.childActorOf(WhiskContainer.props(factory, ack, store))
+        within(timeout.duration) {
+            pool.registerCallback(machine)
+            pool.run(machine, Uninitialized)
+            timeout(machine)
+            pool.expectPause(machine)
+            timeout(machine)
+
+            // We don't know of this timeout, so we schedule a run.
+            pool.send(machine, Run(action, message))
+
+            // State-machine shuts down nonetheless.
+            pool.expectMsg(ContainerRemoved)
+            pool.expectMsg(Transition(machine, Paused, Removing))
+
+            // Pool gets the message again.
+            pool.expectMsg(Run(action, message))
+        }
+
+        container.initializeCount shouldBe 1
+        container.runCount shouldBe 1
+        container.logsCount shouldBe 1
+        container.haltCount shouldBe 1
+        container.resumeCount shouldBe 1
+        container.destroyCount shouldBe 1
+        ack.verify(message.transid, *).repeat(1)
+        store.verify(message.transid, *).repeat(1)
+    }
+
+    /**
+     * Implements all the good cases of a perfect run to facilitate error case overriding.
+     */
+    class TestContainer extends Container {
+        var haltCount = 0
+        var resumeCount = 0
+        var destroyCount = 0
+        var initializeCount = 0
+        var runCount = 0
+        var logsCount = 0
+
+        def halt()(implicit transid: TransactionId): Future[Unit] = {
+            haltCount += 1
+            Future.successful(())
+        }
+        def resume()(implicit transid: TransactionId): Future[Unit] = {
+            resumeCount += 1
+            Future.successful(())
+        }
+        def destroy()(implicit transid: TransactionId): Future[Unit] = {
+            destroyCount += 1
+            Future.successful(())
+        }
+        def initialize(initializer: Option[JsObject], timeout: FiniteDuration)(implicit transid: TransactionId): Future[Interval] = {
+            initializeCount += 1
+            initializer shouldBe action.containerInitializer
+            timeout shouldBe action.limits.timeout.duration
+            Future.successful(Interval.zero)
+        }
+        def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
+            runCount += 1
+            environment.fields("api_key") shouldBe message.user.authkey.toJson
+            environment.fields("namespace") shouldBe invocationNamespace.toJson
+            environment.fields("action_name") shouldBe message.action.qualifiedNameWithLeadingSlash.toJson
+            environment.fields("activation_id") shouldBe message.activationId.toJson
+            val deadline = Instant.ofEpochMilli(environment.fields("deadline").convertTo[String].toLong)
+            val maxDeadline = Instant.now.plusMillis(timeout.toMillis)
+
+            // The deadline should be in the future but must be smaller than or equal
+            // a freshly computed deadline, as they get computed slightly after each other
+            deadline should (be <= maxDeadline and be >= Instant.now)
+
+            Future.successful((Interval.zero, ActivationResponse.success()))
+        }
+        def logs(limit: ByteSize, waitForSentinel: Boolean)(implicit transid: TransactionId): Future[List[String]] = {
+            logsCount += 1
+            Future.successful(List("helloTest"))
+        }
+    }
+}

--- a/tests/src/test/scala/whisk/core/invoker/ActionLogDriverTests.scala
+++ b/tests/src/test/scala/whisk/core/invoker/ActionLogDriverTests.scala
@@ -41,8 +41,8 @@ class ActionLogDriverTests
     private def makeLogMsgs(lines: Seq[String], stream: String = "stdout", addSentinel: Boolean = true) = {
         val msgs = if (addSentinel) {
             lines.map((stream, _)) :+
-                ("stdout", s"$LOG_ACTIVATION_SENTINEL\n") :+
-                ("stderr", s"$LOG_ACTIVATION_SENTINEL\n")
+                ("stdout", s"$ActionLogDriver.LOG_ACTIVATION_SENTINEL\n") :+
+                ("stderr", s"$ActionLogDriver.LOG_ACTIVATION_SENTINEL\n")
         } else {
             lines.map((stream, _))
         }
@@ -77,8 +77,8 @@ class ActionLogDriverTests
             raw"""|{"time":"","stream":"stdout","log":"a"}
                   |{"time":"","stream":"stdout","log":"b"}
                   |{"time":"","stream":"stdout","log":"c"}
-                  |{"time":"","stream":"stdout","log":"$LOG_ACTIVATION_SENTINEL\n"}
-                  |{"time":"","stream":"stderr","log":"$LOG_ACTIVATION_SENTINEL\n"}""".stripMargin('|')
+                  |{"time":"","stream":"stdout","log":"$ActionLogDriver.LOG_ACTIVATION_SENTINEL\n"}
+                  |{"time":"","stream":"stderr","log":"$ActionLogDriver.LOG_ACTIVATION_SENTINEL\n"}""".stripMargin('|')
         }
     }
 

--- a/tests/src/test/scala/whisk/core/invoker/ActionLogDriverTests.scala
+++ b/tests/src/test/scala/whisk/core/invoker/ActionLogDriverTests.scala
@@ -41,8 +41,8 @@ class ActionLogDriverTests
     private def makeLogMsgs(lines: Seq[String], stream: String = "stdout", addSentinel: Boolean = true) = {
         val msgs = if (addSentinel) {
             lines.map((stream, _)) :+
-                ("stdout", s"$ActionLogDriver.LOG_ACTIVATION_SENTINEL\n") :+
-                ("stderr", s"$ActionLogDriver.LOG_ACTIVATION_SENTINEL\n")
+                ("stdout", s"${ActionLogDriver.LOG_ACTIVATION_SENTINEL}") :+
+                ("stderr", s"${ActionLogDriver.LOG_ACTIVATION_SENTINEL}")
         } else {
             lines.map((stream, _))
         }
@@ -77,8 +77,8 @@ class ActionLogDriverTests
             raw"""|{"time":"","stream":"stdout","log":"a"}
                   |{"time":"","stream":"stdout","log":"b"}
                   |{"time":"","stream":"stdout","log":"c"}
-                  |{"time":"","stream":"stdout","log":"$ActionLogDriver.LOG_ACTIVATION_SENTINEL\n"}
-                  |{"time":"","stream":"stderr","log":"$ActionLogDriver.LOG_ACTIVATION_SENTINEL\n"}""".stripMargin('|')
+                  |{"time":"","stream":"stdout","log":"${ActionLogDriver.LOG_ACTIVATION_SENTINEL}"}
+                  |{"time":"","stream":"stderr","log":"${ActionLogDriver.LOG_ACTIVATION_SENTINEL}"}""".stripMargin('|')
         }
     }
 


### PR DESCRIPTION
This implements an entirely new ContainerPool (and eventually Invoker) which is based entirely on an event- and message-driven architecture. It does not use any busy-loops nor manually tweaked Thread.sleeps to distribute its work. As a consequence, this pool does not need locking or synchronized access to any data-structures.

Containers are modeled as a finite-state-machine to reflect the lifecycle of a container in the code itself as close as possible.

Signed-off-by: Sven Lange-Last <slange@de.ibm.com>

## Todos

- [x] Feature toggle (to activate new or old pool)
- [x] Blackbox support (`docker pull`)
- [x] Container eviction strategy (start with LRU first)
- [x] Pre-Warmed containers
- [x] Error handling (Remove containers in certain states)
- [x] Start/Shutdown Cleanup
- [x] Container parameter passing (environment variables)
- [x] Container startup parameters
- [x] Container Naming
- [x] Docker file inspect
- [x] Proper log reading according to limits
- [x] Select containers properly (not based on action but based on action + user)
- [x] Testcoverage