### PR TITLE
allow concurrent activation processing

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/Parameter.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Parameter.scala
@@ -107,6 +107,17 @@ protected[core] class Parameters protected[entity] (
             case _           => None
         }
     }
+
+    /**
+      * Retrieves parameter by name if it exist. If value of parameter
+      * is a number, return its Long value else none.
+      */
+    protected[core] def asLong(p: String): Option[Long] = {
+        get(p) flatMap {
+            case JsNumber(s) => Some(s.toLong)
+            case _           => None
+        }
+    }
 }
 
 /**

--- a/core/invoker/src/main/scala/whisk/core/container/Container.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/Container.scala
@@ -47,6 +47,7 @@ class Container(
 
     implicit var transid = originalId
 
+    var paused:Boolean = false
     val id = Container.idCounter.next()
     val nameAsString = containerName.map(_.name).getOrElse("anon")
 
@@ -59,19 +60,22 @@ class Container(
         s"container [$name] [$id] [$ip]"
     }
 
-    def pause(): Boolean =
+    def pause(): Boolean = {
+        paused = true
         if (useRunc) {
             RuncUtils.isSuccessful(RuncUtils.pause(containerId))
         } else {
             DockerOutput.isSuccessful(pauseContainer(containerId))
         }
-
-    def unpause(): Boolean =
+    }
+    def unpause(): Boolean = {
+        paused = false
         if (useRunc) {
             RuncUtils.isSuccessful(RuncUtils.resume(containerId))
         } else {
             DockerOutput.isSuccessful(unpauseContainer(containerId))
         }
+    }
 
     /**
      * A prefix of the container id known to be displayed by docker ps.

--- a/core/invoker/src/main/scala/whisk/core/container/package.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/package.scala
@@ -72,7 +72,7 @@ package object container {
 
     case object CacheMiss extends CacheResult
     case object CacheBusy extends CacheResult
-    case class CacheHit(con: WhiskContainer) extends CacheResult
+    case class CacheHit(con: WhiskContainer, currentActivations:Long) extends CacheResult
 
     /**
      * The result of trying to obtain a container which is known to exist or to create one.


### PR DESCRIPTION
allows concurrent processing of activations in a single container IFF 
- action created with "concurrent-max <long>" annotation
- only allow up to specified concurrent actions in-flight per container at any given time
 to address https://github.com/openwhisk/openwhisk/issues/2026

Should be refactored/replaced after #2021 (which will make this logic simpler I think), but providing this PR as basis for conversation in the meantime before that PR is merged.  