### PR TITLE
Add Test to Ensure Preservation of Annotations for Action Web Flag

### DIFF
--- a/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -634,11 +634,12 @@ class WskBasicUsageTests
         (wp, assetHelper) =>
             val name = "webaction"
             val file = Some(TestUtils.getTestActionFilename("echo.js"))
-            val annots = Map("someKey" -> JsString("someValue"))
+            val key = "someKey"
+            val value = JsString("someValue")
+            val annots = Map(key -> value)
 
             assetHelper.withCleaner(wsk.action, name) {
                 (action, _) => action.create(name, file, annotations = annots)
-
             }
 
             wsk.action.create(name, file, web = Some("true"), update = true)
@@ -656,8 +657,8 @@ class WskBasicUsageTests
                     "key" -> JsString("final"),
                     "value" -> JsBoolean(true)),
                 JsObject(
-                    "key" -> JsString("someKey"),
-                    "value" -> JsString("someValue")),
+                    "key" -> JsString(key),
+                    "value" -> value),
                 JsObject(
                     "key" -> JsString("exec"),
                     "value" -> JsString("nodejs:6")))


### PR DESCRIPTION
Using the --web flag during an action update call does not preserve the action annotations.