### PR TITLE
Send active ack on failed activations

### DIFF
--- a/common/scala/src/main/scala/whisk/common/Scheduler.scala
+++ b/common/scala/src/main/scala/whisk/common/Scheduler.scala
@@ -25,6 +25,7 @@ import scala.util.Try
 
 import akka.actor.Actor
 import akka.actor.ActorSystem
+import akka.actor.Cancellable
 import akka.actor.Props
 
 /**
@@ -32,7 +33,8 @@ import akka.actor.Props
  * even for asynchronous tasks.
  */
 object Scheduler {
-    private case object Work
+    case object WorkOnceNow
+    private case object ScheduledWork
 
     /**
      * Sets up an Actor to send itself a message to mimic schedulers behavior in a more controllable way.
@@ -41,24 +43,40 @@ object Scheduler {
      * @param alwaysWait always wait for the given amount of time or calculate elapsed time to wait
      * @param closure the closure to be executed
      */
-    private class Worker(interval: FiniteDuration, alwaysWait: Boolean, closure: () => Future[Any])(implicit logging: Logging) extends Actor {
+    private class Worker(
+        initialDelay: FiniteDuration,
+        interval: FiniteDuration,
+        alwaysWait: Boolean,
+        name: String,
+        closure: () => Future[Any])(
+            implicit logging: Logging,
+            transid: TransactionId) extends Actor {
         implicit val ec = context.dispatcher
 
-        override def preStart() = {
-            self ! Work
+        var lastSchedule: Option[Cancellable] = {
+            Some(context.system.scheduler.scheduleOnce(initialDelay, self, ScheduledWork))
+        }
+
+        override def postStop() = {
+            logging.info(this, s"$name shutdown")
+            lastSchedule.foreach(_.cancel())
         }
 
         def receive = {
-            case Work =>
+            case WorkOnceNow => Try(closure())
+
+            case ScheduledWork =>
                 val deadline = interval.fromNow
                 Try(closure()) match {
                     case Success(result) =>
                         result onComplete { _ =>
                             val timeToWait = if (alwaysWait) interval else deadline.timeLeft.max(Duration.Zero)
                             // context might be null here if a PoisonPill is sent while doing computations
-                            Option(context) foreach { _.system.scheduler.scheduleOnce(timeToWait, self, Work) }
+                            lastSchedule = Option(context).map(_.system.scheduler.scheduleOnce(timeToWait, self, ScheduledWork))
                         }
-                    case Failure(e) => logging.error(this, s"next iteration could not be scheduled because of ${e.getMessage}. Scheduler is halted")
+
+                    case Failure(e) =>
+                        logging.error(name, s"halted because ${e.getMessage}")
                 }
         }
     }
@@ -70,11 +88,19 @@ object Scheduler {
      * is immediately fired.
      *
      * @param interval the time to wait at most between two runs of the closure
+     * @param initialDelay optionally delay the first scheduled iteration by given duration
      * @param f the function to run
      */
-    def scheduleWaitAtMost(interval: FiniteDuration)(f: () => Future[Any])(implicit system: ActorSystem, logging: Logging) = {
+    def scheduleWaitAtMost(
+        interval: FiniteDuration,
+        initialDelay: FiniteDuration = Duration.Zero,
+        name: String = "Scheduler")(
+            f: () => Future[Any])(
+                implicit system: ActorSystem,
+                logging: Logging,
+                transid: TransactionId = TransactionId.unknown) = {
         require(interval > Duration.Zero)
-        system.actorOf(Props(new Worker(interval, false, f)))
+        system.actorOf(Props(new Worker(initialDelay, interval, false, name, f)))
     }
 
     /**
@@ -83,10 +109,18 @@ object Scheduler {
      * given interval.
      *
      * @param interval the time to wait between two runs of the closure
+     * @param initialDelay optionally delay the first scheduled iteration by given duration
      * @param f the function to run
      */
-    def scheduleWaitAtLeast(interval: FiniteDuration)(f: () => Future[Any])(implicit system: ActorSystem, logging: Logging) = {
+    def scheduleWaitAtLeast(
+        interval: FiniteDuration,
+        initialDelay: FiniteDuration = Duration.Zero,
+        name: String = "Scheduler")(
+            f: () => Future[Any])(
+                implicit system: ActorSystem,
+                logging: Logging,
+                transid: TransactionId = TransactionId.unknown) = {
         require(interval > Duration.Zero)
-        system.actorOf(Props(new Worker(interval, true, f)))
+        system.actorOf(Props(new Worker(initialDelay, interval, true, name, f)))
     }
 }

--- a/common/scala/src/main/scala/whisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/whisk/core/connector/Message.scala
@@ -96,12 +96,7 @@ case class CompletionMessage(
     extends Message {
 
     override def serialize: String = {
-        val fmt = CompletionMessage.Serdes(transid,
-            response.fold(l => Some(l), r => None),
-            response.fold(l => None, r => Some(r)),
-            invoker)
-
-        CompletionMessage.serdes.write(fmt).compactPrint
+        CompletionMessage.serdes.write(this).compactPrint
     }
 
     override def toString = {
@@ -110,19 +105,8 @@ case class CompletionMessage(
 }
 
 object CompletionMessage extends DefaultJsonProtocol {
-    def parse(msg: String): Try[CompletionMessage] = Try {
-        val fmt = serdes.read(msg.parseJson)
-        val response = fmt.response.toRight(left = fmt.activationId.get)
-        CompletionMessage(fmt.transid, response, fmt.invoker)
-    }
-
-    private case class Serdes(
-        transid: TransactionId,
-        activationId: Option[ActivationId],
-        response: Option[WhiskActivation],
-        invoker: String)
-
-    private val serdes = jsonFormat4(Serdes.apply)
+    def parse(msg: String): Try[CompletionMessage] = Try(serdes.read(msg.parseJson))
+    private val serdes = jsonFormat3(CompletionMessage.apply)
 }
 
 case class PingMessage(name: String) extends Message {

--- a/common/scala/src/main/scala/whisk/core/entity/InstanceId.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/InstanceId.scala
@@ -1,11 +1,12 @@
 /*
- * Copyright 2015-2016 IBM Corporation
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/scala/src/main/scala/whisk/utils/ExecutionContextFactory.scala
+++ b/common/scala/src/main/scala/whisk/utils/ExecutionContextFactory.scala
@@ -50,18 +50,10 @@ object ExecutionContextFactory {
             implicit val ec = system.dispatcher
             firstCompletedOf(Seq(f, expire(timeout, system.scheduler)(Future.failed(msg))))
         }
-    }
 
-    /**
-     * Extends a promise with an scheduled call back. The call back may be used to complete the promise. The result of the
-     * call back is not interesting to this method.
-     * The idiom to use is: promise after(duration, promise.tryFailure(TimeoutException)`.
-     */
-    implicit class PromiseExtensions[T](p: Promise[T]) {
-        def after(timeout: FiniteDuration, next: => Unit)(implicit system: ActorSystem): Promise[T] = {
+        def withAlternativeAfterTimeout(timeout: FiniteDuration, alt: => Future[T])(implicit system: ActorSystem): Future[T] = {
             implicit val ec = system.dispatcher
-            expire(timeout, system.scheduler)(Future { next })
-            p
+            firstCompletedOf(Seq(f, expire(timeout, system.scheduler)(alt)))
         }
     }
 

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PostActionActivation.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PostActionActivation.scala
@@ -18,14 +18,12 @@
 package whisk.core.controller.actions
 
 import scala.concurrent.Future
-import scala.concurrent.TimeoutException
 import scala.concurrent.duration.FiniteDuration
 
 import spray.http.StatusCodes.BadRequest
 import spray.json._
 import whisk.common.TransactionId
 import whisk.core.controller.RejectRequest
-import whisk.core.controller.WhiskActionsApi._
 import whisk.core.controller.WhiskServices
 import whisk.core.entity._
 import whisk.http.Messages
@@ -40,25 +38,25 @@ protected[core] trait PostActionActivation extends PrimitiveActions with Sequenc
      * @param user the user posting the activation
      * @param action the action to activate (parameters for packaged actions must already be merged)
      * @param payload the parameters to pass to the action
-     * @param blocking iff true, wait for the activation result
-     * @param waitOverride iff blocking, wait up up to the action limit or a given max duration
-     * @return a future that resolves with the (activation id, and some whisk activation if a blocking invoke)
+     * @param waitForResponse if not empty, wait up to specified duration for a response (this is used for blocking activations)
+     * @return a future that resolves with Left(activation id) when the request is queued, or Right(activation) for a blocking request
+     *         which completes in time iff waiting for an response
      */
-    protected[controller] def invokeAction(user: Identity, action: WhiskAction, payload: Option[JsObject], blocking: Boolean, waitOverride: Option[FiniteDuration] = None)(
-        implicit transid: TransactionId): Future[(ActivationId, Option[WhiskActivation])] = {
+    protected[controller] def invokeAction(
+        user: Identity,
+        action: WhiskAction,
+        payload: Option[JsObject],
+        waitForResponse: Option[FiniteDuration],
+        cause: Option[ActivationId])(
+            implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
         action.exec match {
             // this is a topmost sequence
             case SequenceExec(components) =>
-                val futureSeqTuple = invokeSequence(user, action, payload, blocking, topmost = true, components, cause = None, 0)
-                futureSeqTuple map { case (activationId, wskActivation, _) => (activationId, wskActivation) }
+                invokeSequence(user, action, components, payload, waitForResponse, cause, topmost = true, 0).map(r => r._1)
             case supportedExec if !supportedExec.deprecated =>
-                val duration = action.limits.timeout.duration + blockingInvokeGrace
-                val timeout = waitOverride.getOrElse(duration)
-                invokeSingleAction(user, action, payload, timeout, blocking)
+                invokeSingleAction(user, action, payload, waitForResponse, cause)
             case deprecatedExec =>
                 Future.failed(RejectRequest(BadRequest, Messages.runtimeDeprecated(deprecatedExec)))
         }
     }
 }
-
-protected[controller] case class BlockingInvokeTimeout(activationId: ActivationId) extends TimeoutException

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
@@ -20,21 +20,28 @@ package whisk.core.controller.actions
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.Promise
-import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
+import scala.util.Failure
 
+import akka.actor.Actor
 import akka.actor.ActorSystem
+import akka.actor.Props
+
 import spray.json._
+
 import whisk.common.Logging
 import whisk.common.LoggingMarkers
+import whisk.common.Scheduler
 import whisk.common.TransactionId
 import whisk.core.connector.ActivationMessage
-import whisk.core.controller.WhiskActionsApi
 import whisk.core.controller.WhiskServices
 import whisk.core.database.NoDocumentException
 import whisk.core.entity._
 import whisk.core.entity.types.ActivationStore
 import whisk.core.entity.types.EntityStore
+import whisk.utils.ExecutionContextFactory.FutureExtensions
+import scala.collection.mutable.Buffer
+import akka.actor.Cancellable
 
 protected[actions] trait PrimitiveActions {
     /** The core collections require backend services to be injected in this trait. */
@@ -60,15 +67,11 @@ protected[actions] trait PrimitiveActions {
     /** Database service to get activations. */
     protected val activationStore: ActivationStore
 
-    /** Max duration for active ack. */
-    protected val activeAckTimeout = WhiskActionsApi.maxWaitForBlockingActivation
-
     /**
-     * Gets document from datastore to confirm a valid action activation then posts request to loadbalancer.
-     * If the loadbalancer accepts the requests with an activation id, then wait for the result of the activation
-     * if this is a blocking invoke, else return the activation id.
+     * Posts request to the loadbalancer. If the loadbalancer accepts the requests with an activation id,
+     * then wait for the result of the activation if necessary.
      *
-     * NOTE: This is a point-in-time type of statement:
+     * NOTE:
      * For activations of actions, cause is populated only for actions that were invoked as a result of a sequence activation.
      * For actions that are enclosed in a sequence and are activated as a result of the sequence activation, the cause
      * contains the activation id of the immediately enclosing sequence.
@@ -77,23 +80,25 @@ protected[actions] trait PrimitiveActions {
      * cause for c is the activation id of x
      * cause for s is not defined
      *
-     * @param subject the subject invoking the action
-     * @param docid the action document id
+     * @param user the identity invoking the action
+     * @param action the action to invoke
      * @param payload the dynamic arguments for the activation
-     * @param timeout the timeout used for polling for result if the invoke is blocking
-     * @param blocking true iff this is a blocking invoke
+     * @param waitForResponse if not empty, wait upto specified duration for a response (this is used for blocking activations)
      * @param cause the activation id that is responsible for this invoke/activation
      * @param transid a transaction id for logging
-     * @return a promise that completes with (ActivationId, Some(WhiskActivation)) if blocking else (ActivationId, None)
+     * @return a promise that completes with one of the following successful cases:
+     *            Right(WhiskActivation) if waiting for a response and response is ready within allowed duration,
+     *            Left(ActivationId) if not waiting for a response, or allowed duration has elapsed without a result ready
+     *         or these custom failures:
+     *            RequestEntityTooLarge if the message is too large to to post to the message bus
      */
     protected[actions] def invokeSingleAction(
         user: Identity,
         action: WhiskAction,
         payload: Option[JsObject],
-        timeout: FiniteDuration,
-        blocking: Boolean,
-        cause: Option[ActivationId] = None)(
-            implicit transid: TransactionId): Future[(ActivationId, Option[WhiskActivation])] = {
+        waitForResponse: Option[FiniteDuration],
+        cause: Option[ActivationId])(
+            implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
         require(action.exec.kind != Exec.SEQUENCE, "this method requires a primitive action")
 
         // merge package parameters with action (action parameters supersede), then merge in payload
@@ -109,95 +114,137 @@ protected[actions] trait PrimitiveActions {
             args,
             cause = cause)
 
-        val startActivation = transid.started(this, if (blocking) LoggingMarkers.CONTROLLER_ACTIVATION_BLOCKING else LoggingMarkers.CONTROLLER_ACTIVATION)
-        val startLoadbalancer = transid.started(this, LoggingMarkers.CONTROLLER_LOADBALANCER, s"[POST] action activation id: ${message.activationId}")
-        val postedFuture = loadBalancer.publish(action, message, activeAckTimeout)
-        postedFuture flatMap { activationResponse =>
+        val startActivation = transid.started(this, waitForResponse.map(_ => LoggingMarkers.CONTROLLER_ACTIVATION_BLOCKING).getOrElse(LoggingMarkers.CONTROLLER_ACTIVATION))
+        val startLoadbalancer = transid.started(this, LoggingMarkers.CONTROLLER_LOADBALANCER, s"action activation id: ${message.activationId}")
+        val postedFuture = loadBalancer.publish(action, message)
+
+        postedFuture.flatMap { activeAckResponse =>
+            // successfully posted activation request to the message bus
             transid.finished(this, startLoadbalancer)
-            if (blocking) {
-                waitForActivationResponse(user, message.activationId, timeout, activationResponse) map {
-                    whiskActivation => (whiskActivation.activationId, Some(whiskActivation))
-                } andThen {
-                    case _ => transid.finished(this, startActivation)
-                }
-            } else {
+
+            // is caller waiting for the result of the activation?
+            waitForResponse.map { timeout =>
+                // yes, then wait for the activation response from the message bus
+                // (known as the active response or active ack)
+                waitForActivationResponse(user, message.activationId, timeout, activeAckResponse)
+                    .andThen { case _ => transid.finished(this, startActivation) }
+            }.getOrElse {
+                // no, return the activation id
                 transid.finished(this, startActivation)
-                Future.successful { (message.activationId, None) }
+                Future.successful(Left(message.activationId))
             }
         }
     }
 
     /**
-     * This is a fast path used for blocking calls in which we do not need the full WhiskActivation record from the DB.
-     * Polls for the activation response from an underlying data structure populated from Kafka active acknowledgements.
-     * If this mechanism fails to produce an answer quickly, the future will switch to polling the database for the response
-     * record.
+     * Waits for a response from the message bus (e.g., Kafka) containing the result of the activation. This is the fast path
+     * used for blocking calls where only the result of the activation is needed. This path is called active acknowledgement
+     * or active ack.
+     *
+     * While waiting for the active ack, periodically poll the datastore in case there is a failure in the fast path delivery
+     * which could happen if the connection from an invoker to the message bus is disrupted, or if the publishing of the response
+     * fails because the message is too large.
      */
-    private def waitForActivationResponse(user: Identity, activationId: ActivationId, totalWaitTime: FiniteDuration, activationResponse: Future[WhiskActivation])(implicit transid: TransactionId) = {
-        // this is the promise which active ack or db polling will try to complete in one of four ways:
-        // 1. active ack response
+    private def waitForActivationResponse(
+        user: Identity,
+        activationId: ActivationId,
+        totalWaitTime: FiniteDuration,
+        activeAckResponse: Future[Either[ActivationId, WhiskActivation]])(
+            implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
+        // this is the promise which active ack or db polling will try to complete via:
+        // 1. active ack response, or
         // 2. failing active ack (due to active ack timeout), fall over to db polling
         // 3. timeout on db polling => converts activation to non-blocking (returns activation id only)
-        // 4. internal error
-        val promise = Promise[WhiskActivation]
-        val docid = DocId(WhiskEntity.qualifiedName(user.namespace.toPath, activationId))
+        // 4. internal error message
+        val promise = Promise[Either[ActivationId, WhiskActivation]] // this is strictly completed by the finishing actor
+        val finisher = actorSystem.actorOf(Props(new ActivationFinisher(user, activationId, promise)))
 
-        logging.info(this, s"[POST] action activation will block on result up to $totalWaitTime")
+        logging.info(this, s"action activation will block for result upto $totalWaitTime")
 
-        // the active ack will timeout after specified duration, causing the db polling to kick in
-        activationResponse map {
-            activation => promise.trySuccess(activation)
-        } onFailure {
-            case t: TimeoutException =>
-                logging.info(this, s"[POST] switching to poll db, active ack expired")
-                pollDbForResult(docid, activationId, promise)
-            case t: Throwable =>
-                logging.info(this, s"[POST] switching to poll db, active ack exception: ${t.getMessage}")
-                pollDbForResult(docid, activationId, promise)
+        activeAckResponse map {
+            case result @ Right(_) =>
+                // activation complete, result is available
+                finisher ! Finish(result)
+
+            case _ =>
+                // active ack received but it does not carry the response,
+                // no result available except by polling the db
+                logging.warn(this, "pre-emptively polling db because active ack is missing result")
+                finisher ! Scheduler.WorkOnceNow
         }
 
-        // install a timeout handler; this is the handler for "the action took longer than its Limit"
-        // note the use of WeakReferences; this is to avoid the handler's closure holding on to the
-        // WhiskActivation, which in turn holds on to the full JsObject of the response
-        val promiseRef = new java.lang.ref.WeakReference(promise)
-        actorSystem.scheduler.scheduleOnce(totalWaitTime) {
-            val p = promiseRef.get
-            if (p != null) {
-                p.tryFailure(new BlockingInvokeTimeout(activationId))
+        // return the promise which is either fulfilled by active ack, polling from the database,
+        // or the timeout alternative when the allowed duration expires (i.e., the action took
+        // longer than the permitted, per totalWaitTime).
+        promise.future.withAlternativeAfterTimeout(totalWaitTime, {
+            Future.successful(Left(activationId)).andThen {
+                // result no longer interesting; terminate the finisher/shut down db polling if necessary
+                case _ => actorSystem.stop(finisher)
             }
-        }
-
-        // return the future. note that pollDbForResult's isCompleted check will protect against unnecessary db activity
-        // that may overlap with a totalWaitTime timeout (because the promise will have already by tryFailure'd)
-        promise.future
+        })
     }
 
-    /**
-     * Polls for activation record. It is assumed that an activation record is created atomically and never updated.
-     * Fetch the activation record by its id. If it exists, complete the promise. Otherwise recursively poll until
-     * either there is an error in the get, or the promise has completed because it timed out. The promise MUST
-     * complete in the caller to terminate the polling.
-     */
-    private def pollDbForResult(
-        docid: DocId,
+    /** Periodically polls the db to cover missing active acks. */
+    val datastorePollPeriodForActivation = 15.seconds
+    val datastorePreemptivePolling = Seq(1.second, 3.seconds, 5.seconds, 7.seconds)
+
+    protected case class Finish(activation: Right[ActivationId, WhiskActivation])
+
+    protected class ActivationFinisher(
+        user: Identity,
         activationId: ActivationId,
-        promise: Promise[WhiskActivation])(
-            implicit transid: TransactionId): Unit = {
-        // check if promise already completed due to timeout expiration (abort polling if so)
-        if (!promise.isCompleted) {
-            WhiskActivation.get(activationStore, docid) map {
-                activation => promise.trySuccess(activation.withoutLogs) // Logs always not provided on blocking call
-            } onFailure {
-                case e: NoDocumentException =>
-                    Thread.sleep(500)
-                    logging.debug(this, s"[POST] action activation not yet timed out, will poll for result")
-                    pollDbForResult(docid, activationId, promise)
-                case t: Throwable =>
-                    logging.error(this, s"[POST] action activation failed while waiting on result: ${t.getMessage}")
-                    promise.tryFailure(t)
-            }
-        } else {
-            logging.info(this, s"[POST] action activation timed out, terminated polling for result")
+        promise: Promise[Either[ActivationId, WhiskActivation]])(
+            implicit transid: TransactionId) extends Actor {
+
+        // when the future completes, self-destruct
+        promise.future.andThen { case _ => shutdown() }
+
+        val docid = DocId(WhiskEntity.qualifiedName(user.namespace.toPath, activationId))
+        val preemptiveMsgs: Buffer[Cancellable] = Buffer.empty
+
+        val poller = {
+            Scheduler.scheduleWaitAtMost(
+                datastorePollPeriodForActivation,
+                initialDelay = datastorePollPeriodForActivation,
+                name = "dbpoll")(() => {
+                    if (!promise.isCompleted) {
+                        WhiskActivation.get(activationStore, docid) map {
+                            // complete the future, which in turn will poison pill this scheduler
+                            activation =>
+                                promise.trySuccess(Right(activation.withoutLogs)) // Logs always not provided on blocking call
+                        } andThen {
+                            case Failure(e: NoDocumentException) => // do nothing, scheduler will reschedule another poll
+                            case Failure(t: Throwable) => // something went wrong, abort
+                                logging.error(this, s"failed while waiting on result: ${t.getMessage}")
+                                promise.tryFailure(t) // complete the future, which in turn will poison pill this scheduler
+                        }
+                    } else Future.successful({}) // the scheduler will be halted because the promise is now resolved
+                })
+        }
+
+        def receive = {
+            case Finish(activation) =>
+                promise.trySuccess(activation)
+
+            case msg @ Scheduler.WorkOnceNow =>
+                // try up to three times when pre-emptying the schedule
+                datastorePreemptivePolling.foreach {
+                    s => preemptiveMsgs += context.system.scheduler.scheduleOnce(s, poller, msg)
+                }
+
+            case msg =>
+                poller ! msg
+        }
+
+        def shutdown(): Unit = {
+            context.stop(poller)
+            context.stop(self)
+        }
+
+        override def postStop() = {
+            logging.info(this, "finisher shutdown")
+            preemptiveMsgs.foreach(_.cancel())
+            context.stop(poller)
         }
     }
 }

--- a/tests/src/test/scala/whisk/core/connector/tests/CompletionMessageTests.scala
+++ b/tests/src/test/scala/whisk/core/connector/tests/CompletionMessageTests.scala
@@ -60,7 +60,7 @@ class CompletionMessageTests extends FlatSpec with Matchers {
         val m = CompletionMessage(TransactionId.testing, Left(ActivationId()), "xyz")
         m.serialize shouldBe JsObject(
             "transid" -> m.transid.toJson,
-            "activationId" -> m.response.left.get.toJson,
+            "response" -> m.response.left.get.toJson,
             "invoker" -> m.invoker.toJson).compactPrint
     }
 

--- a/tests/src/test/scala/whisk/core/connector/tests/CompletionMessageTests.scala
+++ b/tests/src/test/scala/whisk/core/connector/tests/CompletionMessageTests.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.connector.tests
+
+import java.time.Instant
+
+import scala.util.Success
+import scala.concurrent.duration.DurationInt
+
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+import org.scalatest.junit.JUnitRunner
+
+import spray.json.DefaultJsonProtocol.StringJsonFormat
+import spray.json._
+import whisk.common.TransactionId
+import whisk.core.connector.CompletionMessage
+import whisk.core.entity._
+import whisk.core.entity.size.SizeInt
+
+/**
+ * Unit tests for the CompletionMessage object.
+ */
+@RunWith(classOf[JUnitRunner])
+class CompletionMessageTests extends FlatSpec with Matchers {
+
+    behavior of "completion message"
+
+    val activation = WhiskActivation(
+        namespace = EntityPath("ns"),
+        name = EntityName("a"),
+        Subject(),
+        activationId = ActivationId(),
+        start = Instant.now(),
+        end = Instant.now(),
+        response = ActivationResponse.success(Some(JsObject("res" -> JsNumber(1)))),
+        annotations = Parameters("limits", ActionLimits(
+            TimeLimit(1.second),
+            MemoryLimit(128.MB),
+            LogLimit(1.MB)).toJson),
+        duration = Some(123))
+
+    it should "serialize a left completion message" in {
+        val m = CompletionMessage(TransactionId.testing, Left(ActivationId()), "xyz")
+        m.serialize shouldBe JsObject(
+            "transid" -> m.transid.toJson,
+            "activationId" -> m.response.left.get.toJson,
+            "invoker" -> m.invoker.toJson).compactPrint
+    }
+
+    it should "serialize a right completion message" in {
+        val m = CompletionMessage(TransactionId.testing, Right(activation), "xyz")
+        m.serialize shouldBe JsObject(
+            "transid" -> m.transid.toJson,
+            "response" -> m.response.right.get.toJson,
+            "invoker" -> m.invoker.toJson).compactPrint
+    }
+
+    it should "deserialize a left completion message" in {
+        val m = CompletionMessage(TransactionId.testing, Left(ActivationId()), "xyz")
+        CompletionMessage.parse(m.serialize) shouldBe Success(m)
+    }
+
+    it should "deserialize a right completion message" in {
+        val m = CompletionMessage(TransactionId.testing, Right(activation), "xyz")
+        CompletionMessage.parse(m.serialize) shouldBe Success(m)
+    }
+}

--- a/tests/src/test/scala/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ControllerTestCommon.scala
@@ -201,7 +201,7 @@ class DegenerateLoadBalancerService(config: WhiskConfig)(implicit ec: ExecutionC
 
     override def getActiveUserActivationCounts: Map[String, Int] = Map()
 
-    override def publish(action: WhiskAction, msg: ActivationMessage, timeout: FiniteDuration)(implicit transid: TransactionId): Future[Future[WhiskActivation]] =
+    override def publish(action: WhiskAction, msg: ActivationMessage)(implicit transid: TransactionId): Future[Future[Either[ActivationId, WhiskActivation]]] =
         Future.successful {
             whiskActivationStub map {
                 case (timeout, activation) => Future {
@@ -210,7 +210,7 @@ class DegenerateLoadBalancerService(config: WhiskConfig)(implicit ec: ExecutionC
                         Thread.sleep(timeout.toMillis)
                         println(".... done waiting")
                     }
-                    activation
+                    Right(activation)
                 }
             } getOrElse Future.failed(new IllegalArgumentException("Unit test does not need fast path"))
         }

--- a/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
@@ -260,8 +260,13 @@ trait WebActionsApiTests extends ControllerTestCommon with BeforeAndAfterEach wi
         }
     }
 
-    override protected[controller] def invokeAction(user: Identity, action: WhiskAction, payload: Option[JsObject], blocking: Boolean, waitOverride: Option[FiniteDuration] = None)(
-        implicit transid: TransactionId): Future[(ActivationId, Option[WhiskActivation])] = {
+    override protected[controller] def invokeAction(
+        user: Identity,
+        action: WhiskAction,
+        payload: Option[JsObject],
+        waitForResponse: Option[FiniteDuration],
+        cause: Option[ActivationId])(
+            implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
         invocationCount = invocationCount + 1
 
         if (failActivation == 0) {
@@ -304,9 +309,9 @@ trait WebActionsApiTests extends ControllerTestCommon with BeforeAndAfterEach wi
             }
             action.parameters.get("z") shouldBe defaultActionParameters.get("z")
 
-            Future.successful(activation.activationId, Some(activation))
+            Future.successful(Right(activation))
         } else if (failActivation == 1) {
-            Future.successful(ActivationId(), None)
+            Future.successful(Left(ActivationId()))
         } else {
             Future.failed(new IllegalStateException("bad activation"))
         }

--- a/tests/src/test/scala/whisk/core/limits/ActionLimitsTests.scala
+++ b/tests/src/test/scala/whisk/core/limits/ActionLimitsTests.scala
@@ -120,27 +120,39 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers {
             }
     }
 
-    it should "succeed but truncate result, if result exceeds its limit" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "TestActionCausingExcessiveResult"
-            assetHelper.withCleaner(wsk.action, name) {
-                val actionName = TestUtils.getTestActionFilename("sizedResult.js")
-                (action, _) => action.create(name, Some(actionName))
-            }
-
-            val allowedSize = ActivationEntityLimit.MAX_ACTIVATION_ENTITY_LIMIT.toBytes
-            val run = wsk.action.invoke(name, Map("size" -> (allowedSize + 1).toJson, "char" -> "a".toJson))
-            withActivation(wsk.activation, run) { activation =>
-                val response = activation.response
-                response.success shouldBe false
-                response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ContainerError)
-                val msg = response.result.get.fields(ActivationResponse.ERROR_FIELD).convertTo[String]
-                val expected = Messages.truncatedResponse((allowedSize + 10).B, allowedSize.B)
-                withClue(s"is: ${msg.take(expected.length)}\nexpected: $expected") {
-                    msg.startsWith(expected) shouldBe true
+    Seq(true, false).foreach { blocking =>
+        it should s"succeed but truncate result, if result exceeds its limit (blocking: $blocking)" in withAssetCleaner(wskprops) {
+            (wp, assetHelper) =>
+                val name = "TestActionCausingExcessiveResult"
+                assetHelper.withCleaner(wsk.action, name) {
+                    val actionName = TestUtils.getTestActionFilename("sizedResult.js")
+                    (action, _) => action.create(name, Some(actionName), timeout = Some(15.seconds))
                 }
-                msg.endsWith("a") shouldBe true
-            }
+
+                val allowedSize = ActivationEntityLimit.MAX_ACTIVATION_ENTITY_LIMIT.toBytes
+
+                def checkResponse(activation: CliActivation) = {
+                    val response = activation.response
+                    response.success shouldBe false
+                    response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ContainerError)
+                    val msg = response.result.get.fields(ActivationResponse.ERROR_FIELD).convertTo[String]
+                    val expected = Messages.truncatedResponse((allowedSize + 10).B, allowedSize.B)
+                    withClue(s"is: ${msg.take(expected.length)}\nexpected: $expected") {
+                        msg.startsWith(expected) shouldBe true
+                    }
+                    msg.endsWith("a") shouldBe true
+                }
+
+                // this tests an active ack failure to post from invoker
+                val args = Map("size" -> (allowedSize + 1).toJson, "char" -> "a".toJson)
+                val code = if (blocking) TestUtils.APP_ERROR else TestUtils.SUCCESS_EXIT
+                val rr = wsk.action.invoke(name, args, blocking = blocking, expectedExitCode = code)
+                if (blocking) {
+                    checkResponse(wsk.parseJsonString(rr.stderr).convertTo[CliActivation])
+                } else {
+                    withActivation(wsk.activation, rr) { checkResponse(_) }
+                }
+        }
     }
 
     it should "succeed with one log line" in withAssetCleaner(wskprops) {
@@ -245,7 +257,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers {
                 (action, _) => action.create(name, Some(actionName), memory = Some(allowedMemory))
             }
 
-            for( a <- 1 to 10){
+            for (a <- 1 to 10) {
                 val run = wsk.action.invoke(name, Map("payload" -> "128".toJson))
                 withActivation(wsk.activation, run) { response =>
                     response.response.status shouldBe "success"


### PR DESCRIPTION
Fixes an active ack accounting bug in the load balancer for certain failed activations (where the invoker previously did not send an ack for the completed (but failed) activation. 

Fixes #2118.
Fixes #2324.
Fixes #1906.