### PR TITLE
To resolve #2245 - optimize container removal

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/ContainerPool.scala
@@ -200,7 +200,7 @@ object ContainerPool {
     def remove[A](action: ExecutableWhiskAction, invocationNamespace: EntityName, pool: Map[A, WorkerData]): Option[A] = {
         //try to find a Free container that is initialized with any OTHER action
         val grouped = pool.collect {
-            case (ref, WorkerData(w: WarmedData, Free)) if (w.action != action || w.invocationNamespace != invocationNamespace) => ref -> w
+            case (ref, WorkerData(w: WarmedData, _)) if (w.action != action || w.invocationNamespace != invocationNamespace) => ref -> w
         }.groupBy {
             case (ref, data) => data.invocationNamespace
         }

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerPoolTests.scala
@@ -20,6 +20,7 @@ import java.time.Instant
 
 import scala.collection.mutable
 import scala.concurrent.duration._
+import scala.language.postfixOps
 
 import org.junit.runner.RunWith
 import org.scalamock.scalatest.MockFactory


### PR DESCRIPTION
Resolves #2245
Only remove a running container to make room for activation in a max'ed out ContainerPool IFF a) the running container is in "Free" state and b) the running container is a DIFFERENT action than the incoming activation