### PR TITLE
Final conversion of api-experimental to web action (not experimental)

### DIFF
--- a/core/routemgmt/common/apigw-utils.js
+++ b/core/routemgmt/common/apigw-utils.js
@@ -60,16 +60,15 @@ function addApiToGateway(gwInfo, spaceGuid, swaggerApi, apiId) {
     requestFcn(options, function(error, response, body) {
       var statusCode = response ? response.statusCode : undefined;
       console.log('addApiToGateway: response status:'+ statusCode);
-      if (error) console.error('Warning: addRouteToGateway request failed: '+ JSON.stringify(error));
-      if (body) console.log('addApiToGateway: response body: '+JSON.stringify(body));
+      if (error) console.error('Warning: addRouteToGateway request failed: '+ makeJsonString(error));
+      if (body) console.log('addApiToGateway: response body: '+makeJsonString(body));
 
       if (error) {
-        console.error('addApiToGateway: Unable to configure the API Gateway: '+JSON.stringify(error));
-        reject('Unable to configure the API Gateway: '+JSON.stringify(error));
+        console.error('addApiToGateway: Unable to configure the API Gateway');
+        reject('Unable to configure the API Gateway: '+makeJsonString(error));
       } else if (statusCode != 200) {
-        console.error('addApiToGateway: Response code: '+statusCode);
         if (body) {
-          var errMsg = JSON.stringify(body);
+          var errMsg = makeJsonString(body);
           if (body.error && body.error.message) errMsg = body.error.message;
           reject('Unable to configure the API Gateway (status code '+statusCode+'): '+ errMsg);
         } else {
@@ -112,16 +111,14 @@ function deleteApiFromGateway(gwInfo, spaceGuid, apiId) {
     request.delete(options, function(error, response, body) {
       var statusCode = response ? response.statusCode : undefined;
       console.log('deleteApiFromGateway: response status:'+ statusCode);
-      if (error) console.error('Warning: deleteGatewayApi request failed: '+ JSON.stringify(error));
-      if (body) console.log('deleteApiFromGateway: response body: '+JSON.stringify(body));
-
+      if (error) console.error('Warning: deleteGatewayApi request failed: '+ makeJsonString(error));
+      if (body) console.log('deleteApiFromGateway: response body: '+makeJsonString(body));
       if (error) {
-        console.error('deleteApiFromGateway: Unable to delete the API Gateway: '+JSON.stringify(error));
-        reject('Unable to delete the API Gateway: '+JSON.stringify(error));
+        console.error('deleteApiFromGateway: Unable to delete the API Gateway');
+        reject('Unable to delete the API Gateway: '+makeJsonString(error));
       } else if (statusCode != 200  && statusCode != 204) {
-        console.error('deleteApiFromGateway: Response code: '+statusCode);
         if (body) {
-          var errMsg = JSON.stringify(body);
+          var errMsg = makeJsonString(body);
           if (body.error && body.error.message) errMsg = body.error.message;
           reject('Unable to delete the API Gateway (status code '+statusCode+'): '+ errMsg);
         } else {
@@ -169,17 +166,17 @@ function getApis(gwInfo, spaceGuid, bpOrApiName) {
     request.get(options, function(error, response, body) {
       var statusCode = response ? response.statusCode : undefined;
       console.log('getApis: response status: '+ statusCode);
-      if (response.headers) console.log('getApis: response headers: '+JSON.stringify(response.headers));
-      if (error) console.error('Warning: getApis request failed: '+JSON.stringify(error));
+      if (response.headers) console.log('getApis: response headers: '+makeJsonString(response.headers));
+      if (error) console.error('Warning: getApis request failed: '+makeJsonString(error));
       console.log('getApis: body type = '+typeof body);
-      if (body) console.log('getApis: response JSON.stringify(body): '+JSON.stringify(body));
+      if (body) console.log('getApis: response JSON.stringify(body): '+makeJsonString(body));
       if (error) {
-        console.error('getApis: Unable to obtain API(s) from the API Gateway: '+JSON.stringify(error));
-        reject('Unable to obtain API(s) from the API Gateway: '+JSON.stringify(error));
+        console.error('getApis: Unable to obtain API(s) from the API Gateway');
+        reject('Unable to obtain API(s) from the API Gateway: '+makeJsonString(error));
       } else if (statusCode != 200) {
         console.error('getApis: failure: response code: '+statusCode);
         if (body) {
-          var errMsg = JSON.stringify(body);
+          var errMsg = makeJsonString(body);
           if (body.error && body.error.error && body.error.error.message) errMsg = body.error.error.message;
           reject('Unable to obtain API(s) from the API Gateway (status code '+statusCode+'): '+ errMsg);
         } else {
@@ -482,7 +479,7 @@ function removeEndpointFromSwaggerApi(swaggerApi, endpoint) {
           delete swaggerApi.paths[relpath];
       } else {
           console.log('removeEndpointFromSwaggerApi: relpath '+relpath+' does not exist in the API');
-          return 'path '+relpath+' does not exist in the API';
+          return 'path \''+relpath+'\' does not exist in the API';
       }
   } else { // relpath and operation are specified, just delete the specific operation
       var operationId = operation + '_' + relpath;
@@ -495,7 +492,7 @@ function removeEndpointFromSwaggerApi(swaggerApi, endpoint) {
           deleteActionOperationInvocationDetails(swaggerApi, operationId);
       } else {
           console.log('removeEndpointFromSwaggerApi: relpath '+relpath+' with operation '+operation+' does not exist in the API');
-          return 'path '+relpath+' with operation '+operation+' does not exist in the API';
+          return 'path \''+relpath+'\' with operation \''+operation+'\' does not exist in the API';
       }
   }
 
@@ -713,7 +710,7 @@ function updateNamespace(apidoc, namespace) {
  */
 function replaceNamespaceInUrl(url, namespace) {
   var namespacesPattern = /\/api\/v1\/web\/([\w@.-]+)\//;
-  console.log('replaceNamespaceInUrl: url before - '+url);
+  console.log('replaceNamespaceInUrl: namspace='+namespace+' url before - '+url);
   matchResult = url.match(namespacesPattern);
   if (matchResult !== null) {
     console.log('replaceNamespaceInUrl: replacing namespace \''+matchResult[1]+'\' with \''+namespace+'\'');
@@ -756,7 +753,7 @@ function makeErrorResponseObject(err, isWebAction) {
   var bodystr;
   if (typeof err === 'string') {
     bodystr = JSON.stringify({
-      "error": err,
+      "error": JSON.parse(makeJsonString(err)),  // Make sure err is plain old string to avoid duplicate JSON escaping
     });
   } else {
     bodystr = JSON.stringify(err);
@@ -800,7 +797,7 @@ function makeResponseObject(resp, isWebAction) {
 
   var bodystr;
   if (typeof resp === 'string') {
-    bodystr = resp;
+    bodystr = makeJsonString(resp);
   } else {
     bodystr = JSON.stringify(resp);
   }
@@ -810,6 +807,38 @@ function makeResponseObject(resp, isWebAction) {
     body: new Buffer(bodystr).toString('base64')
   };
   return retobj;
+}
+
+/*
+ * Take an object and serialize it into a JSON string.
+ *
+ * Special consideration is give to strings that are already JSON formatted since
+ * serializing these strings can result in redundant escaping.
+ *
+ * If the value is simply not JSON compliant, a JSON error string is returned.
+ */
+function makeJsonString(x) {
+  // If the value is not already a string, rely on JSON.stringify to convert it correctly
+  if (typeof x != 'string') {
+    try {
+      return JSON.stringify(x);
+    } catch (e) {
+      console.error('makeJsonString: value cannot be JSON serialized: '+e);
+      return e;
+    }
+  } else {
+    // It's a string. If it's already a JSON formatted string, leave it alone
+    // Otherwise, convert it into a JSON formatted string
+    try {
+      var temp = JSON.parse(x);
+      return x;
+    } catch (e) {
+      // The string is not a JSON string, so convert it to a JSON string.
+      console.log('makeJsonString: String is not JSON, so need to convert it: '+e);
+      return JSON.stringify(x);
+    }
+  }
+  return 'Unexpected JSON parsing failure';
 }
 
 module.exports.getApis = getApis;
@@ -827,3 +856,4 @@ module.exports.generateCliApiFromGwApi = generateCliApiFromGwApi;
 module.exports.updateNamespace = updateNamespace;
 module.exports.makeErrorResponseObject = makeErrorResponseObject;
 module.exports.makeResponseObject = makeResponseObject;
+module.exports.makeJsonString = makeJsonString;

--- a/core/routemgmt/common/utils.js
+++ b/core/routemgmt/common/utils.js
@@ -17,6 +17,7 @@
  *
  **/
 var request = require('request');
+var utils2 = require('./apigw-utils.js');
 
 /*
  * Register a tenant with the API GW.
@@ -52,14 +53,13 @@ function createTenant(gwInfo, namespace, tenantInstance) {
     request.put(options, function(error, response, body) {
       var statusCode = response ? response.statusCode : undefined;
       console.log('addTenantToGateway: response status: '+ statusCode);
-      if (error) console.error('Warning: addTenantToGateway request failed: '+JSON.stringify(error));
-      if (body) console.log('addTenantToGateway: response body: '+JSON.stringify(body));
+      if (error) console.error('Warning: addTenantToGateway request failed: '+utils2.makeJsonString(error));
+      if (body) console.log('addTenantToGateway: response body: '+utils2.makeJsonString(body));
 
       if (error) {
-        console.error('addTenantToGateway: Unable to configure a tenant on the API Gateway: '+JSON.stringify(error));
-        reject('Unable to configure the API Gateway: '+JSON.stringify(error));
+        console.error('addTenantToGateway: Unable to configure a tenant on the API Gateway');
+        reject('Unable to configure the API Gateway: '+utils2.makeJsonString(error));
       } else if (statusCode != 200) {
-        console.error('addTenantToGateway: failure: response code: '+statusCode);
         if (body) {
           var errMsg = JSON.stringify(body);
           if (body.error && body.error.message) errMsg = body.error.message;
@@ -106,13 +106,12 @@ function getTenants(gwInfo, ns, tenantInstance) {
     request.get(options, function(error, response, body) {
       var statusCode = response ? response.statusCode : undefined;
       console.log('getTenants: response status: '+ statusCode);
-      if (error) console.error('Warning: getTenant request failed: '+JSON.stringify(error));
-      if (body) console.log('getTenants: response body: '+body);
+      if (error) console.error('Warning: getTenant request failed: '+utils2.makeJsonString(error));
+      if (body) console.log('getTenants: response body: '+utils2.makeJsonString(body));
       if (error) {
-        console.error('getTenants: Unable to obtain tenant from the API Gateway: '+JSON.stringify(error));
-        reject('Unable to obtain Tenant from the API Gateway: '+JSON.stringify(error));
+        console.error('getTenants: Unable to obtain tenant from the API Gateway');
+        reject('Unable to obtain Tenant from the API Gateway: '+utils2.makeJsonString(error));
       } else if (statusCode != 200) {
-        console.error('getTenants: failure: response code: '+statusCode);
         if (body) {
           var errMsg = JSON.stringify(body);
           if (body.error && body.error.message) errMsg = body.error.message;
@@ -196,14 +195,13 @@ function addApiToGateway(gwInfo, tenantId, swaggerApi, gwApiId) {
     requestFcn(options, function(error, response, body) {
       var statusCode = response ? response.statusCode : undefined;
       console.log('addApiToGateway: response status:'+ statusCode);
-      if (error) console.error('Warning: addRouteToGateway request failed: '+ JSON.stringify(error));
-      if (body) console.log('addApiToGateway: response body: '+JSON.stringify(body));
+      if (error) console.error('Warning: addRouteToGateway request failed: '+ utils2.makeJsonString(error));
+      if (body) console.log('addApiToGateway: response body: '+utils2.makeJsonString(body));
 
       if (error) {
-        console.error('addApiToGateway: Unable to configure the API Gateway: '+JSON.stringify(error));
-        reject('Unable to configure the API Gateway: '+JSON.stringify(error));
+        console.error('addApiToGateway: Unable to configure the API Gateway');
+        reject('Unable to configure the API Gateway: '+utils2.makeJsonString(error));
       } else if (statusCode != 200) {
-        console.error('addApiToGateway: Response code: '+statusCode);
         if (body) {
           var errMsg = JSON.stringify(body);
           if (body.error && body.error.message) errMsg = body.error.message;
@@ -247,14 +245,13 @@ function deleteApiFromGateway(gwInfo, gwApiId) {
     request.delete(options, function(error, response, body) {
       var statusCode = response ? response.statusCode : undefined;
       console.log('deleteApiFromGateway: response status:'+ statusCode);
-      if (error) console.error('Warning: deleteGatewayApi request failed: '+ JSON.stringify(error));
-      if (body) console.log('deleteApiFromGateway: response body: '+JSON.stringify(body));
+      if (error) console.error('Warning: deleteGatewayApi request failed: '+ utils2.makeJsonString(error));
+      if (body) console.log('deleteApiFromGateway: response body: '+utils2.makeJsonString(body));
 
       if (error) {
-        console.error('deleteApiFromGateway: Unable to delete the API Gateway: '+JSON.stringify(error));
-        reject('Unable to delete the API Gateway: '+JSON.stringify(error));
+        console.error('deleteApiFromGateway: Unable to delete the API Gateway');
+        reject('Unable to delete the API Gateway: '+utils2.makeJsonString(error));
       } else if (statusCode != 200) {
-        console.error('deleteApiFromGateway: Response code: '+statusCode);
         if (body) {
           var errMsg = JSON.stringify(body);
           if (body.error && body.error.message) errMsg = body.error.message;
@@ -303,13 +300,12 @@ function getApis(gwInfo, tenantId, bpOrApiName) {
     request.get(options, function(error, response, body) {
       var statusCode = response ? response.statusCode : undefined;
       console.log('getApis: response status: '+ statusCode);
-      if (error) console.error('Warning: getApis request failed: '+JSON.stringify(error));
-      if (body) console.log('getApis: response body: '+JSON.stringify(body));
+      if (error) console.error('Warning: getApis request failed: '+utils2.makeJsonString(error));
+      if (body) console.log('getApis: response body: '+utils2.makeJsonString(body));
       if (error) {
-        console.error('getApis: Unable to obtain API(s) from the API Gateway: '+JSON.stringify(error));
-        reject('Unable to obtain API(s) from the API Gateway: '+JSON.stringify(error));
+        console.error('getApis: Unable to obtain API(s) from the API Gateway');
+        reject('Unable to obtain API(s) from the API Gateway: '+utils2.makeJsonString(error));
       } else if (statusCode != 200) {
-        console.error('getApis: failure: response code: '+statusCode);
         if (body) {
           var errMsg = JSON.stringify(body);
           if (body.error && body.error.message) errMsg = body.error.message;

--- a/tests/src/test/scala/whisk/core/apigw/actions/test/ApiGwRoutemgmtActionTests.scala
+++ b/tests/src/test/scala/whisk/core/apigw/actions/test/ApiGwRoutemgmtActionTests.scala
@@ -73,7 +73,7 @@ class ApiGwRoutemgmtActionTests
         operation: Option[String] = None,
         docid: Option[String] = None): Vector[JsValue] = {
         val parms = Map[String, JsValue]() ++
-            Map("__ow_meta_namespace" -> wskprops.namespace.toJson) ++
+            Map("__ow_user" -> wskprops.namespace.toJson) ++
             { bpOrName map { b => Map("basepath" -> b.toJson) } getOrElse Map[String, JsValue]() } ++
             { relpath map { r => Map("relpath" -> r.toJson) } getOrElse Map[String, JsValue]() } ++
             { operation map { o => Map("operation" -> o.toJson) } getOrElse Map[String, JsValue]() } ++
@@ -114,7 +114,7 @@ class ApiGwRoutemgmtActionTests
             { action map { a => Map("action" -> a.toJson) } getOrElse Map[String, JsValue]() } ++
             { swagger map { s => Map("swagger" -> s.toJson) } getOrElse Map[String, JsValue]() }
         val parm = Map[String, JsValue]("apidoc" -> JsObject(parms)) ++
-            { namespace map { n => Map("__ow_meta_namespace" -> n.toJson) } getOrElse Map[String, JsValue]() }
+            { namespace map { n => Map("__ow_user" -> n.toJson) } getOrElse Map[String, JsValue]() }
 
         val rr = wsk.action.invoke(
             name = "routemgmt/createApi",
@@ -133,7 +133,7 @@ class ApiGwRoutemgmtActionTests
         apiname: Option[String] = None,
         expectedExitCode: Int = SUCCESS_EXIT): RunResult = {
         val parms = Map[String, JsValue]() ++
-            { namespace map { n => Map("__ow_meta_namespace" -> n.toJson) } getOrElse Map[String, JsValue]() } ++
+            { namespace map { n => Map("__ow_user" -> n.toJson) } getOrElse Map[String, JsValue]() } ++
             { basepath map { b => Map("basepath" -> b.toJson) } getOrElse Map[String, JsValue]() } ++
             { relpath map { r => Map("relpath" -> r.toJson) } getOrElse Map[String, JsValue]() } ++
             { operation map { o => Map("operation" -> o.toJson) } getOrElse Map[String, JsValue]() } ++
@@ -426,40 +426,40 @@ class ApiGwRoutemgmtActionTests
     it should "reject routemgmt actions that are invoked with not enough parameters" in {
         val invalidArgs = Seq(
             //getApi
-            ("/whisk.system/routemgmt/getApi", ANY_ERROR_EXIT, "namespace is required", Seq()),
+            ("/whisk.system/routemgmt/getApi", ANY_ERROR_EXIT, "__ow_user is required", Seq()),
 
             //deleteApi
-            ("/whisk.system/routemgmt/deleteApi", ANY_ERROR_EXIT, "namespace is required", Seq("-p", "basepath", "/ApiGwRoutemgmtActionTests_bp")),
-            ("/whisk.system/routemgmt/deleteApi", ANY_ERROR_EXIT, "basepath is required", Seq("-p", "__ow_meta_namespace", "_")),
+            ("/whisk.system/routemgmt/deleteApi", ANY_ERROR_EXIT, "__ow_user is required", Seq("-p", "basepath", "/ApiGwRoutemgmtActionTests_bp")),
+            ("/whisk.system/routemgmt/deleteApi", ANY_ERROR_EXIT, "basepath is required", Seq("-p", "__ow_user", "_")),
             ("/whisk.system/routemgmt/deleteApi", ANY_ERROR_EXIT, "When specifying an operation, the path is required",
-                Seq("-p", "__ow_meta_namespace", "_", "-p", "basepath", "/ApiGwRoutemgmtActionTests_bp", "-p", "operation", "get")),
+                Seq("-p", "__ow_user", "_", "-p", "basepath", "/ApiGwRoutemgmtActionTests_bp", "-p", "operation", "get")),
 
             //createApi
-            ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "apidoc is required", Seq("-p", "__ow_meta_namespace", "_")),
+            ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "apidoc is required", Seq("-p", "__ow_user", "_")),
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "apidoc is missing the namespace field",
-                Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", "{}")),
+                Seq("-p", "__ow_user", "_", "-p", "apidoc", "{}")),
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "apidoc is missing the gatewayBasePath field",
-                Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_"}""")),
+                Seq("-p", "__ow_user", "_", "-p", "apidoc", """{"namespace":"_"}""")),
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "apidoc is missing the gatewayPath field",
-                Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp"}""")),
+                Seq("-p", "__ow_user", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp"}""")),
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "apidoc is missing the gatewayMethod field",
-                Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp"}""")),
+                Seq("-p", "__ow_user", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp"}""")),
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "apidoc is missing the action field",
-                Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get"}""")),
+                Seq("-p", "__ow_user", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get"}""")),
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "action is missing the backendMethod field",
-                Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{}}""")),
+                Seq("-p", "__ow_user", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{}}""")),
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "action is missing the backendUrl field",
-                Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post"}}""")),
+                Seq("-p", "__ow_user", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post"}}""")),
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "action is missing the namespace field",
-                Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post","backendUrl":"URL"}}""")),
+                Seq("-p", "__ow_user", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post","backendUrl":"URL"}}""")),
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "action is missing the name field",
-                Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post","backendUrl":"URL","namespace":"_"}}""")),
+                Seq("-p", "__ow_user", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post","backendUrl":"URL","namespace":"_"}}""")),
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "action is missing the authkey field",
-                Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post","backendUrl":"URL","namespace":"_","name":"N"}}""")),
+                Seq("-p", "__ow_user", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post","backendUrl":"URL","namespace":"_","name":"N"}}""")),
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "swagger and gatewayBasePath are mutually exclusive and cannot be specified together",
-                Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post","backendUrl":"URL","namespace":"_","name":"N","authkey":"XXXX"},"swagger":{}}""")),
+                Seq("-p", "__ow_user", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post","backendUrl":"URL","namespace":"_","name":"N","authkey":"XXXX"},"swagger":{}}""")),
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "apidoc field cannot be parsed. Ensure it is valid JSON",
-                Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", "{1:[}}}")))
+                Seq("-p", "__ow_user", "_", "-p", "apidoc", "{1:[}}}")))
 
         invalidArgs foreach {
             case (action: String, exitcode: Int, errmsg: String, params: Seq[String]) =>
@@ -559,10 +559,10 @@ class ApiGwRoutemgmtActionTests
     it should "reject apimgmt actions that are invoked with not enough parameters" in {
         val invalidArgs = Seq(
             //getApi
-            ("/whisk.system/apimgmt/getApi", ANY_ERROR_EXIT, "namespace is required", Seq()),
+            ("/whisk.system/apimgmt/getApi", ANY_ERROR_EXIT, "__ow_user is required", Seq()),
 
             //deleteApi
-            ("/whisk.system/apimgmt/deleteApi", ANY_ERROR_EXIT, "namespace is required", Seq("-p", "basepath", "/ApiGwRoutemgmtActionTests_bp")),
+            ("/whisk.system/apimgmt/deleteApi", ANY_ERROR_EXIT, "__ow_user is required", Seq("-p", "basepath", "/ApiGwRoutemgmtActionTests_bp")),
             ("/whisk.system/apimgmt/deleteApi", ANY_ERROR_EXIT, "basepath is required", Seq("-p", "__ow_user", "_", "-p", "accesstoken", "TOKEN")),
             ("/whisk.system/apimgmt/deleteApi", ANY_ERROR_EXIT, "When specifying an operation, the path is required",
               Seq("-p", "__ow_user", "_", "-p", "accesstoken", "TOKEN", "-p", "basepath", "/ApiGwRoutemgmtActionTests_bp", "-p", "operation", "get")),

--- a/tests/src/test/scala/whisk/core/cli/test/ApiGwTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/ApiGwTests.scala
@@ -206,7 +206,7 @@ class ApiGwTests
 
     behavior of "Wsk api-experimental"
 
-    it should "reject an api commands with an invalid path parameter" in {
+    it should "reject api commands having an invalid path parameter" in {
         val badpath = "badpath"
 
         var rr = apiCreateExperimental(basepath = Some("/basepath"), relpath = Some(badpath), operation = Some("GET"), action = Some("action"), expectedExitCode = ANY_ERROR_EXIT)
@@ -578,6 +578,13 @@ class ApiGwTests
             var deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
             deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath2, expectedExitCode = DONTCARE_EXIT)
         }
+    }
+
+    it should "reject deletion of a non-existent api" in {
+        val nonexistentApi = "/not-there"
+
+        var rr = apiDeleteExperimental(basepathOrApiName = nonexistentApi, expectedExitCode = ANY_ERROR_EXIT)
+        rr.stderr should include (s"API '${nonexistentApi}' does not exist")
     }
 
     behavior of "Wsk api"
@@ -1193,5 +1200,12 @@ class ApiGwTests
         } finally {
             val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
         }
+    }
+
+    it should "reject deletion of a non-existent api" in {
+        val nonexistentApi = "/not-there"
+
+        var rr = apiDelete(basepathOrApiName = nonexistentApi, expectedExitCode = ANY_ERROR_EXIT)
+        rr.stderr should include (s"API '${nonexistentApi}' does not exist")
     }
 }

--- a/tools/cli/go-whisk-cli/commands/api.go
+++ b/tools/cli/go-whisk-cli/commands/api.go
@@ -299,7 +299,7 @@ var apiDeleteCmd = &cobra.Command{
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Apis.Delete(%#v, %#v) error: %s\n", apiDeleteReq, apiDeleteReqOptions, err)
             errMsg := wski18n.T("Unable to delete API: {{.err}}", map[string]interface{}{"err": err})
-            whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
+            whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return whiskErr
         }

--- a/tools/cli/go-whisk/whisk/api.go
+++ b/tools/cli/go-whisk/whisk/api.go
@@ -203,7 +203,7 @@ const (
 ////////////////////
 
 func (s *ApiService) List(apiListOptions *ApiListRequestOptions) (*ApiListResponse, *http.Response, error) {
-    route := "experimental/web/whisk.system/routemgmt/getApi.json"
+    route := "web/whisk.system/routemgmt/getApi.http"
     Debug(DbgInfo, "Api GET/list route: %s\n", route)
 
     routeUrl, err := addRouteOptions(route, apiListOptions)
@@ -238,7 +238,7 @@ func (s *ApiService) List(apiListOptions *ApiListRequestOptions) (*ApiListRespon
 }
 
 func (s *ApiService) Insert(api *ApiCreateRequest, options *ApiCreateRequestOptions, overwrite bool) (*ApiCreateResponse, *http.Response, error) {
-    route := "experimental/web/whisk.system/routemgmt/createApi.json"
+    route := "web/whisk.system/routemgmt/createApi.http"
     Debug(DbgInfo, "Api PUT route: %s\n", route)
 
     routeUrl, err := addRouteOptions(route, options)
@@ -273,7 +273,7 @@ func (s *ApiService) Insert(api *ApiCreateRequest, options *ApiCreateRequestOpti
 }
 
 func (s *ApiService) Get(api *ApiGetRequest, options *ApiGetRequestOptions) (*ApiGetResponse, *http.Response, error) {
-    route := "experimental/web/whisk.system/routemgmt/getApi.json"
+    route := "web/whisk.system/routemgmt/getApi.http"
     Debug(DbgInfo, "Api GET route: %s\n", route)
 
     routeUrl, err := addRouteOptions(route, options)
@@ -308,7 +308,7 @@ func (s *ApiService) Get(api *ApiGetRequest, options *ApiGetRequestOptions) (*Ap
 }
 
 func (s *ApiService) Delete(api *ApiDeleteRequest, options *ApiDeleteRequestOptions) (*http.Response, error) {
-    route := "experimental/web/whisk.system/routemgmt/deleteApi.json"
+    route := "web/whisk.system/routemgmt/deleteApi.http"
     Debug(DbgInfo, "Api DELETE route: %s\n", route)
 
     routeUrl, err := addRouteOptions(route, options)

--- a/tools/cli/go-whisk/whisk/client.go
+++ b/tools/cli/go-whisk/whisk/client.go
@@ -361,9 +361,9 @@ func parseApplicationError(resp *http.Response, data []byte, v interface{}) (*ht
     whiskErrorResponse := &WhiskErrorResponse{}
     err := json.Unmarshal(data, whiskErrorResponse)
 
-    // Handle application errors that occur when result is false (#5)
+    // Handle application errors that occur when --result option is false (#5)
     if err == nil && whiskErrorResponse != nil && whiskErrorResponse.Response != nil && whiskErrorResponse.Response.Status != nil {
-        Debug(DbgInfo, "Detected response status `%s` that a whisk.error(\"%s\") was returned\n",
+        Debug(DbgInfo, "Detected response status `%s` that a whisk.error(\"%#v\") was returned\n",
             *whiskErrorResponse.Response.Status, *whiskErrorResponse.Response.Result)
         errMsg := wski18n.T("The following application error was received: {{.err}}",
             map[string]interface{}{"err": *whiskErrorResponse.Response.Result})
@@ -375,14 +375,11 @@ func parseApplicationError(resp *http.Response, data []byte, v interface{}) (*ht
     appErrResult := &AppErrorResult{}
     err = json.Unmarshal(data, appErrResult)
 
-    // Handle application errors that occur with blocking invocations when result is true (#5)
+    // Handle application errors that occur with blocking invocations when --result option is true (#5)
     if err == nil && appErrResult.Error != nil {
         Debug(DbgInfo, "Error code is null, blocking with result invocation error has occured\n")
-        errMsg := wski18n.T(
-            "The following application error was received: {{.err}}",
-            map[string]interface{}{
-                "err": *appErrResult.Error,
-            })
+        errMsg := fmt.Sprintf("%v", *appErrResult.Error)
+        Debug(DbgInfo, "Application error received: %s\n", errMsg)
 
         whiskErr := MakeWskError(errors.New(errMsg), resp.StatusCode - 256, NO_DISPLAY_MSG, NO_DISPLAY_USAGE,
             NO_MSG_DISPLAYED, DISPLAY_PREFIX, APPLICATION_ERR)


### PR DESCRIPTION
Actions changes:
- Change parameters used (i.e. no longer use __ow_meta_*)
- Resolve()/Reject() responses now in .http format

CLI changes:
- Invoke api gw actions at .http for v1/experimental commands
- Better handling/messaging of error responses
