### PR TITLE
Move load balancer data into a separate class

### DIFF
--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerData.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerData.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.loadBalancer
+
+import java.time.Instant
+
+import whisk.core.entity.{ActivationId, UUID, WhiskActivation}
+
+import scala.collection.concurrent.TrieMap
+
+import scala.concurrent.Promise
+
+
+
+case class ActivationEntry(id: ActivationId, namespaceId: UUID, invokerName: String, created: Instant, promise: Promise[Either[ActivationId, WhiskActivation]])
+
+
+class LoadBalancerDataWithLocalMap {
+
+ type TrieSet[T] = TrieMap[T, Unit]
+
+ private val activationByInvoker = new TrieMap[String, TrieSet[ActivationEntry]]
+ private val activationByNamespaceId = new TrieMap[UUID, TrieSet[ActivationEntry]]
+
+
+ def getActivationCountByNamespace() = {
+  activationByNamespaceId.toMap mapValues { _.size }
+ }
+
+ def getActivationCountByInvoker() = {
+  activationByInvoker.toMap mapValues { _.size }
+ }
+
+ def activationsByInvokerSize() = {
+  activationByInvoker.mapValues(_.size)
+ }
+
+
+ def removeActivationByNamespaceId(namespaceId :UUID, entry :ActivationEntry) = {
+  activationByNamespaceId.getOrElseUpdate(namespaceId, new TrieSet[ActivationEntry]).remove(entry)
+ }
+
+ def removeActivationByNamespaceIdWithResponse(namespaceId :UUID, entry :ActivationEntry) = {
+  activationByNamespaceId.get(namespaceId) map { _.remove(entry) }
+ }
+
+
+ def putActivationByNamespaceId(namespaceId :UUID, entry :ActivationEntry) = {
+  activationByNamespaceId.getOrElseUpdate(namespaceId, new TrieSet[ActivationEntry]).put(entry, {})
+ }
+
+ def putActivationbyInvoker(invokerName :String, entry :ActivationEntry) = {
+  activationByInvoker.getOrElseUpdate(invokerName, new TrieSet[ActivationEntry]).put(entry, {})
+ }
+
+ def removeActivationByInvoker(invokerIndex :String, entry :ActivationEntry) = {
+  activationByInvoker.getOrElseUpdate(invokerIndex, new TrieSet[ActivationEntry]).remove(entry)
+ }
+
+ def getActivationsByInvoker(invokerName :String) ={
+  activationByInvoker.getOrElseUpdate(invokerName, new TrieSet[ActivationEntry])
+ }
+
+}

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerData.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerData.scala
@@ -24,7 +24,7 @@ import scala.concurrent.Promise
 
 case class ActivationEntry(id: ActivationId, namespaceId: UUID, invokerName: String, created: Instant, promise: Promise[Either[ActivationId, WhiskActivation]])
 
