### PR TITLE
Disconnect WhiskConfig from Consul

### DIFF
--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -36,6 +36,7 @@
       "SERVICE_CHECK_INTERVAL": "15s"
       "JAVA_OPTS": "-Xmx{{ controller.heap }}"
       "CONTROLLER_OPTS": "{{ controller.arguments }}"
+    env_file: "{{ openwhisk_home }}/whisk.env"
     volumes:
       - "{{ whisk_logs_dir }}/controller:/logs"
     ports:

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -36,7 +36,27 @@
       "SERVICE_CHECK_INTERVAL": "15s"
       "JAVA_OPTS": "-Xmx{{ controller.heap }}"
       "CONTROLLER_OPTS": "{{ controller.arguments }}"
-    env_file: "{{ openwhisk_home }}/whisk.env"
+
+      "WHISK_LOGS_DIR": "{{ whisk_logs_dir }}"
+
+      "DB_PREFIX": "{{ db_prefix }}"
+      "DB_WHISK_ACTIONS": "{{ db.whisk.actions }}"
+      "DB_WHISK_AUTHS": "{{ db.whisk.auth }}"
+      "DB_WHISK_ACTIVATIONS": "{{ db.whisk.activations }}"
+
+      "DEFAULTLIMITS_ACTIONS_INVOKES_PERMINUTE": "{{ defaultLimits.actions.invokes.perMinute }}"
+      "DEFAULTLIMITS_ACTIONS_INVOKES_CONCURRENT": "{{ defaultLimits.actions.invokes.concurrent }}"
+      "DEFAULTLIMITS_TRIGGERS_FIRES_PERMINUTE":"{{ defaultLimits.triggers.fires.perMinute }}"
+      "DEFAULTLIMITS_ACTIONS_INVOKES_CONCURRENTINSYSTEM": "{{ defaultLimits.actions.invokes.concurrentInSystem }}"
+      "DEFAULTLIMITS_ACTIONS_SEQUENCE_MAXLENGTH": "{{ defaultLimits.actions.sequence.maxLength }}"
+      "LIMITS_ACTIONS_INVOKES_PERMINUTE": "{{ limits.actions.invokes.perMinute }}"
+      "LIMITS_ACTIONS_INVOKES_CONCURRENT": "{{ limits.actions.invokes.concurrent }}"
+      "LIMITS_ACTIONS_INVOKES_CONCURRENTINSYSTEM": "{{ limits.actions.invokes.concurrentInSystem }}"
+      "LIMITS_TRIGGERS_FIRES_PERMINUTE": "{{ limits.triggers.fires.perMinute }}"
+      "LOADBALANCER_ACTIVATIONCOUNTBEFORENEXTINVOKER": "{{ loadbalancer_activation_count_before_next_invoker }}"
+
+      "WHISK_SYSTEM_KEY": "whisk.system"
+      "RUNTIMES_MANIFEST": "{{ runtimesManifest | to_json }}"
     volumes:
       - "{{ whisk_logs_dir }}/controller:/logs"
     ports:

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -46,7 +46,7 @@
 
       "DEFAULTLIMITS_ACTIONS_INVOKES_PERMINUTE": "{{ defaultLimits.actions.invokes.perMinute }}"
       "DEFAULTLIMITS_ACTIONS_INVOKES_CONCURRENT": "{{ defaultLimits.actions.invokes.concurrent }}"
-      "DEFAULTLIMITS_TRIGGERS_FIRES_PERMINUTE":"{{ defaultLimits.triggers.fires.perMinute }}"
+      "DEFAULTLIMITS_TRIGGERS_FIRES_PERMINUTE": "{{ defaultLimits.triggers.fires.perMinute }}"
       "DEFAULTLIMITS_ACTIONS_INVOKES_CONCURRENTINSYSTEM": "{{ defaultLimits.actions.invokes.concurrentInSystem }}"
       "DEFAULTLIMITS_ACTIONS_SEQUENCE_MAXLENGTH": "{{ defaultLimits.actions.sequence.maxLength }}"
       "LIMITS_ACTIONS_INVOKES_PERMINUTE": "{{ limits.actions.invokes.perMinute }}"

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -51,6 +51,7 @@
         -e SERVICE_CHECK_INTERVAL=15s
         -e JAVA_OPTS=-Xmx{{ invoker.heap }}
         -e INVOKER_OPTS={{ invoker.arguments }}
+        --env-file {{ openwhisk_home }}/whisk.env
         -v /sys/fs/cgroup:/sys/fs/cgroup
         -v /run/runc:/run/runc
         -v {{whisk_logs_dir}}/invoker{{play_hosts.index(inventory_hostname)}}:/logs

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -51,7 +51,23 @@
         -e SERVICE_CHECK_INTERVAL=15s
         -e JAVA_OPTS=-Xmx{{ invoker.heap }}
         -e INVOKER_OPTS={{ invoker.arguments }}
