### PR TITLE
Update install Catalog script.

### DIFF
--- a/ansible/tasks/installOpenwhiskCatalog.yml
+++ b/ansible/tasks/installOpenwhiskCatalog.yml
@@ -29,6 +29,6 @@
     version: "{{ version }}"
 
 - name: install the catalog from the catalog location
-  shell: ./installCatalog.sh {{ catalog_auth_key }} {{ api_host }} {{ catalog_namespace }} {{ cli.path }} chdir="{{ catalog_location }}/packages"
+  shell: ./installCatalog.sh {{ catalog_auth_key }} {{ api_host }} {{ cli.path }} chdir="{{ catalog_location }}/packages"
   environment:
     OPENWHISK_HOME: "{{ openwhisk_home }}"


### PR DESCRIPTION
* Removes unused parameter

There is a PR for the OpenWhiskCatalog repo to remove an unused parameter from the `installCatalog.sh` script. Once this [#pr](https://github.com/apache/incubator-openwhisk-catalog/pull/231) has been merged, this PR can be merged.