### PR TITLE
Back-off threshold and choose home invoker as default.

### DIFF
--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -367,7 +367,7 @@ object LoadBalancerService {
                 if (activationsPerInvoker.get(invokerName).getOrElse(0) < invokerBusyThreshold) {
                     invokerName
                 } else {
-                    // ... otherwise look for a less loaded invoker by stepping through a pre computed
+                    // ... otherwise look for a less loaded invoker by stepping through a pre-computed
                     // list of invokers; there are two possible outcomes:
                     // 1. the search lands on a new invoker that has capacity, choose it
                     // 2. walked through the entire list and found no better invoker than the
@@ -375,7 +375,10 @@ object LoadBalancerService {
                     val newTarget = (targetInvoker + step) % numInvokers
                     if (newTarget == homeInvoker || seenInvokers > numInvokers) {
                         // fall back to the invoker with the least load.
-                        activationsPerInvoker.minBy(_._2)._1
+                        availableInvokers.reduce { (a, b) =>
+                            if (activationsPerInvoker.get(a).getOrElse(0) < activationsPerInvoker.get(b).getOrElse(0)) a
+                            else b
+                        }
                     } else {
                         search(newTarget, seenInvokers + 1)
                     }

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -336,8 +336,8 @@ object LoadBalancerService {
 
     /**
      * Scans through all invokers and searches for an invoker, that has a queue length
-     * below the defined threshold. Iff no "underloaded" invoker was found it will
-     * default to the least loaded invoker in the list.
+     * below the defined threshold. The threshold is subject to a 3 times back off. Iff
+     * no "underloaded" invoker was found it will default to the home invoker.
      *
      * @param availableInvokers a list of available (healthy) invokers to search in
      * @param activationsPerInvoker a map of the number of outstanding activations per invoker
@@ -359,33 +359,33 @@ object LoadBalancerService {
             val step = stepSizes(hash % stepSizes.size)
 
             @tailrec
-            def search(targetInvoker: Int, seenInvokers: Int): A = {
+            def search(targetInvoker: Int, iteration: Int = 1): A = {
                 // map the computed index to the actual invoker index
                 val invokerName = availableInvokers(targetInvoker)
 
                 // send the request to the target invoker if it has capacity...
-                if (activationsPerInvoker.get(invokerName).getOrElse(0) < invokerBusyThreshold) {
+                if (activationsPerInvoker.get(invokerName).getOrElse(0) < invokerBusyThreshold * iteration) {
                     invokerName
                 } else {
                     // ... otherwise look for a less loaded invoker by stepping through a pre-computed
                     // list of invokers; there are two possible outcomes:
                     // 1. the search lands on a new invoker that has capacity, choose it
                     // 2. walked through the entire list and found no better invoker than the
-                    //    "home invoker", choose the least loaded invoker
+                    //    "home invoker", force the home invoker
                     val newTarget = (targetInvoker + step) % numInvokers
-                    if (newTarget == homeInvoker || seenInvokers > numInvokers) {
-                        // fall back to the invoker with the least load.
-                        availableInvokers.reduce { (a, b) =>
-                            if (activationsPerInvoker.get(a).getOrElse(0) < activationsPerInvoker.get(b).getOrElse(0)) a
-                            else b
+                    if (newTarget == homeInvoker) {
+                        if (iteration < 3) {
+                            search(newTarget, iteration + 1)
+                        } else {
+                            availableInvokers(homeInvoker)
                         }
                     } else {
-                        search(newTarget, seenInvokers + 1)
+                        search(newTarget, iteration)
                     }
                 }
             }
 
-            Some(search(homeInvoker, 0))
+            Some(search(homeInvoker))
         } else {
             None
         }

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/LoadBalancerServiceObjectTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/LoadBalancerServiceObjectTests.scala
@@ -123,4 +123,17 @@ class LoadBalancerServiceObjectTests extends FlatSpec with Matchers {
             1,
             hash) shouldBe Some("invoker2")
     }
+
+    it should "not choose an invoker from the map which is not in the passed in invoker list when falling back to the least loaded invoker" in {
+        val invokerCount = 3
+        val invs = invokers(invokerCount)
+        val hash = 1
+
+        LoadBalancerService.schedule(
+            invs,
+            // Note that invoker3 is not in the list provided above (which ranges from 0-2)
+            Map("invoker0" -> 3, "invoker1" -> 3, "invoker2" -> 2, "invoker3" -> 0),
+            1,
+            hash) shouldBe Some("invoker2")
+    }
 }


### PR DESCRIPTION
The loadbalancer falls back to picking the home invoker for the action iff all invokers are loaded above a defined threshold. That threshold is backed off 3 times to prevent a "all hell breaks loose" scenario in a sustained high load.