### PR TITLE
Add container pool health status in invoker

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/dispatcher/MessageHandler.scala
+++ b/core/invoker/src/main/scala/whisk/core/dispatcher/MessageHandler.scala
@@ -26,6 +26,8 @@ import whisk.core.connector.{ ActivationMessage => Message }
  */
 abstract class MessageHandler(val name: String) {
 
+    def getPoolStatus(): Int
+
     /**
      * Runs handler for a Kafka message. This method is run inside a future.
      * If the method fails with an exception, the exception completes

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -75,6 +75,8 @@ class Invoker(
 
     TransactionId.invoker.mark(this, LoggingMarkers.INVOKER_STARTUP(instance.toInt), s"starting invoker instance ${instance.toInt}")
 
+    override def getPoolStatus() = { pool.getCurrentPoolState }
+
     /**
      * This is the handler for the kafka message
      *
@@ -501,8 +503,14 @@ object Invoker {
         dispatcher.start()
 
         Scheduler.scheduleWaitAtMost(1.seconds)(() => {
-            producer.send("health", PingMessage(s"invoker${invokerInstance.toInt}")).andThen {
-                case Failure(t) => logger.error(this, s"failed to ping the controller: $t")
+            // Send invoker health ping message when invoker is really healthy
+            if (invoker.getPoolStatus() == 0) {
+                producer.send("health", PingMessage(s"invoker${invokerInstance.toInt}")).andThen {
+                    case Failure(t) => logger.error(this, s"failed to ping the controller: $t")
+                }
+            }
+            else {
+                Future.successful(())
             }
         })
 

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
@@ -69,6 +69,10 @@ class InvokerReactive(
     implicit val docker = new DockerClientWithFileAccess()(ec)
     implicit val runc = new RuncClient(ec)
 
+    // Need to set the status when Reactive Pool is unhealthy
+    var _currentPoolState = 0
+    override def getPoolStatus() = { _currentPoolState }
+
     /** Cleans up all running wsk_ containers */
     def cleanup() = {
         val cleaning = docker.ps(Seq("name" -> "wsk_"))(TransactionId.invokerNanny).flatMap { containers =>

--- a/tests/src/test/scala/whisk/core/dispatcher/test/DispatcherTests.scala
+++ b/tests/src/test/scala/whisk/core/dispatcher/test/DispatcherTests.scala
@@ -70,6 +70,7 @@ class DispatcherTests
     }
 
     class TestRule(dosomething: Message => Any) extends MessageHandler("test message handler") {
+        override def getPoolStatus() = { 0 }
         override def onMessage(msg: Message)(implicit transid: TransactionId): Future[Any] = {
             logging.debug(this, s"received: ${msg.content.get.compactPrint}")
             Future.successful {


### PR DESCRIPTION
I tried to tons of test using OW on K8s and found some unexpected result like a #2481.
anyway it is one of my trials which gives good result.
current invoker **always** sends healthy message to loadBalancer.
But sometimes, it is meaingless except for invoker creation time.
so, loadBalancer assigns request to unhealthy invoker.
thus, I added container pool status check code and it disturbs sending health message when it is not healthy.
I think, the invoker who knows best about itself is itself.
so healty message should be sent by invoker.

Signed-off-by: keunseob.kim <keunseob.kim@samsung.com>