### PR TITLE
Make action container log reading more robust

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
@@ -759,7 +759,7 @@ class ContainerPool(
                 this.getDockerLogContent(container.containerId, 0, size, mounted)
             }
             val filename = s"${_logDir}/${container.nameAsString}.log"
-            Files.write(Paths.get(filename), rawLogBytes)
+            Files.write(Paths.get(filename), rawLogBytes.array)
             logging.info(this, s"teardownContainers: wrote docker logs to $filename")
         }
         container.transid = transid

--- a/core/invoker/src/main/scala/whisk/core/container/ContainerUtils.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/ContainerUtils.scala
@@ -17,7 +17,8 @@
 
 package whisk.core.container
 
-import java.io.{ File, FileNotFoundException }
+import java.io.{ File, FileNotFoundException, FileInputStream }
+import java.nio.ByteBuffer
 
 import scala.language.postfixOps
 import scala.util.Try
@@ -158,14 +159,14 @@ trait ContainerUtils {
      * Reads the contents of the file at the given position.
      * It is assumed that the contents does exist and that region is not changing concurrently.
      */
-    def getDockerLogContent(containerHash: ContainerHash, start: Long, end: Long, mounted: Boolean)(implicit transid: TransactionId): java.nio.ByteBuffer = {
-        var fis: java.io.FileInputStream = null
+    def getDockerLogContent(containerHash: ContainerHash, start: Long, end: Long, mounted: Boolean)(implicit transid: TransactionId): ByteBuffer = {
+        var fis: FileInputStream = null
         try {
             val file = getDockerLogFile(containerHash, mounted)
-            fis = new java.io.FileInputStream(file)
+            fis = new FileInputStream(file)
             val channel = fis.getChannel().position(start)
             var remain = (end - start).toInt
-            val buffer = java.nio.ByteBuffer.allocate(remain)
+            val buffer = ByteBuffer.allocate(remain)
             while (remain > 0) {
                 val read = channel.read(buffer)
                 if (read >= 0) {
@@ -180,7 +181,7 @@ trait ContainerUtils {
             case e: Exception =>
                 logging.error(this, s"getDockerLogContent failed on ${containerHash.hash}: ${e.getClass}: ${e.getMessage}")
                 // Return an empty buffer
-                java.nio.ByteBuffer.wrap(Array())
+                ByteBuffer.wrap(Array())
         } finally {
             if (fis != null) fis.close()
         }
@@ -239,7 +240,7 @@ trait ContainerUtils {
     /**
      * Gets the filename of the docker logs of other containers that is mapped back into the invoker.
      */
-    private def getDockerLogFile(containerId: ContainerHash, mounted: Boolean) = {
+    protected def getDockerLogFile(containerId: ContainerHash, mounted: Boolean) = {
         new java.io.File(s"""${dockerContainerDir(mounted, containerId)}/${containerId.hash}-json.log""").getCanonicalFile()
     }
 

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -318,7 +318,7 @@ class Invoker(
                 pool.getDockerLogContent(con.containerId, con.lastLogSize, size, runningInContainer)
             }
 
-            val rawLog = new String(rawLogBytes, StandardCharsets.UTF_8)
+            val rawLog = new String(rawLogBytes.array, rawLogBytes.arrayOffset, rawLogBytes.position, StandardCharsets.UTF_8)
 
             val (complete, isTruncated, logs) = processJsonDriverLogContents(rawLog, sentinelled, loglimit.asMegaBytes)
 

--- a/tests/src/test/scala/whisk/core/container/test/ContainerUtilsTests.scala
+++ b/tests/src/test/scala/whisk/core/container/test/ContainerUtilsTests.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.container.test
+
+import org.junit.runner.RunWith
+import org.scalatest.fixture.FlatSpec
+import org.scalatest.junit.JUnitRunner
+import java.io.File
+
+import common.StreamLogging
+
+import whisk.common.TransactionId
+import whisk.core.container.ContainerUtils
+import whisk.common.Logging
+import whisk.core.container.ContainerHash
+import org.scalatest.BeforeAndAfter
+import java.io.FileWriter
+import java.nio.charset.StandardCharsets
+import org.scalatest.Matchers
+import org.scalatest.concurrent.TimeLimitedTests
+import org.scalatest.time.SpanSugar._
+
+/**
+ * Unit tests for ContainerPool and, by association, Container and WhiskContainer.
+ */
+@RunWith(classOf[JUnitRunner])
+class ContainerUtilsTests extends FlatSpec
+    with BeforeAndAfter
+    with Matchers
+    with StreamLogging
+    with TimeLimitedTests {
+
+    val timeLimit = 100 millis
+
+    before {
+        stream.reset()
+    }
+
+    implicit val transid = TransactionId.testing
+
+    behavior of "getDockerLogContent"
+
+    case class FixtureParam(file: File, writer: FileWriter, cu: ContainerUtilsTester)
+
+    def withFixture(test: OneArgTest) = {
+        val file = File.createTempFile(this.getClass.getName, test.name.replaceAll("[^a-zA-Z0-9.-]", "_"))
+        val writer = new FileWriter(file)
+        val cu = new ContainerUtilsTester(file)
+
+        val fixture = FixtureParam(file, writer, cu)
+
+        try {
+            withFixture(test.toNoArgTest(fixture))
+        } finally {
+            writer.close()
+            file.delete()
+        }
+    }
+
+    def writeLogFile(fixture: FixtureParam, content: String): Long = {
+        fixture.writer.write(content)
+        fixture.writer.flush()
+        fixture.file.length
+    }
+
+    it should "tolerate an empty log file" in { fixture =>
+        val logText = ""
+        val size = writeLogFile(fixture, logText)
+
+        val buffer = fixture.cu.getDockerLogContent(containerHash = ContainerHash.fromString("0123"), start = 0, end = size, mounted = false)
+        val logContent = new String(buffer.array, buffer.arrayOffset, buffer.position, StandardCharsets.UTF_8)
+
+        logContent shouldBe logText
+        stream.size() shouldBe 0
+    }
+
+    it should "read a full log file" in { fixture =>
+        val logText = "text"
+        val size = writeLogFile(fixture, logText)
+
+        val buffer = fixture.cu.getDockerLogContent(containerHash = ContainerHash.fromString("0123"), start = 0, end = size, mounted = false)
+        val logContent = new String(buffer.array, buffer.arrayOffset, buffer.position, StandardCharsets.UTF_8)
+
+        logContent shouldBe logText
+        stream.size() shouldBe 0
+    }
+
+    it should "read a log file portion" in { fixture =>
+        val count = 4
+        val logText = (1 to count).map(i => s"Line ${i}\n").mkString("")
+        val size = writeLogFile(fixture, logText)
+        val quarter = count / 4
+        val qlen = logText.length / 4 // length of a quarter
+        val from = qlen // start reading from second quarter
+        val to = from + 2 * qlen // read second and third quarter
+        val expectedText = logText.substring(from, to)
+
+        val buffer = fixture.cu.getDockerLogContent(containerHash = ContainerHash.fromString("0123"), start = from, end = to, mounted = false)
+        val logContent = new String(buffer.array, buffer.arrayOffset, buffer.position, StandardCharsets.UTF_8)
+
+        logContent shouldBe expectedText
+        stream.size() shouldBe 0
+    }
+
+    it should "tolerate premature end of log file" in { fixture =>
+        val logText = (1 to 2).map(i => s"Line ${i}\n").mkString("")
+        val size = writeLogFile(fixture, logText)
+        val to = 2 * size
+
+        val buffer = fixture.cu.getDockerLogContent(containerHash = ContainerHash.fromString("0123"), start = 0, end = to, mounted = false)
+        val logContent = new String(buffer.array, buffer.arrayOffset, buffer.position, StandardCharsets.UTF_8)
+
+        logContent shouldBe logText
+        stream.size() shouldBe 0
+    }
+
+    it should "provide an empty result on failure" in { fixture =>
+        fixture.cu.logFile = new File("/nonsense")
+
+        val buffer = fixture.cu.getDockerLogContent(containerHash = ContainerHash.fromString("0123"), start = 0, end = 1, mounted = false)
+
+        buffer.capacity() shouldBe 0
+        logLines.head should include("getDockerLogContent failed")
+    }
+}
+
+class ContainerUtilsTester(var logFile: File)(implicit val logging: Logging) extends ContainerUtils {
+    val dockerhost: String = ""
+
+    override def getDockerLogFile(containerId: ContainerHash, mounted: Boolean) = {
+        logFile
+    }
+}


### PR DESCRIPTION
This PR fixes a small defect in action container log file reading in the invoker and addresses a premature file end when reading the log file.