### PR TITLE
Start Scala components with JMX enabled locally

### DIFF
--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -33,3 +33,6 @@ apigw_host_v2: "http://{{ groups['apigateway']|first }}:{{apigateway.port.api}}/
 # RunC enablement
 invoker_use_runc: true
 invoker_use_reactive_pool: false
+
+controller_arguments: '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1098'
+invoker_arguments: "{{ controller_arguments }}"

--- a/ansible/environments/mac/group_vars/all
+++ b/ansible/environments/mac/group_vars/all
@@ -38,3 +38,6 @@ apigw_host_v2: "http://{{ groups['apigateway']|first }}:{{apigateway.port.api}}/
 # RunC enablement
 invoker_use_runc: true
 invoker_use_reactive_pool: false
+
+controller_arguments: '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1098'
+invoker_arguments: "{{ controller_arguments }}"

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -50,7 +50,7 @@
         -e SERVICE_CHECK_TIMEOUT=2s
         -e SERVICE_CHECK_INTERVAL=15s
         -e JAVA_OPTS=-Xmx{{ invoker.heap }}
-        -e INVOKER_OPTS={{ invoker.arguments }}
+        -e INVOKER_OPTS='{{ invoker.arguments }}'
         -v /sys/fs/cgroup:/sys/fs/cgroup
         -v /run/runc:/run/runc
         -v {{whisk_logs_dir}}/invoker{{play_hosts.index(inventory_hostname)}}:/logs


### PR DESCRIPTION
Enables easier profiling of local components via JVM standard tooling.

**Note:** Those parameters are only enabled in local envs. for a reason. They don't cope with securing the JMX port.