### PR TITLE
Make kafka heap size configurable.

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -124,6 +124,7 @@ kafka:
   port: 9092
   ras:
     port: 9093
+  heap: "{{ kafka_heap | default('1g') }}"
   topics:
     completed:
       segmentBytes: 536870912

--- a/ansible/roles/kafka/tasks/deploy.yml
+++ b/ansible/roles/kafka/tasks/deploy.yml
@@ -37,6 +37,7 @@
       - "zookeeper:zookeeper"
     env:
       "KAFKA_ADVERTISED_HOST_NAME": "{{ inventory_hostname }}"
+      "KAFKA_HEAP_OPTS": "-Xmx{{ kafka.heap }} -Xms{{ kafka.heap }}"
     ports:
       - "{{ kafka.port }}:9092"
 


### PR DESCRIPTION
Kafka is set to 1 gigabyte by default which might not be suitable for all deployments.