### PR TITLE
Improve ExecutableWhiskAction coverage and general typesafety

### DIFF
--- a/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
@@ -114,7 +114,7 @@ protected[actions] trait PrimitiveActions {
 
         val startActivation = transid.started(this, waitForResponse.map(_ => LoggingMarkers.CONTROLLER_ACTIVATION_BLOCKING).getOrElse(LoggingMarkers.CONTROLLER_ACTIVATION))
         val startLoadbalancer = transid.started(this, LoggingMarkers.CONTROLLER_LOADBALANCER, s"action activation id: ${message.activationId}")
-        val postedFuture = loadBalancer.publish(action.toWhiskAction, message)
+        val postedFuture = loadBalancer.publish(action, message)
 
         postedFuture.flatMap { activeAckResponse =>
             // successfully posted activation request to the message bus

--- a/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
@@ -169,7 +169,7 @@ class ContainerPool(
      * The invariant of returning the container back to the pool holds regardless of whether init succeeded or not.
      * In case of failure to start a container (or for failed docker operations e.g., pull), an exception is thrown.
      */
-    def getAction(action: WhiskAction, auth: AuthKey)(implicit transid: TransactionId): (WhiskContainer, Option[RunResult]) = {
+    def getAction(action: ExecutableWhiskAction, auth: AuthKey)(implicit transid: TransactionId): (WhiskContainer, Option[RunResult]) = {
         if (shuttingDown) {
             logging.info(this, s"Shutting down: Not getting container for ${action.fullyQualifiedName(true)} with ${auth.uuid}")
             throw new Exception("system is shutting down")
@@ -431,7 +431,7 @@ class ContainerPool(
     private def makeContainerName(localName: String): ContainerName =
         ContainerCounter.containerName(invokerInstance.toInt.toString, localName)
 
-    private def makeContainerName(action: WhiskAction): ContainerName =
+    private def makeContainerName(action: ExecutableWhiskAction): ContainerName =
         makeContainerName(action.fullyQualifiedName(true).toString)
 
     /**
@@ -561,7 +561,7 @@ class ContainerPool(
         }
 
     // Obtain a container (by creation or promotion) and initialize by sending code.
-    private def makeWhiskContainer(action: WhiskAction, auth: AuthKey)(implicit transid: TransactionId): WhiskContainer = {
+    private def makeWhiskContainer(action: ExecutableWhiskAction, auth: AuthKey)(implicit transid: TransactionId): WhiskContainer = {
         val imageName = getDockerImageName(action)
         val limits = action.limits
         val nodeImageName = NODEJS6_IMAGE.localImageName(config.dockerRegistry, config.dockerImagePrefix, Some(config.dockerImageTag))
@@ -624,11 +624,9 @@ class ContainerPool(
     }
 
     // We send the payload here but eventually must also handle morphing a pre-allocated container into the right state.
-    private def initWhiskContainer(action: WhiskAction, con: WhiskContainer)(implicit transid: TransactionId): RunResult = {
-        // only Exec instances that are subtypes of CodeExec reach the invoker
-        val Some(initArg) = action.containerInitializer
+    private def initWhiskContainer(action: ExecutableWhiskAction, con: WhiskContainer)(implicit transid: TransactionId): RunResult = {
         // Then send it the init payload which is code for now
-        con.init(initArg, action.limits.timeout.duration)
+        con.init(action.containerInitializer, action.limits.timeout.duration)
     }
 
     /**
@@ -659,12 +657,11 @@ class ContainerPool(
         logging.debug(this, s"$prefix: keyMap = ${keyMapToString()}")
     }
 
-    private def getDockerImageName(action: WhiskAction)(implicit transid: TransactionId): String = {
+    private def getDockerImageName(action: ExecutableWhiskAction)(implicit transid: TransactionId): String = {
         // only Exec instances that are subtypes of CodeExec reach the invoker
-        val exec = action.exec.asInstanceOf[CodeExec[_]]
-        val imageName = if (!exec.pull) {
-            exec.image.localImageName(config.dockerRegistry, config.dockerImagePrefix, Some(config.dockerImageTag))
-        } else exec.image.publicImageName
+        val imageName = if (!action.exec.pull) {
+            action.exec.image.localImageName(config.dockerRegistry, config.dockerImagePrefix, Some(config.dockerImageTag))
+        } else action.exec.image.publicImageName
         logging.debug(this, s"Using image ${imageName}")
         imageName
     }

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -99,6 +99,7 @@ class Invoker(
         // 1. success: there were no exceptions and hence the invoke path operated normally,
         // 2. error during invocation: an exception occurred while trying to run the action (failed to bring up a container for example),
         // 3. error fetching action: an exception occurred reading from the db, didn't get to run.
+        // 4. internal error: the controller passed a wrong action to the invoker.
         val transactionPromise = Promise[DocInfo]
 
         // caching is enabled since actions have revision id and an updated
@@ -111,21 +112,29 @@ class Invoker(
         WhiskAction.get(entityStore, actionid.id, actionid.rev, fromCache = actionid.rev != DocRevision.empty) onComplete {
             case Success(action) =>
                 // only Exec instances that are subtypes of CodeExec reach the invoker
-                assume(action.exec.isInstanceOf[CodeExec[_]])
+                action.toExecutableWhiskAction match {
+                    case Some(executable) =>
+                        invokeAction(tran, executable) onComplete {
+                            case Success(activation) =>
+                                transactionPromise.completeWith {
+                                    // this completes the successful activation case (1)
+                                    completeTransaction(tran, activation, ContainerReleased)
+                                }
 
-                invokeAction(tran, action) onComplete {
-                    case Success(activation) =>
-                        transactionPromise.completeWith {
-                            // this completes the successful activation case (1)
-                            completeTransaction(tran, activation, ContainerReleased)
+                            case Failure(t) =>
+                                logging.info(this, s"activation failed")
+                                val failure = disambiguateActivationException(t, executable)
+                                transactionPromise.completeWith {
+                                    // this completes the failed activation case (2)
+                                    completeTransactionWithError(action.docid, action.version, tran, failure.activationResponse, Some(action.limits))
+                                }
                         }
-
-                    case Failure(t) =>
-                        logging.info(this, s"activation failed")
-                        val failure = disambiguateActivationException(t, action)
+                    case None =>
+                        logging.error(this, s"non-primitive action reached the invoker: $action")
+                        val failureResponse = ActivationResponse.whiskError(s"Invalid action.")
                         transactionPromise.completeWith {
-                            // this completes the failed activation case (2)
-                            completeTransactionWithError(action.docid, action.version, tran, failure.activationResponse, Some(action.limits))
+                            // this completes the wrong action case (4)
+                            completeTransactionWithError(actionid.id, msg.action.version.get, tran, failureResponse, None)
                         }
                 }
 
@@ -192,7 +201,7 @@ class Invoker(
      *
      * @return WhiskActivation
      */
-    protected def invokeAction(tran: Transaction, action: WhiskAction)(
+    protected def invokeAction(tran: Transaction, action: ExecutableWhiskAction)(
         implicit transid: TransactionId): Future[WhiskActivation] = {
         Future { pool.getAction(action, tran.msg.user.authkey) } map {
             case (con, initResultOpt) => runAction(tran, action, con, initResultOpt)
@@ -224,7 +233,7 @@ class Invoker(
      * Runs the action in the container if the initialization succeeded and returns a triple
      * (initialization failed?, the container, the init result if initialization failed else the run result)
      */
-    private def runAction(tran: Transaction, action: WhiskAction, con: WhiskContainer, initResultOpt: Option[RunResult])(
+    private def runAction(tran: Transaction, action: ExecutableWhiskAction, con: WhiskContainer, initResultOpt: Option[RunResult])(
         implicit transid: TransactionId): (Boolean, WhiskContainer, RunResult) = {
         def run() = {
             val msg = tran.msg
@@ -257,7 +266,7 @@ class Invoker(
      *
      * @return WhiskActivation
      */
-    private def makeActivationResultForSuccess(tran: Transaction, action: WhiskAction, failedInit: Boolean, result: RunResult)(
+    private def makeActivationResultForSuccess(tran: Transaction, action: ExecutableWhiskAction, failedInit: Boolean, result: RunResult)(
         implicit transid: TransactionId): WhiskActivation = {
         if (!failedInit) tran.runInterval = Some(result.interval)
 
@@ -405,7 +414,7 @@ class Invoker(
     /**
      * Rewrites exceptions during invocation into new exceptions.
      */
-    private def disambiguateActivationException(t: Throwable, action: WhiskAction)(
+    private def disambiguateActivationException(t: Throwable, action: ExecutableWhiskAction)(
         implicit transid: TransactionId): ActivationException = {
         t match {
             // in case of container pull/run operations that fail to execute, assign an appropriate error response

--- a/tests/src/test/scala/whisk/core/container/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/whisk/core/container/test/ContainerPoolTests.scala
@@ -42,7 +42,6 @@ import whisk.core.entity.AuthKey
 import whisk.core.entity.EntityName
 import whisk.core.entity.EntityPath
 import whisk.core.entity.InstanceId
-import whisk.core.entity.WhiskAction
 import whisk.core.entity.WhiskAuthStore
 import whisk.core.entity.WhiskEntityStore
 import whisk.core.entity.test.ExecHelpers

--- a/tests/src/test/scala/whisk/core/container/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/whisk/core/container/test/ContainerPoolTests.scala
@@ -47,6 +47,8 @@ import whisk.core.entity.WhiskAuthStore
 import whisk.core.entity.WhiskEntityStore
 import whisk.core.entity.test.ExecHelpers
 import whisk.utils.retry
+import whisk.core.entity.ExecutableWhiskAction
+import whisk.core.entity.CodeExec
 
 /**
  * Unit tests for ContainerPool and, by association, Container and WhiskContainer.
@@ -227,9 +229,9 @@ class ContainerPoolTests extends FlatSpec
      * Create an action with the given name that print hello_N payload !
      * where N is specified.
      */
-    private def makeHelloAction(name: String, index: Integer): WhiskAction = {
+    private def makeHelloAction(name: String, index: Integer): ExecutableWhiskAction = {
         val code = """console.log('ABCXYZ'); function main(msg) { console.log('hello_${index}', msg.payload+'!');} """
-        WhiskAction(defaultNamespace, EntityName(name), jsDefault(code))
+        ExecutableWhiskAction(defaultNamespace, EntityName(name), jsDefault(code).asInstanceOf[CodeExec[String]])
     }
 
     it should "be able to start a nodejs action with init, do a run, return to pool, do another get testing reuse, another run" in {
@@ -252,9 +254,9 @@ class ContainerPoolTests extends FlatSpec
     /*
      * Create an action that will crash the container after succesfully returning
      */
-    private def makeCrashingAction(name: String, timeToLiveMs: Integer): WhiskAction = {
+    private def makeCrashingAction(name: String, timeToLiveMs: Integer): ExecutableWhiskAction = {
         val code = s"""function main(msg) { console.log('I expect you to die'); setTimeout(function(){ process.exit(1); }, ${timeToLiveMs}); }"""
-        WhiskAction(defaultNamespace, EntityName(name), jsDefault(code))
+        ExecutableWhiskAction(defaultNamespace, EntityName(name), jsDefault(code))
     }
 
     it should "cleanly handle a container that crashes" in {

--- a/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
@@ -250,7 +250,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     it should "reject create with exec which is too big" in {
         implicit val tid = transid()
         val code = "a" * (actionLimit.toBytes.toInt + 1)
-        val exec = jsDefault(code)
+        val exec: Exec = jsDefault(code)
         val content = JsObject("exec" -> exec.toJson)
         Put(s"$collectionPath/${aname}", content) ~> sealRoute(routes(creds)) ~> check {
             status should be(RequestEntityTooLarge)
@@ -265,7 +265,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         val oldCode = "function main()"
         val code = "a" * (actionLimit.toBytes.toInt + 1)
         val action = WhiskAction(namespace, aname, jsDefault("??"))
-        val exec = jsDefault(code)
+        val exec: Exec = jsDefault(code)
         val content = JsObject("exec" -> exec.toJson)
         put(entityStore, action)
         Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> sealRoute(routes(creds)) ~> check {

--- a/tests/src/test/scala/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ControllerTestCommon.scala
@@ -201,7 +201,7 @@ class DegenerateLoadBalancerService(config: WhiskConfig)(implicit ec: ExecutionC
 
     override def getActiveUserActivationCounts: Map[String, Int] = Map()
 
-    override def publish(action: WhiskAction, msg: ActivationMessage)(implicit transid: TransactionId): Future[Future[Either[ActivationId, WhiskActivation]]] =
+    override def publish(action: ExecutableWhiskAction, msg: ActivationMessage)(implicit transid: TransactionId): Future[Future[Either[ActivationId, WhiskActivation]]] =
         Future.successful {
             whiskActivationStub map {
                 case (timeout, activation) => Future {

--- a/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
@@ -43,11 +43,11 @@ trait ExecHelpers
 
     protected def imagename(name: String) = ExecManifest.ImageName(s"${name}action".replace(":", ""), Some("openwhisk"), Some("latest"))
 
-    protected def js(code: String, main: Option[String] = None): Exec = {
+    protected def js(code: String, main: Option[String] = None) = {
         CodeExecAsString(RuntimeManifest(NODEJS, imagename(NODEJS), deprecated = Some(true)), trim(code), main.map(_.trim))
     }
 
-    protected def js6(code: String, main: Option[String] = None): Exec = {
+    protected def js6(code: String, main: Option[String] = None) = {
         CodeExecAsString(RuntimeManifest(NODEJS6, imagename(NODEJS6), default = Some(true), deprecated = Some(false)), trim(code), main.map(_.trim))
     }
 
@@ -55,19 +55,19 @@ trait ExecHelpers
         js6(code, main)
     }
 
-    protected def swift(code: String, main: Option[String] = None): Exec = {
+    protected def swift(code: String, main: Option[String] = None) = {
         CodeExecAsString(RuntimeManifest(SWIFT, imagename(SWIFT), deprecated = Some(true)), trim(code), main.map(_.trim))
     }
 
-    protected def swift3(code: String, main: Option[String] = None): Exec = {
-        CodeExecAsString(RuntimeManifest(SWIFT3, imagename(SWIFT3), default = Some(true), deprecated = Some(false)),  trim(code), main.map(_.trim))
+    protected def swift3(code: String, main: Option[String] = None) = {
+        CodeExecAsString(RuntimeManifest(SWIFT3, imagename(SWIFT3), default = Some(true)), trim(code), main.map(_.trim))
     }
 
-    protected def sequence(components: Vector[FullyQualifiedEntityName]): Exec = SequenceExec(components)
+    protected def sequence(components: Vector[FullyQualifiedEntityName]) = SequenceExec(components)
 
-    protected def bb(image: String): Exec = BlackBoxExec(ExecManifest.ImageName(trim(image)), None, None, false)
+    protected def bb(image: String) = BlackBoxExec(ExecManifest.ImageName(trim(image)), None, None, false)
 
-    protected def bb(image: String, code: String, main: Option[String] = None): Exec = {
+    protected def bb(image: String, code: String, main: Option[String] = None) = {
         BlackBoxExec(ExecManifest.ImageName(trim(image)), Some(trim(code)).filter(_.nonEmpty), main, false)
     }
 }

--- a/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
@@ -60,7 +60,7 @@ trait ExecHelpers
     }
 
     protected def swift3(code: String, main: Option[String] = None) = {
-        CodeExecAsString(RuntimeManifest(SWIFT3, imagename(SWIFT3), default = Some(true)), trim(code), main.map(_.trim))
+        CodeExecAsString(RuntimeManifest(SWIFT3, imagename(SWIFT3), default = Some(true), deprecated = Some(false)), trim(code), main.map(_.trim))
     }
 
     protected def sequence(components: Vector[FullyQualifiedEntityName]) = SequenceExec(components)

--- a/tests/src/test/scala/whisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/SchemaTests.scala
@@ -366,14 +366,14 @@ class SchemaTests
     }
 
     it should "exclude undefined code in whisk action initializer" in {
-        WhiskAction(EntityPath("a"), EntityName("b"), bb("container1")).containerInitializer shouldBe {
-            Some(JsObject("name" -> "b".toJson, "binary" -> false.toJson, "main" -> "main".toJson))
+        ExecutableWhiskAction(EntityPath("a"), EntityName("b"), bb("container1")).containerInitializer shouldBe {
+            JsObject("name" -> "b".toJson, "binary" -> false.toJson, "main" -> "main".toJson)
         }
-        WhiskAction(EntityPath("a"), EntityName("b"), bb("container1", "xyz")).containerInitializer shouldBe {
-            Some(JsObject("name" -> "b".toJson, "binary" -> false.toJson, "main" -> "main".toJson, "code" -> "xyz".toJson))
+        ExecutableWhiskAction(EntityPath("a"), EntityName("b"), bb("container1", "xyz")).containerInitializer shouldBe {
+            JsObject("name" -> "b".toJson, "binary" -> false.toJson, "main" -> "main".toJson, "code" -> "xyz".toJson)
         }
-        WhiskAction(EntityPath("a"), EntityName("b"), bb("container1", "", Some("naim"))).containerInitializer shouldBe {
-            Some(JsObject("name" -> "b".toJson, "binary" -> false.toJson, "main" -> "naim".toJson))
+        ExecutableWhiskAction(EntityPath("a"), EntityName("b"), bb("container1", "", Some("naim"))).containerInitializer shouldBe {
+            JsObject("name" -> "b".toJson, "binary" -> false.toJson, "main" -> "naim".toJson)
         }
     }
 


### PR DESCRIPTION
- Improves the implementation of ExecutableWhiskAction to conform closer to existing implementations.
- Use ExecutableWhiskAction as early as possible to statically check only the right types reach the Invoker.