### PR TITLE
Choose target invoker based on specific invoker load.

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -124,6 +124,7 @@ invoker:
   arguments: "{{ invoker_arguments | default('') }}"
   numcore: 2
   coreshare: 2
+  busyThreshold: "{{ invoker_busy_threshold | default(16) }}"
   serializeDockerOp: true
   serializeDockerPull: true
   useRunc: false

--- a/ansible/templates/whisk.properties.j2
+++ b/ansible/templates/whisk.properties.j2
@@ -107,4 +107,4 @@ apigw.auth.pwd={{apigw_auth_pwd}}
 apigw.host={{apigw_host}}
 apigw.host.v2={{apigw_host_v2}}
 
-loadbalancer.activationCountBeforeNextInvoker={{ loadbalancer_activation_count_before_next_invoker | default(10) }}
+loadbalancer.invokerBusyThreshold={{ invoker.busyThreshold }}

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -83,7 +83,7 @@ class WhiskConfig(
     val wskApiHost = this(WhiskConfig.wskApiProtocol) + "://" + this(WhiskConfig.wskApiHostname) + ":" + this(WhiskConfig.wskApiPort)
     val controllerHost = this(WhiskConfig.controllerHostName) + ":" + this(WhiskConfig.controllerHostPort)
     val controllerBlackboxFraction = this.getAsDouble(WhiskConfig.controllerBlackboxFraction, 0.10)
-    val loadbalancerActivationCountBeforeNextInvoker = this.getAsInt(WhiskConfig.loadbalancerActivationCountBeforeNextInvoker, 10)
+    val loadbalancerInvokerBusyThreshold = this.getAsInt(WhiskConfig.loadbalancerInvokerBusyThreshold, 16)
 
     val edgeHost = this(WhiskConfig.edgeHostName) + ":" + this(WhiskConfig.edgeHostApiPort)
     val kafkaHost = this(WhiskConfig.kafkaHostName) + ":" + this(WhiskConfig.kafkaHostPort)
@@ -251,7 +251,7 @@ object WhiskConfig {
     private val controllerHostPort = "controller.host.port"
     private val controllerBlackboxFraction = "controller.blackboxFraction"
 
-    val loadbalancerActivationCountBeforeNextInvoker = "loadbalancer.activationCountBeforeNextInvoker"
+    val loadbalancerInvokerBusyThreshold = "loadbalancer.invokerBusyThreshold"
 
     val kafkaHostName = "kafka.host"
     val loadbalancerHostName = "loadbalancer.host"

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/LoadBalancerServiceObjectTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/LoadBalancerServiceObjectTests.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.loadBalancer.test
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+import whisk.core.loadBalancer.LoadBalancerService
+
+/**
+ * Unit tests for the ContainerPool object.
+ *
+ * These tests test only the "static" methods "schedule" and "remove"
+ * of the ContainerPool object.
+ */
+@RunWith(classOf[JUnitRunner])
+class LoadBalancerServiceObjectTests extends FlatSpec with Matchers {
+    behavior of "memoize"
+
+    it should "not recompute a value which was already given" in {
+        var calls = 0
+        val add1: Int => Int = LoadBalancerService.memoize {
+            case second =>
+                calls += 1
+                1 + second
+        }
+
+        add1(1) shouldBe 2
+        calls shouldBe 1
+        add1(1) shouldBe 2
+        calls shouldBe 1
+        add1(2) shouldBe 3
+        calls shouldBe 2
+        add1(1) shouldBe 2
+        calls shouldBe 2
+    }
+
+    behavior of "pairwiseCoprimeNumbersUntil"
+
+    it should "return an empty set for malformed inputs" in {
+        LoadBalancerService.pairwiseCoprimeNumbersUntil(0) shouldBe Seq()
+        LoadBalancerService.pairwiseCoprimeNumbersUntil(-1) shouldBe Seq()
+    }
+
+    it should "return all coprime numbers until the number given" in {
+        LoadBalancerService.pairwiseCoprimeNumbersUntil(1) shouldBe Seq(1)
+        LoadBalancerService.pairwiseCoprimeNumbersUntil(2) shouldBe Seq(1)
+        LoadBalancerService.pairwiseCoprimeNumbersUntil(3) shouldBe Seq(1, 2)
+        LoadBalancerService.pairwiseCoprimeNumbersUntil(4) shouldBe Seq(1, 3)
+        LoadBalancerService.pairwiseCoprimeNumbersUntil(5) shouldBe Seq(1, 2, 3)
+        LoadBalancerService.pairwiseCoprimeNumbersUntil(9) shouldBe Seq(1, 2, 5, 7)
+        LoadBalancerService.pairwiseCoprimeNumbersUntil(10) shouldBe Seq(1, 3, 7)
+    }
+
+    behavior of "chooseInvoker"
+
+    def invokers(n: Int) = (0 until n).map(i => s"invoker$i")
+    def hashInto[A](list: Seq[A], hash: Int) = list(hash % list.size)
+
+    it should "return None on an empty invokers list" in {
+        LoadBalancerService.schedule(Seq(), Map(), 0, 1) shouldBe None
+    }
+
+    it should "schedule to the home invoker" in {
+        val invs = invokers(10)
+        val hash = 2
+
+        LoadBalancerService.schedule(invs, Map(), 1, hash) shouldBe Some(hashInto(invs, hash))
+    }
+
+    it should "jump to the next invoker determined by a hashed stepsize if the home invoker is overloaded" in {
+        val invokerCount = 10
+        val invs = invokers(invokerCount)
+        val hash = 2
+
+        val targetInvoker = hashInto(invs, hash)
+        val step = hashInto(LoadBalancerService.pairwiseCoprimeNumbersUntil(invokerCount), hash)
+
+        LoadBalancerService.schedule(invs, Map(targetInvoker -> 1), 1, hash) shouldBe Some(hashInto(invs, hash + step))
+    }
+
+    it should "wrap the search at the end of the invoker list" in {
+        val invokerCount = 3
+        val invs = invokers(invokerCount)
+        val hash = 1
+
+        val targetInvoker = hashInto(invs, hash) // will be invoker1
+        val step = hashInto(LoadBalancerService.pairwiseCoprimeNumbersUntil(invokerCount), hash) // will be 2
+        step shouldBe 2
+
+        // invoker1 is overloaded so it will step (2 steps) to the next one --> 1 2 0 --> invoker0 is next target
+        // invoker0 is overloaded so it will step to the next one --> 0 1 2 --> invoker2 is next target and underloaded
+        LoadBalancerService.schedule(
+            invs,
+            Map("invoker0" -> 1, "invoker1" -> 1),
+            1, hash) shouldBe Some(hashInto(invs, hash + step + step))
+    }
+
+    it should "choose the least loaded invoker if all invokers are overloaded to begin with" in {
+        val invokerCount = 3
+        val invs = invokers(invokerCount)
+        val hash = 1
+
+        LoadBalancerService.schedule(
+            invs,
+            Map("invoker0" -> 3, "invoker1" -> 3, "invoker2" -> 2),
+            1,
+            hash) shouldBe Some("invoker2")
+    }
+}


### PR DESCRIPTION
Currently, the loadbalancer advances from one Invoker to another after a fixed amount of invocations, which isn't aware of any load in the system causing suboptimal behavior.

This only advances away from the home invoker of an action (determined by hash) if that home invoker is "heavily" loaded. We advance further if the next chosen invoker is busy and so forth. If we arrive at the home invoker again, the system is completely loaded and we force schedule to the home invoker. Step sizes are determined by prime numbers and also chosen by hashing to prevent chasing behavior.