### PR TITLE
Adjust kafka's maximum poll period.

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -120,7 +120,7 @@ registry:
   confdir: "{{ config_root_dir }}/registry"
 
 kafka:
-  version: 0.10.0.1
+  version: 0.10.2.1
   port: 9092
   ras:
     port: 9093

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     compile 'commons-logging:commons-logging:1.2'
     compile 'commons-collections:commons-collections:3.2.2'
     compile 'org.apache.zookeeper:zookeeper:3.4.6'
-    compile 'org.apache.kafka:kafka-clients:0.10.0.0'
+    compile 'org.apache.kafka:kafka-clients:0.10.2.1'
     compile 'org.apache.httpcomponents:httpclient:4.4.1'
     compile 'com.github.ben-manes.caffeine:caffeine:2.4.0'
     compile 'com.google.code.findbugs:jsr305:3.0.2'

--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaConsumerConnector.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaConsumerConnector.scala
@@ -103,6 +103,10 @@ class KafkaConsumerConnector(
         props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPeek.toString)
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, if (!readeos) "latest" else "earliest")
 
+        // We allow for 5 minutes of execution time so there should be at most 5 minutes of
+        // no polling happening if the queues are fully loaded.
+        props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, 6.minutes.toMillis.toString)
+
         // This value controls the server-side wait time which affects polling latency.
         // A low value improves latency performance but it is important to not set it too low
         // as that will cause excessive busy-waiting.

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -235,8 +235,7 @@ class LoadBalancerService(config: WhiskConfig, instance: InstanceId, entityStore
     }
 
     /** Subscribes to active acks (completion messages from the invokers). */
