### PR TITLE
set kafka retention

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -117,6 +117,19 @@ kafka:
   port: 9092
   ras:
     port: 9093
+  topics:
+    completed:
+      segmentBytes: 536870912
+      retentionBytes: "{{ kafka_topics_completed_retentionBytes | default(1073741824) }}"
+      retentionMS: 3600000
+    health:
+      segmentBytes: 536870912
+      retentionBytes: "{{ kafka_topics_health_retentionBytes | default(1073741824) }}"
+      retentionMS: 3600000
+    invoker:
+      segmentBytes: 536870912
+      retentionBytes: "{{ kafka_topics_invoker_retentionBytes | default(1073741824) }}"
+      retentionMS: 172800000
 
 zookeeper:
   version: 3.4

--- a/ansible/roles/kafka/tasks/deploy.yml
+++ b/ansible/roles/kafka/tasks/deploy.yml
@@ -48,23 +48,22 @@
   delay: 5
 
 - name: create the health topic
-  shell: "docker exec kafka bash -c 'unset JMX_PORT; kafka-topics.sh --create --topic {{ item }} --replication-factor 1 --partitions 1 --zookeeper {{ inventory_hostname }}:{{ zookeeper.port }}'"
-  with_items:
-    - health
+  shell: "docker exec kafka bash -c 'unset JMX_PORT; kafka-topics.sh --create --topic health --replication-factor 1 --partitions 1 --zookeeper {{ inventory_hostname }}:{{ zookeeper.port }} --config retention.bytes={{ kafka.topics.health.retentionBytes }} --config retention.ms={{ kafka.topics.health.retentionMS }} --config segment.bytes={{ kafka.topics.health.segmentBytes }}'"
   register: command_result
   failed_when: "not ('Created topic' in command_result.stdout or 'already exists' in command_result.stdout)"
   changed_when: "'Created topic' in command_result.stdout"
 
 - name: create the active-ack topics
-  shell: "docker exec kafka bash -c 'unset JMX_PORT; kafka-topics.sh --create --topic health{{ item.0 }} --replication-factor 1 --partitions 1 --zookeeper {{ inventory_hostname }}:{{ zookeeper.port }}'"
+  shell: "docker exec kafka bash -c 'unset JMX_PORT; kafka-topics.sh --create --topic completed{{ item.0 }} --replication-factor 1 --partitions 1 --zookeeper {{ inventory_hostname }}:{{ zookeeper.port }} --config retention.bytes={{ kafka.topics.completed.retentionBytes }} --config retention.ms={{ kafka.topics.completed.retentionMS }} --config segment.bytes={{ kafka.topics.completed.segmentBytes }}'"
   with_indexed_items: "{{ groups['controllers'] }}"
   register: command_result
   failed_when: "not ('Created topic' in command_result.stdout or 'already exists' in command_result.stdout)"
   changed_when: "'Created topic' in command_result.stdout"
 
 - name: create the invoker topics
-  shell: "docker exec kafka bash -c 'unset JMX_PORT; kafka-topics.sh --create --topic invoker{{ item.0 }} --replication-factor 1 --partitions 1 --zookeeper {{ inventory_hostname }}:{{ zookeeper.port }}'"
+  shell: "docker exec kafka bash -c 'unset JMX_PORT; kafka-topics.sh --create --topic invoker{{ item.0 }} --replication-factor 1 --partitions 1 --zookeeper {{ inventory_hostname }}:{{ zookeeper.port }} --config retention.bytes={{ kafka.topics.invoker.retentionBytes }} --config retention.ms={{ kafka.topics.invoker.retentionMS }} --config segment.bytes={{ kafka.topics.invoker.segmentBytes }}'"
   with_indexed_items: "{{ groups['invokers'] }}"
   register: command_result
   failed_when: "not ('Created topic' in command_result.stdout or 'already exists' in command_result.stdout)"
   changed_when: "'Created topic' in command_result.stdout"
+


### PR DESCRIPTION
make kafka retention attributes configurable.

For each topic the following of the above attributes can be set/changed :

**retention.bytes**	( controls the maximum size a log can grow to before we will discard old log segments to free up space )
**retention.ms**	( controls the maximum time we will retain a log before we will discard old log segments to free up space )
**segment.bytes**	( controls the segment file size for the log. Retention and cleaning is always done a file at a time )

@jeremiaswerner
For our topics (completed, health, invoker) the values (defined for each environment) are:

kafka_topic_completed_logRetentionBytes: 1073741824
kafka_topic_completed_logRetentionMS: 3600000
kafka_topic_completed_logSegmentBytes: 536870912
kafka_topic_health_logRetentionBytes: 1073741824
kafka_topic_health_logRetentionMS: 3600000
kafka_topic_health_logSegmentBytes: 536870912
kafka_topic_invoker_logRetentionBytes: 1073741824
kafka_topic_invoker_logRetentionMS: 172800000
kafka_topic_invoker_logSegmentBytes: 536870912

 