### PR TITLE
Fix install command in Docker for Mac bash script

### DIFF
--- a/tools/macos/README.md
+++ b/tools/macos/README.md
@@ -30,7 +30,7 @@ brew install scala
 # install pip
 sudo easy_install pip
 # install docker for python
-/usr/local/bin/pip install docker=2.2.1
+/usr/local/bin/pip install docker==2.2.1
 # install script prerequisites
 sudo -H pip install ansible==2.3.0.0 jsonschema couchdb' | bash
 ```


### PR DESCRIPTION
There is a missing `=` which causes an error when trying to install Docker 2.2.1