### PR TITLE
Pin CCurl version in Package.swift

### DIFF
--- a/core/swift3Action/spm-build/Package.swift
+++ b/core/swift3Action/spm-build/Package.swift
@@ -19,7 +19,8 @@ import PackageDescription
 let package = Package(
     name: "Action",
         dependencies: [
-    .Package(url: "https://github.com/IBM-Swift/Kitura-net.git", "1.0.1"),
+            .Package(url: "https://github.com/IBM-Swift/CCurl.git", "0.2.3"),
+            .Package(url: "https://github.com/IBM-Swift/Kitura-net.git", "1.0.1"),
             .Package(url: "https://github.com/IBM-Swift/SwiftyJSON.git", "14.2.0"),
             .Package(url: "https://github.com/IBM-Swift/swift-watson-sdk.git", "0.4.1")
         ]


### PR DESCRIPTION
Fixes issue #2394.  Pins CCurl version to 0.2.3 to fix potential self-signed certificates issue.