### PR TITLE
Controller memory tuning for zip actions: use Regex rather than Base64.decode

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Exec.scala
@@ -20,7 +20,6 @@ import java.nio.charset.StandardCharsets
 import java.util.Base64
 
 import scala.language.postfixOps
-import scala.util.Try
 
 import spray.json._
 import spray.json.DefaultJsonProtocol._
@@ -261,10 +260,13 @@ protected[core] object Exec
         }
     }
 
+    val isBase64Pattern = new scala.util.matching.Regex("^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$")
+
     def isBinaryCode(code: String): Boolean = {
         if (code != null) {
             val t = code.trim
-            (t.length > 0) && (t.length % 4 == 0) && Try(b64decoder.decode(t)).isSuccess
+            
+            (t.length > 0) && (t.length % 4 == 0) && isBase64Pattern.findFirstIn(t).isDefined
         } else false
     }
 

--- a/common/scala/src/main/scala/whisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Exec.scala
@@ -17,9 +17,9 @@
 package whisk.core.entity
 
 import java.nio.charset.StandardCharsets
-import java.util.Base64
 
 import scala.language.postfixOps
+import scala.util.matching.Regex
 
 import spray.json._
 import spray.json.DefaultJsonProtocol._
@@ -260,15 +260,12 @@ protected[core] object Exec
         }
     }
 
-    val isBase64Pattern = new scala.util.matching.Regex("^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$")
+    val isBase64Pattern = new Regex("^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$").pattern
 
     def isBinaryCode(code: String): Boolean = {
         if (code != null) {
             val t = code.trim
-            
-            (t.length > 0) && (t.length % 4 == 0) && isBase64Pattern.findFirstIn(t).isDefined
+            (t.length > 0) && (t.length % 4 == 0) && isBase64Pattern.matcher(t).matches()
         } else false
     }
-
-    private lazy val b64decoder = Base64.getDecoder()
 }


### PR DESCRIPTION
use a Regex to determine isBinaryCode, rather than going through with a full base64 decoding in the controller. this reduces peak memory consumption, and also decreases the latency of zip-action update operations

Fixes #2295 

PG3 665 🔵 