### PR TITLE
Hook up reactive pool into invoker startup

### DIFF
--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -39,3 +39,4 @@ apigw_host_v2: "http://{{ groups['apigateway']|first }}:{{apigateway.port.api}}/
 
 # RunC enablement
 invoker_use_runc: true
+invoker_use_reactive_pool: true

--- a/ansible/environments/mac/group_vars/all
+++ b/ansible/environments/mac/group_vars/all
@@ -44,3 +44,4 @@ apigw_host_v2: "http://{{ groups['apigateway']|first }}:{{apigateway.port.api}}/
 
 # RunC enablement
 invoker_use_runc: true
+invoker_use_reactive_pool: true

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -123,6 +123,7 @@ invoker:
   serializeDockerOp: true
   serializeDockerPull: true
   useRunc: false
+  useReactivePool: "{{ invoker_use_reactive_pool | default(false) }}"
 
 nginx:
   version: 1.11

--- a/ansible/templates/whisk.properties.j2
+++ b/ansible/templates/whisk.properties.j2
@@ -73,6 +73,7 @@ invoker.coreshare={{ invoker.coreshare }}
 invoker.serializeDockerOp={{ invoker.serializeDockerOp }}
 invoker.serializeDockerPull={{ invoker.serializeDockerPull }}
 invoker.useRunc={{ invoker_use_runc | default(invoker.useRunc) }}
