### PR TITLE
Externalize access to some CLI methods to facilitate access across packages

### DIFF
--- a/tools/cli/go-whisk-cli/commands/api.go
+++ b/tools/cli/go-whisk-cli/commands/api.go
@@ -1524,7 +1524,7 @@ func getAccessToken() (string, error) {
     var token string = "DUMMY TOKEN"
     var err error
 
-    props, err := readProps(Properties.PropsFile)
+    props, err := ReadProps(Properties.PropsFile)
     if err == nil {
         if len(props["APIGW_ACCESS_TOKEN"]) > 0 {
             token = props["APIGW_ACCESS_TOKEN"]
@@ -1542,7 +1542,7 @@ func getUserContextId() (string, error) {
     var guid string
     var err error
 
-    props, err := readProps(Properties.PropsFile)
+    props, err := ReadProps(Properties.PropsFile)
     if err == nil {
         if len(props["AUTH"]) > 0 {
             guid = strings.Split(props["AUTH"], ":")[0]

--- a/tools/cli/go-whisk-cli/commands/commands.go
+++ b/tools/cli/go-whisk-cli/commands/commands.go
@@ -19,7 +19,6 @@ package commands
 
 import (
     "errors"
-    "fmt"
     "net/http"
     "os"
 
@@ -75,14 +74,7 @@ func setupClientConfig(cmd *cobra.Command, args []string) (error){
 }
 
 func init() {
-    var err error
 
-    err = loadProperties()
-    if err != nil {
-        whisk.Debug(whisk.DbgError, "loadProperties() error: %s\n", err)
-        fmt.Println(err)
-        os.Exit(whisk.EXITCODE_ERR_GENERAL)
-    }
 }
 
 func getKeyValueArgs(args []string, argIndex int, parsedArgs []string) ([]string, []string, error) {
@@ -206,6 +198,15 @@ func Execute() error {
     if err != nil {
         whisk.Debug(whisk.DbgError, "parseParams(%s) failed: %s\n", os.Args, err)
         errMsg := wski18n.T("Failed to parse arguments: {{.err}}", map[string]interface{}{"err":err})
+        whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
+            whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+        return whiskErr
+    }
+
+    err = loadProperties()
+    if err != nil {
+        whisk.Debug(whisk.DbgError, "loadProperties() error: %s\n", err)
+        errMsg := wski18n.T("Unable to access configuration properties: {{.err}}", map[string]interface{}{"err":err})
         whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
             whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
         return whiskErr

--- a/tools/cli/go-whisk-cli/commands/property.go
+++ b/tools/cli/go-whisk-cli/commands/property.go
@@ -68,7 +68,7 @@ var propertySetCmd = &cobra.Command{
         var werr *whisk.WskError = nil
 
         // get current props
-        props, err := readProps(Properties.PropsFile)
+        props, err := ReadProps(Properties.PropsFile)
         if err != nil {
             whisk.Debug(whisk.DbgError, "readProps(%s) failed: %s\n", Properties.PropsFile, err)
             errStr := wski18n.T("Unable to set the property value: {{.err}}", map[string]interface{}{"err": err})
@@ -146,7 +146,7 @@ var propertySetCmd = &cobra.Command{
             }
         }
 
-        err = writeProps(Properties.PropsFile, props)
+        err = WriteProps(Properties.PropsFile, props)
         if err != nil {
             whisk.Debug(whisk.DbgError, "writeProps(%s, %#v) failed: %s\n", Properties.PropsFile, props, err)
             errStr := fmt.Sprintf(
@@ -172,7 +172,7 @@ var propertyUnsetCmd = &cobra.Command{
     SilenceErrors:  true,
     RunE: func(cmd *cobra.Command, args []string) error {
         var okMsg string = ""
-        props, err := readProps(Properties.PropsFile)
+        props, err := ReadProps(Properties.PropsFile)
         if err != nil {
             whisk.Debug(whisk.DbgError, "readProps(%s) failed: %s\n", Properties.PropsFile, err)
             errStr := fmt.Sprintf(
@@ -228,7 +228,7 @@ var propertyUnsetCmd = &cobra.Command{
             }
         }
 
-        err = writeProps(Properties.PropsFile, props)
+        err = WriteProps(Properties.PropsFile, props)
         if err != nil {
             whisk.Debug(whisk.DbgError, "writeProps(%s, %#v) failed: %s\n", Properties.PropsFile, props, err)
             errStr := fmt.Sprintf(
@@ -349,7 +349,7 @@ func setDefaultProperties() {
     // Properties.CLIVersion value is set from main's init()
 }
 
-func getPropertiesFilePath() (propsFilePath string, werr error) {
+func GetPropertiesFilePath() (propsFilePath string, werr error) {
     var envExists bool
 
     // Environment variable overrides the default properties file path
@@ -381,16 +381,16 @@ func loadProperties() error {
 
     setDefaultProperties()
 
-    Properties.PropsFile, err = getPropertiesFilePath()
+    Properties.PropsFile, err = GetPropertiesFilePath()
     if err != nil {
         return nil
-        //whisk.Debug(whisk.DbgError, "getPropertiesFilePath() failed: %s\n", err)
+        //whisk.Debug(whisk.DbgError, "GetPropertiesFilePath() failed: %s\n", err)
         //errStr := fmt.Sprintf("Unable to load the properties file: %s", err)
         //werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         //return werr
     }
 
-    props, err := readProps(Properties.PropsFile)
+    props, err := ReadProps(Properties.PropsFile)
     if err != nil {
         whisk.Debug(whisk.DbgError, "readProps(%s) failed: %s\n", Properties.PropsFile, err)
         errStr := wski18n.T("Unable to read the properties file '{{.filename}}': {{.err}}",

--- a/tools/cli/go-whisk-cli/commands/util.go
+++ b/tools/cli/go-whisk-cli/commands/util.go
@@ -950,7 +950,7 @@ func min (a int, b int) int {
     return b
 }
 
-func readProps(path string) (map[string]string, error) {
+func ReadProps(path string) (map[string]string, error) {
 
     props := map[string]string{}
 
@@ -982,7 +982,7 @@ func readProps(path string) (map[string]string, error) {
 
 }
 
-func writeProps(path string, props map[string]string) error {
+func WriteProps(path string, props map[string]string) error {
 
     file, err := os.Create(path)
     if err != nil {
@@ -1010,7 +1010,7 @@ func writeProps(path string, props map[string]string) error {
 
 func getSpaceGuid() (string, error) {
     // get current props
-    props, err := readProps(Properties.PropsFile)
+    props, err := ReadProps(Properties.PropsFile)
     if err != nil {
         whisk.Debug(whisk.DbgError, "readProps(%s) failed: %s\n", Properties.PropsFile, err)
         errStr := wski18n.T("Unable to obtain the `auth` property value: {{.err}}", map[string]interface{}{"err": err})

--- a/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
+++ b/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
@@ -381,6 +381,10 @@
     "translation": "Unable to read the properties file '{{.filename}}': {{.err}}"
   },
   {
+    "id": "Unable to access configuration properties: {{.err}}",
+    "translation": "Unable to access configuration properties: {{.err}}"
+  },
+  {
     "id": "Invalid host address '{{.host}}': {{.err}}",
     "translation": "Invalid host address '{{.host}}': {{.err}}"
   },

--- a/tools/cli/go-whisk/whisk/client.go
+++ b/tools/cli/go-whisk/whisk/client.go
@@ -225,7 +225,7 @@ func (c *Client) Do(req *http.Request, v interface{}, ExitWithErrorOnTimeout boo
         fmt.Printf("[%s]\t%s\n", req.Method, req.URL)
         if len(req.Header) > 0 {
             fmt.Println("Req Headers")
-            printJSON(req.Header)
+            PrintJSON(req.Header)
         }
         if req.Body != nil {
             fmt.Println("Req Body")
@@ -247,7 +247,7 @@ func (c *Client) Do(req *http.Request, v interface{}, ExitWithErrorOnTimeout boo
     Verbose("Got response with code %d\n", resp.StatusCode)
     if (IsVerbose() && len(resp.Header) > 0) {
         fmt.Println("Resp Headers")
-        printJSON(resp.Header)
+        PrintJSON(resp.Header)
     }
 
     // Read the response body

--- a/tools/cli/go-whisk/whisk/sdk.go
+++ b/tools/cli/go-whisk/whisk/sdk.go
@@ -56,7 +56,7 @@ func (s *SdkService) Install(relFileUrl string) (*http.Response, error) {
         fmt.Printf("[%s]\t%s\n", req.Method, req.URL)
         if len(req.Header) > 0 {
             fmt.Println("Req Headers")
-            printJSON(req.Header)
+            PrintJSON(req.Header)
         }
         if req.Body != nil {
             fmt.Println("Req Body")

--- a/tools/cli/go-whisk/whisk/util.go
+++ b/tools/cli/go-whisk/whisk/util.go
@@ -61,7 +61,7 @@ func addRouteOptions(route string, options interface{}) (*url.URL, error) {
     return u, nil
 }
 
-func printJSON(v interface{}) {
+func PrintJSON(v interface{}) {
     output, _ := prettyjson.Marshal(v)
     fmt.Fprintln(color.Output, string(output))
 }


### PR DESCRIPTION
- Also move properties file reading/loading to when the command is executed, not at binary load time