### PR TITLE
Create swagger operationId values for code tooling consumption

### DIFF
--- a/tests/src/test/scala/whisk/core/cli/test/ApiGwTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/ApiGwTests.scala
@@ -639,7 +639,7 @@ class ApiGwTests
     it should "verify successful creation and deletion of a new API" in {
         val testName = "CLI_APIGWTEST1"
         val testbasepath = "/"+testName+"_bp"
-        val testrelpath = "/path"
+        val testrelpath = "/path/with/sub_paths/in/it"
         val testnewrelpath = "/path_new"
         val testurlop = "get"
         val testapiname = testName+" API Name"
@@ -657,6 +657,8 @@ class ApiGwTests
             rr.stdout should include("ok: APIs")
             rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
             rr.stdout should include(testbasepath + testrelpath)
+            rr = apiGet(basepathOrApiName = Some(testbasepath))
+            rr.stdout should include regex (s""""operationId":\\s+"getPathWithSub_pathsInIt"""")
             val deleteresult = apiDelete(basepathOrApiName = testbasepath)
             deleteresult.stdout should include("ok: deleted API")
         }


### PR DESCRIPTION
Currently, the CLI generates operationId swagger field values that are usable by coding tools.  The PR alters the operationId algorithm to generate strings that more closely match allowable programmatic variable/method names.

Field description from the Open API 2.0 specification

https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#operationObject 

>Unique string used to identify the operation. The id MUST be unique among all operations described in the API. Tools and libraries MAY use the operationId to uniquely identify an operation, therefore, it is recommended to follow common programming naming conventions.