+invoker.useReactivePool={{ invoker.useReactivePool }}
 
 consulserver.docker.endpoint={{ groups["consul_servers"]|first }}:{{ docker.port }}
 edge.docker.endpoint={{ groups["edge"]|first }}:{{ docker.port }}

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -77,6 +77,7 @@ class WhiskConfig(
     val invokerSerializeDockerOp = this(WhiskConfig.invokerSerializeDockerOp)
     val invokerSerializeDockerPull = this(WhiskConfig.invokerSerializeDockerPull)
     val invokerUseRunc = this(WhiskConfig.invokerUseRunc)
+    val invokerUseReactivePool = this(WhiskConfig.invokerUseReactivePool)
 
     val wskApiHost = this(WhiskConfig.wskApiProtocol) + "://" + this(WhiskConfig.wskApiHostname) + ":" + this(WhiskConfig.wskApiPort)
     val controllerHost = this(WhiskConfig.controllerHostName) + ":" + this(WhiskConfig.controllerHostPort)
@@ -234,6 +235,7 @@ object WhiskConfig {
     val invokerSerializeDockerOp = "invoker.serializeDockerOp"
     val invokerSerializeDockerPull = "invoker.serializeDockerPull"
     val invokerUseRunc = "invoker.useRunc"
+    val invokerUseReactivePool = "invoker.useReactivePool"
 
     val wskApiProtocol = "whisk.api.host.proto"
     val wskApiPort = "whisk.api.host.port"

--- a/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
+++ b/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
@@ -93,7 +93,7 @@ protected[core] trait DocumentRevisionProvider {
 
     protected[core] def rev = _rev
 
-    private var _rev: DocRevision = DocRevision()
+    private var _rev: DocRevision = DocRevision.empty
 }
 
 /**
@@ -212,7 +212,7 @@ trait DocumentFactory[W] extends MultipleReadersSingleWriterCache[W, DocInfo] {
      * @param mw a manifest for W (hint to compiler to preserve type R for runtime)
      * @return Future[W] with completion to Success(W), or Failure(Throwable) if the raw record cannot be converted into W
      */
-    def get[Wsuper >: W](db: ArtifactStore[Wsuper], doc: DocId, rev: DocRevision = DocRevision(), fromCache: Boolean = cacheEnabled)(
+    def get[Wsuper >: W](db: ArtifactStore[Wsuper], doc: DocId, rev: DocRevision = DocRevision.empty, fromCache: Boolean = cacheEnabled)(
         implicit transid: TransactionId, mw: Manifest[W]): Future[W] = {
         Try {
             require(db != null, "db undefined")

--- a/common/scala/src/main/scala/whisk/core/entity/DocInfo.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/DocInfo.scala
@@ -66,7 +66,7 @@ protected[core] class DocRevision private (val rev: String) extends AnyVal {
  * @param id the document id
  * @param rev the document revision, optional; this is an opaque value determined by the datastore
  */
-protected[core] case class DocInfo protected[entity] (id: DocId, rev: DocRevision = DocRevision()) {
+protected[core] case class DocInfo protected[entity] (id: DocId, rev: DocRevision = DocRevision.empty) {
     override def toString = {
         if (rev.empty) {
             s"id: $id"
@@ -107,14 +107,16 @@ protected[core] object DocRevision {
      * @param s is the document revision as a string, may be null
      * @return DocRevision
      */
-    protected[core] def apply(s: String = null): DocRevision = new DocRevision(trim(s))
+    protected[core] def apply(s: String): DocRevision = new DocRevision(trim(s))
+
+    protected[core] val empty: DocRevision = new DocRevision(null)
 
     implicit val serdes = new RootJsonFormat[DocRevision] {
         def write(d: DocRevision) = if (d.rev != null) JsString(d.rev) else JsNull
 
         def read(value: JsValue) = value match {
             case JsString(s) => DocRevision(s)
-            case JsNull      => DocRevision()
+            case JsNull      => DocRevision.empty
             case _           => deserializationError("doc revision malformed")
         }
     }

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -181,7 +181,7 @@ case class ExecutableWhiskAction(
     exec: CodeExec[_],
     limits: ActionLimits = ActionLimits(),
     version: SemVer = SemVer(),
-    rev: DocRevision = DocRevision()) {
+    rev: DocRevision = DocRevision.empty) {
 
     /**
      * Gets initializer for action. This typically includes the code to execute,
@@ -249,7 +249,7 @@ object WhiskAction
     }
 
     // overriden to retrieve attached code
-    override def get[A >: WhiskAction](db: ArtifactStore[A], doc: DocId, rev: DocRevision = DocRevision(), fromCache: Boolean)(
+    override def get[A >: WhiskAction](db: ArtifactStore[A], doc: DocId, rev: DocRevision = DocRevision.empty, fromCache: Boolean)(
         implicit transid: TransactionId, mw: Manifest[WhiskAction]): Future[WhiskAction] = {
 
         implicit val ec = db.executionContext

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
@@ -305,7 +305,7 @@ class InvokerActor extends FSM[InvokerState, InvokerInfo] {
                 transid = transid,
                 action = action.fullyQualifiedName(true),
                 // Use empty DocRevision to force the invoker to pull the action from db all the time
-                revision = DocRevision(),
+                revision = DocRevision.empty,
                 user = InvokerPool.healthActionIdentity,
                 // Create a new Activation ID for this activation
                 activationId = new ActivationIdGenerator {}.make(),

--- a/core/invoker/src/main/scala/whisk/core/container/WhiskContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/WhiskContainer.scala
@@ -73,7 +73,7 @@ class WhiskContainer(
     def init(args: JsObject, timeout: FiniteDuration)(implicit system: ActorSystem, transid: TransactionId): RunResult = {
         val startMarker = transid.started("Invoker", LoggingMarkers.INVOKER_ACTIVATION_INIT, s"sending initialization to ${this.details}")
         // when invoking /init, don't wait longer than the timeout configured for this action
-        val result = sendPayload("/init", JsObject("value" -> args), timeout, retry=true)
+        val result = sendPayload("/init", JsObject("value" -> args), timeout, retry = true)
         val RunResult(Interval(startActivation, endActivation), _) = result
         transid.finished("Invoker", startMarker.copy(startActivation), s"initialization result: ${result.toBriefString}", endTime = endActivation)
         result
@@ -99,7 +99,7 @@ class WhiskContainer(
      */
     def run(msg: ActivationMessage, args: JsObject, timeout: FiniteDuration)(implicit system: ActorSystem, transid: TransactionId): RunResult = {
         val startMarker = transid.started("Invoker", LoggingMarkers.INVOKER_ACTIVATION_RUN, s"sending arguments to ${msg.action} $details")
-        val result = sendPayload("/run", constructActivationMetadata(msg, args, timeout), timeout, retry=false)
+        val result = sendPayload("/run", constructActivationMetadata(msg, args, timeout), timeout, retry = false)
         // Use start and end time of the activation
         val RunResult(Interval(startActivation, endActivation), _) = result
         transid.finished("Invoker", startMarker.copy(startActivation), s"running result: ${result.toBriefString}", endTime = endActivation)
@@ -115,7 +115,7 @@ class WhiskContainer(
         val msg = ActivationMessage(
             TransactionId.testing,
             FullyQualifiedEntityName(EntityPath("no_namespace"), EntityName("no_action")),
-            DocRevision(),
+            DocRevision.empty,
             WhiskAuth(Subject(), AuthKey()).toIdentity,
             ActivationId(),
             EntityPath("no_namespace"),

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -99,10 +99,10 @@ class Invoker(
         // caching is enabled since actions have revision id and an updated
         // action will not hit in the cache due to change in the revision id;
         // if the doc revision is missing, then bypass cache
-        if (actionid.rev == DocRevision()) {
+        if (actionid.rev == DocRevision.empty) {
             logging.error(this, s"revision was not provided for ${actionid.id}")
         }
-        WhiskAction.get(entityStore, actionid.id, actionid.rev, fromCache = actionid.rev != DocRevision()) onComplete {
+        WhiskAction.get(entityStore, actionid.id, actionid.rev, fromCache = actionid.rev != DocRevision.empty) onComplete {
             case Success(action) =>
                 // only Exec instances that are subtypes of CodeExec reach the invoker
                 assume(action.exec.isInstanceOf[CodeExec[_]])

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -34,7 +34,7 @@ import whisk.common.{ Counter, Logging, LoggingMarkers, TransactionId }
 import whisk.common.AkkaLogging
 import whisk.connector.kafka.{ KafkaConsumerConnector, KafkaProducerConnector }
 import whisk.core.WhiskConfig
-import whisk.core.WhiskConfig.{ consulServer, dockerImagePrefix, dockerRegistry, kafkaHost, logsDir, servicePort, whiskVersion }
+import whisk.core.WhiskConfig.{ consulServer, dockerImagePrefix, dockerRegistry, kafkaHost, logsDir, servicePort, whiskVersion, invokerUseReactivePool }
 import whisk.core.connector.{ ActivationMessage, CompletionMessage }
 import whisk.core.container._
 import whisk.core.dispatcher.{ Dispatcher, MessageHandler }
@@ -45,6 +45,8 @@ import whisk.http.Messages
 import whisk.utils.ExecutionContextFactory
 import whisk.common.Scheduler
 import whisk.core.connector.PingMessage
+import scala.util.Try
+import whisk.core.connector.MessageProducer
 
 /**
  * A kafka message handler that invokes actions as directed by message on topic "/actions/invoke".
@@ -58,6 +60,7 @@ class Invoker(
     config: WhiskConfig,
     instance: Int,
     activationFeed: ActorRef,
+    producer: MessageProducer,
     runningInContainer: Boolean = true)(implicit actorSystem: ActorSystem, logging: Logging)
     extends MessageHandler(s"invoker$instance")
     with ActionLogDriver {
@@ -65,9 +68,6 @@ class Invoker(
     private implicit val executionContext: ExecutionContext = actorSystem.dispatcher
 
     TransactionId.invoker.mark(this, LoggingMarkers.INVOKER_STARTUP(instance), s"starting invoker instance ${instance}")
-
-    /** This generates completion messages back to the controller */
-    val producer = new KafkaProducerConnector(config.kafkaHost, executionContext)
 
     /**
      * This is the handler for the kafka message
@@ -397,12 +397,6 @@ class Invoker(
     private val activationStore = WhiskActivationStore.datastore(config)
     private val pool = new ContainerPool(config, instance)
     private val activationCounter = new Counter() // global activation counter
-
-    Scheduler.scheduleWaitAtMost(1.seconds)(() => {
-        producer.send("health", PingMessage(s"invoker$instance")).andThen {
-            case Failure(t) => logging.error(this, s"failed to ping the controller: $t")
-        }
-    })
 }
 
 object Invoker {
@@ -413,7 +407,8 @@ object Invoker {
         servicePort -> 8080.toString(),
         logsDir -> null,
         dockerRegistry -> null,
-        dockerImagePrefix -> null) ++
+        dockerImagePrefix -> null,
+        invokerUseReactivePool -> false.toString) ++
         ExecManifest.requiredProperties ++
         WhiskAuthStore.requiredProperties ++
         WhiskEntityStore.requiredProperties ++
@@ -442,11 +437,24 @@ object Invoker {
             val groupid = "invokers"
             val maxdepth = ContainerPool.getDefaultMaxActive(config)
             val consumer = new KafkaConsumerConnector(config.kafkaHost, groupid, topic, maxdepth)
+            val producer = new KafkaProducerConnector(config.kafkaHost, ec)
             val dispatcher = new Dispatcher(consumer, 500 milliseconds, 2 * maxdepth, actorSystem)
 
-            val invoker = new Invoker(config, instance, dispatcher.activationFeed)
+            val invoker = if (Try(config.invokerUseReactivePool.toBoolean).getOrElse(false)) {
+                new InvokerReactive(config, instance, dispatcher.activationFeed, producer)
+            } else {
+                new Invoker(config, instance, dispatcher.activationFeed, producer)
+            }
+            logger.info(this, s"using $invoker")
+
             dispatcher.addHandler(invoker, true)
             dispatcher.start()
+
+            Scheduler.scheduleWaitAtMost(1.seconds)(() => {
+                producer.send("health", PingMessage(s"invoker$instance")).andThen {
+                    case Failure(t) => logger.error(this, s"failed to ping the controller: $t")
+                }
+            })
 
             val port = config.servicePort.toInt
             BasicHttpService.startService(actorSystem, "invoker", "0.0.0.0", port, new Creator[InvokerServer] {

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
@@ -143,10 +143,10 @@ class InvokerReactive(
         // caching is enabled since actions have revision id and an updated
         // action will not hit in the cache due to change in the revision id;
         // if the doc revision is missing, then bypass cache
-        if (actionid.rev == DocRevision()) {
+        if (actionid.rev == DocRevision.empty) {
             logging.error(this, s"revision was not provided for ${actionid.id}")
         }
-        WhiskAction.get(entityStore, actionid.id, actionid.rev, fromCache = actionid.rev != DocRevision()).flatMap { action =>
+        WhiskAction.get(entityStore, actionid.id, actionid.rev, fromCache = actionid.rev != DocRevision.empty).flatMap { action =>
             action.toExecutableWhiskAction match {
                 case Some(executable) =>
                     pool ! Run(executable, msg)

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.invoker
+
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.Failure
+import scala.util.Success
+
+import akka.actor.ActorRef
+import akka.actor.ActorRefFactory
+import akka.actor.ActorSystem
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+import whisk.common.Logging
+import whisk.common.LoggingMarkers
+import whisk.common.TransactionId
+import whisk.core.WhiskConfig
+import whisk.core.connector.ActivationMessage
+import whisk.core.connector.CompletionMessage
+import whisk.core.connector.MessageProducer
+import whisk.core.container.{ ContainerPool => OldContainerPool }
+import whisk.core.container.Interval
+import whisk.core.containerpool.ContainerProxy
+import whisk.core.containerpool.PrewarmingConfig
+import whisk.core.containerpool.Run
+import whisk.core.containerpool.docker.DockerClientWithFileAccess
+import whisk.core.containerpool.docker.DockerContainer
+import whisk.core.containerpool.docker.RuncClient
+import whisk.core.dispatcher.MessageHandler
+import whisk.core.entity._
+import whisk.core.entity.ExecManifest.ImageName
+import whisk.core.entity.size._
+
+class InvokerReactive(
+    config: WhiskConfig,
+    instance: Int,
+    activationFeed: ActorRef,
+    producer: MessageProducer)(implicit actorSystem: ActorSystem, logging: Logging)
+    extends MessageHandler(s"invoker$instance") {
+
+    implicit val ec = actorSystem.dispatcher
+
+    private val entityStore = WhiskEntityStore.datastore(config)
+    private val activationStore = WhiskActivationStore.datastore(config)
+
+    implicit val docker = new DockerClientWithFileAccess()(ec)
+    implicit val runc = new RuncClient(ec)
+
+    /** Cleans up all running wsk_ containers */
+    def cleanup() = {
+        val cleaning = docker.ps(Seq("name" -> "wsk_"))(TransactionId.invokerNanny).flatMap { containers =>
+            val removals = containers.map { id =>
+                runc.resume(id)(TransactionId.invokerNanny).recoverWith {
+                    case _ => Future.successful(())
+                }.flatMap {
+                    _ => docker.rm(id)(TransactionId.invokerNanny)
+                }
+            }
+            Future.sequence(removals)
+        }
+
+        Await.ready(cleaning, 30.seconds)
+    }
+    cleanup()
+    sys.addShutdownHook(cleanup())
+
+    val containerFactory = (tid: TransactionId, name: String, actionImage: ImageName, userProvidedImage: Boolean, memory: ByteSize) => {
+        val image = if (userProvidedImage) {
+            actionImage.publicImageName
+        } else {
+            actionImage.localImageName(config.dockerRegistry, config.dockerImagePrefix, Some(config.dockerImageTag))
+        }
+
+        DockerContainer.create(
+            tid,
+            image = image,
+            userProvidedImage = userProvidedImage,
+            memory = memory,
+            cpuShares = OldContainerPool.cpuShare(config),
+            environment = Map("__OW_API_HOST" -> config.wskApiHost),
+            network = config.invokerContainerNetwork,
+            dnsServers = config.invokerContainerDns,
+            name = Some(name))
+    }
+
+    val ack = (tid: TransactionId, activation: WhiskActivation) => {
+        implicit val transid = tid
+        producer.send("completed", CompletionMessage(tid, activation, s"invoker$instance")).andThen {
+            case Success(_) => logging.info(this, s"posted completion of activation ${activation.activationId}")
+        }
+    }
+
+    val store = (tid: TransactionId, activation: WhiskActivation) => {
+        implicit val transid = tid
+        logging.info(this, "recording the activation result to the data store")
+        WhiskActivation.put(activationStore, activation).andThen {
+            case Success(id) => logging.info(this, s"recorded activation")
+            case Failure(t)  => logging.error(this, s"failed to record activation")
+        }
+    }
+
+    val prewarmKind = "nodejs:6"
+    val prewarmExec = ExecManifest.runtimesManifest.resolveDefaultRuntime(prewarmKind).map { manifest =>
+        new CodeExecAsString(manifest, "", None)
+    }.get
+
+    val childFactory = (f: ActorRefFactory) => f.actorOf(ContainerProxy.props(containerFactory, ack, store))
+    val pool = actorSystem.actorOf(whisk.core.containerpool.ContainerPool.props(
+        childFactory,
+        OldContainerPool.getDefaultMaxActive(config),
+        activationFeed,
+        Some(PrewarmingConfig(2, prewarmExec, 256.MB))))
+
+    override def onMessage(msg: ActivationMessage)(implicit transid: TransactionId): Future[Unit] = {
+        require(msg != null, "message undefined")
+        require(msg.action.version.isDefined, "action version undefined")
+
+        val start = transid.started(this, LoggingMarkers.INVOKER_ACTIVATION)
+        val namespace = msg.action.path
+        val name = msg.action.name
+        val actionid = FullyQualifiedEntityName(namespace, name).toDocId.asDocInfo(msg.revision)
+        val tran = Transaction(msg)
+        val subject = msg.user.subject
+
+        logging.info(this, s"${actionid.id} $subject ${msg.activationId}")
+
+        // caching is enabled since actions have revision id and an updated
+        // action will not hit in the cache due to change in the revision id;
+        // if the doc revision is missing, then bypass cache
+        if (actionid.rev == DocRevision()) {
+            logging.error(this, s"revision was not provided for ${actionid.id}")
+        }
+        WhiskAction.get(entityStore, actionid.id, actionid.rev, fromCache = actionid.rev != DocRevision()).flatMap { action =>
+            action.toExecutableWhiskAction match {
+                case Some(executable) =>
+                    pool ! Run(executable, msg)
+                    Future.successful(())
+                case None =>
+                    logging.error(this, s"non-executable action reached the invoker ${action.fullyQualifiedName(false)}")
+                    Future.failed(new IllegalStateException())
+            }
+        }.recover {
+            case _ =>
+                val interval = Interval.zero
+                val causedBy = if (msg.causedBySequence) Parameters("causedBy", "sequence".toJson) else Parameters()
+                val activation = WhiskActivation(
+                    activationId = msg.activationId,
+                    namespace = msg.activationNamespace,
+                    subject = msg.user.subject,
+                    cause = msg.cause,
+                    name = msg.action.name,
+                    version = msg.action.version.getOrElse(SemVer()),
+                    start = interval.start,
+                    end = interval.end,
+                    duration = Some(interval.duration.toMillis),
+                    response = ActivationResponse.applicationError("action could not be found"),
+                    annotations = {
+                        Parameters("path", msg.action.toString.toJson) ++ causedBy
+                    })
+
+                ack(msg.transid, activation)
+                store(msg.transid, activation)
+        }
+    }
+
+}

--- a/tests/src/test/scala/whisk/core/dispatcher/test/DispatcherTests.scala
+++ b/tests/src/test/scala/whisk/core/dispatcher/test/DispatcherTests.scala
@@ -64,7 +64,7 @@ class DispatcherTests
         val content = JsObject("payload" -> JsNumber(count))
         val user = WhiskAuth(Subject(), AuthKey()).toIdentity
         val path = FullyQualifiedEntityName(EntityPath("test"), EntityName(s"count-$count"), Some(SemVer()))
-        val msg = Message(TransactionId.testing, path, DocRevision(), user, ActivationId(), EntityPath(user.subject.asString), Some(content))
+        val msg = Message(TransactionId.testing, path, DocRevision.empty, user, ActivationId(), EntityPath(user.subject.asString), Some(content))
         connector.send(msg)
     }
 

--- a/tests/src/test/scala/whisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/SchemaTests.scala
@@ -101,7 +101,7 @@ class SchemaTests
             assert(d.rev == (if (i != null) i.trim else null))
         }
 
-        DocRevision.serdes.read(JsNull) shouldBe DocRevision()
+        DocRevision.serdes.read(JsNull) shouldBe DocRevision.empty
         DocRevision.serdes.read(JsString("")) shouldBe DocRevision("")
         DocRevision.serdes.read(JsString("a")) shouldBe DocRevision("a")
         DocRevision.serdes.read(JsString(" a")) shouldBe DocRevision("a")

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/InvokerSupervisionTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/InvokerSupervisionTests.scala
@@ -219,7 +219,7 @@ class InvokerSupervisionTests extends TestKit(ActorSystem("InvokerSupervision"))
         val activationMessage = ActivationMessage(
             transid = TransactionId.invokerHealth,
             action = FullyQualifiedEntityName(EntityPath("whisk.system/utils"), EntityName("date")),
-            revision = DocRevision(),
+            revision = DocRevision.empty,
             user = Identity(Subject("unhealthyInvokerCheck"), EntityName("unhealthyInvokerCheck"), AuthKey(UUID(), Secret()), Set[Privilege]()),
             activationId = new ActivationIdGenerator {}.make(),
             activationNamespace = EntityPath("guest"),


### PR DESCRIPTION
**Note for reviewers:** We can (should?) take the flags out before merging this. It's merely there to test the new pool in Travis for now. Alternatively, we can state that nobody should use local/mac in production and thus it's safeish to let the flag in and immediately switch to the new pool. For production environments though, we need more experience with it.

Makes the new InvokerReactive accessible behind a feature flag `invoker_use_reactive_pool`.

This concludes the work on the new containerpool.