### PR TITLE
Get Action URL from CLI (Review)

### DIFF
--- a/tests/src/test/scala/common/Wsk.scala
+++ b/tests/src/test/scala/common/Wsk.scala
@@ -168,12 +168,14 @@ trait ListOrGetFromCollection extends FullyQualifiedNames {
         name: String,
         expectedExitCode: Int = SUCCESS_EXIT,
         summary: Boolean = false,
-        fieldFilter: Option[String] = None)(
+        fieldFilter: Option[String] = None,
+        url: Option[Boolean] = None)(
             implicit wp: WskProps): RunResult = {
         val params = Seq(noun, "get", "--auth", wp.authKey) ++
             Seq(fqn(name)) ++
             { if (summary) Seq("--summary") else Seq() } ++
-            { fieldFilter map { f => Seq(f) } getOrElse Seq() }
+            { fieldFilter map { f => Seq(f) } getOrElse Seq() } ++
+            { url map { u => Seq("--url") } getOrElse Seq() }
 
         cli(wp.overrides ++ params, expectedExitCode)
     }

--- a/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -21,6 +21,7 @@ import java.io.File
 import java.io.BufferedWriter
 import java.io.FileWriter
 import java.time.Instant
+import java.net.URLEncoder
 
 import scala.language.postfixOps
 import scala.concurrent.duration.Duration
@@ -693,6 +694,59 @@ class WskBasicUsageTests
                     activation.response.result shouldBe Some(output)
                     activation.logs.toList.flatten.filter(_.contains(nonescape)).length shouldBe 1
             }
+    }
+
+    it should "get an action URL" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val actionName = "action name"
+            val packageName = "package name"
+            val defaultPackageName = "default"
+            val webActionName = "web action name"
+            val nonExistentActionName = "non-existence action"
+            val packagedAction = s"$packageName/$actionName"
+            val packagedWebAction = s"$packageName/$webActionName"
+            val (user, namespace) = WskAdmin.getUser(wskprops.authKey)
+            val encodedActionName = URLEncoder.encode(actionName, "UTF-8").replace("+", "%20")
+            val encodedPackageName = URLEncoder.encode(packageName, "UTF-8").replace("+", "%20")
+            val encodedWebActionName = URLEncoder.encode(webActionName, "UTF-8").replace("+", "%20")
+            val encodedNamespace = URLEncoder.encode(namespace, "UTF-8").replace("+", "%20")
+            val actionPath = "https://%s/api/%s/namespaces/%s/actions/%s"
+            val packagedActionPath = s"$actionPath/%s"
+            val webActionPath = "https://%s/api/%s/web/%s/%s/%s"
+
+            assetHelper.withCleaner(wsk.action, actionName) {
+                (action, _) => action.create(actionName, defaultAction)
+            }
+
+            assetHelper.withCleaner(wsk.action, webActionName) {
+                (action, _) => action.create(webActionName, defaultAction, web = Some("true"))
+            }
+
+            assetHelper.withCleaner(wsk.pkg, packageName) {
+                (pkg, _) => pkg.create(packageName)
+            }
+
+            assetHelper.withCleaner(wsk.action, packagedAction) {
+                (action, _) => action.create(packagedAction, defaultAction)
+            }
+
+            assetHelper.withCleaner(wsk.action, packagedWebAction) {
+                (action, _) => action.create(packagedWebAction, defaultAction, web = Some("true"))
+            }
+
+            wsk.action.get(actionName, url = Some(true)).
+                stdout should include(actionPath.format(wskprops.apihost, wskprops.apiversion, encodedNamespace, encodedActionName))
+
+            wsk.action.get(webActionName, url = Some(true)).
+                stdout should include(webActionPath.format(wskprops.apihost, wskprops.apiversion, encodedNamespace, defaultPackageName, encodedWebActionName))
+
+            wsk.action.get(packagedAction, url = Some(true)).
+                stdout should include(packagedActionPath.format(wskprops.apihost, wskprops.apiversion, encodedNamespace, encodedPackageName, encodedActionName))
+
+            wsk.action.get(packagedWebAction, url = Some(true)).
+                stdout should include(webActionPath.format(wskprops.apihost, wskprops.apiversion, encodedNamespace, encodedPackageName, encodedWebActionName))
+
+            wsk.action.get(nonExistentActionName, url = Some(true), expectedExitCode = NOT_FOUND)
     }
 
     behavior of "Wsk packages"

