### PR TITLE
add support for email address scan to scanCode.py

### DIFF
--- a/tools/build/scanCode.cfg
+++ b/tools/build/scanCode.cfg
@@ -7,6 +7,9 @@
 ASFLicenseHeader.txt
 ApacheIBMLicenseHeader.txt
 
+[EmailPatterns]
+# Add your bad email patterns here, e.g. \w+@company.com
+
 # Filters (path/filename) with wildcards and associated scan checks
 # that are to be run against them.  The checks are actual valid
 # function names found in scanCode.py.
@@ -17,7 +20,7 @@ ApacheIBMLicenseHeader.txt
 *.java=has_block_license, no_tabs, no_trailing_spaces, eol_at_eof
 *.js=no_tabs, no_trailing_spaces, eol_at_eof
 *.gradle=no_tabs, no_trailing_spaces, eol_at_eof
-*.md=no_tabs, eol_at_eof
+*.md=no_tabs, eol_at_eof, no_emails
 *.go=has_block_license, no_tabs, no_trailing_spaces, eol_at_eof
 build.xml=no_tabs, no_trailing_spaces, eol_at_eof
 deploy.xml=no_tabs, no_trailing_spaces, eol_at_eof


### PR DESCRIPTION
Added feature to scan for given email address regex patterns. Useful if you want to avoid internal company or private emails in the code.

Greeting from SAP, keep up the good work! :-)