-class LoadBalancerData(){
+class LoadBalancerData() {
 
     type TrieSet[T] = TrieMap[T, Unit]
 
@@ -52,7 +52,7 @@ class LoadBalancerData(){
         activationByNamespaceId.getOrElseUpdate(namespaceId, new TrieSet[ActivationEntry])
     }
 
-    def putActivation(entry: ActivationEntry): Any= {
+    def putActivation(entry: ActivationEntry): Any = {
         activationsById.put(entry.id, entry)
         activationByNamespaceId.getOrElseUpdate(entry.namespaceId, new TrieSet[ActivationEntry]).put(entry, {})
         activationByInvoker.getOrElseUpdate(entry.invokerName, new TrieSet[ActivationEntry]).put(entry, {})
@@ -65,7 +65,7 @@ class LoadBalancerData(){
         entry
     }
 
-    def removeActivation(aid: ActivationId): Option[ActivationEntry]= {
+    def removeActivation(aid: ActivationId): Option[ActivationEntry] = {
         activationsById.get(aid).map(removeActivation)
     }
 }

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -123,12 +123,12 @@ class LoadBalancerService(
     private def processCompletion(response: Either[ActivationId, WhiskActivation], tid: TransactionId, forced: Boolean): Unit = {
         val aid = response.fold(l => l, r => r.activationId)
         loadBalancerData.removeActivation(aid) match {
-            case Some(entry @ ActivationEntry(_, _, _, _, p)) =>
+            case Some(entry) =>
                 logging.info(this, s"${if (!forced) "received" else "forced"} active ack for '$aid'")(tid)
                 if (!forced) {
-                    p.trySuccess(response)
+                    entry.promise.trySuccess(response)
                 } else {
-                    p.tryFailure(new Throwable("no active ack received"))
+                    entry.promise.tryFailure(new Throwable("no active ack received"))
                 }
             case None =>
                 // the entry was already removed

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -20,7 +20,6 @@ package whisk.core.loadBalancer
 import java.nio.charset.StandardCharsets
 import java.time.{ Clock, Instant }
 
-import scala.collection.concurrent.TrieMap
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -49,7 +48,7 @@ import whisk.core.connector.{ ActivationMessage, CompletionMessage }
 import whisk.core.connector.MessageFeed
 import whisk.core.connector.MessageProducer
 import whisk.core.database.NoDocumentException
-import whisk.core.entity.{ ActivationId, WhiskAction, WhiskActivation }
+import whisk.core.entity.{ ActivationId, WhiskActivation }
 import whisk.core.entity.InstanceId
 import whisk.core.entity.ExecutableWhiskAction
 import whisk.core.entity.UUID
@@ -99,9 +98,9 @@ class LoadBalancerService(
     private val blackboxFraction: Double = Math.max(0.0, Math.min(1.0, config.controllerBlackboxFraction))
     logging.info(this, s"blackboxFraction = $blackboxFraction")
 
-    val LoadBalancerData = new LoadBalancerDataWithLocalMap()
+    private val loadBalancerData = new LoadBalancerData()
 
-    override def getActiveNamespaceActivationCounts: Map[UUID, Int] = LoadBalancerData.getActivationCountByNamespace()
+    override def getActiveNamespaceActivationCounts: Map[UUID, Int] = loadBalancerData.activationCountByNamespace
 
     override def publish(action: ExecutableWhiskAction, msg: ActivationMessage)(
         implicit transid: TransactionId): Future[Future[Either[ActivationId, WhiskActivation]]] = {
@@ -116,13 +115,6 @@ class LoadBalancerService(
     def invokerHealth: Future[Map[String, InvokerState]] = invokerPool.ask(GetStatus)(Timeout(5.seconds)).mapTo[Map[String, InvokerState]]
 
     /**
-     * A map storing current activations based on ActivationId.
-     * The promise value represents the obligation of writing the answer back.
-     */
-    type TrieSet[T] = TrieMap[T, Unit]
-    private val activationById = new TrieMap[ActivationId, ActivationEntry]
-
-    /**
      * Tries to fill in the result slot (i.e., complete the promise) when a completion message arrives.
      * The promise is removed form the map when the result arrives or upon timeout.
      *
@@ -130,17 +122,14 @@ class LoadBalancerService(
      */
     private def processCompletion(response: Either[ActivationId, WhiskActivation], tid: TransactionId, forced: Boolean): Unit = {
         val aid = response.fold(l => l, r => r.activationId)
-        activationById.remove(aid) match {
-            case Some(entry @ ActivationEntry(_, namespaceId, invokerIndex, _, p)) =>
+        loadBalancerData.removeActivation(aid) match {
+            case Some(entry @ ActivationEntry(_, _, _, _, p)) =>
                 logging.info(this, s"${if (!forced) "received" else "forced"} active ack for '$aid'")(tid)
-                LoadBalancerData.removeActivationByInvoker(invokerIndex, entry)
-                LoadBalancerData.removeActivationByNamespaceId(namespaceId, entry)
                 if (!forced) {
                     p.trySuccess(response)
                 } else {
                     p.tryFailure(new Throwable("no active ack received"))
                 }
-
             case None =>
                 // the entry was already removed
                 logging.debug(this, s"received active ack for '$aid' which has no entry")(tid)
@@ -151,23 +140,22 @@ class LoadBalancerService(
      * Creates an activation entry and insert into various maps.
      */
     private def setupActivation(action: ExecutableWhiskAction, activationId: ActivationId, namespaceId: UUID, invokerName: String, transid: TransactionId): ActivationEntry = {
-        // either create a new promise or reuse a previous one for this activation if it exists
-        val timeout = action.limits.timeout.duration + activeAckTimeoutGrace
-        val entry = activationById.getOrElseUpdate(activationId, {
-            // Install a timeout handler for the catastrophic case where an active ack is not received at all
-            // (because say an invoker is down completely, or the connection to the message bus is disrupted) or when
-            // the active ack is significantly delayed (possibly dues to long queues but the subject should not be penalized);
-            // in this case, if the activation handler is still registered, remove it and update the books.
-            actorSystem.scheduler.scheduleOnce(timeout) {
-                processCompletion(Left(activationId), transid, forced = true)
-            }
 
-            ActivationEntry(activationId, namespaceId, invokerName, Instant.now(Clock.systemUTC()), Promise[Either[ActivationId, WhiskActivation]]())
-        })
+        val timeout = action.limits.timeout.duration + activeAckTimeoutGrace
+        // Install a timeout handler for the catastrophic case where an active ack is not received at all
+        // (because say an invoker is down completely, or the connection to the message bus is disrupted) or when
+        // the active ack is significantly delayed (possibly dues to long queues but the subject should not be penalized);
+        // in this case, if the activation handler is still registered, remove it and update the books.
+
+        actorSystem.scheduler.scheduleOnce(timeout) {
+            processCompletion(Left(activationId), transid, forced = true)
+        }
+
+        val entry = ActivationEntry(activationId, namespaceId, invokerName, Instant.now(Clock.systemUTC()),
+            Promise[Either[ActivationId, WhiskActivation]]())
 
         // add the entry to our maps, for bookkeeping
-        LoadBalancerData.putActivationbyInvoker(invokerName, entry)
-        LoadBalancerData.putActivationByNamespaceId(namespaceId, entry)
+        loadBalancerData.putActivation(entry)
         entry
     }
 
@@ -175,19 +163,14 @@ class LoadBalancerService(
       * When invoker health detects a new invoker has come up, this callback is called.
       */
     private def clearInvokerState(invokerName: String) = {
-        val actSet = LoadBalancerData.getActivationsByInvoker(invokerName)
+        val actSet = loadBalancerData.activationsByInvoker(invokerName)
         actSet.keySet map {
             case actEntry @ ActivationEntry(activationId, namespaceId, invokerIndex, _, promise) =>
                 promise.tryFailure(new LoadBalancerException(s"Invoker $invokerIndex restarted"))
-                activationById.remove(activationId)
-                LoadBalancerData.removeActivationByNamespaceIdWithResponse(namespaceId, actEntry)
+                loadBalancerData.removeActivation(actEntry)
         }
         actSet.clear()
     }
-
-
-    /** Make a new immutable map so caller cannot mess up the state */
-    private def getActiveCountByInvoker(): Map[String, Int] = LoadBalancerData.getActivationCountByInvoker()
 
     /**
      * Creates or updates a health test action by updating the entity store.
@@ -300,7 +283,7 @@ class LoadBalancerService(
         invokers.flatMap { invokers =>
             LoadBalancerService.schedule(
                 invokers,
-                LoadBalancerData.activationsByInvokerSize(),
+                loadBalancerData.activationCountByInvoker,
                 config.loadbalancerInvokerBusyThreshold,
                 hash) match {
                     case Some(invoker) => Future.successful(invoker)

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/LoadBalancerDataTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/LoadBalancerDataTests.scala
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.loadBalancer.test
+
+import java.time.{Clock, Instant}
+
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FlatSpec, Matchers}
+import whisk.core.entity.{ActivationId, UUID, WhiskActivation}
+import whisk.core.loadBalancer.{ActivationEntry, LoadBalancerData}
+
+import scala.concurrent.duration.{FiniteDuration, _}
+import scala.concurrent.{Await, Future, Promise}
+
+
+
+class LoadBalancerDataSpec extends FlatSpec with Matchers with BeforeAndAfterAll with BeforeAndAfterEach{
+  def await[A](f: Future[A], timeout: FiniteDuration = 500.milliseconds) = Await.result[A](f,
+    timeout)
+
+  var firstActivationEntry :ActivationEntry = null
+  var secondActivationEntry :ActivationEntry = null
+  var loadBalancerData :LoadBalancerData = null
+  val firstUUID :UUID = UUID()
+  val secondUUID = UUID()
+
+  val activationIdPromise = Promise[Either[ActivationId, WhiskActivation]]()
+  var firstActivationId :ActivationId = ActivationId()
+  var secondActivationId :ActivationId = ActivationId()
+
+  override def beforeEach() = {
+    loadBalancerData = new LoadBalancerData()
+    firstActivationEntry = new ActivationEntry(firstActivationId, firstUUID, "invoker0",
+      Instant.now(Clock.systemUTC()), activationIdPromise)
+    secondActivationEntry = new ActivationEntry(secondActivationId, secondUUID, "invoker1",
+      Instant.now(Clock.systemUTC()), activationIdPromise)
+  }
+
+  behavior of "LoadBalancerData"
+
+  it should "return the number of activations for a namespace" in {
+
+    loadBalancerData.putActivation(firstActivationEntry)
+
+    val result = loadBalancerData.activationCountByNamespace
+    result.size should be (1)
+    result.keys.head should be (firstUUID)
+    loadBalancerData.activationsByNamespaceId(firstUUID).toMap.size should be (1)
+    loadBalancerData.activationsByInvoker("invoker0").toMap.size should be (1)
+    loadBalancerData.activationById(firstActivationId).size should be (1)
+  }
+
+  it should "return the number of activations for each invoker" in {
+
+    loadBalancerData.putActivation(firstActivationEntry)
+    loadBalancerData.putActivation(secondActivationEntry)
+
+    val result = loadBalancerData.activationCountByInvoker
+
+    result.size should be (2)
+
+    loadBalancerData.activationsByInvoker("invoker0").size should be (1)
+    loadBalancerData.activationsByInvoker("invoker1").size should be (1)
+    loadBalancerData.activationById(firstActivationId).size should be (1)
+    loadBalancerData.activationById(secondActivationId).size should be (1)
+  }
+
+  it should "remove activations from all 3 maps" in {
+
+    loadBalancerData.putActivation(firstActivationEntry)
+    loadBalancerData.putActivation(secondActivationEntry)
+
+    loadBalancerData.removeActivation(firstActivationEntry)
+    loadBalancerData.removeActivation(secondActivationEntry)
+
+    val activationsByInvoker = loadBalancerData.activationCountByInvoker
+    val activationsByNamespace = loadBalancerData.activationCountByNamespace
+
+
+    activationsByInvoker.values.sum should be (0)
+    activationsByNamespace.values.sum should be (0)
+    loadBalancerData.activationById(firstActivationId).size should be (0)
+    loadBalancerData.activationById(secondActivationId).size should be (0)
+  }
+  it should "remove activations from all 3 maps by activation id" in {
+
+    loadBalancerData.putActivation(firstActivationEntry)
+
+    loadBalancerData.removeActivation(firstActivationId)
+
+    val activationsByInvoker = loadBalancerData.activationCountByInvoker
+    val activationsByNamespace = loadBalancerData.activationCountByNamespace
+
+    activationsByInvoker.values.sum should be (0)
+    activationsByNamespace.values.sum should be (0)
+    loadBalancerData.activationById(firstActivationId).size should be (0)
+
+  }
+
+
+}

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/LoadBalancerDataTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/LoadBalancerDataTests.scala
@@ -132,4 +132,17 @@ class LoadBalancerDataTests extends FlatSpec with Matchers {
 
     }
 
+    it should "not add the same entry more then once" in {
+
+        val loadBalancerData = new LoadBalancerData()
+
+        loadBalancerData.putActivation(firstEntry)
+        loadBalancerData.activationCountByInvoker shouldBe Map(firstEntry.invokerName -> 1)
+        loadBalancerData.activationCountByNamespace shouldBe Map(firstEntry.namespaceId -> 1)
+
+        loadBalancerData.putActivation(firstEntry)
+        loadBalancerData.activationCountByInvoker shouldBe Map(firstEntry.invokerName -> 1)
+        loadBalancerData.activationCountByNamespace shouldBe Map(firstEntry.namespaceId -> 1)
+    }
+
 }


### PR DESCRIPTION
Hello, 

this PR contains a companion commit that separates the the load balancer data from its main logic. 

This change will simplify the introduction of the load balancer state that will be shared across several controllers. 

@markusthoemmes could you please have a look?

regards, 
Vadim
