### PR TITLE
Fix actionContainerPrefix value

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
@@ -746,7 +746,7 @@ class ContainerPool(
 
     // Getter/setter for this are above.
     private var _logDir = "/logs"
-    private val actionContainerPrefix = "wsk"
+    private val actionContainerPrefix = s"wsk${invokerInstance.toInt}_"
 
     /**
      * Actually deletes the containers.


### PR DESCRIPTION
I found a minor bug. 
actionContainerPrefix has been used to killStragglers but current static string value uses "wsk" only.
so current code can affect anything else on the kubernetes environment.
I didn't include additional code for this regarding invokerReactive, because invokerReative is not verified on K8s environment our side

Signed-off-by: keunseob.kim <keunseob.kim@samsung.com>