### PR TITLE
CacheConcurrencyTests: tie number of threads to number of available CPUs instead of hard-coded value.

### DIFF
--- a/tests/src/test/scala/whisk/core/database/test/CacheConcurrencyTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/CacheConcurrencyTests.scala
@@ -37,15 +37,16 @@ class CacheConcurrencyTests extends FlatSpec
     with WskTestHelpers
     with BeforeAndAfter {
 
-    println(s"Running tests on # proc: ${Runtime.getRuntime.availableProcessors()}")
-
     implicit private val transId = TransactionId.testing
     implicit private val wp = WskProps()
     private val wsk = new Wsk
 
+    val nCPU = Runtime.getRuntime.availableProcessors()
     val nExternalIters = 1
     val nInternalIters = 5
-    val nThreads = nInternalIters * 30
+    val nThreads = nInternalIters * 8 * nCPU
+
+    println(s"Running tests on ${nCPU} CPUs with a total of ${nThreads} threads.")
 
     val parallel = (1 to nInternalIters).par
     parallel.tasksupport = new ForkJoinTaskSupport(new ForkJoinPool(nThreads))

--- a/tests/src/test/scala/whisk/core/database/test/CacheConcurrencyTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/CacheConcurrencyTests.scala
@@ -42,9 +42,9 @@ class CacheConcurrencyTests extends FlatSpec
     private val wsk = new Wsk
 
     val nCPU = Runtime.getRuntime.availableProcessors()
-    val nExternalIters = 1
+    val nExternalIters = 50
     val nInternalIters = 5
-    val nThreads = nInternalIters * 8 * nCPU
+    val nThreads = nInternalIters * 4 * nCPU
 
     println(s"Running tests on ${nCPU} CPUs with a total of ${nThreads} threads.")
 


### PR DESCRIPTION
this should reduce the number of intermittent failures of this test on smaller systems.