### PR TITLE
Use unique test API Names for unique basepaths

### DIFF
--- a/tests/src/test/scala/whisk/core/cli/test/ApiGwTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/ApiGwTests.scala
@@ -804,6 +804,7 @@ class ApiGwTests
         val testnewrelpath = "/path_new"
         val testurlop = "get"
         val testapiname = testName+" API Name"
+        val testapiname2 = testName+" API Name 2"
         val actionName = testName+"_action"
         val newEndpoint = "/newEndpoint"
         try {
@@ -813,7 +814,7 @@ class ApiGwTests
 
             var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
             rr.stdout should include("ok: created API")
-            rr = apiCreate(basepath = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr = apiCreate(basepath = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname2))
             rr.stdout should include("ok: created API")
 
             // Update both APIs - each with a new endpoint
@@ -985,6 +986,7 @@ class ApiGwTests
         val testnewrelpath = "/path_new"
         val testurlop = "get"
         val testapiname = testName + " API Name"
+        val testapiname2 = testName + " API Name 2"
         val actionName = testName + "_action"
         try {
             // Create the action for the API.  It must be a "web-action" action.
@@ -997,7 +999,7 @@ class ApiGwTests
             rr.stdout should include("ok: APIs")
             rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
             rr.stdout should include(testbasepath + testrelpath)
-            rr = apiCreate(basepath = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr = apiCreate(basepath = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname2))
             rr.stdout should include("ok: created API")
             rr = apiList(basepathOrApiName = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop))
             rr.stdout should include("ok: APIs")
@@ -1038,7 +1040,6 @@ class ApiGwTests
     it should "reject an API created with an action that is not a web action" in {
         val testName = "CLI_APIGWTEST16"
         val testbasepath = "/" + testName + "_bp"
-        val testbasepath2 = "/" + testName + "_bp2"
         val testrelpath = "/path"
         val testnewrelpath = "/path_new"
         val testurlop = "get"


### PR DESCRIPTION
- New API GW restriction