### PR TITLE
Update documentation: a note about formatting, fix links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,3 +67,4 @@ code base. Some basic rules include:
 
  - all files must have the Apache license in the header.
  - all PRs must have passing builds for all operating systems.
+ - the code is correctly formatted as defined in the [Scalariform plugin properties](tools/eclipse/scala.properties). If you use IntelliJ for development this [page](https://plugins.jetbrains.com/plugin/7480-scalariform) describes the setup and configuration of the plugin.


### PR DESCRIPTION
Hello, 

this PR add minor updates of the documentation:

- adds a note about the formatting standards (fyi @markusthoemmes) 
- fixes broken/wrong links to cli docs. 

regards, Vadim. 