### PR TITLE
surface errors in runtimes.manifest configuration in the controller logs

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/ExecManifest.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ExecManifest.scala
@@ -16,9 +16,7 @@
 
 package whisk.core.entity
 
-import scala.util.Try
-import scala.util.Failure
-
+import scala.util.{Failure, Success, Try}
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import whisk.core.WhiskConfig
@@ -47,10 +45,15 @@ protected[core] object ExecManifest {
      */
     protected[core] def initialize(config: WhiskConfig, reinit: Boolean = false): Boolean = {
         if (manifest.isEmpty || reinit) {
-            Try(config.runtimesManifest.parseJson.asJsObject)
+            val result = Try(config.runtimesManifest.parseJson.asJsObject)
                 .flatMap(runtimes(_))
                 .map(m => manifest = Some(m))
-                .isSuccess
+            result match {
+                case Success(res) =>
+                    true
+                case Failure(e) =>
+                    throw new IllegalStateException("Runtimes manifest is set but it's invalid: " + e.toString)
+            }
         } else true
     }
 

--- a/common/scala/src/main/scala/whisk/core/entity/ExecManifest.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ExecManifest.scala
@@ -43,12 +43,12 @@ protected[core] object ExecManifest {
      * @param reinit re-initialize singleton iff true
      * @return the manifest if initialized successfully, or if previously initialized
      */
-    protected[core] def initialize(config: WhiskConfig, reinit: Boolean = false): Try[_] = {
+    protected[core] def initialize(config: WhiskConfig, reinit: Boolean = false): Try[Runtimes] = {
         if (manifest.isEmpty || reinit) {
-            Try(config.runtimesManifest.parseJson.asJsObject)
-                .flatMap(runtimes(_))
-                .map(m => manifest = Some(m))
-        } else Success(manifest)
+            val mf = Try(config.runtimesManifest.parseJson.asJsObject).flatMap(runtimes(_))
+            mf.foreach(m => manifest = Some(m))
+            mf
+        } else Success(manifest.get)
     }
 
     /**

--- a/common/scala/src/main/scala/whisk/core/entity/ExecManifest.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ExecManifest.scala
@@ -41,20 +41,14 @@ protected[core] object ExecManifest {
      *
      * @param config a valid configuration
      * @param reinit re-initialize singleton iff true
-     * @return true if initialized successfully, or if previously initialized
+     * @return the manifest if initialized successfully, or if previously initialized
      */
-    protected[core] def initialize(config: WhiskConfig, reinit: Boolean = false): Boolean = {
+    protected[core] def initialize(config: WhiskConfig, reinit: Boolean = false): Try[_] = {
         if (manifest.isEmpty || reinit) {
-            val result = Try(config.runtimesManifest.parseJson.asJsObject)
+            Try(config.runtimesManifest.parseJson.asJsObject)
                 .flatMap(runtimes(_))
                 .map(m => manifest = Some(m))
-            result match {
-                case Success(res) =>
-                    true
-                case Failure(e) =>
-                    throw new IllegalStateException("Runtimes manifest is set but it's invalid: " + e.toString)
-            }
-        } else true
+        } else Success(manifest)
     }
 
     /**

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -182,12 +182,14 @@ object Controller {
 
         // initialize the runtimes manifest
         val execManifest = ExecManifest.initialize(config)
+        if (execManifest.isFailure) {
+            logger.error(this, "Required property runtimes.manifest is invalid: " + execManifest.failed.get.toString)
+        }
         if (config.isValid && execManifest.isSuccess) {
             val port = config.servicePort.toInt
             BasicHttpService.startService(actorSystem, "controller", "0.0.0.0", port, new ServiceBuilder(config, instance, logger))
         } else {
-            logger.error(this, "Bad configuration, cannot start." +
-              (if (execManifest.isFailure) " Invalid runtimes.manifest: " + execManifest.failed.get.toString else ""))
+            logger.error(this, "Bad configuration, cannot start.")
             actorSystem.terminate()
             Await.result(actorSystem.whenTerminated, 30.seconds)
         }

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -183,11 +183,11 @@ object Controller {
             logger.error(this, "Bad configuration, cannot start.")
             actorSystem.terminate()
             Await.result(actorSystem.whenTerminated, 30.seconds)
+            sys.exit(1)
         }
 
         if (!config.isValid) {
             abort()
-            return
         }
 
         ExecManifest.initialize(config) match {

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -181,11 +181,13 @@ object Controller {
         val instance = if (args.length > 0) args(1).toInt else 0
 
         // initialize the runtimes manifest
-        if (config.isValid && ExecManifest.initialize(config)) {
+        val execManifest = ExecManifest.initialize(config)
+        if (config.isValid && execManifest.isSuccess) {
             val port = config.servicePort.toInt
             BasicHttpService.startService(actorSystem, "controller", "0.0.0.0", port, new ServiceBuilder(config, instance, logger))
         } else {
-            logger.error(this, "Bad configuration, cannot start.")
+            logger.error(this, "Bad configuration, cannot start." +
+              (if (execManifest.isFailure) " Invalid runtimes.manifest: " + execManifest.failed.get.toString else ""))
             actorSystem.terminate()
             Await.result(actorSystem.whenTerminated, 30.seconds)
         }

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -433,6 +433,9 @@ object Invoker {
 
         // if configuration is valid, initialize the runtimes manifest
         val execManifest = ExecManifest.initialize(config)
+        if (execManifest.isFailure) {
+          logger.error(this, "Required property runtimes.manifest is invalid: " + execManifest.failed.get.toString)
+        }
         if (config.isValid && execManifest.isSuccess) {
             val topic = s"invoker$instance"
             val groupid = "invokers"
@@ -464,8 +467,7 @@ object Invoker {
                 }
             })
         } else {
-            logger.error(this, "Bad configuration, cannot start." +
-              (if (execManifest.isFailure) " Invalid runtimes.manifest: " + execManifest.failed.get.toString else ""))
+            logger.error(this, "Bad configuration, cannot start.")
             actorSystem.terminate()
             Await.result(actorSystem.whenTerminated, 30.seconds)
         }

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -435,18 +435,17 @@ object Invoker {
             logger.error(this, "Bad configuration, cannot start.")
             actorSystem.terminate()
             Await.result(actorSystem.whenTerminated, 30.seconds)
+            sys.exit(1)
         }
 
         if (!config.isValid) {
             abort()
-            return
         }
 
         val execManifest = ExecManifest.initialize(config)
         if (execManifest.isFailure) {
             logger.error(this, s"Invalid runtimes manifest: ${execManifest.failed.get}")
             abort()
-            return
         }
 
         val topic = s"invoker$instance"

--- a/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
@@ -33,7 +33,7 @@ trait ExecHelpers
     self: Suite =>
 
     private val config = new WhiskConfig(ExecManifest.requiredProperties)
-    ExecManifest.initialize(config) shouldBe true
+    ExecManifest.initialize(config).isSuccess shouldBe true
 
     protected val NODEJS = "nodejs"
     protected val NODEJS6 = "nodejs:6"

--- a/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
@@ -33,7 +33,7 @@ trait ExecHelpers
     self: Suite =>
 
     private val config = new WhiskConfig(ExecManifest.requiredProperties)
-    ExecManifest.initialize(config).isSuccess shouldBe true
+    ExecManifest.initialize(config) should be a 'success
 
     protected val NODEJS = "nodejs"
     protected val NODEJS6 = "nodejs:6"

--- a/tests/src/test/scala/whisk/core/entity/test/ExecManifestTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecManifestTests.scala
@@ -186,7 +186,7 @@ class ExecManifestTests
         bw.write("runtimes.manifest=" + config_manifest + "\n")
         bw.close()
 
-        var result:Try[_] = ExecManifest.initialize(new WhiskConfig(Map("runtimes.manifest" -> null), Set(), file), true)
+        val result = ExecManifest.initialize(new WhiskConfig(Map("runtimes.manifest" -> null), Set(), file), true)
 
         result.isSuccess should be (false)
 

--- a/tests/src/test/scala/whisk/core/entity/test/ExecManifestTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecManifestTests.scala
@@ -177,8 +177,8 @@ class ExecManifestTests
             }
     }
 
-    it should "throw an error when configured manifest is invalid" in {
-        val config_manifest = "{\"nodejs\":[{\"kind\":\"nodejs\",\"image\":{\"name\":\"nodejsaction\"},\"deprecated\":true},{\"kind\":\"nodejs:6\",\"default\":true,\"image\":{\"name\":\"nodejs6action\"}}]}"
+    it should "throw an error when configured manifest is a valid JSON, but with a missing key" in {
+        val config_manifest = """{"nodejs":[{"kind":"nodejs:6","default":true,"image":{"name":"nodejs6action"}}]}"""
         val file = File.createTempFile("cxt", ".txt")
         file.deleteOnExit()
 
@@ -188,7 +188,7 @@ class ExecManifestTests
 
         val result = ExecManifest.initialize(new WhiskConfig(Map("runtimes.manifest" -> null), Set(), file), true)
 
-        result.isSuccess should be (false)
+        result should be a 'failure
 
         the [NoSuchElementException] thrownBy {
             result.get

--- a/tests/src/test/scala/whisk/core/entity/test/ExecManifestTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecManifestTests.scala
@@ -19,7 +19,7 @@ package whisk.core.entity.test
 import java.io.{BufferedWriter, File, FileWriter}
 import java.util.NoSuchElementException
 
-import scala.util.{Success, Try}
+import scala.util.{Success}
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers

--- a/tests/src/test/scala/whisk/core/entity/test/ExecManifestTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecManifestTests.scala
@@ -19,7 +19,7 @@ package whisk.core.entity.test
 import java.io.{BufferedWriter, File, FileWriter}
 import java.util.NoSuchElementException
 
-import scala.util.{Failure, Success, Try}
+import scala.util.{Success, Try}
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers


### PR DESCRIPTION
This PR ensures than when `runtimes.manifest` property is incorrectly configured that the controller prints what the error is in the logs. 

Without this PR we would only see in the logs:
```
[2017-05-17T21:21:53.457Z] [ERROR] [??] [Controller] Bad configuration, cannot start. 
```

With this PR we can see:
```
Exception in thread "main" java.lang.IllegalStateException: Runtimes manifest is set but it's invalid: spray.json.DeserializationException: Object is missing required member 'image'
	at whisk.core.entity.ExecManifest$.initialize(ExecManifest.scala:55)
	at whisk.core.controller.Controller$.main(Controller.scala:185)
	at whisk.core.controller.Controller.main(Controller.scala)
```

This is very helpful when debugging issues with the configuration such as the one mentioned at https://github.com/apache/incubator-openwhisk-devtools/issues/29