### PR TITLE
Normalize rate checks to the identity namespace (uuid).

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/Identity.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Identity.scala
@@ -27,7 +27,9 @@ import whisk.core.database.NoDocumentException
 import whisk.core.entitlement.Privilege
 import whisk.core.entitlement.Privilege.Privilege
 
-protected[core] case class Identity(subject: Subject, namespace: EntityName, authkey: AuthKey, rights: Set[Privilege])
+protected[core] case class Identity(subject: Subject, namespace: EntityName, authkey: AuthKey, rights: Set[Privilege]) {
+    def uuid = authkey.uuid
+}
 
 object Identity extends MultipleReadersSingleWriterCache[Identity, DocInfo] with DefaultJsonProtocol {
 

--- a/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
@@ -26,7 +26,7 @@ import whisk.common.ConsulClient
 import whisk.common.ConsulKV.ControllerKeys
 import whisk.common.Logging
 import whisk.common.Scheduler
-import whisk.core.entity.Subject
+import whisk.core.entity.Identity
 import whisk.core.loadBalancer.LoadBalancer
 
 /**
@@ -58,7 +58,7 @@ class ActivationThrottler(consulServer: String, loadBalancer: LoadBalancer, conc
     /**
      * Checks whether the operation should be allowed to proceed.
      */
-    def check(subject: Subject): Boolean = userActivationCounter.getOrElse(subject.asString, 0) < concurrencyLimit
+    def check(user: Identity): Boolean = userActivationCounter.getOrElse(user.uuid.asString, 0) < concurrencyLimit
 
     /**
      * Checks whether the system is in a generally overloaded state.

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -119,20 +119,20 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
     protected def entitled(subject: Subject, right: Privilege, resource: Resource)(implicit transid: TransactionId): Future[Boolean]
 
     /**
-     * Checks action activation rate throttles for subject.
+     * Checks action activation rate throttles for an identity.
      *
-     * @param user the subject to check rate throttles for
-     * @return a promise that completes with success iff the subject is within their activation quota
+     * @param user the identity to check rate throttles for
+     * @return a promise that completes with success iff the user is within their activation quota
      */
     protected[core] def checkThrottles(user: Identity)(
         implicit transid: TransactionId): Future[Unit] = {
-        val subject = user.subject
-        logging.info(this, s"checking user '$subject' has not exceeded activation quota")
+
+        logging.info(this, s"checking user '${user.subject}' has not exceeded activation quota")
 
         checkSystemOverload(ACTIVATE) orElse {
-            checkThrottleOverload(!invokeRateThrottler.check(subject), tooManyRequests)
+            checkThrottleOverload(!invokeRateThrottler.check(user), tooManyRequests)
         } orElse {
-            checkThrottleOverload(!concurrentInvokeThrottler.check(subject), tooManyConcurrentRequests)
+            checkThrottleOverload(!concurrentInvokeThrottler.check(user), tooManyConcurrentRequests)
         } map {
             Future.failed(_)
         } getOrElse Future.successful({})
@@ -163,7 +163,7 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
      * resource for example, or explicit. The implicit check is computed here. The explicit check
      * is delegated to the service implementing this interface.
      *
-     * @param user the subject to check rights for
+     * @param user the subject identity to check rights for
      * @param right the privilege the subject is requesting (applies to the entire set of resources)
      * @param resources the set of resources the subject requests access to
      * @return a promise that completes with success iff the subject is permitted to access all of the requested resources
@@ -176,9 +176,9 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
             if (resources.nonEmpty) {
                 logging.info(this, s"checking user '$subject' has privilege '$right' for '${resources.mkString(",")}'")
                 checkSystemOverload(right) orElse {
-                    checkUserThrottle(subject, right, resources)
+                    checkUserThrottle(user, right, resources)
                 } orElse {
-                    checkConcurrentUserThrottle(subject, right, resources)
+                    checkConcurrentUserThrottle(user, right, resources)
                 } map {
                     Future.failed(_)
                 } getOrElse checkPrivilege(user, right, resources)
@@ -247,17 +247,17 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
      * While it is possible for the set of resources to contain more than one action or trigger, the plurality is ignored and treated
      * as one activation since these should originate from a single macro resources (e.g., a sequence).
      *
-     * @param subject the subject to check quota for
+     * @param user the subject identity to check rights for
      * @param right the privilege, if ACTIVATE then check quota else return None
      * @param resource the set of resources must contain at least one resource that can be activated else return None
      * @return None if subject is not throttled else a rejection
      */
-    private def checkUserThrottle(subject: Subject, right: Privilege, resources: Set[Resource])(
+    private def checkUserThrottle(user: Identity, right: Privilege, resources: Set[Resource])(
         implicit transid: TransactionId): Option[RejectRequest] = {
         def userThrottled = {
             val isInvocation = resources.exists(_.collection.path == Collection.ACTIONS)
             val isTrigger = resources.exists(_.collection.path == Collection.TRIGGERS)
-            (isInvocation && !invokeRateThrottler.check(subject)) || (isTrigger && !triggerRateThrottler.check(subject))
+            (isInvocation && !invokeRateThrottler.check(user)) || (isTrigger && !triggerRateThrottler.check(user))
         }
 
         checkThrottleOverload(right == ACTIVATE && userThrottled, tooManyRequests)
@@ -269,16 +269,16 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
      * While it is possible for the set of resources to contain more than one action, the plurality is ignored and treated
      * as one activation since these should originate from a single macro resources (e.g., a sequence).
      *
-     * @param subject the subject to check quota for
+     * @param user the subject identity to check rights for
      * @param right the privilege, if ACTIVATE then check quota else return None
      * @param resource the set of resources must contain at least one resource that can be activated else return None
      * @return None if subject is not throttled else a rejection
      */
-    private def checkConcurrentUserThrottle(subject: Subject, right: Privilege, resources: Set[Resource])(
+    private def checkConcurrentUserThrottle(user: Identity, right: Privilege, resources: Set[Resource])(
         implicit transid: TransactionId): Option[RejectRequest] = {
         def userThrottled = {
             val isInvocation = resources.exists(_.collection.path == Collection.ACTIONS)
-            (isInvocation && !concurrentInvokeThrottler.check(subject))
+            (isInvocation && !concurrentInvokeThrottler.check(user))
         }
 
         checkThrottleOverload(right == ACTIVATE && userThrottled, tooManyConcurrentRequests)

--- a/core/controller/src/main/scala/whisk/core/entitlement/RateThrottler.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/RateThrottler.scala
@@ -20,7 +20,8 @@ import scala.collection.concurrent.TrieMap
 
 import whisk.common.Logging
 import whisk.common.TransactionId
-import whisk.core.entity.Subject
+import whisk.core.entity.Identity
+import whisk.core.entity.UUID
 
 /**
  * A class tracking the rate of invocation (or any operation) by subject (any key really).
@@ -32,21 +33,22 @@ class RateThrottler(description: String, maxPerMinute: Int)(implicit logging: Lo
     logging.info(this, s"$description: maxPerMinute = $maxPerMinute")(TransactionId.controller)
 
     /**
-     * Maintains map of subject to operations rates.
+     * Maintains map of subject namespace to operations rates.
      */
-    private val rateMap = new TrieMap[Subject, RateInfo]
+    private val rateMap = new TrieMap[UUID, RateInfo]
 
     /**
      * Checks whether the operation should be allowed to proceed.
-     * Every `check` operation charges the subject for one operation.
+     * Every `check` operation charges the subject namespace for one operation.
      *
-     * @param subject the subject to check
-     * @return true iff subject is below allowed limit
+     * @param user the identity to check
+     * @return true iff subject namespace is below allowed limit
      */
-    def check(subject: Subject)(implicit transid: TransactionId): Boolean = {
-        val rate = rateMap.getOrElseUpdate(subject, new RateInfo(maxPerMinute))
+    def check(user: Identity)(implicit transid: TransactionId): Boolean = {
+        val uuid = user.uuid // this is namespace identifier
+        val rate = rateMap.getOrElseUpdate(uuid, new RateInfo(maxPerMinute))
         val belowLimit = rate.check()
-        logging.info(this, s"subject = ${subject.toString}, rate = ${rate.count()}, below limit = $belowLimit")
+        logging.info(this, s"namespace = ${uuid.asString} rate = ${rate.count()}, below limit = $belowLimit")
         belowLimit
     }
 }

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -385,7 +385,7 @@ The following table lists the default limits for actions.
 | memory | a container is not allowed to allocate more than N MB of memory | per action | MB | 256 |
 | logs | a container is not allowed to write more than N MB to stdout | per action | MB | 10 |
 | concurrent | no more than N activations may be submitted per namespace either executing or queued for execution | per namespace | number | 100 |
-| minuteRate | no more than N activations may be submitted per namespace per minute | per user | number | 120 |
+| minuteRate | no more than N activations may be submitted per namespace per minute | per namespace | number | 120 |
 | codeSize | the maximum size of the actioncode | not configurable, limit per action | MB | 48 |
 | parameters | the maximum size of the parameters that can be attached | not configurable, limit per action/package/trigger | MB | 1 |
 

--- a/tests/src/test/scala/whisk/core/controller/test/RateThrottleTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/RateThrottleTests.scala
@@ -27,6 +27,7 @@ import common.StreamLogging
 import whisk.common.TransactionId
 import whisk.core.entitlement._
 import whisk.core.entity.Subject
+import whisk.core.entity.AuthKey
 
 /**
  * Tests rate throttle.
@@ -41,7 +42,7 @@ class RateThrottleTests
     with StreamLogging {
 
     implicit val transid = TransactionId.testing
-    val subject = Subject()
+    val subject = Subject().toIdentity(AuthKey())
 
     behavior of "Rate Throttle"
 


### PR DESCRIPTION
Fixes #2266.