### PR TITLE
Let each controller create its own health action

### DIFF
--- a/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
@@ -177,10 +177,10 @@ object InvokerPool {
     }
 
     /** An action to use for monitoring invoker health. */
-    val healthAction = ExecManifest.runtimesManifest.resolveDefaultRuntime("nodejs:6").map { manifest =>
+    def healthAction(i: InstanceId) = ExecManifest.runtimesManifest.resolveDefaultRuntime("nodejs:6").map { manifest =>
         new WhiskAction(
             namespace = healthActionIdentity.namespace.toPath,
-            name = EntityName("invokerHealthTestAction"),
+            name = EntityName(s"invokerHealthTestAction${i.toInt}"),
             exec = new CodeExecAsString(manifest, """function main(params) { return params; }""", None))
     }
 }
@@ -301,7 +301,7 @@ class InvokerActor(controllerInstance: InstanceId) extends FSM[InvokerState, Inv
      * The InvokerPool redirects it to the invoker which is represented by this InvokerActor.
      */
     private def invokeTestAction() = {
-        InvokerPool.healthAction.map { action =>
+        InvokerPool.healthAction(controllerInstance).map { action =>
             val activationMessage = ActivationMessage(
                 // Use the sid of the InvokerSupervisor as tid
                 transid = transid,

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -216,7 +216,7 @@ class LoadBalancerService(config: WhiskConfig, instance: InstanceId, entityStore
 
     private val invokerPool = {
         // Do not create the invokerPool if it is not possible to create the health test action to recover the invokers.
-        InvokerPool.healthAction.map {
+        InvokerPool.healthAction(instance).map {
             // Await the creation of the test action; on failure, this will abort the constructor which should
             // in turn abort the startup of the controller.
             a => Await.result(createTestActionForInvokerHealth(entityStore, a), 1.minute)


### PR DESCRIPTION
Let each controller create its own health action to avoid race condition parallel startup of several controllers.

PG2#1774 is green.