### PR TITLE
Update sequence impl to tune controller memory consumption

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/ActivationId.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ActivationId.scala
@@ -39,7 +39,7 @@ import whisk.http.Messages
  *
  * @param id the activation id, required not null
  */
-protected[core] class ActivationId private (private val id: java.util.UUID) extends AnyVal {
+protected[whisk] class ActivationId private (private val id: java.util.UUID) extends AnyVal {
     def asString = toString
     override def toString = id.toString.replaceAll("-", "")
     def toJsObject = JsObject("activationId" -> toString.toJson)

--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -35,6 +35,7 @@ import whisk.common.TransactionId
 import whisk.core.entity.SizeError
 import whisk.core.entity.ByteSize
 import whisk.core.entity.Exec
+import whisk.core.entity.ActivationId
 
 object Messages {
     /** Standard message for reporting resource conflicts. */
@@ -95,7 +96,7 @@ object Messages {
     val notAllowedOnBinding = "Operation not permitted on package binding."
 
     /** Error messages for sequence activations. */
-    val sequenceRetrieveActivationTimeout = "Timeout reached when retrieving activation for sequence component."
+    def sequenceRetrieveActivationTimeout(id: ActivationId) = s"Timeout reached when retrieving activation $id for sequence component."
     val sequenceActivationFailure = "Sequence failed."
 
     /** Error messages for bad requests where parameters do not conform. */

--- a/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
@@ -18,12 +18,13 @@ package whisk.core.controller.actions
 
 import java.time.Clock
 import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
 
 import scala.Left
 import scala.Right
+import scala.collection._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-import scala.concurrent.Promise
 import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.Failure
@@ -98,67 +99,59 @@ protected[actions] trait SequenceActions {
         // create new activation id that corresponds to the sequence
         val seqActivationId = activationIdFactory.make()
         logging.info(this, s"invoking sequence $action topmost $topmost activationid '$seqActivationId'")
+
         val start = Instant.now(Clock.systemUTC())
-        val seqActivationPromise = Promise[Option[WhiskActivation]]
-        // the cause for the component activations is the current sequence
-        val futureSeqResult = invokeSequenceComponents(user, action, seqActivationId, payload, components, cause = Some(seqActivationId), atomicActionsCount)
-        val response: Future[(ActivationId, Option[WhiskActivation], Int)] =
-            if (topmost) { // need to deal with blocking and closing connection
-                if (blocking) {
-                    logging.info(this, s"invoke sequence blocking topmost!")
-                    val timeout = maxWaitForBlockingActivation + blockingInvokeGrace
-
-                    val futureSeqResultTimeout = futureSeqResult withTimeout (timeout, new BlockingInvokeTimeout(seqActivationId))
-                    // if the future fails with a timeout, the failure is dealt with at the caller level
-                    futureSeqResultTimeout map { accounting =>
-                        // the execution of the sequence was successful, return the result
-                        val end = Instant.now(Clock.systemUTC())
-                        val seqActivation = Some(makeSequenceActivation(user, action, seqActivationId, accounting, topmost, cause, start, end))
-                        (seqActivationId, seqActivation, accounting.atomicActionCnt)
-                    } andThen {
-                        case Success((_, seqActivation, _)) => seqActivationPromise.success(seqActivation)
-                        case Failure(t)                     => seqActivationPromise.success(None)
-                    }
-                } else {
-                    // non-blocking sequence execution, return activation id
-                    Future.successful((seqActivationId, None, 0)) andThen {
-                        case _ => seqActivationPromise.success(None)
-                    }
-                }
-            } else {
-                // not topmost, no need to worry about terminating incoming request
-                futureSeqResult map { accounting =>
-                    // all activations are successful, the result of the sequence is the result of the last activation
-                    val end = Instant.now(Clock.systemUTC())
-                    val seqActivation = Some(makeSequenceActivation(user, action, seqActivationId, accounting, topmost, cause, start, end))
-                    (seqActivationId, seqActivation, accounting.atomicActionCnt)
-                } andThen {
-                    case Success((_, seqActivation, _)) => seqActivationPromise.success(seqActivation)
-                    case Failure(t)                     => seqActivationPromise.success(None)
-                }
-            }
-
-        // store result of sequence execution
-        // if seqActivation is defined, use it; otherwise create it (e.g., for non-blocking activations)
-        // the execution can reach here without a seqActivation due to non-blocking activations OR blocking activations that reach the blocking invoke timeout
-        // futureSeqResult should always be successful, if failed, there is an error
-        futureSeqResult flatMap { accounting => seqActivationPromise.future map { (accounting, _) } } onComplete {
-            case Success((accounting, seqActivation)) =>
-                // all activations were successful
-                val activation = seqActivation getOrElse {
-                    val end = Instant.now(Clock.systemUTC())
-                    // the response of the sequence is the response of the very last activation
-                    makeSequenceActivation(user, action, seqActivationId, accounting, topmost, cause, start, end)
-                }
-                storeSequenceActivation(activation)
-            case Failure(t: Throwable) =>
-                // consider this whisk error
-                // TODO shall we attempt storing the activation if it exists or even inspect the futures?
-                // this should be a pretty serious whisk errror if it gets here
-                logging.error(this, s"Sequence activation failed: ${t.getMessage}")
+        val futureSeqResult = {
+            completeSequenceActivation(
+                seqActivationId,
+                // the cause for the component activations is the current sequence
+                invokeSequenceComponents(user, action, seqActivationId, payload, components, cause = Some(seqActivationId), atomicActionsCount),
+                user, action, topmost, start, cause)
         }
 
-        response
+        if (topmost) { // need to deal with blocking and closing connection
+            if (blocking) {
+                logging.info(this, s"invoke sequence blocking topmost!")
+                val timeout = maxWaitForBlockingActivation + blockingInvokeGrace
+                // if the future fails with a timeout, the failure is dealt with at the caller level
+                futureSeqResult.withTimeout(timeout, new BlockingInvokeTimeout(seqActivationId))
+            } else {
+                // non-blocking sequence execution, return activation id
+                Future.successful((seqActivationId, None, 0))
+            }
+        } else {
+            // not topmost, no need to worry about terminating incoming request
+            // Note: the future for the sequence result recovers from all throwable failures
+            futureSeqResult
+        }
+    }
+
+    /**
+     * Creates an activation for the sequence and writes it back to the datastore.
+     */
+    private def completeSequenceActivation(
+        seqActivationId: ActivationId,
+        futureSeqResult: Future[SequenceAccounting],
+        user: Identity,
+        action: WhiskAction,
+        topmost: Boolean,
+        start: Instant,
+        cause: Option[ActivationId])(
+            implicit transid: TransactionId): Future[(ActivationId, Some[WhiskActivation], Int)] = {
+        // not topmost, no need to worry about terminating incoming request
+        // Note: the future for the sequence result recovers from all throwable failures
+        futureSeqResult.map { accounting =>
+            // sequence terminated, the result of the sequence is the result of the last completed activation
+            val end = Instant.now(Clock.systemUTC())
+            val seqActivation = makeSequenceActivation(user, action, seqActivationId, accounting, topmost, cause, start, end)
+            (seqActivationId, Some(seqActivation), accounting.atomicActionCnt)
+        }.andThen {
+            case Success((_, Some(seqActivation), _)) => storeSequenceActivation(seqActivation)
+            case Failure(t) =>
+                // This should never happen; in this case, there is no activation record created or stored:
+                // should there be?
+                logging.error(this, s"Sequence activation failed: ${t.getMessage}")
+        }
     }
 
     /**
@@ -188,7 +181,8 @@ protected[actions] trait SequenceActions {
         // compute max memory
         val sequenceLimits = accounting.maxMemory map {
             maxMemoryAcrossActionsInSequence =>
-                Parameters("limits", ActionLimits(action.limits.timeout,
+                Parameters("limits", ActionLimits(
+                    action.limits.timeout,
                     MemoryLimit(maxMemoryAcrossActionsInSequence MB),
                     action.limits.logs).toJson)
         } getOrElse (Parameters())
@@ -209,7 +203,7 @@ protected[actions] trait SequenceActions {
             start = start,
             end = end,
             cause = if (topmost) None else cause, // propagate the cause for inner sequences, but undefined for topmost
-            response = accounting.previousResponse.getAndSet(null),
+            response = accounting.previousResponse.getAndSet(null), // getAndSet(null) drops reference to the activation result
             logs = accounting.finalLogs,
             version = action.version,
             publish = false,
@@ -219,117 +213,6 @@ protected[actions] trait SequenceActions {
                 causedBy ++
                 sequenceLimits,
             duration = Some(accounting.duration))
-    }
-
-    /**
-     * Cumulative accounting of what happened during the execution of a sequence
-     *
-     */
-    case class SequenceAccounting(atomicActionCnt: Int, previousResponse: java.util.concurrent.atomic.AtomicReference[ActivationResponse],
-                                  logs: Array[ActivationId], duration: Long = 0, cursor: Int = 0, maxMemory: Option[Int] = None,
-                                  shortcircuit: Boolean = false) {
-
-        /** @return the ActivationLogs data structure for this sequence invocation */
-        def finalLogs = ActivationLogs(logs.take(cursor).map(id => id.asString).toVector)
-
-        /** the previous activation was successful */
-        def success(activation: WhiskActivation, newCnt: Int, shortcircuit: Boolean = false) = {
-          previousResponse.set(null)
-          SequenceAccounting(
-            prev = this,
-            newCnt = newCnt,
-            shortcircuit = shortcircuit,
-            incrDuration = activation.duration,
-            previousResponse = activation.response,
-            previousActivationId = activation.activationId,
-            previousMemoryLimit = activation.annotations.get("limits") map {
-                limitsAnnotation => // we have a limits annotation
-                    limitsAnnotation.asJsObject.getFields("memory") match {
-                        case Seq(JsNumber(memory)) => Some(memory.toInt) // we have a numerical "memory" field in the "limits" annotation
-                    }
-            } getOrElse { None })
-        }
-
-        /** the previous activation failed */
-        def fail(failureResponse: ActivationResponse) = SequenceAccounting(this, failureResponse)
-
-        /** determine whether the previous activation succeeded or failed */
-        def maybe(response: Either[ActivationResponse, WhiskActivation], newCnt: Int) = {
-            response match {
-                case Right(activation) =>
-                    // check conditions on payload that may lead to interrupting the execution of the sequence
-                    //     short-circuit the execution of the sequence iff the payload contains an error field
-                    //     and is the result of an action return, not the initial payload
-                    val outputPayload = activation.response.result.map(_.asJsObject)
-                    val payloadContent = outputPayload getOrElse JsObject.empty
-                    val errorFields = payloadContent.getFields(ActivationResponse.ERROR_FIELD)
-                    val errorShortcircuit = !errorFields.isEmpty
-
-                    if (newCnt > actionSequenceLimit) {
-                        // oops, the dynamic count of actions exceeds the threshold
-                        fail(ActivationResponse.applicationError(s"$sequenceIsTooLong"))
-                    } else if (!errorShortcircuit) {
-                        // all good with this action invocation!
-                        success(activation, newCnt)
-                    } else {
-                        // there is an error field in the activation response. here, we treat this like success,
-                        // in the sense of tallying up the accounting fields, but terminate the sequence early
-                        success(activation, newCnt, shortcircuit = true)
-                    }
-                case Left(response) =>
-                    // utter failure somewhere downstream
-                    fail(response)
-            }
-        }
-    }
-    /**
-     *  Three constructors for SequenceAccounting:
-     *     - one for successful invocation of an action in the sequence,
-     *     - one for failed invocation, and
-     *     - one to initialize things
-     */
-    object SequenceAccounting {
-        // constructor for successful invocations, or error'ing ones (where shortcircuit = true)
-        def apply(prev: SequenceAccounting, newCnt: Int,
-                  incrDuration: Option[Long],
-                  previousResponse: ActivationResponse,
-                  previousActivationId: ActivationId,
-                  previousMemoryLimit: Option[Int],
-                  shortcircuit: Boolean): SequenceAccounting = {
-
-            // compute the new max memory
-            val newMaxMemory = prev.maxMemory map {
-                currentMax => // currentMax is Some
-                    previousMemoryLimit map {
-                        previousLimit => // previousMemoryLimit is Some
-                            Some(Math.max(currentMax, previousLimit)) // so take the max of them
-                    } getOrElse { prev.maxMemory } // currentMax is Some, previousMemoryLimit is None
-            } getOrElse { previousMemoryLimit } // currentMax is None
-
-            // append log entry
-            prev.logs.update(prev.cursor, previousActivationId)
-
-            SequenceAccounting(
-                atomicActionCnt = newCnt,
-                previousResponse = new java.util.concurrent.atomic.AtomicReference(previousResponse),
-                logs = prev.logs,
-                duration = incrDuration map { prev.duration + _ } getOrElse { prev.duration },
-                cursor = prev.cursor + 1,
-                maxMemory = newMaxMemory,
-                shortcircuit = shortcircuit)
-        }
-
-        // constructor for failures, or limits exceeded
-        def apply(prev: SequenceAccounting, failureResponse: ActivationResponse): SequenceAccounting =
-            SequenceAccounting(prev.atomicActionCnt, new java.util.concurrent.atomic.AtomicReference(failureResponse),
-                prev.logs, prev.duration,
-                prev.cursor, prev.maxMemory,
-                shortcircuit = true)
-
-        // constructor for initial payload
-        def apply(length: Int, atomicActionCnt: Int, initialPayload: ActivationResponse): SequenceAccounting =
-            SequenceAccounting(atomicActionCnt, new java.util.concurrent.atomic.AtomicReference(initialPayload), new Array[ActivationId](length))
-
     }
 
     /**
@@ -345,9 +228,7 @@ protected[actions] trait SequenceActions {
      * @param components the components in the sequence
      * @param cause the activation id of the sequence that lead to invoking this sequence or None if this sequence is topmost
      * @param atomicActionCnt the dynamic atomic action count observed so far since the start of the execution of the topmost sequence
-     * @return a vector of successful futures; each element contains a tuple with
-     *         1. an either with activation(right) or activation response in case of error (left)
-     *         2. the dynamic atomic action count after executing the components
+     * @return a future which resolves with the accounting for a sequence, including the last result, duration, and activation ids
      */
     private def invokeSequenceComponents(
         user: Identity,
@@ -358,45 +239,58 @@ protected[actions] trait SequenceActions {
         cause: Option[ActivationId],
         atomicActionCnt: Int)(
             implicit transid: TransactionId): Future[SequenceAccounting] = {
-        // logging.info(this, s"invoke sequence $seqAction ($seqActivationId) with components $components")
 
-        // first retrieve the information/entities on all actions
-        // do not wait to successfully retrieve all the actions before starting the execution
-        // start execution of the first action while potentially still retrieving entities
-        // Note: the execution starts even if one of the futures retrieving an entity may fail
-        // first components need to be resolved given any package bindings and the params need to be merged
-        // NOTE: OLD-STYLE sequences may have default namespace in the names of the components, resolve default namespace first
-        val resolvedFutureActions = resolveDefaultNamespace(components, user) map { c => WhiskAction.resolveActionAndMergeParameters(entityStore, c) }
+        // For each action in the sequence, fetch any of its associated parameters (including package or binding).
+        // We do this for all of the actions in the sequence even though it may be short circuited. This is to
+        // hide the latency of the fetches from the datastore and the parameter merging that has to occur. It
+        // may be desirable in the future to selectively speculate over a smaller number of components rather than
+        // the entire sequence.
+        //
+        // This action/parameter resolution is done in futures; the execution starts as soon as the first component
+        // is resolved.
+        val resolvedFutureActions = resolveDefaultNamespace(components, user) map {
+            c => WhiskAction.resolveActionAndMergeParameters(entityStore, c)
+        }
 
-        // this holds the initial value of the accounting structure, including an ActivationResponse to house the input payload
-        val initialAccounting = Future.successful(SequenceAccounting(components.length, atomicActionCnt,
-            ActivationResponse.payloadPlaceholder(inputPayload)))
+        // this holds the initial value of the accounting structure, including the input boxed as an ActivationResponse
+        val initialAccounting = Future.successful {
+            SequenceAccounting(atomicActionCnt, ActivationResponse.payloadPlaceholder(inputPayload))
+        }
 
-        // execute the wskActions in sequential blocking fashion
-        // TODO: double-check the package param policy
+        // execute the actions in sequential blocking fashion
         resolvedFutureActions.foldLeft(initialAccounting) {
             (accountingFuture, futureAction) =>
-                accountingFuture flatMap { accounting =>
-                    if (accounting.shortcircuit) {
-                        // this sequence has been short-circuited
-                        Future.successful(accounting)
-                    } else {
-                        futureAction flatMap {
-                            action =>
-                                val inputPayload = accounting.previousResponse.getAndSet(null).result.map(_.asJsObject)
-                                // logging.info(this, s"invoke sequence component of ($seqActivationId) component ${action.name} payload ${inputPayload}")
-                                invokeSeqOneComponent(user, action, inputPayload, cause, accounting.atomicActionCnt) map {
-                                    case (response, newCnt) => accounting.maybe(response, newCnt)
-                                }
-
-                        } recover {
-                            // check any failure here and generate an activation response to encapsulate the failure mode
+                accountingFuture.flatMap { accounting =>
+                    futureAction.flatMap { action =>
+                        // the previous response becomes input for the next action in the sequence;
+                        // the accounting no longer needs to hold a reference to it once the action is
+                        // invoked, so previousResponse.getAndSet(null) drops the reference at this point
+                        // which prevents dragging the previous response for the lifetime of the next activation
+                        val inputPayload = accounting.previousResponse.getAndSet(null).result.map(_.asJsObject)
+                        invokeSeqOneComponent(user, action, inputPayload, cause, accounting.atomicActionCnt).map {
+                            // disambiguate result and updated accounting
+                            case (response, newCnt) => accounting.maybe(response, newCnt, actionSequenceLimit)
+                        }.recover {
+                            // check any failure here and generate an activation response to encapsulate
+                            // the failure mode; consider this failure a whisk error
                             case t: Throwable =>
-                                // consider this failure a whisk error
+                                logging.error(this, s"component activation failed: $t")
                                 accounting.fail(ActivationResponse.whiskError(sequenceActivationFailure))
+                        }.flatMap { accounting =>
+                            if (!accounting.shortcircuit) {
+                                Future.successful(accounting)
+                            } else {
+                                // this is to short circuit the fold
+                                Future.failed(FailedSequenceActivation(accounting))
+                            }
                         }
                     }
                 }
+        }.recoverWith {
+            // turn the failed accounting back to success; this is the only possible failure
+            // since all throwables are recovered with a failed accounting instance and this is
+            // in turned boxed to FailedSequenceActivation
+            case FailedSequenceActivation(accounting) => Future.successful(accounting)
         }
     }
 
@@ -414,8 +308,13 @@ protected[actions] trait SequenceActions {
      * @param atomicActionCount the number of activations
      * @return future with the result of the invocation and the dynamic atomic action count so far
      */
-    private def invokeSeqOneComponent(user: Identity, action: WhiskAction, payload: Option[JsObject], cause: Option[ActivationId], atomicActionCount: Int)(
-        implicit transid: TransactionId): Future[(Either[ActivationResponse, WhiskActivation], Int)] = {
+    private def invokeSeqOneComponent(
+        user: Identity,
+        action: WhiskAction,
+        payload: Option[JsObject],
+        cause: Option[ActivationId],
+        atomicActionCount: Int)(
+            implicit transid: TransactionId): Future[(Either[ActivationResponse, WhiskActivation], Int)] = {
         // invoke the action by calling the right method depending on whether it's an atomic action or a sequence
         // the tuple contains activationId, wskActivation, atomicActionCount (up till this point in execution)
         val futureWhiskActivationTuple = action.exec match {
@@ -449,11 +348,132 @@ protected[actions] trait SequenceActions {
 
     /** Replaces default namespaces in a vector of components from a sequence with appropriate namespace. */
     private def resolveDefaultNamespace(components: Vector[FullyQualifiedEntityName], user: Identity): Vector[FullyQualifiedEntityName] = {
-        // if components are part of the default namespace, they contain `_`; replace it!
-        val resolvedComponents = components map { c => FullyQualifiedEntityName(c.path.resolveNamespace(user.namespace), c.name) }
-        resolvedComponents
+        // resolve any namespaces that may appears as "_" (the default namespace)
+        components.map(c => FullyQualifiedEntityName(c.path.resolveNamespace(user.namespace), c.name))
     }
 
     /** Max atomic action count allowed for sequences */
     private lazy val actionSequenceLimit = whiskConfig.actionSequenceLimit.toInt
 }
+
+/**
+ * Cumulative accounting of what happened during the execution of a sequence.
+ *
+ * @param atomicActionCnt the current count of non-sequence (c.f. atomic) actions already invoked
+ * @param previousResponse a reference to the previous activation result which will be nulled out
+ *        when no longer needed (see previousResponse.getAndSet(null) below)
+ * @param logs a mutable buffer that is appended with new activation ids as the sequence unfolds
+ * @param duration the "user" time so far executing the sequence (sum of durations for
+ *        all actions invoked so far which is different from the total time spent executing the sequence)
+ * @param maxMemory the maximum memory annotation observed so far for the
+ *        components (needed to annotate the sequence with GB-s)
+ * @param shortcircuit when true, stops the execution of the next component in the sequence
+ */
+protected[actions] case class SequenceAccounting(
+    atomicActionCnt: Int,
+    previousResponse: AtomicReference[ActivationResponse],
+    logs: mutable.ArrayBuffer[ActivationId],
+    duration: Long = 0,
+    maxMemory: Option[Int] = None,
+    shortcircuit: Boolean = false) {
+
+    /** @return the ActivationLogs data structure for this sequence invocation */
+    def finalLogs = ActivationLogs(logs.map(id => id.asString).toVector)
+
+    /** the previous activation was successful */
+    private def success(activation: WhiskActivation, newCnt: Int, shortcircuit: Boolean = false) = {
+        previousResponse.set(null)
+        SequenceAccounting(
+            prev = this,
+            newCnt = newCnt,
+            shortcircuit = shortcircuit,
+            incrDuration = activation.duration,
+            previousResponse = activation.response,
+            previousActivationId = activation.activationId,
+            previousMemoryLimit = activation.annotations.get("limits") map {
+                limitsAnnotation => // we have a limits annotation
+                    limitsAnnotation.asJsObject.getFields("memory") match {
+                        case Seq(JsNumber(memory)) => Some(memory.toInt) // we have a numerical "memory" field in the "limits" annotation
+                    }
+            } getOrElse { None })
+    }
+
+    /** the previous activation failed */
+    def fail(failureResponse: ActivationResponse) = {
+        copy(previousResponse = new AtomicReference(failureResponse), shortcircuit = true)
+    }
+
+    /** determine whether the previous activation succeeded or failed */
+    def maybe(response: Either[ActivationResponse, WhiskActivation], newCnt: Int, maxSequenceCnt: Int) = {
+        response match {
+            case Right(activation) =>
+                // check conditions on payload that may lead to interrupting the execution of the sequence
+                //     short-circuit the execution of the sequence iff the payload contains an error field
+                //     and is the result of an action return, not the initial payload
+                val outputPayload = activation.response.result.map(_.asJsObject)
+                val payloadContent = outputPayload getOrElse JsObject.empty
+                val errorField = payloadContent.fields.get(ActivationResponse.ERROR_FIELD)
+
+                if (newCnt > maxSequenceCnt) {
+                    // oops, the dynamic count of actions exceeds the threshold
+                    fail(ActivationResponse.applicationError(sequenceIsTooLong))
+                } else if (errorField.isEmpty) {
+                    // all good with this action invocation!
+                    success(activation, newCnt)
+                } else {
+                    // there is an error field in the activation response. here, we treat this like success,
+                    // in the sense of tallying up the accounting fields, but terminate the sequence early
+                    success(activation, newCnt, shortcircuit = true)
+                }
+            case Left(response) =>
+                // utter failure somewhere downstream
+                fail(response)
+        }
+    }
+}
+
+/**
+ *  Three constructors for SequenceAccounting:
+ *     - one for successful invocation of an action in the sequence,
+ *     - one for failed invocation, and
+ *     - one to initialize things
+ */
+protected[actions] object SequenceAccounting {
+    // constructor for successful invocations, or error'ing ones (where shortcircuit = true)
+    def apply(
+        prev: SequenceAccounting,
+        newCnt: Int,
+        incrDuration: Option[Long],
+        previousResponse: ActivationResponse,
+        previousActivationId: ActivationId,
+        previousMemoryLimit: Option[Int],
+        shortcircuit: Boolean): SequenceAccounting = {
+
+        // compute the new max memory
+        val newMaxMemory = prev.maxMemory map {
+            currentMax => // currentMax is Some
+                previousMemoryLimit map {
+                    previousLimit => // previousMemoryLimit is Some
+                        Some(Math.max(currentMax, previousLimit)) // so take the max of them
+                } getOrElse { prev.maxMemory } // currentMax is Some, previousMemoryLimit is None
+        } getOrElse { previousMemoryLimit } // currentMax is None
+
+        // append log entry
+        prev.logs += previousActivationId
+
+        SequenceAccounting(
+            atomicActionCnt = newCnt,
+            previousResponse = new AtomicReference(previousResponse),
+            logs = prev.logs,
+            duration = incrDuration map { prev.duration + _ } getOrElse { prev.duration },
+            maxMemory = newMaxMemory,
+            shortcircuit = shortcircuit)
+    }
+
+    // constructor for initial payload
+    def apply(atomicActionCnt: Int, initialPayload: ActivationResponse): SequenceAccounting = {
+        SequenceAccounting(atomicActionCnt, new AtomicReference(initialPayload), mutable.ArrayBuffer.empty)
+    }
+}
+
+protected[actions] case class FailedSequenceActivation(accounting: SequenceAccounting) extends Throwable

--- a/tests/src/test/scala/system/basic/WskSequenceTests.scala
+++ b/tests/src/test/scala/system/basic/WskSequenceTests.scala
@@ -219,8 +219,7 @@ class WskSequenceTests
                     withActivation(wsk.activation, getInnerSeq, totalWait = allowedActionDuration) {
                         innerSeqActivation =>
                             innerSeqActivation.logs.get.size shouldBe (limit - 1)
-                            innerSeqActivation.cause shouldBe defined
-                            innerSeqActivation.cause.get shouldBe (activation.activationId)
+                            innerSeqActivation.cause shouldBe Some(activation.activationId)
                     }
             }
     }

--- a/tests/src/test/scala/system/basic/WskSequenceTests.scala
+++ b/tests/src/test/scala/system/basic/WskSequenceTests.scala
@@ -60,7 +60,7 @@ class WskSequenceTests
 
     behavior of "Wsk Sequence"
 
-    it should "invoke a blocking sequence action and invoke the updated sequence with normal payload and payload with error field" in withAssetCleaner(wskprops) {
+    it should "invoke a sequence with normal payload and payload with error field" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             val name = "sequence"
             val actions = Seq("split", "sort", "head", "cat")
@@ -109,12 +109,52 @@ class WskSequenceTests
             // result of sequence should be identical to previous invocation above
             val payload = Map("error" -> JsString("irrelevant error string"), "payload" -> args.mkString("\n").toJson)
             val thirdrun = wsk.action.invoke(name, payload)
-            withActivation(wsk.activation, thirdrun, totalWait = 2 *allowedActionDuration) {
+            withActivation(wsk.activation, thirdrun, totalWait = 2 * allowedActionDuration) {
                 activation =>
                     checkSequenceLogsAndAnnotations(activation, 2) // 2 activations in this sequence
                     val result = activation.response.result.get
                     result.fields.get("length") shouldBe Some(2.toJson)
                     result.fields.get("lines") shouldBe Some(args.sortWith(_.compareTo(_) < 0).toArray.toJson)
+            }
+    }
+
+    it should "invoke a sequence with an enclosing sequence action" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val inner_name = "inner_sequence"
+            val outer_name = "outer_sequence"
+            val inner_actions = Seq("sort", "head")
+            val actions = Seq("split") ++ inner_actions ++ Seq("cat")
+            // create atomic actions
+            for (actionName <- actions) {
+                val file = TestUtils.getTestActionFilename(s"$actionName.js")
+                assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
+                    action.create(name = actionName, artifact = Some(file), timeout = Some(allowedActionDuration))
+                }
+            }
+
+            // create inner sequence
+            assetHelper.withCleaner(wsk.action, inner_name) {
+                val inner_sequence = inner_actions.mkString(",")
+                (action, _) => action.create(inner_name, Some(inner_sequence), kind = Some("sequence"))
+            }
+
+            // create outer sequence
+            assetHelper.withCleaner(wsk.action, outer_name) {
+                val outer_sequence = Seq("split", "inner_sequence", "cat").mkString(",")
+                (action, _) => action.create(outer_name, Some(outer_sequence), kind = Some("sequence"))
+            }
+
+            val now = "it is now " + new Date()
+            val args = Array("what time is it?", now)
+            val run = wsk.action.invoke(outer_name, Map("payload" -> args.mkString("\n").toJson))
+            withActivation(wsk.activation, run, totalWait = 4 * allowedActionDuration) {
+                activation =>
+                    checkSequenceLogsAndAnnotations(activation, 3) // 3 activations in this sequence
+                    activation.cause shouldBe None // topmost sequence
+                    val result = activation.response.result.get
+                    result.fields.get("payload") shouldBe defined
+                    result.fields.get("length") should not be defined
+                    result.fields.get("lines") shouldBe Some(JsArray(Vector(now.toJson)))
             }
     }
 
@@ -124,8 +164,11 @@ class WskSequenceTests
      *
      * update x -> <limit-1> echo -- should work
      * run s -> should stop after <limit> echo
+     *
+     * This confirms that a dynamic check on the sequence length holds within the system limit.
+     * This is different from creating a long sequence up front which will report a length error at create time.
      */
-    it should "create a sequence, run it, update one of the atomic actions to a sequence and stop executing the outer sequence when limit reached" in withAssetCleaner(wskprops) {
+    it should "replace atomic component in a sequence that is too long and report invoke error" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             val xName = "xSequence"
             val sName = "sSequence"
@@ -179,46 +222,6 @@ class WskSequenceTests
                             innerSeqActivation.cause shouldBe defined
                             innerSeqActivation.cause.get shouldBe (activation.activationId)
                     }
-            }
-    }
-
-    it should "invoke a blocking sequence action with an enclosing sequence action" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val inner_name = "inner_sequence"
-            val outer_name = "outer_sequence"
-            val inner_actions = Seq("sort", "head")
-            val actions = Seq("split") ++ inner_actions ++ Seq("cat")
-            // create atomic actions
-            for (actionName <- actions) {
-                val file = TestUtils.getTestActionFilename(s"$actionName.js")
-                assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
-                    action.create(name = actionName, artifact = Some(file), timeout = Some(allowedActionDuration))
-                }
-            }
-
-            // create inner sequence
-            assetHelper.withCleaner(wsk.action, inner_name) {
-                val inner_sequence = inner_actions.mkString(",")
-                (action, _) => action.create(inner_name, Some(inner_sequence), kind = Some("sequence"))
-            }
-
-            // create outer sequence
-            assetHelper.withCleaner(wsk.action, outer_name) {
-                val outer_sequence = Seq("split", "inner_sequence", "cat").mkString(",")
-                (action, _) => action.create(outer_name, Some(outer_sequence), kind = Some("sequence"))
-            }
-
-            val now = "it is now " + new Date()
-            val args = Array("what time is it?", now)
-            val run = wsk.action.invoke(outer_name, Map("payload" -> args.mkString("\n").toJson))
-            withActivation(wsk.activation, run, totalWait = 4 * allowedActionDuration) {
-                activation =>
-                    checkSequenceLogsAndAnnotations(activation, 3) // 3 activations in this sequence
-                    activation.cause shouldBe None // topmost sequence
-                    val result = activation.response.result.get
-                    result.fields.get("payload") shouldBe defined
-                    result.fields.get("length") should not be defined
-                    result.fields.get("lines") shouldBe Some(JsArray(Vector(now.toJson)))
             }
     }
 
@@ -294,6 +297,7 @@ class WskSequenceTests
             // action params trump package params
             checkLogsAtomicAction(0, run, new Regex(String.format(".*key0: value0.*key1a: value1a.*key1b: value2b.*key2a: value2a.*payload: %s", now)))
     }
+
     /**
      * s -> apperror, echo
      * only apperror should run

--- a/tests/src/test/scala/whisk/core/controller/actions/test/SequenceAccountingTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/actions/test/SequenceAccountingTests.scala
@@ -81,7 +81,7 @@ class SequenceAccountingTests extends FlatSpec with Matchers with WskActorSystem
 
     it should "resolve maybe to success and update accounting object" in {
         val p = SequenceAccounting(2, okRes1)
-        val n1 = p.maybe(Right(okActivation), 3, 5)
+        val n1 = p.maybe(okActivation, 3, 5)
         n1.atomicActionCnt shouldBe 3
         n1.previousResponse.get shouldBe okRes2
         n1.logs.length shouldBe 1
@@ -93,8 +93,8 @@ class SequenceAccountingTests extends FlatSpec with Matchers with WskActorSystem
 
     it should "resolve maybe and enable short circuit" in {
         val p = SequenceAccounting(2, okRes1)
-        val n1 = p.maybe(Right(okActivation), 3, 5)
-        val n2 = n1.maybe(Right(notOkActivation), 4, 5)
+        val n1 = p.maybe(okActivation, 3, 5)
+        val n2 = n1.maybe(notOkActivation, 4, 5)
         n2.atomicActionCnt shouldBe 4
         n2.previousResponse.get shouldBe failedRes
         n2.logs.length shouldBe 2
@@ -107,7 +107,7 @@ class SequenceAccountingTests extends FlatSpec with Matchers with WskActorSystem
 
     it should "record an activation that exceeds allowed limit but also short circuit" in {
         val p = SequenceAccounting(2, okRes1)
-        val n = p.maybe(Right(okActivation), 3, 2)
+        val n = p.maybe(okActivation, 3, 2)
         n.atomicActionCnt shouldBe 3
         n.previousResponse.get shouldBe ActivationResponse.applicationError(Messages.sequenceIsTooLong)
         n.logs.length shouldBe 1
@@ -119,8 +119,8 @@ class SequenceAccountingTests extends FlatSpec with Matchers with WskActorSystem
 
     it should "set failed response and short circuit on failure" in {
         val p = SequenceAccounting(2, okRes1)
-        val n = p.maybe(Right(okActivation), 3, 3)
-        val f = n.fail(failedRes)
+        val n = p.maybe(okActivation, 3, 3)
+        val f = n.fail(failedRes, None)
         f.atomicActionCnt shouldBe 3
         f.previousResponse.get shouldBe failedRes
         f.logs.length shouldBe 1

--- a/tests/src/test/scala/whisk/core/controller/actions/test/SequenceAccountingTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/actions/test/SequenceAccountingTests.scala
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package whisk.core.controller.actions.test
+
+import java.time.Instant
+
+import scala.concurrent.duration.DurationInt
+
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+import org.scalatest.junit.JUnitRunner
+
+import common.WskActorSystem
+import spray.json._
+import whisk.core.controller.actions.SequenceAccounting
+import whisk.core.entity._
+import whisk.core.entity.ActivationResponse
+import whisk.core.entity.size.SizeInt
+import whisk.http.Messages
+
+@RunWith(classOf[JUnitRunner])
+class SequenceAccountingTests extends FlatSpec with Matchers with WskActorSystem {
+
+    behavior of "sequence accounting"
+
+    val okRes1 = ActivationResponse.success(Some(JsObject("res" -> JsNumber(1))))
+    val okRes2 = ActivationResponse.success(Some(JsObject("res" -> JsNumber(2))))
+    val failedRes = ActivationResponse.applicationError(JsNumber(3))
+
+    val okActivation = WhiskActivation(
+        namespace = EntityPath("ns"),
+        name = EntityName("a"),
+        Subject(),
+        activationId = ActivationId(),
+        start = Instant.now(),
+        end = Instant.now(),
+        response = okRes2,
+        annotations = Parameters("limits", ActionLimits(
+            TimeLimit(1.second),
+            MemoryLimit(128.MB),
+            LogLimit(1.MB)).toJson),
+        duration = Some(123))
+
+    val notOkActivation = WhiskActivation(
+        namespace = EntityPath("ns"),
+        name = EntityName("a"),
+        Subject(),
+        activationId = ActivationId(),
+        start = Instant.now(),
+        end = Instant.now(),
+        response = failedRes,
+        annotations = Parameters("limits", ActionLimits(
+            TimeLimit(11.second),
+            MemoryLimit(256.MB),
+            LogLimit(2.MB)).toJson),
+        duration = Some(234))
+
+    it should "create initial accounting object" in {
+        val s = SequenceAccounting(2, okRes1)
+        s.atomicActionCnt shouldBe 2
+        s.previousResponse.get shouldBe okRes1
+        s.logs shouldBe empty
+        s.duration shouldBe 0
+        s.maxMemory shouldBe None
+        s.shortcircuit shouldBe false
+    }
+
+    it should "resolve maybe to success and update accounting object" in {
+        val p = SequenceAccounting(2, okRes1)
+        val n1 = p.maybe(Right(okActivation), 3, 5)
+        n1.atomicActionCnt shouldBe 3
+        n1.previousResponse.get shouldBe okRes2
+        n1.logs.length shouldBe 1
+        n1.logs(0) shouldBe okActivation.activationId
+        n1.duration shouldBe 123
+        n1.maxMemory shouldBe Some(128)
+        n1.shortcircuit shouldBe false
+    }
+
+    it should "resolve maybe and enable short circuit" in {
+        val p = SequenceAccounting(2, okRes1)
+        val n1 = p.maybe(Right(okActivation), 3, 5)
+        val n2 = n1.maybe(Right(notOkActivation), 4, 5)
+        n2.atomicActionCnt shouldBe 4
+        n2.previousResponse.get shouldBe failedRes
+        n2.logs.length shouldBe 2
+        n2.logs(0) shouldBe okActivation.activationId
+        n2.logs(1) shouldBe notOkActivation.activationId
+        n2.duration shouldBe (123 + 234)
+        n2.maxMemory shouldBe Some(256)
+        n2.shortcircuit shouldBe true
+    }
+
+    it should "record an activation that exceeds allowed limit but also short circuit" in {
+        val p = SequenceAccounting(2, okRes1)
+        val n = p.maybe(Right(okActivation), 3, 2)
+        n.atomicActionCnt shouldBe 3
+        n.previousResponse.get shouldBe ActivationResponse.applicationError(Messages.sequenceIsTooLong)
+        n.logs.length shouldBe 1
+        n.logs(0) shouldBe okActivation.activationId
+        n.duration shouldBe 123
+        n.maxMemory shouldBe Some(128)
+        n.shortcircuit shouldBe true
+    }
+
+    it should "set failed response and short circuit on failure" in {
+        val p = SequenceAccounting(2, okRes1)
+        val n = p.maybe(Right(okActivation), 3, 3)
+        val f = n.fail(failedRes)
+        f.atomicActionCnt shouldBe 3
+        f.previousResponse.get shouldBe failedRes
+        f.logs.length shouldBe 1
+        f.logs(0) shouldBe okActivation.activationId
+        f.duration shouldBe 123
+        f.maxMemory shouldBe Some(128)
+        f.shortcircuit shouldBe true
+    }
+
+    it should "resolve max memory" in {
+        SequenceAccounting.maxMemory(None, None) shouldBe None
+        SequenceAccounting.maxMemory(None, Some(1)) shouldBe Some(1)
+        SequenceAccounting.maxMemory(Some(1), None) shouldBe Some(1)
+        SequenceAccounting.maxMemory(Some(1), Some(2)) shouldBe Some(2)
+        SequenceAccounting.maxMemory(Some(2), Some(1)) shouldBe Some(2)
+        SequenceAccounting.maxMemory(Some(2), Some(2)) shouldBe Some(2)
+    }
+}

--- a/tests/src/test/scala/whisk/utils/test/ExecutionContextFactoryTests.scala
+++ b/tests/src/test/scala/whisk/utils/test/ExecutionContextFactoryTests.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package whisk.utils.test
+
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+import org.scalatest.junit.JUnitRunner
+
+import common.WskActorSystem
+import whisk.utils.ExecutionContextFactory.FutureExtensions
+
+@RunWith(classOf[JUnitRunner])
+class ExecutionContextFactoryTests extends FlatSpec with Matchers with WskActorSystem {
+
+    behavior of "future extensions"
+
+    it should "take first to complete" in {
+        val f1 = Future.successful({}).withTimeout(500.millis, new Throwable("error"))
+        Await.result(f1, 1.second) shouldBe ({})
+
+        val failure = new Throwable("error")
+        val f2 = Future { Thread.sleep(1.second.toMillis) }.withTimeout(500.millis, failure)
+        a[Throwable] shouldBe thrownBy { Await.result(f2, 1.seconds) }
+    }
+}


### PR DESCRIPTION
Fixes #2386

This PR changes SequenceActions to use foldLeft rather than scanLeft. The change requires the introduction of a new accumulator data structure, to maintain the accumulated state for the reduction. The accumulated state includes an array of handles to logs (for the components), the cumulative duration, and a few other bits needed for creation of the final sequence activation record.

This fix also patches a closely related memory drag, caused by the way timeouts of sequence invocations are handled. See #2294 which patches other parts of the controller for the same kind of timeout drag. This patch needs to be a little different, due to the complex way the SequenceActions impl uses nested Promises.

PG3 625 🔵