--- a/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -698,10 +698,10 @@ class WskBasicUsageTests
 
     it should "get an action URL" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val actionName = "action name"
-            val packageName = "package name"
+            val actionName = "action name@_-."
+            val packageName = "package name@_-."
             val defaultPackageName = "default"
-            val webActionName = "web action name"
+            val webActionName = "web action name@_-."
             val nonExistentActionName = "non-existence action"
             val packagedAction = s"$packageName/$actionName"
             val packagedWebAction = s"$packageName/$webActionName"
@@ -735,6 +735,10 @@ class WskBasicUsageTests
             }
 
             wsk.action.get(actionName, url = Some(true)).
+                stdout should include(actionPath.format(wskprops.apihost, wskprops.apiversion, encodedNamespace, encodedActionName))
+
+            // Ensure url flag works when a field filter and summary flag are specified
+            wsk.action.get(actionName, url = Some(true), fieldFilter = Some("field"), summary = true).
                 stdout should include(actionPath.format(wskprops.apihost, wskprops.apiversion, encodedNamespace, encodedActionName))
 
             wsk.action.get(webActionName, url = Some(true)).

--- a/tools/cli/go-whisk-cli/commands/action.go
+++ b/tools/cli/go-whisk-cli/commands/action.go
@@ -228,7 +228,10 @@ var actionGetCmd = &cobra.Command{
             return actionGetError(qualifiedName.entityName, err)
         }
 
