### PR TITLE
Add Configurable Limits to Controller

### DIFF
--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -17,9 +17,12 @@ db_port: "{{ lookup('ini', 'db_port section=db_creds file={{ playbook_dir }}/db_
 limits:
   actions:
     invokes:
-      perMinute: 60
       concurrent: 30
       concurrentInSystem: 5000
+      perMinute: 60
+  activations:
+    polls:
+      maxRecords: 200
   triggers:
     fires:
       perMinute: 60

--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -17,6 +17,7 @@ db_port: "{{ lookup('ini', 'db_port section=db_creds file={{ playbook_dir }}/db_
 limits:
   actions:
     invokes:
+      blockingTimeout: 60
       concurrent: 30
       concurrentInSystem: 5000
       perMinute: 60

--- a/ansible/environments/mac/group_vars/all
+++ b/ansible/environments/mac/group_vars/all
@@ -22,9 +22,12 @@ db_port: "{{ lookup('ini', 'db_port section=db_creds file={{ playbook_dir }}/db_
 limits:
   actions:
     invokes:
-      perMinute: 60
       concurrent: 30
       concurrentInSystem: 5000
+      perMinute: 60
+  activations:
+    polls:
+      maxRecords: 200
   triggers:
     fires:
       perMinute: 60

--- a/ansible/environments/mac/group_vars/all
+++ b/ansible/environments/mac/group_vars/all
@@ -22,6 +22,7 @@ db_port: "{{ lookup('ini', 'db_port section=db_creds file={{ playbook_dir }}/db_
 limits:
   actions:
     invokes:
+      blockingTimeout: 60
       concurrent: 30
       concurrentInSystem: 5000
       perMinute: 60

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -78,12 +78,15 @@ runtimesManifest:
 defaultLimits:
   actions:
     invokes:
-      perMinute: 120
+      blockingTimeout: 60
       concurrent: 100
       concurrentInSystem: 5000
-      blockingTimeout: 60
+      perMinute: 120
     sequence:
       maxLength: 50
+  activations:
+    polls:
+      maxRecords: 200
   triggers:
     fires:
       perMinute: 60

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -81,6 +81,7 @@ defaultLimits:
       perMinute: 120
       concurrent: 100
       concurrentInSystem: 5000
+      blockingTimeout: 60
     sequence:
       maxLength: 50
   triggers:

