### PR TITLE
Correctly recover from errors when fetching an action

### DIFF
--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -155,6 +155,8 @@ object Messages {
             if (!init) "." else " during initialization."
         }
     }
+
+    val actionRemovedWhileInvoking = "Action could not be found or may have been deleted."
 }
 
 /** Replaces rejections with Json object containing cause and transaction id. */
@@ -171,13 +173,13 @@ object ErrorResponse extends Directives {
         } getOrElse None)
     }
 
-     def terminate(status: StatusCode, error: Option[ErrorResponse] = None, asJson: Boolean = true)(implicit transid: TransactionId): StandardRoute = {
+    def terminate(status: StatusCode, error: Option[ErrorResponse] = None, asJson: Boolean = true)(implicit transid: TransactionId): StandardRoute = {
         val errorResponse = error getOrElse response(status)
-            if (asJson) {
-                complete(status, errorResponse)
-            } else {
-                complete(status, s"${errorResponse.error} (code: ${errorResponse.code})")
-            }
+        if (asJson) {
+            complete(status, errorResponse)
+        } else {
+            complete(status, s"${errorResponse.error} (code: ${errorResponse.code})")
+        }
     }
 
     def response(status: StatusCode)(implicit transid: TransactionId): ErrorResponse = status match {


### PR DESCRIPTION
If the invoker fails to fetch an action from the database it needs to inform the ActivationFeed that it still has resources (it didn't consume a container after all).

Reporting of those errors needs some disambiguation, as an error on fetching the action could also be caused by the user (for example by concurrently deleting the action while invoking it). The InvokerHealth protocol would shutdown the invoker, iff the activation was reported as a WHISK_ERROR. All errors but DocumentNotFound are considered WHISK_ERRORs though.

Also in this commit:
- Loglevel change from error to warn for a missing revision. The InvokerHealth protocol produces ERROR otherwise.
- Some documentation and restructuring of the ContainerPool's setup.