### PR TITLE
Action limit test for log truncation produces less log entries

### DIFF
--- a/tests/src/test/scala/whisk/core/limits/ActionLimitsTests.scala
+++ b/tests/src/test/scala/whisk/core/limits/ActionLimitsTests.scala
@@ -99,20 +99,22 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers {
 
     it should "succeed but truncate logs, if log size exceeds its limit" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val allowedSize = 2 megabytes
+            val bytesPerLine = 16
+            val allowedSize = 1 megabytes
             val name = "TestActionCausingExceededLogs"
             assetHelper.withCleaner(wsk.action, name, confirmDelete = true) {
                 val actionName = TestUtils.getTestActionFilename("dosLogs.js")
                 (action, _) => action.create(name, Some(actionName), logsize = Some(allowedSize))
             }
 
-            val attemptedSize = allowedSize + 1.megabytes
+            // Add 10% to allowed size to exceed limit
+            val attemptedSize = (allowedSize.toBytes * 1.1).toLong.bytes
 
             val run = wsk.action.invoke(name, Map("payload" -> attemptedSize.toBytes.toJson))
             withActivation(wsk.activation, run) { response =>
                 val lines = response.logs.get
                 lines.last shouldBe Messages.truncateLogs(allowedSize)
-                (lines.length - 1) shouldBe (allowedSize.toBytes / 16)
+                (lines.length - 1) shouldBe (allowedSize.toBytes / bytesPerLine)
                 // dropping 39 characters (timestamp + stream name)
                 // then reform total string adding back newlines
                 val actual = lines.dropRight(1).map(_.drop(39)).mkString("", "\n", "\n").sizeInBytes.toBytes
@@ -245,7 +247,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers {
                 (action, _) => action.create(name, Some(actionName), memory = Some(allowedMemory))
             }
 
-            for( a <- 1 to 10){
+            for (a <- 1 to 10) {
                 val run = wsk.action.invoke(name, Map("payload" -> "128".toJson))
                 withActivation(wsk.activation, run) { response =>
                     response.response.status shouldBe "success"


### PR DESCRIPTION
The test now uses the minimum supported log limit (1M) and creates 10% more log output as the limit. In the past, the test had a limit of 2M and produced 3M logs.

We frequently saw this test failing in mainOpenwhisk in the past few days because it took too
long to PUT the activation record to Cloudant, i.e. more than 60 sec. We suspect that
concurrent load tests in YS0 may have caused the long Cloudant response times because the
Cloudant DB cluster is shared. But we don`t have enough diagnostic data to prove this assumption.

At the same time, making the log portion in the activation record smaller with this change
should also make the Cloudant request faster. This change does only affect limits and sizes but
does not change the test's design.