-        if flags.common.summary {
+        if flags.action.url {
+            actionURL := action.ActionURL(Properties.APIHost, DefaultOpenWhiskApiPath, Properties.APIVersion, qualifiedName.packageName)
+            printActionGetWithURL(qualifiedName.entity, actionURL)
+        } else if flags.common.summary {
             printSummary(action)
         } else {
             if len(field) > 0 {
@@ -822,6 +825,18 @@ func printActionGetWithField(entityName string, field string, action *whisk.Acti
     printField(action, field)
 }
 
+func printActionGetWithURL(entityName string, actionURL string) {
+    fmt.Fprintf(
+        color.Output,
+        wski18n.T(
+            "{{.ok}} got action {{.name}}, displaying url\n",
+            map[string]interface{}{
+                "ok": color.GreenString("ok:"),
+                "name": boldString(entityName),
+            }))
+    fmt.Println(actionURL)
+}
+
 func printActionGet(entityName string, action *whisk.Action) {
     fmt.Fprintf(
         color.Output,
@@ -846,7 +861,7 @@ func printActionDeleted(entityName string) {
 }
 
 // Check if the specified action is a web-action
-func isWebAction(client *whisk.Client, qname QualifiedName) error {
+func isWebAction(client *whisk.Client, qname QualifiedName) (error) {
     var err error = nil
 
     savedNs := client.Namespace
@@ -854,30 +869,23 @@ func isWebAction(client *whisk.Client, qname QualifiedName) error {
     fullActionName := "/" + qname.namespace + "/" + qname.entityName
 
     action, _, err := client.Actions.Get(qname.entityName)
+
     if err != nil {
         whisk.Debug(whisk.DbgError, "client.Actions.Get(%s) error: %s\n", fullActionName, err)
         whisk.Debug(whisk.DbgError, "Unable to obtain action '%s' for web action validation\n", fullActionName)
-        err = errors.New(wski18n.T("API action '{{.name}}' does not exist", map[string]interface{}{"name": fullActionName}))
+        err = errors.New(wski18n.T("API action '{{.name}}' does not exist", map[string]interface{}{"name": fullActionName})) // wrong need 404
     } else {
+        // wrong error messages
         err = errors.New(wski18n.T("API action '{{.name}}' is not a web action. Issue 'wsk action update {{.name}} --web true' to convert the action to a web action.",
             map[string]interface{}{"name": fullActionName}))
-        weVal := getValue(action.Annotations, "web-export")
-        if (weVal == nil) {
-            whisk.Debug(whisk.DbgError, "getValue(annotations, web-export) for action %s found no value\n", fullActionName)
-        } else {
-            var webExport bool
-            var ok bool
-            if webExport, ok = weVal.(bool); !ok {
-                whisk.Debug(whisk.DbgError, "web-export annotation value (%v) is not a boolean\n", weVal)
-            } else if !webExport {
-                whisk.Debug(whisk.DbgError, "web-export annotation value is false\n", weVal)
-            } else {
-                err = nil
-            }
+
+        if action.WebAction() {
+            err = nil
         }
     }
 
     client.Namespace = savedNs
+
     return err
 }
 
@@ -918,6 +926,7 @@ func init() {
     actionInvokeCmd.Flags().BoolVarP(&flags.action.result, "result", "r", false, wski18n.T("blocking invoke; show only activation result (unless there is a failure)"))
 
     actionGetCmd.Flags().BoolVarP(&flags.common.summary, "summary", "s", false, wski18n.T("summarize action details"))
+    actionGetCmd.Flags().BoolVarP(&flags.action.url, "url", "r", false, wski18n.T("get action url"))
 
     actionListCmd.Flags().IntVarP(&flags.common.skip, "skip", "s", 0, wski18n.T("exclude the first `SKIP` number of actions from the result"))
     actionListCmd.Flags().IntVarP(&flags.common.limit, "limit", "l", 30, wski18n.T("only return `LIMIT` number of actions from the collection"))

--- a/tools/cli/go-whisk-cli/commands/action.go
+++ b/tools/cli/go-whisk-cli/commands/action.go
@@ -33,13 +33,13 @@ import (
     "github.com/mattn/go-colorable"
 )
 
-const MEMORY_LIMIT = 256
-const TIMEOUT_LIMIT = 60000
-const LOGSIZE_LIMIT = 10
-const ACTIVATION_ID = "activationId"
-const WEB_EXPORT_ANNOT = "web-export"
-const RAW_HTTP_ANNOT = "raw-http"
-const FINAL_ANNOT = "final"
+const MEMORY_LIMIT      = 256
+const TIMEOUT_LIMIT     = 60000
+const LOGSIZE_LIMIT     = 10
+const ACTIVATION_ID     = "activationId"
+const WEB_EXPORT_ANNOT  = "web-export"
+const RAW_HTTP_ANNOT    = "raw-http"
+const FINAL_ANNOT       = "final"
 
 var actionCmd = &cobra.Command{
     Use:   "action",
@@ -195,7 +195,7 @@ func handleInvocationResponse(
 }
 
 var actionGetCmd = &cobra.Command{
-    Use:           "get ACTION_NAME [FIELD_FILTER]",
+    Use:           "get ACTION_NAME [FIELD_FILTER | --summary | --url]",
     Short:         wski18n.T("get action"),
     SilenceUsage:  true,
     SilenceErrors: true,
@@ -210,7 +210,7 @@ var actionGetCmd = &cobra.Command{
             return whiskErr
         }
 
-        if len(args) > 1 {
+        if !flags.action.url && !flags.common.summary && len(args) > 1 {
             field = args[1]
 
             if !fieldExists(&whisk.Action{}, field) {
@@ -229,7 +229,10 @@ var actionGetCmd = &cobra.Command{
         }
 
         if flags.action.url {
-            actionURL := action.ActionURL(Properties.APIHost, DefaultOpenWhiskApiPath, Properties.APIVersion, qualifiedName.packageName)
+            actionURL := action.ActionURL(Properties.APIHost,
+                DefaultOpenWhiskApiPath,
+                Properties.APIVersion,
+                qualifiedName.packageName)
             printActionGetWithURL(qualifiedName.entity, actionURL)
         } else if flags.common.summary {
             printSummary(action)
@@ -828,8 +831,7 @@ func printActionGetWithField(entityName string, field string, action *whisk.Acti
 func printActionGetWithURL(entityName string, actionURL string) {
     fmt.Fprintf(
         color.Output,
-        wski18n.T(
-            "{{.ok}} got action {{.name}}, displaying url\n",
+        wski18n.T("{{.ok}} got action {{.name}}\n",
             map[string]interface{}{
                 "ok": color.GreenString("ok:"),
                 "name": boldString(entityName),
@@ -873,9 +875,8 @@ func isWebAction(client *whisk.Client, qname QualifiedName) (error) {
     if err != nil {
         whisk.Debug(whisk.DbgError, "client.Actions.Get(%s) error: %s\n", fullActionName, err)
         whisk.Debug(whisk.DbgError, "Unable to obtain action '%s' for web action validation\n", fullActionName)
-        err = errors.New(wski18n.T("API action '{{.name}}' does not exist", map[string]interface{}{"name": fullActionName})) // wrong need 404
+        err = errors.New(wski18n.T("API action '{{.name}}' does not exist", map[string]interface{}{"name": fullActionName}))
     } else {
-        // wrong error messages
         err = errors.New(wski18n.T("API action '{{.name}}' is not a web action. Issue 'wsk action update {{.name}} --web true' to convert the action to a web action.",
             map[string]interface{}{"name": fullActionName}))
 

--- a/tools/cli/go-whisk-cli/commands/flags.go
+++ b/tools/cli/go-whisk-cli/commands/flags.go
@@ -126,6 +126,7 @@ type ActionFlags struct {
     result      bool
     kind        string
     main        string
+    url         bool
 }
 
 func IsVerbose() bool {

--- a/tools/cli/go-whisk-cli/commands/util.go
+++ b/tools/cli/go-whisk-cli/commands/util.go
@@ -487,26 +487,11 @@ func getKeys(keyValueArr whisk.KeyValueArr) ([]string) {
     return res
 }
 
-func getValue(keyValueArr whisk.KeyValueArr, key string) (interface{}) {
-    var res interface{}
-
-    for i := 0; i < len(keyValueArr); i++ {
-        if keyValueArr[i].Key == key {
-            res = keyValueArr[i].Value
-            break;
-        }
-    }
-
-    whisk.Debug(whisk.DbgInfo, "Got value '%v' from '%v' for key '%s'\n", res, keyValueArr, key)
-
-    return res
-}
-
 func getValueString(keyValueArr whisk.KeyValueArr, key string) (string) {
     var value interface{}
     var res string
 
-    value = getValue(keyValueArr, key)
+    value = keyValueArr.GetValue(key)
     castedValue, canCast := value.(string)
 
     if (canCast) {
@@ -522,7 +507,7 @@ func getChildValues(keyValueArr whisk.KeyValueArr, key string, childKey string) 
     var value interface{}
     var res []interface{}
 
-    value = getValue(keyValueArr, key)
+    value = keyValueArr.GetValue(key)
 
     castedValue, canCast := value.([]interface{})
     if canCast {

--- a/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
+++ b/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
@@ -1470,5 +1470,13 @@
   {
     "id": "An entity name, '{{.name}}', was provided instead of a namespace. Valid namespaces are of the following format: /NAMESPACE.",
     "translation": "An entity name, '{{.name}}', was provided instead of a namespace. Valid namespaces are of the following format: /NAMESPACE."
+  },
+  {
+    "id": "{{.ok}} got action {{.name}}, displaying url\n",
+    "translation": "{{.ok}} got action {{.name}}, displaying url\n"
+  },
+  {
+    "id": "get action url",
+    "translation": "get action url"
   }
 ]

--- a/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
+++ b/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
@@ -1472,10 +1472,6 @@
     "translation": "An entity name, '{{.name}}', was provided instead of a namespace. Valid namespaces are of the following format: /NAMESPACE."
   },
   {
-    "id": "{{.ok}} got action {{.name}}, displaying url\n",
-    "translation": "{{.ok}} got action {{.name}}, displaying url\n"
-  },
-  {
     "id": "get action url",
     "translation": "get action url"
   }

--- a/tools/cli/go-whisk/whisk/action.go
+++ b/tools/cli/go-whisk/whisk/action.go
@@ -59,21 +59,25 @@ type ActionListOptions struct {
     Docs        bool        `url:"docs,omitempty"`
 }
 
-func (action Action) WebAction() (bool) {
-    var webExportValue, isBool bool
-
+/*
+Determines if an action is a web action by examining the action's annotations. A value of true is returned if the
+action's annotations contains a "web-export" key and its associated value is a boolean value of "true". Otherwise, false
+is returned.
+ */
+func (action Action) WebAction() (webExportValue bool) {
     webExport := action.Annotations.GetValue("web-export")
+    webExportValue, _ = webExport.(bool)
 
-    if webExportValue, isBool = webExport.(bool); isBool {
-        return webExportValue
-    } else {
-        return false
-    }
+    Debug(DbgInfo, "Web export value is '%t'\n", webExportValue)
+
+    return webExportValue
 }
 
-func (action Action) ActionURL(apiHost string, apiPath string, apiVersion string, pkg string) (string) {
-    var actionURL string
-
+/*
+Returns the URL of an action as a string. A valid API host, path and version must be passed. A package that contains the
+action must be passed as well. An empty string must be passed if the action is not packaged.
+ */
+func (action Action) ActionURL(apiHost string, apiPath string, apiVersion string, pkg string) (actionURL string) {
     webActionPath := "https://%s%s/%s/web/%s/%s/%s"
     actionPath := "https://%s%s/%s/namespaces/%s/actions/%s"
     packagedActionPath := actionPath + "/%s"
@@ -88,11 +92,14 @@ func (action Action) ActionURL(apiHost string, apiPath string, apiVersion string
         }
 
         actionURL = fmt.Sprintf(webActionPath, apiHost, apiPath, apiVersion, namespace, pkg, name)
+        Debug(DbgInfo, "Web action URL: %s\n", actionURL)
     } else {
         if len(pkg) == 0 {
             actionURL = fmt.Sprintf(actionPath, apiHost, apiPath, apiVersion, namespace, name)
+            Debug(DbgInfo, "Packaged action URL: %s\n", actionURL)
         } else {
             actionURL = fmt.Sprintf(packagedActionPath, apiHost, apiPath, apiVersion, namespace, pkg, name)
+            Debug(DbgInfo, "Action URL: %s\n", actionURL)
         }
     }
 

--- a/tools/cli/go-whisk/whisk/shared.go
+++ b/tools/cli/go-whisk/whisk/shared.go
@@ -20,15 +20,17 @@ package whisk
 import "encoding/json"
 
 type KeyValue struct {
-    Key  string         `json:"key"`
-    Value interface{}   `json:"value"`
+    Key     string          `json:"key"`
+    Value   interface{}     `json:"value"`
 }
 
 type KeyValueArr []KeyValue
 
-func (keyValueArr KeyValueArr) GetValue(key string) (interface{}) {
-    var res interface{}
-
+/*
+Retrieves a value associated with a given key from a KeyValueArr. A key of type string must be passed to the method.
+An interface will be returned containing the found value. If a key could not be found, a nil value will be returned.
+ */
+func (keyValueArr KeyValueArr) GetValue(key string) (res interface{}) {
     for i := 0; i < len(keyValueArr); i++ {
         if keyValueArr[i].Key == key {
             res = keyValueArr[i].Value
@@ -36,7 +38,7 @@ func (keyValueArr KeyValueArr) GetValue(key string) (interface{}) {
         }
     }
 
-    Debug(DbgInfo, "Got value '%v' from '%v' for key '%s'\n", res, keyValueArr, key)
+    Debug(DbgInfo, "Got value '%v' for key '%s' from '%v'\n", res, key, keyValueArr)
 
     return res
 }

--- a/tools/cli/go-whisk/whisk/shared.go
+++ b/tools/cli/go-whisk/whisk/shared.go
@@ -26,6 +26,21 @@ type KeyValue struct {
 
 type KeyValueArr []KeyValue
 
+func (keyValueArr KeyValueArr) GetValue(key string) (interface{}) {
+    var res interface{}
+
+    for i := 0; i < len(keyValueArr); i++ {
+        if keyValueArr[i].Key == key {
+            res = keyValueArr[i].Value
+            break;
+        }
+    }
+
+    Debug(DbgInfo, "Got value '%v' from '%v' for key '%s'\n", res, keyValueArr, key)
+
+    return res
+}
+
 type Annotations []map[string]interface{}
 
 type Parameters *json.RawMessage


### PR DESCRIPTION
Adds a `--url` flag to the `action get` command that retrieves non-web action, and web action URLs.