### PR TITLE
CLI summaries for actions without annotations

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -484,12 +484,18 @@ Several utility actions are provided in a package called `/whisk.system/utils` t
   ```
   ```
   package /whisk.system/utils: Building blocks that format and assemble data
-   action /whisk.system/utils/head: Extract prefix of an array
-   action /whisk.system/utils/split: Split a string into an array
-   action /whisk.system/utils/sort: Sorts an array
-   action /whisk.system/utils/echo: Returns the input
-   action /whisk.system/utils/date: Current date and time
-   action /whisk.system/utils/cat: Concatenates input into a string
+   (parameters: none defined)
+     action /whisk.system/utils/namespace: Returns namespace for the authorization key used to invoke this action
+       (parameters: none defined)
+     action /whisk.system/utils/date: Current date and time
+       (parameters: none defined)
+     action /whisk.system/utils/sort: Sorts an array
+       (parameters: lines)
+     action /whisk.system/utils/split: Split a string into an array
+       (parameters: payload, separator)
+     action /whisk.system/utils/hosturl: Returns the URL to activation an action or trigger
+       (parameters: ext, path, trigger, web)
+     ...
   ```
 
   You will be using the `split` and `sort` actions in this example.

--- a/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -647,6 +647,97 @@ class WskBasicUsageTests
             msg.r.findAllIn(notTruncated).length shouldBe 0
     }
 
+    it should "denote bound and finalized action parameters for action summaries" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val nameBoundParams = "actionBoundParams"
+            val nameFinalParams = "actionFinalParams"
+            val paramAnnot = "paramAnnot"
+            val paramOverlap = "paramOverlap"
+            val paramBound = "paramBound"
+            val annots = Map(
+                "parameters" -> JsArray(
+                    JsObject(
+                        "name" -> JsString(paramAnnot),
+                        "description" -> JsString("Annotated")),
+                    JsObject(
+                        "name" -> JsString(paramOverlap),
+                        "description" -> JsString("Annotated And Bound"))))
+            val annotsFinal = Map(
+                "final" -> JsBoolean(true),
+                "parameters" -> JsArray(
+                    JsObject(
+                        "name" -> JsString(paramAnnot),
+                        "description" -> JsString("Annotated Parameter description")),
+                    JsObject(
+                        "name" -> JsString(paramOverlap),
+                        "description" -> JsString("Annotated And Bound"))))
+            val paramsBound = Map(
+                paramBound -> JsString("Bound"),
+                paramOverlap -> JsString("Bound And Annotated"))
+
+            assetHelper.withCleaner(wsk.action, nameBoundParams) {
+                (action, _) =>
+                    action.create(nameBoundParams, defaultAction, annotations = annots, parameters = paramsBound)
+            }
+            assetHelper.withCleaner(wsk.action, nameFinalParams) {
+                (action, _) =>
+                    action.create(nameFinalParams, defaultAction, annotations = annotsFinal, parameters = paramsBound)
+            }
+
+            val stdoutBound = wsk.action.get(nameBoundParams, summary = true).stdout
+            val stdoutFinal = wsk.action.get(nameFinalParams, summary = true).stdout
+
+            stdoutBound should include (
+                s"(parameters: $paramAnnot, *$paramBound, *$paramOverlap)")
+            stdoutFinal should include (
+                s"(parameters: $paramAnnot, **$paramBound, **$paramOverlap)")
+    }
+
+    it should "create, and get an action summary without a description and/or defined parameters" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val actNameNoParams = "actionNoParams"
+            val actNameNoDesc = "actionNoDesc"
+            val actNameNoDescOrParams = "actionNoDescOrParams"
+            val desc = "Action description"
+            val descFromParamsResp = "Returns a result based on parameters"
+            val annotsNoParams = Map(
+                "description" -> JsString(desc)
+            )
+            val annotsNoDesc = Map(
+                "parameters" -> JsArray(
+                    JsObject(
+                        "name" -> JsString("paramName1"),
+                        "description" -> JsString("Parameter description 1")),
+                    JsObject(
+                        "name" -> JsString("paramName2"),
+                        "description" -> JsString("Parameter description 2"))))
+
+            assetHelper.withCleaner(wsk.action, actNameNoDesc) {
+                (action, _) =>
+                    action.create(actNameNoDesc, defaultAction, annotations = annotsNoDesc)
+            }
+            assetHelper.withCleaner(wsk.action, actNameNoParams) {
+                (action, _) =>
+                    action.create(actNameNoParams, defaultAction, annotations = annotsNoParams)
+            }
+            assetHelper.withCleaner(wsk.action, actNameNoDescOrParams) {
+                (action, _) =>
+                    action.create(actNameNoDescOrParams, defaultAction)
+            }
+
+            val stdoutNoDesc = wsk.action.get(actNameNoDesc, summary = true).stdout
+            val stdoutNoParams = wsk.action.get(actNameNoParams, summary = true).stdout
+            val stdoutNoDescOrParams = wsk.action.get(actNameNoDescOrParams, summary = true).stdout
+            val namespace = wsk.namespace.whois()
+
+            stdoutNoDesc should include regex (
+                s"(?i)action /${namespace}/${actNameNoDesc}: ${descFromParamsResp} paramName1 and paramName2\\s*\\(parameters: paramName1, paramName2\\)")
+            stdoutNoParams should include regex (
+                s"(?i)action /${namespace}/${actNameNoParams}: ${desc}\\s*\\(parameters: none defined\\)")
+            stdoutNoDescOrParams should include regex (
+                s"(?i)action /${namespace}/${actNameNoDescOrParams}\\s*\\(parameters: none defined\\)")
+    }
+
     behavior of "Wsk packages"
 
     it should "create, and delete a package" in {
@@ -741,6 +832,83 @@ class WskBasicUsageTests
             wsk.pkg.bind("bogus", "alsobogus", expectedExitCode = BAD_REQUEST).
                 stderr should include(Messages.bindingDoesNotExist)
 
+    }
+
+    it should "create, and get a package summary without a description and/or parameters" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val pkgNoDesc = "pkgNoDesc"
+            val pkgNoParams = "pkgNoParams"
+            val pkgNoDescOrParams = "pkgNoDescOrParams"
+            val pkgDesc = "Package description"
+            val descFromParams = "Returns a result based on parameters"
+            val namespace = wsk.namespace.whois()
+            val qualpkgNoDesc = s"/${namespace}/${pkgNoDesc}"
+            val qualpkgNoParams = s"/${namespace}/${pkgNoParams}"
+            val qualpkgNoDescOrParams = s"/${namespace}/${pkgNoDescOrParams}"
+
+            val pkgAnnotsNoParams = Map(
+                "description" -> JsString(pkgDesc)
+            )
+            val pkgAnnotsNoDesc = Map(
+                "parameters" -> JsArray(
+                    JsObject(
+                        "name" -> JsString("paramName1"),
+                        "description" -> JsString("Parameter description 1")),
+                    JsObject(
+                        "name" -> JsString("paramName2"),
+                        "description" -> JsString("Parameter description 2"))))
+
+            assetHelper.withCleaner(wsk.pkg, pkgNoDesc) {
+                (pkg, _) =>
+                    pkg.create(pkgNoDesc, annotations = pkgAnnotsNoDesc)
+            }
+            assetHelper.withCleaner(wsk.pkg, pkgNoParams) {
+                (pkg, _) =>
+                    pkg.create(pkgNoParams, annotations = pkgAnnotsNoParams)
+            }
+            assetHelper.withCleaner(wsk.pkg, pkgNoDescOrParams) {
+                (pkg, _) =>
+                    pkg.create(pkgNoDescOrParams)
+            }
+
+            val stdoutNoDescPkg = wsk.pkg.get(pkgNoDesc, summary = true).stdout
+            val stdoutNoParamsPkg = wsk.pkg.get(pkgNoParams, summary = true).stdout
+            val stdoutNoDescOrParams = wsk.pkg.get(pkgNoDescOrParams, summary = true).stdout
+
+            stdoutNoDescPkg should include regex (
+                s"(?i)package ${qualpkgNoDesc}: ${descFromParams} paramName1 and paramName2\\s*\\(parameters: paramName1, paramName2\\)")
+            stdoutNoParamsPkg should include regex (
+                s"(?i)package ${qualpkgNoParams}: ${pkgDesc}\\s*\\(parameters: none defined\\)")
+            stdoutNoDescOrParams should include regex (
+                s"(?i)package ${qualpkgNoDescOrParams}\\s*\\(parameters: none defined\\)")
+    }
+
+    it should "denote bound package parameters for package summaries" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val pkgBoundParams = "pkgBoundParams"
+            val pkgParamAnnot = "pkgParamAnnot"
+            val pkgParamOverlap = "pkgParamOverlap"
+            val pkgParamBound = "pkgParamBound"
+            val pkgAnnots = Map(
+                "parameters" -> JsArray(
+                    JsObject(
+                        "name" -> JsString(pkgParamAnnot),
+                        "description" -> JsString("Annotated")),
+                    JsObject(
+                        "name" -> JsString(pkgParamOverlap),
+                        "description" -> JsString("Annotated And Bound"))))
+            val pkgParamsBound = Map(
+                pkgParamBound -> JsString("Bound"),
+                pkgParamOverlap -> JsString("Bound And Annotated"))
+
+            assetHelper.withCleaner(wsk.pkg, pkgBoundParams) {
+                (pkg, _) =>
+                    pkg.create(pkgBoundParams, annotations = pkgAnnots, parameters = pkgParamsBound)
+            }
+
+            val pkgStdoutBound = wsk.pkg.get(pkgBoundParams, summary = true).stdout
+
+            pkgStdoutBound should include (s"(parameters: $pkgParamAnnot, *$pkgParamBound, *$pkgParamOverlap)")
     }
 
     behavior of "Wsk triggers"
@@ -839,6 +1007,83 @@ class WskBasicUsageTests
                         exitCode should equal(NOT_FOUND)
                     trigger.get(name, expectedExitCode = NOT_FOUND)
             }
+    }
+
+    it should "denote bound trigger parameters for trigger summaries" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val trgBoundParams = "trgBoundParams"
+            val trgParamAnnot = "trgParamAnnot"
+            val trgParamOverlap = "trgParamOverlap"
+            val trgParamBound = "trgParamBound"
+            val trgAnnots = Map(
+                "parameters" -> JsArray(
+                    JsObject(
+                        "name" -> JsString(trgParamAnnot),
+                        "description" -> JsString("Annotated")),
+                    JsObject(
+                        "name" -> JsString(trgParamOverlap),
+                        "description" -> JsString("Annotated And Bound"))))
+            val trgParamsBound = Map(
+                trgParamBound -> JsString("Bound"),
+                trgParamOverlap -> JsString("Bound And Annotated"))
+
+            assetHelper.withCleaner(wsk.trigger, trgBoundParams) {
+                (trigger, _) =>
+                    trigger.create(trgBoundParams, annotations = trgAnnots, parameters = trgParamsBound)
+            }
+
+            val trgStdoutBound = wsk.trigger.get(trgBoundParams, summary = true).stdout
+
+            trgStdoutBound should include (s"(parameters: $trgParamAnnot, *$trgParamBound, *$trgParamOverlap)")
+    }
+
+    it should "create, and get a trigger summary without a description and/or parameters" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val trgNoDesc = "trgNoDesc"
+            val trgNoParams = "trgNoParams"
+            val trgNoDescOrParams = "trgNoDescOrParams"
+            val trgDesc = "Package description"
+            val descFromParams = "Returns a result based on parameters"
+            val namespace = wsk.namespace.whois()
+            val qualtrgNoDesc = s"/${namespace}/${trgNoDesc}"
+            val qualtrgNoParams = s"/${namespace}/${trgNoParams}"
+            val qualtrgNoDescOrParams = s"/${namespace}/${trgNoDescOrParams}"
+
+            val trgAnnotsNoParams = Map(
+                "description" -> JsString(trgDesc)
+            )
+            val trgAnnotsNoDesc = Map(
+                "parameters" -> JsArray(
+                    JsObject(
+                        "name" -> JsString("paramName1"),
+                        "description" -> JsString("Parameter description 1")),
+                    JsObject(
+                        "name" -> JsString("paramName2"),
+                        "description" -> JsString("Parameter description 2"))))
+
+            assetHelper.withCleaner(wsk.trigger, trgNoDesc) {
+                (trigger, _) =>
+                    trigger.create(trgNoDesc, annotations = trgAnnotsNoDesc)
+            }
+            assetHelper.withCleaner(wsk.trigger, trgNoParams) {
+                (trigger, _) =>
+                    trigger.create(trgNoParams, annotations = trgAnnotsNoParams)
+            }
+            assetHelper.withCleaner(wsk.trigger, trgNoDescOrParams) {
+                (trigger, _) =>
+                    trigger.create(trgNoDescOrParams)
+            }
+
+            val stdoutNoDescPkg = wsk.trigger.get(trgNoDesc, summary = true).stdout
+            val stdoutNoParamsPkg = wsk.trigger.get(trgNoParams, summary = true).stdout
+            val stdoutNoDescOrParams = wsk.trigger.get(trgNoDescOrParams, summary = true).stdout
+
+            stdoutNoDescPkg should include regex (
+                s"(?i)trigger ${qualtrgNoDesc}: ${descFromParams} paramName1 and paramName2\\s*\\(parameters: paramName1, paramName2\\)")
+            stdoutNoParamsPkg should include regex (
+                s"(?i)trigger ${qualtrgNoParams}: ${trgDesc}\\s*\\(parameters: none defined\\)")
+            stdoutNoDescOrParams should include regex (
+                s"(?i)trigger ${qualtrgNoDescOrParams}\\s*\\(parameters: none defined\\)")
     }
 
     behavior of "Wsk entity list formatting"

--- a/tools/cli/go-whisk-cli/commands/action.go
+++ b/tools/cli/go-whisk-cli/commands/action.go
@@ -931,7 +931,7 @@ func init() {
     actionInvokeCmd.Flags().BoolVarP(&flags.common.blocking, "blocking", "b", false, wski18n.T("blocking invoke"))
     actionInvokeCmd.Flags().BoolVarP(&flags.action.result, "result", "r", false, wski18n.T("blocking invoke; show only activation result (unless there is a failure)"))
 
-    actionGetCmd.Flags().BoolVarP(&flags.common.summary, "summary", "s", false, wski18n.T("summarize action details"))
+    actionGetCmd.Flags().BoolVarP(&flags.common.summary, "summary", "s", false, wski18n.T("summarize action details; parameters with prefix \"*\" are bound, \"**\" are bound and finalized"))
     actionGetCmd.Flags().BoolVarP(&flags.action.url, "url", "r", false, wski18n.T("get action url"))
 
     actionListCmd.Flags().IntVarP(&flags.common.skip, "skip", "s", 0, wski18n.T("exclude the first `SKIP` number of actions from the result"))

--- a/tools/cli/go-whisk-cli/commands/package.go
+++ b/tools/cli/go-whisk-cli/commands/package.go
@@ -514,7 +514,7 @@ func init() {
   packageUpdateCmd.Flags().StringVarP(&flags.common.paramFile, "param-file", "P", "", wski18n.T("`FILE` containing parameter values in JSON format"))
   packageUpdateCmd.Flags().StringVar(&flags.common.shared, "shared", "", wski18n.T("package visibility `SCOPE`; yes = shared, no = private"))
 
-  packageGetCmd.Flags().BoolVarP(&flags.common.summary, "summary", "s", false, wski18n.T("summarize package details"))
+  packageGetCmd.Flags().BoolVarP(&flags.common.summary, "summary", "s", false, wski18n.T("summarize package details; parameters with prefix \"*\" are bound"))
 
   packageBindCmd.Flags().StringSliceVarP(&flags.common.annotation, "annotation", "a", []string{}, wski18n.T("annotation values in `KEY VALUE` format"))
   packageBindCmd.Flags().StringVarP(&flags.common.annotFile, "annotation-file", "A", "", wski18n.T("`FILE` containing annotation values in JSON format"))

--- a/tools/cli/go-whisk-cli/commands/trigger.go
+++ b/tools/cli/go-whisk-cli/commands/trigger.go
@@ -503,7 +503,7 @@ func init() {
     triggerUpdateCmd.Flags().StringSliceVarP(&flags.common.param, "param", "p", []string{}, wski18n.T("parameter values in `KEY VALUE` format"))
     triggerUpdateCmd.Flags().StringVarP(&flags.common.paramFile, "param-file", "P", "", wski18n.T("`FILE` containing parameter values in JSON format"))
 
-    triggerGetCmd.Flags().BoolVarP(&flags.trigger.summary, "summary", "s", false, wski18n.T("summarize trigger details"))
+    triggerGetCmd.Flags().BoolVarP(&flags.trigger.summary, "summary", "s", false, wski18n.T("summarize trigger details; parameters with prefix \"*\" are bound"))
 
     triggerFireCmd.Flags().StringSliceVarP(&flags.common.param, "param", "p", []string{}, wski18n.T("parameter values in `KEY VALUE` format"))
     triggerFireCmd.Flags().StringVarP(&flags.common.paramFile, "param-file", "P", "", wski18n.T("`FILE` containing parameter values in JSON format"))

--- a/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
+++ b/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
@@ -221,8 +221,8 @@
     "translation": "package visibility `SCOPE`; yes = shared, no = private"
   },
   {
-    "id": "summarize package details",
-    "translation": "summarize package details"
+    "id": "summarize package details; parameters with prefix \"*\" are bound",
+    "translation": "summarize package details; parameters with prefix \"*\" are bound"
   },
   {
     "id": "include publicly shared entities in the result",
@@ -700,8 +700,8 @@
     "translation": "trigger feed `ACTION_NAME`"
   },
   {
-    "id": "summarize trigger details",
-    "translation": "summarize trigger details"
+    "id": "summarize trigger details; parameters with prefix \"*\" are bound",
+    "translation": "summarize trigger details; parameters with prefix \"*\" are bound"
   },
   {
     "id": "parameter values in `KEY VALUE` format",
@@ -952,8 +952,8 @@
     "translation": "only return `LIMIT` number of actions from the collection"
   },
   {
-    "id": "summarize action details",
-    "translation": "summarize action details"
+    "id": "summarize action details; parameters with prefix \"*\" are bound, \"**\" are bound and finalized",
+    "translation": "summarize action details; parameters with prefix \"*\" are bound, \"**\" are bound and finalized"
   },
   {
     "id": "work with activations",


### PR DESCRIPTION
This update is intended to clarify the printed summary when one uses `wsk [ENTITY] [ENTITY_NAME] get --summary`.

Here is an example of what the output of this update should look like:

For entities with multiple parameters and no description:
```
$ wsk action get hola -s
action /guest/hola: Returns a result based on parameters testA, testB and testC
   (parameters: testA, testB, testC)
```

For entities with a single parameter and no description:
```
$ wsk action get hola -s
action /guest/hola: Returns a result based on parameter testA
   (parameters: testA)
```

And entities with no parameters and no description:
```
$ wsk action get hello -s
action /guest/hello
   (Warning: /guest/hello has no annotations)
```

 Closes https://github.com/apache/incubator-openwhisk/issues/2270