-        --env-file {{ openwhisk_home }}/whisk.env
+        -e WHISK_LOGS_DIR={{ whisk_logs_dir }}
+        -e DB_PREFIX={{ db_prefix }}
+        -e DB_WHISK_ACTIONS={{ db.whisk.actions }}
+        -e DB_WHISK_AUTHS={{ db.whisk.auth }}
+        -e DB_WHISK_ACTIVATIONS={{ db.whisk.activations }}
+        -e DEFAULTLIMITS_ACTIONS_INVOKES_PERMINUTE={{ defaultLimits.actions.invokes.perMinute }}
+        -e DEFAULTLIMITS_ACTIONS_INVOKES_CONCURRENT={{ defaultLimits.actions.invokes.concurrent }}
+        -e DEFAULTLIMITS_TRIGGERS_FIRES_PERMINUTE={{ defaultLimits.triggers.fires.perMinute }}
+        -e DEFAULTLIMITS_ACTIONS_INVOKES_CONCURRENTINSYSTEM={{ defaultLimits.actions.invokes.concurrentInSystem }}
+        -e DEFAULTLIMITS_ACTIONS_SEQUENCE_MAXLENGTH={{ defaultLimits.actions.sequence.maxLength }}
+        -e LIMITS_ACTIONS_INVOKES_PERMINUTE={{ limits.actions.invokes.perMinute }}
+        -e LIMITS_ACTIONS_INVOKES_CONCURRENT={{ limits.actions.invokes.concurrent }}
+        -e LIMITS_ACTIONS_INVOKES_CONCURRENTINSYSTEM={{ limits.actions.invokes.concurrentInSystem }}
+        -e LIMITS_TRIGGERS_FIRES_PERMINUTE={{ limits.triggers.fires.perMinute }}
+        -e LOADBALANCER_ACTIVATIONCOUNTBEFORENEXTINVOKER={{ loadbalancer_activation_count_before_next_invoker }}
+        -e WHISK_SYSTEM_KEY=whisk.system
+        -e RUNTIMES_MANIFEST={{ runtimesManifest | to_json }}
         -v /sys/fs/cgroup:/sys/fs/cgroup
         -v /run/runc:/run/runc
         -v {{whisk_logs_dir}}/invoker{{play_hosts.index(inventory_hostname)}}:/logs

--- a/ansible/tasks/writeWhiskProperties.yml
+++ b/ansible/tasks/writeWhiskProperties.yml
@@ -6,3 +6,6 @@
   template:
     src: whisk.properties.j2
     dest: "{{ openwhisk_home }}/whisk.properties"
+
+- name: write whisk.env environment file for docker
+  shell: cat {{ openwhisk_home }}/whisk.properties | awk -F= '!/^($|#)/{ gsub(/\./,"_", $1); print toupper($1)  "=" $2}' > {{ openwhisk_home }}/whisk.env

--- a/tests/src/test/scala/whisk/core/WhiskConfigTests.scala
+++ b/tests/src/test/scala/whisk/core/WhiskConfigTests.scala
@@ -20,9 +20,6 @@ import java.io.BufferedWriter
 import java.io.File
 import java.io.FileWriter
 
-import scala.concurrent.Await
-import scala.concurrent.duration._
-
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
@@ -30,7 +27,6 @@ import org.scalatest.junit.JUnitRunner
 
 import common.StreamLogging
 import common.WskActorSystem
-import whisk.common.ConsulClient
 
 @RunWith(classOf[JUnitRunner])
 class WhiskConfigTests
@@ -95,22 +91,6 @@ class WhiskConfigTests
         val config = new WhiskConfig(Map(WhiskConfig.dockerRegistry -> null))
         println(s"${WhiskConfig.dockerRegistry} is: '${config.dockerRegistry}'")
         assert(config.isValid)
-    }
-
-    it should "read properties from consulserver" in {
-        val tester = new WhiskConfig(WhiskConfig.consulServer);
-        val consul = new ConsulClient(tester.consulServer)
-
-        val key = "whiskprops/CONSUL_TEST_CASE"
-        Await.result(consul.kv.put(key, "thiswastested"), 10.seconds)
-
-        // set optional value which will not be available in environment, it should still be read from consul
-        val config = new WhiskConfig(WhiskConfig.consulServer ++ Map("consul.test.case" -> null), Set("consul.test.case"))
-
-        assert(config.isValid)
-        assert(config("consul.test.case").equals("thiswastested"))
-
-        consul.kv.del(key)
     }
 
 }


### PR DESCRIPTION
This is part 1 that relates to #2254. 

Given that removing consul from our deployment requires more code changes, I'm thinking to complete the task with smaller and incremental PRs. 

The scope of this PR is to remove the code from `WhiskConfig` that loads any configuration data from Consul. 