### PR TITLE
add out-of-the-box support for db2 database client

### DIFF
--- a/core/nodejs6Action/Dockerfile
+++ b/core/nodejs6Action/Dockerfile
@@ -36,6 +36,7 @@ glob@7.1.1 \
 gm@1.23.0 \
 lodash@4.17.2 \
 log4js@0.6.38 \
+ibm_db@2.0.0 \
 iconv-lite@0.4.15 \
 marked@0.3.6 \
 merge@1.2.0 \

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -220,6 +220,7 @@ The following packages are available to be used in the Node.js 6.9.1 environment
 - gm v1.23.0
 - lodash v4.17.2
 - log4js v0.6.38
+- ibm_db v2.0.0
 - iconv-lite v0.4.15
 - marked v0.3.6
 - merge v1.2.0


### PR DESCRIPTION
Users are asking more and more for support of db2 client. The PR proposes to include the library in the standard runtime next to the other database drivers like nano, cloudant, mongodb. 