### PR TITLE
Updates for Max Activation List Limit

### DIFF
--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -112,6 +112,7 @@ object Messages {
     def entityTooBig(error: SizeError) = {
         s"${error.field} larger than allowed: ${error.is.toBytes} > ${error.allowed.toBytes} bytes."
     }
+    def maxActivationLimitExceeded(value: Int, max: Int) = s"Activation limit of $value exceeds maximum limit of $max."
 
     def truncateLogs(limit: ByteSize) = {
         s"Logs were truncated because the total bytes size exceeds the limit of ${limit.toBytes} bytes."

--- a/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -1388,13 +1388,4 @@ class WskBasicUsageTests
             }
             tmpProps.delete()
     }
-
-    behavior of "Wsk activation"
-
-    it should "reject activation list with a limit that exceeds the maximum limit" in {
-        val maxLimit = 200
-        val exceededLimit = maxLimit + 1
-        wsk.activation.list(limit = Some(exceededLimit), expectedExitCode = ERROR_EXIT).
-            stderr should include(s"Activation limit of $exceededLimit exceeds maximum limit of 200")
-    }
 }

--- a/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -1388,4 +1388,13 @@ class WskBasicUsageTests
             }
             tmpProps.delete()
     }
+
+    behavior of "Wsk activation"
+
+    it should "reject activation list with a limit that exceeds the maximum limit" in {
+        val maxLimit = 200
+        val exceededLimit = maxLimit + 1
+        wsk.activation.list(limit = Some(exceededLimit), expectedExitCode = ERROR_EXIT).
+            stderr should include(s"Activation limit of $exceededLimit exceeds maximum limit of 200")
+    }
 }

--- a/tests/src/test/scala/whisk/core/controller/test/ActivationsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActivationsApiTests.scala
@@ -215,6 +215,16 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
         }
     }
 
