### PR TITLE
Bump connection-pool limit to 128

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -8,6 +8,7 @@ akka.http {
     }
 
     host-connection-pool {
-        max-connections = 16
+        max-connections = 128
+        max-open-requests = 128
     }
 }


### PR DESCRIPTION
This will allow 128 concurrent CouchDB requests in a single connection-pool.