--- a/ansible/templates/whisk.properties.j2
+++ b/ansible/templates/whisk.properties.j2
@@ -33,19 +33,21 @@ whisk.api.localhost.name={{ whisk_api_localhost_name | default(whisk_api_host_na
 whisk.api.vanity.subdomain.parts=1
 
 runtimes.manifest={{ runtimesManifest | to_json }}
-defaultLimits.actions.invokes.perMinute={{ defaultLimits.actions.invokes.perMinute }}
-defaultLimits.actions.invokes.concurrent={{ defaultLimits.actions.invokes.concurrent }}
-defaultLimits.triggers.fires.perMinute={{ defaultLimits.triggers.fires.perMinute }}
-defaultLimits.actions.invokes.concurrentInSystem={{ defaultLimits.actions.invokes.concurrentInSystem }}
-defaultLimits.actions.sequence.maxLength={{ defaultLimits.actions.sequence.maxLength }}
 defaultLimits.actions.invokes.blockingTimeout={{ defaultLimits.actions.invokes.blockingTimeout }}
+defaultLimits.actions.invokes.concurrent={{ defaultLimits.actions.invokes.concurrent }}
+defaultLimits.actions.invokes.concurrentInSystem={{ defaultLimits.actions.invokes.concurrentInSystem }}
+defaultLimits.actions.invokes.perMinute={{ defaultLimits.actions.invokes.perMinute }}
+defaultLimits.actions.sequence.maxLength={{ defaultLimits.actions.sequence.maxLength }}
+defaultLimits.activations.polls.maxRecords={{ defaultLimits.activations.polls.maxRecords }}
+defaultLimits.triggers.fires.perMinute={{ defaultLimits.triggers.fires.perMinute }}
 
 {% if limits is defined %}
-limits.actions.invokes.perMinute={{ limits.actions.invokes.perMinute }}
+limits.actions.invokes.blockingTimeout={{ limits.actions.invokes.blockingTimeout }}
 limits.actions.invokes.concurrent={{ limits.actions.invokes.concurrent }}
 limits.actions.invokes.concurrentInSystem={{ limits.actions.invokes.concurrentInSystem }}
+limits.actions.invokes.perMinute={{ limits.actions.invokes.perMinute }}
+limits.activations.polls.maxRecords={{ limits.activations.polls.maxRecords }}
 limits.triggers.fires.perMinute={{ limits.triggers.fires.perMinute }}
-limits.actions.invokes.blockingTimeout={{ limits.actions.invokes.blockingTimeout }}
 {% endif %}
 
 consulserver.host={{ groups["consul_servers"]|first }}

--- a/ansible/templates/whisk.properties.j2
+++ b/ansible/templates/whisk.properties.j2
@@ -38,12 +38,14 @@ defaultLimits.actions.invokes.concurrent={{ defaultLimits.actions.invokes.concur
 defaultLimits.triggers.fires.perMinute={{ defaultLimits.triggers.fires.perMinute }}
 defaultLimits.actions.invokes.concurrentInSystem={{ defaultLimits.actions.invokes.concurrentInSystem }}
 defaultLimits.actions.sequence.maxLength={{ defaultLimits.actions.sequence.maxLength }}
+defaultLimits.actions.invokes.blockingTimeout={{ defaultLimits.actions.invokes.blockingTimeout }}
 
 {% if limits is defined %}
 limits.actions.invokes.perMinute={{ limits.actions.invokes.perMinute }}
 limits.actions.invokes.concurrent={{ limits.actions.invokes.concurrent }}
 limits.actions.invokes.concurrentInSystem={{ limits.actions.invokes.concurrentInSystem }}
 limits.triggers.fires.perMinute={{ limits.triggers.fires.perMinute }}
+limits.actions.invokes.blockingTimeout={{ limits.actions.invokes.blockingTimeout }}
 {% endif %}
 
 consulserver.host={{ groups["consul_servers"]|first }}

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -117,6 +117,7 @@ class WhiskConfig(
     val triggerFirePerMinuteLimit = this(WhiskConfig.triggerFirePerMinuteDefaultLimit, WhiskConfig.triggerFirePerMinuteLimit)
     val actionInvokeSystemOverloadLimit = this(WhiskConfig.actionInvokeSystemOverloadDefaultLimit, WhiskConfig.actionInvokeSystemOverloadLimit)
     val actionSequenceLimit = this(WhiskConfig.actionSequenceDefaultLimit)
+    val actionInvokeBlockingTimeoutLimit = this(WhiskConfig.actionInvokeBlockingTimeoutDefaultLimit, WhiskConfig.actionInvokeBlockingTimeoutLimit)
 }
 
 object WhiskConfig {
@@ -284,4 +285,6 @@ object WhiskConfig {
     val actionInvokeConcurrentLimit = "limits.actions.invokes.concurrent"
     val actionInvokeSystemOverloadLimit = "limits.actions.invokes.concurrentInSystem"
     val triggerFirePerMinuteLimit = "limits.triggers.fires.perMinute"
+    val actionInvokeBlockingTimeoutDefaultLimit = "defaultLimits.actions.invokes.blockingTimeout"
+    val actionInvokeBlockingTimeoutLimit = "limits.actions.invokes.blockingTimeout"
 }

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -112,12 +112,13 @@ class WhiskConfig(
 
     val runtimesManifest = this(WhiskConfig.runtimesManifest)
 
-    val actionInvokePerMinuteLimit = this(WhiskConfig.actionInvokePerMinuteDefaultLimit, WhiskConfig.actionInvokePerMinuteLimit)
-    val actionInvokeConcurrentLimit = this(WhiskConfig.actionInvokeConcurrentDefaultLimit, WhiskConfig.actionInvokeConcurrentLimit)
-    val triggerFirePerMinuteLimit = this(WhiskConfig.triggerFirePerMinuteDefaultLimit, WhiskConfig.triggerFirePerMinuteLimit)
-    val actionInvokeSystemOverloadLimit = this(WhiskConfig.actionInvokeSystemOverloadDefaultLimit, WhiskConfig.actionInvokeSystemOverloadLimit)
-    val actionSequenceLimit = this(WhiskConfig.actionSequenceDefaultLimit)
     val actionInvokeBlockingTimeoutLimit = this(WhiskConfig.actionInvokeBlockingTimeoutDefaultLimit, WhiskConfig.actionInvokeBlockingTimeoutLimit)
+    val actionInvokeConcurrentLimit = this(WhiskConfig.actionInvokeConcurrentDefaultLimit, WhiskConfig.actionInvokeConcurrentLimit)
+    val actionInvokeSystemOverloadLimit = this(WhiskConfig.actionInvokeSystemOverloadDefaultLimit, WhiskConfig.actionInvokeSystemOverloadLimit)
+    val actionInvokePerMinuteLimit = this(WhiskConfig.actionInvokePerMinuteDefaultLimit, WhiskConfig.actionInvokePerMinuteLimit)
+    val actionSequenceLimit = this(WhiskConfig.actionSequenceDefaultLimit)
+    val activationPollMaxRecordLimit = this(WhiskConfig.activationPollMaxRecordDefaultLimit, WhiskConfig.activationPollMaxRecordLimit)
+    val triggerFirePerMinuteLimit = this(WhiskConfig.triggerFirePerMinuteDefaultLimit, WhiskConfig.triggerFirePerMinuteLimit)
 }
 
 object WhiskConfig {
@@ -276,15 +277,18 @@ object WhiskConfig {
 
     val runtimesManifest = "runtimes.manifest"
 
-    val actionInvokePerMinuteDefaultLimit = "defaultLimits.actions.invokes.perMinute"
-    val actionInvokeConcurrentDefaultLimit = "defaultLimits.actions.invokes.concurrent"
-    val actionInvokeSystemOverloadDefaultLimit = "defaultLimits.actions.invokes.concurrentInSystem"
-    val triggerFirePerMinuteDefaultLimit = "defaultLimits.triggers.fires.perMinute"
-    val actionSequenceDefaultLimit = "defaultLimits.actions.sequence.maxLength"
-    val actionInvokePerMinuteLimit = "limits.actions.invokes.perMinute"
-    val actionInvokeConcurrentLimit = "limits.actions.invokes.concurrent"
-    val actionInvokeSystemOverloadLimit = "limits.actions.invokes.concurrentInSystem"
-    val triggerFirePerMinuteLimit = "limits.triggers.fires.perMinute"
-    val actionInvokeBlockingTimeoutDefaultLimit = "defaultLimits.actions.invokes.blockingTimeout"
     val actionInvokeBlockingTimeoutLimit = "limits.actions.invokes.blockingTimeout"
+    val actionInvokeBlockingTimeoutDefaultLimit = "defaultLimits.actions.invokes.blockingTimeout"
+    val actionInvokeConcurrentLimit = "limits.actions.invokes.concurrent"
+    val actionInvokeConcurrentDefaultLimit = "defaultLimits.actions.invokes.concurrent"
+    val actionInvokePerMinuteLimit = "limits.actions.invokes.perMinute"
+    val actionInvokePerMinuteDefaultLimit = "defaultLimits.actions.invokes.perMinute"
+    val actionInvokeSystemOverloadLimit = "limits.actions.invokes.concurrentInSystem"
+    val actionInvokeSystemOverloadDefaultLimit = "defaultLimits.actions.invokes.concurrentInSystem"
+    val actionSequenceDefaultLimit = "defaultLimits.actions.sequence.maxLength"
+    val activationPollMaxRecordLimit = "limits.activations.polls.maxRecords"
+    val activationPollMaxRecordDefaultLimit = "defaultLimits.activations.polls.maxRecords"
+    val triggerFirePerMinuteLimit = "limits.triggers.fires.perMinute"
+    val triggerFirePerMinuteDefaultLimit = "defaultLimits.triggers.fires.perMinute"
+
 }

--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -625,7 +625,7 @@ trait WhiskActionsApi
     /** Max atomic action count allowed for sequences */
     private lazy val actionSequenceLimit = whiskConfig.actionSequenceLimit.toInt
 
-    private lazy val actionInvokeBlockingTimeoutLimit = whiskConfig.actionInvokeBlockingTimeoutLimit.toInt.seconds
+    lazy val actionInvokeBlockingTimeoutLimit = whiskConfig.actionInvokeBlockingTimeoutLimit.toInt.seconds
 
     /** Custom deserializer for timeout query parameter. */
     private implicit val stringToTimeoutDeserializer = new FromStringDeserializer[FiniteDuration] {

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -146,10 +146,7 @@ object Controller {
     def requiredProperties = Map(WhiskConfig.servicePort -> 8080.toString) ++
         ExecManifest.requiredProperties ++
         RestApiCommons.requiredProperties ++
-        LoadBalancerService.requiredProperties ++
-        EntitlementProvider.requiredProperties ++
-        WhiskActionsApi.requiredProperties ++
-        WhiskActivationsApi.requiredProperties
+        LoadBalancerService.requiredProperties
 
     def optionalProperties = EntitlementProvider.optionalProperties
 

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -147,7 +147,8 @@ object Controller {
         ExecManifest.requiredProperties ++
         RestApiCommons.requiredProperties ++
         LoadBalancerService.requiredProperties ++
-        EntitlementProvider.requiredProperties
+        EntitlementProvider.requiredProperties ++
+        WhiskActionsApi.requiredProperties
 
     def optionalProperties = EntitlementProvider.optionalProperties
 
@@ -160,7 +161,8 @@ object Controller {
         "limits" -> JsObject(
             "actions_per_minute" -> config.actionInvokePerMinuteLimit.toInt.toJson,
             "triggers_per_minute" -> config.triggerFirePerMinuteLimit.toInt.toJson,
-            "concurrent_actions" -> config.actionInvokeConcurrentLimit.toInt.toJson),
+            "concurrent_actions" -> config.actionInvokeConcurrentLimit.toInt.toJson,
+            "action_blocking_timeout" -> config.actionInvokeBlockingTimeoutLimit.toInt.toJson),
         "runtimes" -> runtimes.toJson)
 
     // akka-style factory to create a Controller object

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -148,7 +148,8 @@ object Controller {
         RestApiCommons.requiredProperties ++
         LoadBalancerService.requiredProperties ++
         EntitlementProvider.requiredProperties ++
-        WhiskActionsApi.requiredProperties
+        WhiskActionsApi.requiredProperties ++
+        WhiskActivationsApi.requiredProperties
 
     def optionalProperties = EntitlementProvider.optionalProperties
 
@@ -162,7 +163,8 @@ object Controller {
             "actions_per_minute" -> config.actionInvokePerMinuteLimit.toInt.toJson,
             "triggers_per_minute" -> config.triggerFirePerMinuteLimit.toInt.toJson,
             "concurrent_actions" -> config.actionInvokeConcurrentLimit.toInt.toJson,
-            "action_blocking_timeout" -> config.actionInvokeBlockingTimeoutLimit.toInt.toJson),
+            "action_blocking_timeout" -> config.actionInvokeBlockingTimeoutLimit.toInt.toJson,
+            "activation_poll_record_limit" -> config.activationPollMaxRecordLimit.toInt.toJson),
         "runtimes" -> runtimes.toJson)
 
     // akka-style factory to create a Controller object

--- a/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
@@ -273,7 +273,8 @@ protected[controller] class RestAPIVersion(apipath: String, apiversion: String)(
             implicit override val activationStore: ActivationStore,
             override val entitlementProvider: EntitlementProvider,
             override val executionContext: ExecutionContext,
-            override val logging: Logging)
+            override val logging: Logging,
+            override val whiskConfig: WhiskConfig)
         extends WhiskActivationsApi
 
     class PackagesApi(

--- a/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
@@ -95,7 +95,8 @@ protected[controller] object RestApiCommons {
             EntitlementProvider.requiredProperties ++
             WhiskActionsApi.requiredProperties ++
             Authenticate.requiredProperties ++
-            Collection.requiredProperties
+            Collection.requiredProperties ++
+            WhiskActivationsApi.requiredProperties
 
     /**
      * The web actions API is available in both v1 and v2.

--- a/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
@@ -72,11 +72,9 @@ protected[controller] sealed class WebApiDirectives private (prefix: String) {
     lazy val reservedProperties: Set[String] = Set(method, headers, path, namespace, query, body)
     protected final def fields(f: String) = s"$prefix$f"
 
-    def requiredProperties = Map(WhiskConfig.actionSequenceDefaultLimit -> null,
-        WhiskConfig.actionInvokeBlockingTimeoutDefaultLimit -> null)
+    def requiredProperties = Map(WhiskConfig.actionInvokeBlockingTimeoutDefaultLimit -> null)
 
     def optionalProperties = Set(WhiskConfig.actionInvokeBlockingTimeoutLimit)
-
 }
 
 // field names for /web with raw-http action

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
@@ -30,7 +30,6 @@ import whisk.common.LoggingMarkers
 import whisk.common.TransactionId
 import whisk.core.connector.ActivationMessage
 import whisk.core.controller.WhiskServices
-import whisk.core.controller.WhiskActionsApi
 import whisk.core.database.NoDocumentException
 import whisk.core.entity._
 import whisk.core.entity.types.ActivationStore
@@ -55,7 +54,7 @@ protected[actions] trait PrimitiveActions {
     protected val activationStore: ActivationStore
 
     /** Max duration for active ack. */
-    protected val activeAckTimeout = WhiskActionsApi.maxWaitForBlockingActivation
+    protected val activeAckTimeout = whiskConfig.actionInvokeBlockingTimeoutLimit.toInt.seconds
 
     /**
      * Gets document from datastore to confirm a valid action activation then posts request to loadbalancer.

--- a/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
@@ -111,7 +111,7 @@ protected[actions] trait SequenceActions {
         if (topmost) { // need to deal with blocking and closing connection
             if (blocking) {
                 logging.info(this, s"invoke sequence blocking topmost!")
-                val timeout = maxWaitForBlockingActivation + blockingInvokeGrace
+                val timeout = whiskConfig.actionInvokeBlockingTimeoutLimit.toInt.seconds + blockingInvokeGrace
                 // if the future fails with a timeout, the failure is dealt with at the caller level
                 futureSeqResult.withTimeout(timeout, new BlockingInvokeTimeout(seqActivationId))
             } else {

--- a/tests/src/test/scala/common/WhiskProperties.java
+++ b/tests/src/test/scala/common/WhiskProperties.java
@@ -254,10 +254,38 @@ public class WhiskProperties {
         return Integer.parseInt(whiskProperties.getProperty("controller.host.port"));
     }
 
+    public static int getActionInvokeBlockingTimeout() {
+        return getPropertyLimit("limits.actions.invokes.blockingTimeout", "defaultLimits.actions.invokes.blockingTimeout");
+    }
+
+    public static int getActionInvokeConcurent() {
+        return getPropertyLimit("limits.actions.invokes.concurrent", "defaultLimits.actions.invokes.concurrent");
+    }
+
+    public static int getActionInvokeConcurentInSystem() {
+        return getPropertyLimit("limits.actions.invokes.concurrentInSystem", "defaultLimits.actions.invokes.concurrentInSystem");
+    }
+
     public static int getMaxActionInvokesPerMinute() {
-        String valStr = whiskProperties.getProperty("limits.actions.invokes.perMinute");
+        return getPropertyLimit("limits.actions.invokes.perMinute", "defaultLimits.actions.invokes.perMinute");
+    }
+
+    public static int getActionSequenceMaxLength() {
+        return getPropertyLimit("limits.actions.sequence.maxLength", "defaultLimits.actions.sequence.maxLength");
+    }
+
+    public static int getActivationPollMaxRecords() {
+        return getPropertyLimit("limits.activations.polls.maxRecords", "defaultLimits.activations.polls.maxRecords");
+    }
+
+    public static int getTriggerFiresPerMinute() {
+        return getPropertyLimit("imits.triggers.fires.perMinute", "defaultLimits.triggers.fires.perMinute");
+    }
+
+    private static int getPropertyLimit(String property, String defaultProperty) {
+        String valStr = whiskProperties.getProperty(property);
         if (null == valStr) {
-            valStr = whiskProperties.getProperty("defaultLimits.actions.invokes.perMinute");
+            valStr = whiskProperties.getProperty(defaultProperty);
         }
         return Integer.parseInt(valStr);
     }

--- a/tests/src/test/scala/common/WhiskProperties.java
+++ b/tests/src/test/scala/common/WhiskProperties.java
@@ -279,7 +279,7 @@ public class WhiskProperties {
     }
 
     public static int getTriggerFiresPerMinute() {
-        return getPropertyLimit("imits.triggers.fires.perMinute", "defaultLimits.triggers.fires.perMinute");
+        return getPropertyLimit("limits.triggers.fires.perMinute", "defaultLimits.triggers.fires.perMinute");
     }
 
     private static int getPropertyLimit(String property, String defaultProperty) {

--- a/tests/src/test/scala/system/rest/ControllerInfo.scala
+++ b/tests/src/test/scala/system/rest/ControllerInfo.scala
@@ -1,11 +1,12 @@
 /*
- * Copyright 2015-2016 IBM Corporation
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/src/test/scala/system/rest/ControllerInfo.scala
+++ b/tests/src/test/scala/system/rest/ControllerInfo.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package system.rest
+
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+import org.scalatest.junit.JUnitRunner
+
+import com.jayway.restassured.RestAssured
+
+@RunWith(classOf[JUnitRunner])
+class ControllerInfo extends FlatSpec with Matchers with RestUtil {
+
+    it should "get info route from controller" in {
+        val response = RestAssured.given.config(sslconfig).get(getServiceURL)
+        response.statusCode shouldBe 200
+        response.body.asString.contains("\"support\":") shouldBe true
+        response.body.asString.contains("\"description\":") shouldBe true
+        response.body.asString.contains("\"runtimes\":") shouldBe true
+        response.body.asString.contains("\"limits\":") shouldBe true
+    }
+}

--- a/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
@@ -661,12 +661,12 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
 
             Post(s"$collectionPath/${action.name}?blocking=true&timeout=0") ~> sealRoute(routes(creds)) ~> check {
                 status shouldBe BadRequest
-                responseAs[String] should include(Messages.invalidTimeout(WhiskActionsApi.maxWaitForBlockingActivation))
+                responseAs[String] should include(Messages.invalidTimeout(actionInvokeBlockingTimeoutLimit))
             }
 
             Post(s"$collectionPath/${action.name}?blocking=true&timeout=65000") ~> sealRoute(routes(creds)) ~> check {
                 status shouldBe BadRequest
-                responseAs[String] should include(Messages.invalidTimeout(WhiskActionsApi.maxWaitForBlockingActivation))
+                responseAs[String] should include(Messages.invalidTimeout(actionInvokeBlockingTimeoutLimit))
             }
 
             // will not wait long enough should get accepted status


### PR DESCRIPTION
Allows for the configuration of the maximum number of activation records to be displayed for activation list requests, and also allows for the configuration of the blocking action timeout value.

In addition, to making the above values configurable, the mentioned values will also be displayed from the controller's info route.

The goal here is to provide default, min, and max parameter values via controller info route so that the UI/CLI can dynamically read these values.