### PR TITLE
Install/upgrade six module before installing other dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ notifications:
       secure: "nbPjG0Y+P6tbEcQ+Q3k3EYv46IhQQJvRpEr/090H7A349cdn3vJRxSVKn1CtcboN7A+grhSu0Dx7jS8BwlRcOt1iqFAEDMOyN+6QcFGvpAGv3P2vZ9ML/yArH+c7mZ6k2X+BKdpqwQhrsaCwq23OAqKlP00T+S+exSmP9y3F3M6xVgCFP1RRlBTJfJiNnSir2vblskiXtAxHsO9jz/4cCxNGtzxmGD5Lhm6dchgwe7wyUCyhK8RG1NXc/z9x0mFernvPQBJJCn36NoijqbFiji1o8BaVULJszs+Gkd7rQxAntMm2wUQYWLsDTFp+V1HzgkdRHx4GpfoeK+aufGXS1r+kqGpsnMYqAqCQxtbATR7oB7XKlDjmiyFUkHng1ODDoUHp9k01Ow7CvCpwURlVglAOqmwM/+HEbUEvzrA1e5XNTn5auOJ0YsvZ9/SKToXmoZhYBnel0IVTQc2jFpp6obQEGX/0kjRbEQpdi8troSMSYpuCTeQPa0Cxazp9hICPbE7llOcEEA4odyj9NnINPiGAFowBeJNA4u5dln9RlAuNYsyNgMtmN39D5dc/YWri0M7EaWQ9e0Qn9AIDsAf/o7cHg2vcU1kNxp3FM/WyVjwQCV7lfgm9Q7hD1wJP4EdkCg2mDPMfad3eGrWW2AKxv8XYANQo495ODukRdLNLBfk="
 
 before_install:
-  - pip install --upgrade pip setuptools
-  - pip3 install --upgrade pip setuptools
+  - pip install --upgrade pip setuptools six
+  - pip3 install --upgrade pip setuptools six
   - ./tools/travis/flake8.sh  # Check Python files for style and stop the build on syntax errors
 
 install:

--- a/core/actionProxy/Dockerfile
+++ b/core/actionProxy/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache bash \
         bzip2-dev \
         gcc \
         libc-dev \
-  && pip install --upgrade pip setuptools \
+  && pip install --upgrade pip setuptools six \
   && pip install --no-cache-dir gevent==1.2.1 flask==0.12 \
   && apk del .build-deps
 

--- a/core/python2Action/Dockerfile
+++ b/core/python2Action/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --no-cache \
         python-dev
 
 # Install common modules for python
-RUN pip install --no-cache-dir --upgrade pip setuptools \
+RUN pip install --no-cache-dir --upgrade pip setuptools six \
  && pip install --no-cache-dir \
         gevent==1.1.2 \
         flask==0.11.1 \


### PR DESCRIPTION
This fixes our travis build which seems to be broken because something changed in that area. `jsonschema` and `ansible` couldn't be installed.

It seems like a good idea to update those packages (pip, setuptools, six) to latest in general.