+    it should "reject activation list when limit is greater than maximum allowed value" in {
+        implicit val tid = transid()
+        val exceededMaxLimit = maxActivationLimit + 1
+        val response = Get(s"$collectionPath?limit=$exceededMaxLimit") ~> sealRoute(routes(creds)) ~> check {
+            val response = responseAs[String]
+            response should include(Messages.maxActivationLimitExceeded(exceededMaxLimit, maxActivationLimit))
+            status should be(BadRequest)
+        }
+    }
+
     it should "reject get activation by namespace and action name when action name is not a valid name" in {
         implicit val tid = transid()
         Get(s"$collectionPath?name=0%20") ~> sealRoute(routes(creds)) ~> check {

--- a/tests/src/test/scala/whisk/core/controller/test/ActivationsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActivationsApiTests.scala
@@ -217,10 +217,10 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
 
     it should "reject activation list when limit is greater than maximum allowed value" in {
         implicit val tid = transid()
-        val exceededMaxLimit = maxActivationLimit + 1
+        val exceededMaxLimit = WhiskActivationsApi.maxActivationLimit + 1
         val response = Get(s"$collectionPath?limit=$exceededMaxLimit") ~> sealRoute(routes(creds)) ~> check {
             val response = responseAs[String]
-            response should include(Messages.maxActivationLimitExceeded(exceededMaxLimit, maxActivationLimit))
+            response should include(Messages.maxActivationLimitExceeded(exceededMaxLimit, WhiskActivationsApi.maxActivationLimit))
             status should be(BadRequest)
         }
     }

--- a/tools/cli/go-whisk-cli/commands/activation.go
+++ b/tools/cli/go-whisk-cli/commands/activation.go
@@ -31,8 +31,12 @@ import (
     "github.com/spf13/cobra"
 )
 
-const MAX_ACTIVATION_LIMIT = 200
-const DEFAULT_ACTIVATION_LIMIT = 30
+const (
+    PollInterval = time.Second * 2
+    Delay        = time.Second * 5
+    MAX_ACTIVATION_LIMIT = 200
+    DEFAULT_ACTIVATION_LIMIT = 30
+)
 
 var activationCmd = &cobra.Command{
     Use:   "activation",

--- a/tools/cli/go-whisk-cli/commands/activation.go
+++ b/tools/cli/go-whisk-cli/commands/activation.go
@@ -74,15 +74,6 @@ var activationListCmd = &cobra.Command{
             Docs:  flags.common.full,
         }
 
-        if options.Limit > MAX_ACTIVATION_LIMIT {
-            errStr := wski18n.T("Activation limit of {{.limit}} exceeds maximum limit of {{.max}}",
-                map[string]interface{}{
-                    "limit": options.Limit,
-                    "max": MAX_ACTIVATION_LIMIT})
-            whiskErr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
-            return whiskErr
-        }
-
         activations, _, err := client.Activations.List(options)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Activations.List() error: %s\n", err)
@@ -338,7 +329,8 @@ var activationPollCmd = &cobra.Command{
 
 func init() {
     activationListCmd.Flags().IntVarP(&flags.common.skip, "skip", "s", 0, wski18n.T("exclude the first `SKIP` number of activations from the result"))
-    activationListCmd.Flags().IntVarP(&flags.common.limit, "limit", "l", DEFAULT_ACTIVATION_LIMIT, wski18n.T("only return `LIMIT` number of activations from the collection with a maximum LIMIT of 200 activations"))
+    activationListCmd.Flags().IntVarP(&flags.common.limit, "limit", "l", DEFAULT_ACTIVATION_LIMIT, wski18n.T("only return `LIMIT` number of activations from the collection with a maximum LIMIT of {{.max}} activations",
+        map[string]interface{}{"max": MAX_ACTIVATION_LIMIT}))
     activationListCmd.Flags().BoolVarP(&flags.common.full, "full", "f", false, wski18n.T("include full activation description"))
     activationListCmd.Flags().Int64Var(&flags.activation.upto, "upto", 0, wski18n.T("return activations with timestamps earlier than `UPTO`; measured in milliseconds since Th, 01, Jan 1970"))
     activationListCmd.Flags().Int64Var(&flags.activation.since, "since", 0, wski18n.T("return activations with timestamps later than `SINCE`; measured in milliseconds since Th, 01, Jan 1970"))

--- a/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
+++ b/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
@@ -1466,9 +1466,5 @@
   {
     "id": "An entity name, '{{.name}}', was provided instead of a namespace. Valid namespaces are of the following format: /NAMESPACE.",
     "translation": "An entity name, '{{.name}}', was provided instead of a namespace. Valid namespaces are of the following format: /NAMESPACE."
-  },
-  {
-    "id": "Activation limit of {{.limit}} exceeds maximum limit of {{.max}}",
-    "translation": "Activation limit of {{.limit}} exceeds maximum limit of {{.max}}"
   }
 ]

--- a/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
+++ b/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
@@ -996,8 +996,8 @@
     "translation": "exclude the first `SKIP` number of activations from the result"
   },
   {
-    "id": "only return `LIMIT` number of activations from the collection",
-    "translation": "only return `LIMIT` number of activations from the collection"
+    "id": "only return `LIMIT` number of activations from the collection with a maximum LIMIT of 200 activations",
+    "translation": "only return `LIMIT` number of activations from the collection with a maximum LIMIT of 200 activations"
   },
   {
     "id": "include full activation description",
@@ -1466,5 +1466,9 @@
   {
     "id": "An entity name, '{{.name}}', was provided instead of a namespace. Valid namespaces are of the following format: /NAMESPACE.",
     "translation": "An entity name, '{{.name}}', was provided instead of a namespace. Valid namespaces are of the following format: /NAMESPACE."
+  },
+  {
+    "id": "Activation limit of {{.limit}} exceeds maximum limit of {{.max}}",
+    "translation": "Activation limit of {{.limit}} exceeds maximum limit of {{.max}}"
   }
 ]

--- a/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
+++ b/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
@@ -996,8 +996,8 @@
     "translation": "exclude the first `SKIP` number of activations from the result"
   },
   {
-    "id": "only return `LIMIT` number of activations from the collection with a maximum LIMIT of 200 activations",
-    "translation": "only return `LIMIT` number of activations from the collection with a maximum LIMIT of 200 activations"
+    "id": "only return `LIMIT` number of activations from the collection with a maximum LIMIT of {{.max}} activations",
+    "translation": "only return `LIMIT` number of activations from the collection with a maximum LIMIT of {{.max}} activations"
   },
   {
     "id": "include full activation description",


### PR DESCRIPTION
- Inform users that 200 activations is the maximum limit for the list CLI command
- Make controller return an error if activation limit is greater than 200
- Closes https://github.com/openwhisk/openwhisk/issues/2097