### PR TITLE
(WIP) Centralized printing

### DIFF
--- a/tools/cli/go-whisk-cli/commands/package.go
+++ b/tools/cli/go-whisk-cli/commands/package.go
@@ -410,7 +410,6 @@ var packageListCmd = &cobra.Command{
       werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
       return werr
     }
-
     printList(packages)
 
     return nil

--- a/tools/cli/go-whisk-cli/commands/util.go
+++ b/tools/cli/go-whisk-cli/commands/util.go
@@ -248,23 +248,59 @@ func isValidJSON(value string) (bool) {
 
 var boldString = color.New(color.Bold).SprintFunc()
 
+// Prints the parameters/list for wsk xxxx list
+// Identifies type and then copies array into an array of interfaces(Printable) to be printed
+// Param: Takes in an interace which contains an array of a command(Ex: []Action)
 func printList(collection interface{}) {
-    switch collection := collection.(type) {
+    var commandToPrint []whisk.Printable
+    switch collection := collection.(type){
     case []whisk.Action:
-        printActionList(collection)
+        for i := range collection {
+            commandToPrint = append(commandToPrint, collection[i])
+        }
     case []whisk.Trigger:
-        printTriggerList(collection)
+        for i := range collection {
+            commandToPrint = append(commandToPrint, collection[i])
+        }
     case []whisk.Package:
-        printPackageList(collection)
+        for i := range collection {
+            commandToPrint = append(commandToPrint, collection[i])
+        }
     case []whisk.Rule:
-        printRuleList(collection)
+        for i := range collection {
+            commandToPrint = append(commandToPrint, collection[i])
+        }
     case []whisk.Namespace:
-        printNamespaceList(collection)
+        for i := range collection {
+            commandToPrint = append(commandToPrint, collection[i])
+        }
     case []whisk.Activation:
-        printActivationList(collection)
-    case []whisk.Api:
-        printApiList(collection)
+        for i := range collection {
+            commandToPrint = append(commandToPrint, collection[i])
+        }
+    case []whisk.ApiFilteredList:
+        for i := range collection {
+            commandToPrint = append(commandToPrint, collection[i])
+        }
+    case []whisk.ApiFilteredRow:
+        for i := range collection {
+            commandToPrint = append(commandToPrint, collection[i])
+        }
     }
+	printCommandsList(commandToPrint, makeDefaultHeader(collection))
+}
+
+// makeDefaultHeader(collection) returns the default header to be used in case
+//      the list to be printed is empty.
+func makeDefaultHeader(collection interface{}) string {
+    defaultHeader := reflect.TypeOf(collection).String()
+    defaultHeader = strings.ToLower(defaultHeader[8:] + "s")
+    if defaultHeader == "apifilteredrows" {
+        defaultHeader = fmt.Sprintf("%-30s %7s %20s  %s", "Action", "Verb", "API Name", "URL")
+    } else if defaultHeader == "apifilteredlists" {
+        defaultHeader = ""
+    }
+    return defaultHeader
 }
 
 func printFullList(collection interface{}) {
@@ -300,46 +336,18 @@ func printSummary(collection interface{}) {
     }
 }
 
-func printActionList(actions []whisk.Action) {
-    fmt.Fprintf(color.Output, "%s\n", boldString("actions"))
-    for _, action := range actions {
-        publishState := wski18n.T("private")
-        kind := getValueString(action.Annotations, "exec")
-        fmt.Printf("%-70s %s %s\n", fmt.Sprintf("/%s/%s", action.Namespace, action.Name), publishState, kind)
-    }
-}
-
-func printTriggerList(triggers []whisk.Trigger) {
-    fmt.Fprintf(color.Output, "%s\n", boldString("triggers"))
-    for _, trigger := range triggers {
-        publishState := wski18n.T("private")
-        fmt.Printf("%-70s %s\n", fmt.Sprintf("/%s/%s", trigger.Namespace, trigger.Name), publishState)
-    }
-}
-
-func printPackageList(packages []whisk.Package) {
-    fmt.Fprintf(color.Output, "%s\n", boldString("packages"))
-    for _, xPackage := range packages {
-        publishState := wski18n.T("private")
-        if xPackage.Publish != nil && *xPackage.Publish {
-            publishState = wski18n.T("shared")
+// Used to print Action, Tigger, Package, and Rule lists
+// Param: Takes in a array of Printable interface, and the name of the command
+//          being sent to it
+// **Note**: The name sould be an empty string for APIs.
+func printCommandsList(commands []whisk.Printable, defaultHeader string) {
+    if len(commands) != 0 {
+        fmt.Fprint(color.Output, commands[0].ToHeaderString())
+        for i := range commands {
+            fmt.Print(commands[i].ToSummaryString())
         }
-        fmt.Printf("%-70s %s\n", fmt.Sprintf("/%s/%s", xPackage.Namespace, xPackage.Name), publishState)
-    }
-}
-
-func printRuleList(rules []whisk.Rule) {
-    fmt.Fprintf(color.Output, "%s\n", boldString("rules"))
-    for _, rule := range rules {
-        publishState := wski18n.T("private")
-        fmt.Printf("%-70s %s\n", fmt.Sprintf("/%s/%s", rule.Namespace, rule.Name), publishState)
-    }
-}
-
-func printNamespaceList(namespaces []whisk.Namespace) {
-    fmt.Fprintf(color.Output, "%s\n", boldString("namespaces"))
-    for _, namespace := range namespaces {
-        fmt.Printf("%s\n", namespace.Name)
+    } else {
+        fmt.Fprintf(color.Output, "%s\n", boldString(defaultHeader))
     }
 }
 

--- a/tools/cli/go-whisk/whisk/action.go
+++ b/tools/cli/go-whisk/whisk/action.go
@@ -25,6 +25,7 @@ import (
     "strings"
 
     "../wski18n"
+	"github.com/fatih/color"
 )
 
 type ActionService struct {
@@ -57,6 +58,31 @@ type ActionListOptions struct {
     Limit       int         `url:"limit"`
     Skip        int         `url:"skip"`
     Docs        bool        `url:"docs,omitempty"`
+}
+
+// ToHeaderString() returns the header for a list of actions
+// ***Method of type Printable***
+func(action Action) ToHeaderString() string {
+	var boldString = color.New(color.Bold).SprintFunc()
+
+	return fmt.Sprintf("%s\n", boldString("actions"))
+}
+
+// ToSummaryString() returns a compound string of required parameters for printing
+//   from CLI command `wsk action list`.
+// ***Method of type Printable***
+func(action Action) ToSummaryString() string{
+  var kind string
+
+  publishState := wski18n.T("private")
+  for i := range action.Annotations {
+    if (action.Annotations[i].Key == "exec") {
+      kind = action.Annotations[i].Value.(string)
+      break
+    }
+  }
+  
+  return fmt.Sprintf("%-70s %s %s\n", fmt.Sprintf("/%s/%s", action.Namespace, action.Name), publishState, kind)
 }
 
 /*

--- a/tools/cli/go-whisk/whisk/activation.go
+++ b/tools/cli/go-whisk/whisk/activation.go
@@ -23,6 +23,7 @@ import (
     "errors"
     "net/url"
     "../wski18n"
+    "github.com/fatih/color"
 )
 
 type ActivationService struct {
@@ -68,6 +69,20 @@ type Log struct {
     Log    string `json:"log,omitempty"`
     Stream string `json:"stream,omitempty"`
     Time   string `json:"time,omitempty"`
+}
+
+// ToHeaderString() returns the header for a list of activations
+func(activation Activation) ToHeaderString() string {
+	var boldString = color.New(color.Bold).SprintFunc()
+    
+	return fmt.Sprintf("%s\n", boldString("activations"))
+}
+
+// ToSummaryString() returns a compound string of required parameters for printing
+//   from CLI command `wsk activation list`.
+// ***Method of type Printable***
+func(activation Activation) ToSummaryString() string {
+	return fmt.Sprintf("%s %-20s\n", activation.ActivationID, activation.Name)
 }
 
 func (s *ActivationService) List(options *ActivationListOptions) ([]Activation, *http.Response, error) {

--- a/tools/cli/go-whisk/whisk/api.go
+++ b/tools/cli/go-whisk/whisk/api.go
@@ -21,6 +21,7 @@ import (
     "net/http"
     "errors"
     "../wski18n"
+    "fmt"
 )
 
 type ApiService struct {
@@ -184,6 +185,27 @@ type ApiSwaggerOpXOpenWhiskV2 struct {
     ApiUrl          string    `json:"url"`
 }
 
+// Used for printing individual APIs in non-truncated form
+type ApiFilteredList struct {
+    ActionName      string
+    ApiName         string
+    BasePath        string
+    RelPath         string
+    Verb            string
+    Url             string
+}
+
+// Used for printing individual APIs in truncated form
+type ApiFilteredRow struct {
+    ActionName      string
+    ApiName         string
+    BasePath        string
+    RelPath         string
+    Verb            string
+    Url             string
+    FmtString       string
+}
+
 var ApiVerbs map[string]bool = map[string]bool {
     "GET": true,
     "PUT": true,
@@ -202,6 +224,38 @@ const (
 ////////////////////
 // Api Methods //
 ////////////////////
+
+// ToHeaderString() returns the header for a list of apis
+// ***Method of type Printable***
+func(api ApiFilteredList) ToHeaderString() string {
+	return ""
+}
+
+// ToSummaryString() returns a compound string of required parameters for printing
+//   from CLI command `wsk api list` or `wsk api-experimental list`.
+// ***Method of type Printable***
+func(api ApiFilteredList) ToSummaryString() string {
+    return fmt.Sprintf("%s %s %s %s %s %s",
+        fmt.Sprintf("%s: %s\n", wski18n.T("Action"), api.ActionName),
+        fmt.Sprintf("  %s: %s\n", wski18n.T("API Name"), api.ApiName),
+        fmt.Sprintf("  %s: %s\n", wski18n.T("Base path"), api.BasePath),
+        fmt.Sprintf("  %s: %s\n", wski18n.T("Path"), api.RelPath),
+        fmt.Sprintf("  %s: %s\n", wski18n.T("Verb"), api.Verb),
+        fmt.Sprintf("  %s: %s\n", wski18n.T("URL"), api.Url))
+}
+
+// ToHeaderString() returns the header for a row of apis
+// ***Method of type Printable***
+func(api ApiFilteredRow) ToHeaderString() string {
+	return fmt.Sprintf("%s", fmt.Sprintf(api.FmtString, "Action", "Verb", "API Name", "URL"))
+}
+
+// ToSummaryString() returns a compound string of required parameters for printing
+//   from CLI command `wsk api list -f` or `wsk api-experimental list -f`.
+// ***Method of type Printable***
+func(api ApiFilteredRow) ToSummaryString() string {
+  return fmt.Sprintf(api.FmtString, api.ActionName, api.Verb, api.ApiName, api.Url)
+}
 
 func (s *ApiService) List(apiListOptions *ApiListRequestOptions) (*ApiListResponse, *http.Response, error) {
     route := "web/whisk.system/routemgmt/getApi.http"

--- a/tools/cli/go-whisk/whisk/namespace.go
+++ b/tools/cli/go-whisk/whisk/namespace.go
@@ -21,6 +21,8 @@ import (
     "net/http"
     "errors"
     "../wski18n"
+    "fmt"
+	"github.com/fatih/color"
 )
 
 type Namespace struct {
@@ -37,6 +39,21 @@ type Contents struct {
 
 type NamespaceService struct {
     client *Client
+}
+
+// ToHeaderString() returns the header for a list of namespaces
+// ***Method of type Printable***
+func(namespace Namespace) ToHeaderString() string {
+	var boldString = color.New(color.Bold).SprintFunc()
+
+	return fmt.Sprintf("%s\n", boldString("namespaces"))
+}
+
+// ToSummaryString() returns a compound string of required parameters for printing
+//   from CLI command `wsk namespace list`.
+// ***Method of type Printable***
+func(namespace Namespace) ToSummaryString() string {
+    return fmt.Sprintf("%s\n", namespace.Name)
 }
 
 // get a list of available namespaces

--- a/tools/cli/go-whisk/whisk/package.go
+++ b/tools/cli/go-whisk/whisk/package.go
@@ -23,6 +23,7 @@ import (
     "net/url"
     "errors"
     "../wski18n"
+    "github.com/fatih/color"
 )
 
 type PackageService struct {
@@ -82,6 +83,27 @@ type PackageListOptions struct {
     Skip        int                 `url:"skip"`
     Since       int                 `url:"since,omitempty"`
     Docs        bool                `url:"docs,omitempty"`
+}
+
+// ToHeaderString() returns the header for a list of packages
+// ***Method of type Printable***
+func(pkg Package) ToHeaderString() string {
+	var boldString = color.New(color.Bold).SprintFunc()
+    
+	return fmt.Sprintf("%s\n", boldString("packages"))
+}
+
+// ToSummaryString() returns a compound string of required parameters for printing
+//   from CLI command `wsk package list`.
+// ***Method of type Printable***
+func(xPackage Package) ToSummaryString() string{
+    publishState := wski18n.T("private")
+    if xPackage.Publish != nil && *xPackage.Publish {
+        publishState = wski18n.T("shared")
+    }
+
+    return fmt.Sprintf("%-70s %s\n", fmt.Sprintf("/%s/%s", xPackage.Namespace,
+        xPackage.Name), publishState)
 }
 
 func (s *PackageService) List(options *PackageListOptions) ([]Package, *http.Response, error) {

--- a/tools/cli/go-whisk/whisk/rule.go
+++ b/tools/cli/go-whisk/whisk/rule.go
@@ -24,6 +24,7 @@ import (
     "errors"
     "net/url"
     "../wski18n"
+    "github.com/fatih/color"
 )
 
 type RuleService struct {
@@ -45,6 +46,24 @@ type RuleListOptions struct {
     Limit       int     `url:"limit"`
     Skip        int     `url:"skip"`
     Docs        bool    `url:"docs,omitempty"`
+}
+
+// ToHeaderString() returns the header for a list of rules
+// ***Method of type Printable***
+func(rule Rule) ToHeaderString() string {
+	var boldString = color.New(color.Bold).SprintFunc()
+
+	return fmt.Sprintf("%s\n", boldString("rules"))
+}
+
+// ToSummaryString() returns a compound string of required parameters for printing
+//   from CLI command `wsk rule list`.
+// ***Method of type Printable***
+func(rule Rule) ToSummaryString() string{
+    publishState := wski18n.T("private")
+
+    return fmt.Sprintf("%-70s %s\n", fmt.Sprintf("/%s/%s", rule.Namespace,
+        rule.Name), publishState)
 }
 
 func (s *RuleService) List(options *RuleListOptions) ([]Rule, *http.Response, error) {

--- a/tools/cli/go-whisk/whisk/trigger.go
+++ b/tools/cli/go-whisk/whisk/trigger.go
@@ -23,6 +23,7 @@ import (
     "errors"
     "net/url"
     "../wski18n"
+    "github.com/fatih/color"
 )
 
 type TriggerService struct {
@@ -38,13 +39,30 @@ type Trigger struct {
     Parameters      KeyValueArr     `json:"parameters,omitempty"`
     Limits          *Limits         `json:"limits,omitempty"`
     Publish         *bool           `json:"publish,omitempty"`
-
 }
 
 type TriggerListOptions struct {
     Limit           int             `url:"limit"`
     Skip            int             `url:"skip"`
     Docs            bool            `url:"docs,omitempty"`
+}
+
+// ToHeaderString() returns the header for a list of triggers
+// ***Method of type Printable***
+func(trigger Trigger) ToHeaderString() string {
+	var boldString = color.New(color.Bold).SprintFunc()
+    
+	return fmt.Sprintf("%s\n", boldString("triggers"))
+}
+
+// ToSummaryString() returns a compound string of required parameters for printing
+//   from CLI command `wsk trigger list`.
+// ***Method of type Printable***
+func(trigger Trigger) ToSummaryString() string {
+    publishState := wski18n.T("private")
+
+    return fmt.Sprintf("%-70s %s\n", fmt.Sprintf("/%s/%s", trigger.Namespace,
+        trigger.Name), publishState)
 }
 
 func (s *TriggerService) List(options *TriggerListOptions) ([]Trigger, *http.Response, error) {

--- a/tools/cli/go-whisk/whisk/util.go
+++ b/tools/cli/go-whisk/whisk/util.go
@@ -29,6 +29,12 @@ import (
     "../wski18n"
 )
 
+// Printable items are anything that need to be printed for listing purposes.
+type Printable interface {
+    ToHeaderString() string   // Prints header information of a Printable
+    ToSummaryString() string     // Prints summary info of one Printable
+}
+
 // addOptions adds the parameters in opt as URL query parameters to s.  opt
 // must be a struct whose fields may contain "url" tags.
 func addRouteOptions(route string, options interface{}) (*url.URL, error) {


### PR DESCRIPTION
Due to Alphabetize no longer being a CLI issue, sorting needs to be done server side, @underwoodb-sd-ibm and I have extracted the centralized printing statements from Alphabetize to allow for easier access to printing methods. Each command will implement an interface `printable` and be converted to a `printable` to be ran through a singular printing function.  Reference: #2326 