-    val activeAckTopic = s"completed${instance.toInt}"
-    private val activeAckConsumer = new KafkaConsumerConnector(config.kafkaHost, activeAckTopic, activeAckTopic)
+    private val activeAckConsumer = new KafkaConsumerConnector(config.kafkaHost, "completions", s"completed${instance.toInt}")
 
     /** Registers a handler for received active acks from invokers. */
     activeAckConsumer.onMessage((topic, _, _, bytes) => {

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -235,7 +235,8 @@ class LoadBalancerService(config: WhiskConfig, instance: InstanceId, entityStore
     }
 
     /** Subscribes to active acks (completion messages from the invokers). */
-    private val activeAckConsumer = new KafkaConsumerConnector(config.kafkaHost, "completions", s"completed${instance.toInt}")
+    val activeAckTopic = s"completed${instance.toInt}"
+    private val activeAckConsumer = new KafkaConsumerConnector(config.kafkaHost, activeAckTopic, activeAckTopic)
 
     /** Registers a handler for received active acks from invokers. */
     activeAckConsumer.onMessage((topic, _, _, bytes) => {

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -486,7 +486,7 @@ object Invoker {
 
         val topic = s"invoker${invokerInstance.toInt}"
         val maxdepth = ContainerPool.getDefaultMaxActive(config)
-        val consumer = new KafkaConsumerConnector(config.kafkaHost, topic, topic, maxdepth, maxPollInterval = TimeLimit.MAX_DURATION + 1.minute)
+        val consumer = new KafkaConsumerConnector(config.kafkaHost, "invokers", topic, maxdepth, maxPollInterval = TimeLimit.MAX_DURATION + 1.minute)
         val producer = new KafkaProducerConnector(config.kafkaHost, ec)
         val dispatcher = new Dispatcher(consumer, 500 milliseconds, 2 * maxdepth, actorSystem)
 

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -484,9 +484,8 @@ object Invoker {
         }
 
         val topic = s"invoker${invokerInstance.toInt}"
-        val groupid = "invokers"
         val maxdepth = ContainerPool.getDefaultMaxActive(config)
-        val consumer = new KafkaConsumerConnector(config.kafkaHost, groupid, topic, maxdepth)
+        val consumer = new KafkaConsumerConnector(config.kafkaHost, topic, topic, maxdepth)
         val producer = new KafkaProducerConnector(config.kafkaHost, ec)
         val dispatcher = new Dispatcher(consumer, 500 milliseconds, 2 * maxdepth, actorSystem)
 

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -52,6 +52,7 @@ import whisk.core.connector.PingMessage
 import scala.util.Try
 import whisk.core.connector.MessageProducer
 import org.apache.kafka.common.errors.RecordTooLargeException
+import whisk.core.entity.TimeLimit
 
 /**
  * A kafka message handler that invokes actions as directed by message on topic "/actions/invoke".
@@ -485,7 +486,7 @@ object Invoker {
 
         val topic = s"invoker${invokerInstance.toInt}"
         val maxdepth = ContainerPool.getDefaultMaxActive(config)
-        val consumer = new KafkaConsumerConnector(config.kafkaHost, topic, topic, maxdepth)
+        val consumer = new KafkaConsumerConnector(config.kafkaHost, topic, topic, maxdepth, maxPollInterval = TimeLimit.MAX_DURATION + 1.minute)
         val producer = new KafkaProducerConnector(config.kafkaHost, ec)
         val dispatcher = new Dispatcher(consumer, 500 milliseconds, 2 * maxdepth, actorSystem)
 

--- a/tests/src/test/scala/services/KafkaConnectorTests.scala
+++ b/tests/src/test/scala/services/KafkaConnectorTests.scala
@@ -154,7 +154,7 @@ class TestKafkaConsumerConnector(
 
     override def commit() = {
         if (commitFails) {
-            throw new CommitFailedException("commit failed")
+            throw new CommitFailedException()
         } else {
             super.commit()
         }

--- a/tests/src/test/scala/services/KafkaConnectorTests.scala
+++ b/tests/src/test/scala/services/KafkaConnectorTests.scala
@@ -59,8 +59,9 @@ class KafkaConnectorTests
     val groupid = "kafkatest"
     val topic = "Dinosaurs"
     val sessionTimeout = 10 seconds
+    val maxPollInterval = 10 seconds
     val producer = new KafkaProducerConnector(config.kafkaHost, ec)
-    val consumer = new TestKafkaConsumerConnector(config.kafkaHost, groupid, topic, sessionTimeout = sessionTimeout)
+    val consumer = new TestKafkaConsumerConnector(config.kafkaHost, groupid, topic, sessionTimeout = sessionTimeout, maxPollInterval = maxPollInterval)
 
     override def afterAll() {
         producer.close()
@@ -108,7 +109,7 @@ class KafkaConnectorTests
             received.last should be(message.serialize)
 
             if (i < 2) {
-                Thread.sleep((sessionTimeout + 1.second).toMillis)
+                Thread.sleep((maxPollInterval + 1.second).toMillis)
                 a[CommitFailedException] should be thrownBy {
                     consumer.commit() // sleep should cause commit to fail
                 }
@@ -130,9 +131,9 @@ class KafkaConnectorTests
 
         // Send message while commit throws exception -> Message will not be processed
         consumer.commitFails = true
-        retry(stream.toString should include("failed to commit to kafka: commit failed"), 50, Some(100 millisecond))
+        retry(stream.toString should include("failed to commit to kafka:"), 50, Some(100 millisecond))
         Await.result(producer.send(topic, message), 10 seconds)
-        retry(stream.toString should include("failed to commit to kafka: commit failed"), 50, Some(100 millisecond))
+        retry(stream.toString should include("failed to commit to kafka:"), 50, Some(100 millisecond))
 
         // Send message again -> No commit exception -> Should work again
         consumer.commitFails = false
@@ -150,7 +151,9 @@ class TestKafkaConsumerConnector(
     kafkahost: String,
     groupid: String,
     topic: String,
-    sessionTimeout: FiniteDuration)(implicit logging: Logging) extends KafkaConsumerConnector(kafkahost, groupid, topic, sessionTimeout = sessionTimeout) {
+    sessionTimeout: FiniteDuration,
+    maxPollInterval: FiniteDuration)(implicit logging: Logging) extends KafkaConsumerConnector(
+    kafkahost, groupid, topic, sessionTimeout = sessionTimeout, maxPollInterval = maxPollInterval) {
 
     override def commit() = {
         if (commitFails) {


### PR DESCRIPTION
Kafka allows setting the maximum period between two polls. As we allow for 5 minutes of action execution, in a fully loaded invoker it might take 5 minutes for the consumer to poll again. To prevent rebalances this value is adjusted accordingly.

Bumping Kafka's version is needed because that value is exposed only in 0.10.1+.

ConsumerGroups are removed (or rather: each Invoker/Controller is in it's own ConsumerGroup) to prevent rebalances to impact other consumers. OpenWhisk does not use ConsumerGroup mechanics anyway.