### PR TITLE
Cli should ignore a config file env variable value of empty string

### DIFF
--- a/tests/src/test/scala/whisk/core/cli/test/WskConfigTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskConfigTests.scala
@@ -53,6 +53,12 @@ class WskConfigTests extends TestHelpers with WskTestHelpers {
     }
   }
 
+  it should "use default cli configuration when an empty string WSK_CONFIG_FILE is supplied" in {
+    val env = Map("WSK_CONFIG_FILE" -> "")
+    val stderr = wsk.cli(Seq("property", "get", "-i"), env = env, expectedExitCode = ERROR_EXIT).stderr
+    stderr should include("The API host is not valid: An API host must be provided.")
+  }
+
   it should "validate default property values" in {
     val tmpwskprops = File.createTempFile("wskprops", ".tmp")
     val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())

--- a/tools/cli/go-whisk-cli/commands/property.go
+++ b/tools/cli/go-whisk-cli/commands/property.go
@@ -402,8 +402,11 @@ func SetDefaultProperties() {
 func GetPropertiesFilePath() (propsFilePath string, werr error) {
     var envExists bool
 
-    // Environment variable overrides the default properties file path
-    if propsFilePath, envExists = os.LookupEnv("WSK_CONFIG_FILE"); envExists == true || propsFilePath != "" {
+    // WSK_CONFIG_FILE environment variable overrides the default properties file path
+    // NOTE: If this variable is set to an empty string or non-existent/unreadable file
+    // - any existing $HOME/.wskprops is ignored
+    // - a default configuration is used
+    if propsFilePath, envExists = os.LookupEnv("WSK_CONFIG_FILE"); envExists {
         whisk.Debug(whisk.DbgInfo, "Using properties file '%s' from WSK_CONFIG_FILE environment variable\n", propsFilePath)
         return propsFilePath, nil
     } else {


### PR DESCRIPTION
Also fix test framework to not generate an empty string WSK_CONFIG_FILE env value by default