### PR TITLE
Correct java action heap size issue #2389.

### DIFF
--- a/core/javaAction/Dockerfile
+++ b/core/javaAction/Dockerfile
@@ -35,4 +35,4 @@ RUN cd /javaAction; ./gradlew oneJar
 
 RUN rm -rf /javaAction/src
 
-CMD ["java", "-jar", "/javaAction/build/libs/javaAction-all.jar"]
+CMD ["java", "-Xmx56m", "-jar", "/javaAction/build/libs/javaAction-all.jar"]


### PR DESCRIPTION
limit the heap size to 56m, leave some space for stacks etc.