### PR TITLE
Update Swift 3 Package Dependencies to recent versions.

### DIFF
--- a/core/swift3Action/spm-build/Package.swift
+++ b/core/swift3Action/spm-build/Package.swift
@@ -19,8 +19,8 @@ import PackageDescription
 let package = Package(
     name: "Action",
         dependencies: [
-    .Package(url: "https://github.com/IBM-Swift/Kitura-net.git", "1.0.1"),
-            .Package(url: "https://github.com/IBM-Swift/SwiftyJSON.git", "14.2.0"),
-            .Package(url: "https://github.com/IBM-Swift/swift-watson-sdk.git", "0.4.1")
+            .Package(url: "https://github.com/IBM-Swift/Kitura-net.git", "1.7.7"),
+            .Package(url: "https://github.com/IBM-Swift/SwiftyJSON.git", "15.0.1"),
+            .Package(url: "https://github.com/watson-developer-cloud/swift-sdk.git", "0.16.0")
         ]
 )


### PR DESCRIPTION
Swift action container contains a dependencies file that hasn't been updated since September 2016. 
The package versions are well behind the current releases. 

I have moved both the JSON and Kitura libraries to recent versions.

The Watson package currently used is deprecated. There is a new official package from the Watson team which a huge improvement in supported features. I've changed the dependency over to this new repo. 