### PR TITLE
Remove Unsupported Shared Flag from Package List (Review)

### DIFF
--- a/tools/cli/go-whisk-cli/commands/package.go
+++ b/tools/cli/go-whisk-cli/commands/package.go
@@ -378,7 +378,6 @@ var packageListCmd = &cobra.Command{
   PreRunE:       setupClientConfig,
   RunE: func(cmd *cobra.Command, args []string) error {
     var err error
-    var shared bool
     var qualifiedName QualifiedName
 
     if whiskErr := checkArgs(args, 0, 1, "Package list",
@@ -398,16 +397,9 @@ var packageListCmd = &cobra.Command{
       client.Namespace = qualifiedName.namespace
     }
 
-    if flags.common.shared == "yes" {
-      shared = true
-    } else {
-      shared = false
-    }
-
     options := &whisk.PackageListOptions{
       Skip:   flags.common.skip,
       Limit:  flags.common.limit,
-      Public: shared,
     }
 
     packages, _, err := client.Packages.List(options)
@@ -420,6 +412,7 @@ var packageListCmd = &cobra.Command{
     }
 
     printList(packages)
+
     return nil
   },
 }
@@ -528,7 +521,6 @@ func init() {
   packageBindCmd.Flags().StringSliceVarP(&flags.common.param, "param", "p", []string{}, wski18n.T("parameter values in `KEY VALUE` format"))
   packageBindCmd.Flags().StringVarP(&flags.common.paramFile, "param-file", "P", "", wski18n.T("`FILE` containing parameter values in JSON format"))
 
-  //packageListCmd.Flags().StringVar(&flags.common.shared, "shared", "", wski18n.T("include publicly shared entities in the result"))
   packageListCmd.Flags().IntVarP(&flags.common.skip, "skip", "s", 0, wski18n.T("exclude the first `SKIP` number of packages from the result"))
   packageListCmd.Flags().IntVarP(&flags.common.limit, "limit", "l", 30, wski18n.T("only return `LIMIT` number of packages from the collection"))
 

--- a/tools/cli/go-whisk-cli/commands/package.go
+++ b/tools/cli/go-whisk-cli/commands/package.go
@@ -528,7 +528,7 @@ func init() {
   packageBindCmd.Flags().StringSliceVarP(&flags.common.param, "param", "p", []string{}, wski18n.T("parameter values in `KEY VALUE` format"))
   packageBindCmd.Flags().StringVarP(&flags.common.paramFile, "param-file", "P", "", wski18n.T("`FILE` containing parameter values in JSON format"))
 
-  packageListCmd.Flags().StringVar(&flags.common.shared, "shared", "", wski18n.T("include publicly shared entities in the result"))
+  //packageListCmd.Flags().StringVar(&flags.common.shared, "shared", "", wski18n.T("include publicly shared entities in the result"))
   packageListCmd.Flags().IntVarP(&flags.common.skip, "skip", "s", 0, wski18n.T("exclude the first `SKIP` number of packages from the result"))
   packageListCmd.Flags().IntVarP(&flags.common.limit, "limit", "l", 30, wski18n.T("only return `LIMIT` number of packages from the collection"))
 


### PR DESCRIPTION
The `--shared` flag does not work with `package list`, so remove the option from the CLI.

Closes https://github.com/apache/incubator-openwhisk/issues/2485