### PR TITLE
Bump Kafka Connector Test timeout to avoid build breaks

### DIFF
--- a/tests/src/test/scala/services/KafkaConnectorTests.scala
+++ b/tests/src/test/scala/services/KafkaConnectorTests.scala
@@ -73,7 +73,7 @@ class KafkaConnectorTests
         for (i <- 0 until 5) {
             val message = new Message { override val serialize = Calendar.getInstance().getTime().toString }
             val start = java.lang.System.currentTimeMillis
-            val sent = Await.result(producer.send(topic, message), 10 seconds)
+            val sent = Await.result(producer.send(topic, message), 20 seconds)
             val received = consumer.peek(10 seconds).map { case (_, _, _, msg) => new String(msg, "utf-8") }
             val end = java.lang.System.currentTimeMillis
             val elapsed = end - start


### PR DESCRIPTION
- current limit of 10 seconds is too small on PG3 - causing build failures
- other PG3 connector test times have recently been observed at 8/9+ seconds