### PR TITLE
Prints bashauto-completion install script to STDOUT

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,7 +2,7 @@
 
 OpenWhisk offers a powerful command line interface that allows complete management of all aspects of the system.
 
-## Setting up the OpenWhisk CLI 
+## Setting up the OpenWhisk CLI
 
 - Building OpenWhisk from a cloned repository results in the generation of the command line interface. The generated CLIs are located in `openwhisk/bin/`. The main CLI is located in `openwhisk/bin/wsk` that runs on the operating system, and CPU architecture on which it was built. Executables for other operating system, and CPU architectures are located in the following directories: `openwhisk/bin/mac/`, `openwhisk/bin/linux/`, `openwhisk/bin/windows/`.
 
@@ -37,6 +37,32 @@ you can run the following command from your `openwhisk` directory:
 **Tip:** The OpenWhisk CLI stores the properties set in `~/.wskprops` by default. The location of this file can be altered by setting the `WSK_CONFIG_FILE` environment variable.
 
 To verify your CLI setup, try [creating and running an action](#openwhisk-hello-world-example).
+
+### Configure auto-completion for Openwhisk CLI
+
+For most bash users, running the following command will be sufficient to install auto-completion for Openwhisk CLI:
+
+```
+eval "`wsk sdk install bashauto --bashrc`"
+```
+
+**Note:** `--bashrc` flag will attempt to locate your `.bashrc` and append the previous command, without `--bashrc`, to it.
+
+If this doesn't work, you can run a temporary installation using the following command:
+
+```
+eval "`wsk sdk install bashauto`"
+```
+
+**Note:** Every time a new terminal is opened this command will have to be ran in order to use auto-completion. Alternatively, adding the previous command to the `.bashrc` or `.profile` will prevent this.
+
+For those who wish to do a custom installation, you can simply print to the terminal and manipulate the output by using the following command:
+
+```
+wsk sdk install bashauto
+```
+
+**Note:** This will NOT install anything but simply print the Cobra auto-completion script to the terminal. Adding `--bashrc` will ONLY attempt to append the `.bashrc` and still not run the install script.
 
 ## Using the OpenWhisk CLI
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -38,31 +38,29 @@ you can run the following command from your `openwhisk` directory:
 
 To verify your CLI setup, try [creating and running an action](#openwhisk-hello-world-example).
 
-### Configure auto-completion for Openwhisk CLI
+### Configure command completion for Openwhisk CLI
 
-For most bash users, running the following command will be sufficient to install auto-completion for Openwhisk CLI:
+For bash command completion to work, bash 4.1 or newer is required. The most recent Linux distributions should have the correct version of bash but Mac users will most likely have an older version.
+Mac users can check their bash version and update it by running the following commands:
 
 ```
-eval "`wsk sdk install bashauto --bashrc`"
+bash --version
+brew install bash-completion
 ```
 
-**Note:** `--bashrc` flag will attempt to locate your `.bashrc` and append the previous command, without `--bashrc`, to it.
-
-If this doesn't work, you can run a temporary installation using the following command:
+To install bash command completion run the following command:
 
 ```
 eval "`wsk sdk install bashauto`"
 ```
 
-**Note:** Every time a new terminal is opened this command will have to be ran in order to use auto-completion. Alternatively, adding the previous command to the `.bashrc` or `.profile` will prevent this.
+**Note:** Every time a new terminal is opened this command must run to enable bash command completion. Alternatively, adding the previous command to the `.bashrc` or `.profile` will prevent this.
 
-For those who wish to do a custom installation, you can simply print to the terminal and manipulate the output by using the following command:
-
+For those who wish to do a custom installation, the following commands show how to output the wsk command completion script into a separate shell script file to be run later. You will need to explicitly run the script to install wsk command completion support.
 ```
-wsk sdk install bashauto
+wsk sdk install bashauto > wsk_cli_bash_completion.sh
+chmod +x wsk_cli_bash_completion.sh
 ```
-
-**Note:** This will NOT install anything but simply print the Cobra auto-completion script to the terminal. Adding `--bashrc` will ONLY attempt to append the `.bashrc` and still not run the install script.
 
 ## Using the OpenWhisk CLI
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,19 +48,24 @@ bash --version
 brew install bash-completion
 ```
 
-To install bash command completion run the following command:
+To download the bash command completion to your local directory, run the following command:
 
 ```
-eval "`wsk sdk install bashauto`"
+wsk sdk install bashauto
+```
+The command script `wsk_cli_bash_completion.sh` will now be in your current directory. To enable command line completion of wsk commands, source the auto completion script into your bash environment.
+
+```
+source wsk_cli_bash_completion.sh
 ```
 
-**Note:** Every time a new terminal is opened this command must run to enable bash command completion. Alternatively, adding the previous command to the `.bashrc` or `.profile` will prevent this.
+Alternatively, to install bash command completion, run the following command:
 
-For those who wish to do a custom installation, the following commands show how to output the wsk command completion script into a separate shell script file to be run later. You will need to explicitly run the script to install wsk command completion support.
 ```
-wsk sdk install bashauto > wsk_cli_bash_completion.sh
-chmod +x wsk_cli_bash_completion.sh
+eval "`wsk sdk install bashauto --stdout`"
 ```
+
+**Note:** Every time a new terminal is opened, this command must run to enable bash command completion. Alternatively, adding the previous command to the `.bashrc` or `.profile` will prevent this.
 
 ## Using the OpenWhisk CLI
 

--- a/tests/src/test/scala/system/basic/WskSdkTests.scala
+++ b/tests/src/test/scala/system/basic/WskSdkTests.scala
@@ -89,23 +89,14 @@ class WskSdkTests
         FileUtils.deleteDirectory(dir)
     }
 
-    it should "install the bash auto-completion bash script" in {
-        // Use a temp dir for testing to not disturb user's local folder
-        val dir = File.createTempFile("wskinstall", ".tmp")
-        dir.delete()
-        dir.mkdir() should be(true)
 
-        val scriptfilename = "wsk_cli_bash_completion.sh"
-        var scriptfile = new File(dir.getPath(), scriptfilename)
-        try {
-            val stdout = wsk.cli(Seq("sdk", "install", "bashauto"), workingDir = dir, expectedExitCode = SUCCESS_EXIT).stdout
-            stdout should include("is installed in the current directory")
-            val fileContent = FileUtils.readFileToString(scriptfile)
-            fileContent should include("bash completion for wsk")
-        } finally {
-            scriptfile.delete()
-            FileUtils.deleteDirectory(dir)
-        }
+    it should "install the bash auto-completion bash script using --bashrc flag" in {
+        val auth: Seq[String] = Seq("--auth", wskprops.authKey)
+        val msg = "bash completion for wsk"    // Subject to change, dependent on Cobra script
+        // Doesn't actually install, simply checking if the command is printing correctly to STDOUT
+        val stdout = wsk.cli(Seq("sdk", "install", "bashauto", "--bashrc") ++ wskprops.overrides ++ auth, expectedExitCode = SUCCESS_EXIT).stdout
+
+        stdout should include(msg)
     }
 
 }

--- a/tests/src/test/scala/system/basic/WskSdkTests.scala
+++ b/tests/src/test/scala/system/basic/WskSdkTests.scala
@@ -89,10 +89,29 @@ class WskSdkTests
         FileUtils.deleteDirectory(dir)
     }
 
+    it should "install the bash auto-completion bash script" in {
+        // Use a temp dir for testing to not disturb user's local folder
+        val dir = File.createTempFile("wskinstall", ".tmp")
+        dir.delete()
+        dir.mkdir() should be(true)
+
+        val scriptfilename = "wsk_cli_bash_completion.sh"
+        var scriptfile = new File(dir.getPath(), scriptfilename)
+        try {
+            val stdout = wsk.cli(Seq("sdk", "install", "bashauto"), workingDir = dir, expectedExitCode = SUCCESS_EXIT).stdout
+            stdout should include("is installed in the current directory")
+            val fileContent = FileUtils.readFileToString(scriptfile)
+            fileContent should include("bash completion for wsk")
+        } finally {
+            scriptfile.delete()
+            FileUtils.deleteDirectory(dir)
+        }
+    }
+
     it should "print bash command completion script to STDOUT" in {
         val msg = "bash completion for wsk"    // Subject to change, dependent on Cobra script
 
-        val stdout = wsk.cli(Seq("sdk", "install", "bashauto"), expectedExitCode = SUCCESS_EXIT).stdout
+        val stdout = wsk.cli(Seq("sdk", "install", "bashauto", "--stdout")).stdout
         stdout should include(msg)
     }
 }

--- a/tests/src/test/scala/system/basic/WskSdkTests.scala
+++ b/tests/src/test/scala/system/basic/WskSdkTests.scala
@@ -89,14 +89,10 @@ class WskSdkTests
         FileUtils.deleteDirectory(dir)
     }
 
-
-    it should "install the bash auto-completion bash script using --bashrc flag" in {
-        val auth: Seq[String] = Seq("--auth", wskprops.authKey)
+    it should "print bash command completion script to STDOUT" in {
         val msg = "bash completion for wsk"    // Subject to change, dependent on Cobra script
-        // Doesn't actually install, simply checking if the command is printing correctly to STDOUT
-        val stdout = wsk.cli(Seq("sdk", "install", "bashauto", "--bashrc") ++ wskprops.overrides ++ auth, expectedExitCode = SUCCESS_EXIT).stdout
 
+        val stdout = wsk.cli(Seq("sdk", "install", "bashauto"), expectedExitCode = SUCCESS_EXIT).stdout
         stdout should include(msg)
     }
-
 }

--- a/tools/cli/go-whisk-cli/commands/flags.go
+++ b/tools/cli/go-whisk-cli/commands/flags.go
@@ -106,6 +106,11 @@ type Flags struct {
         summary bool
     }
 
+    //sdk
+    sdk struct {
+        stdout bool
+    }
+
     // api
     api struct {
         action     string

--- a/tools/cli/go-whisk-cli/commands/flags.go
+++ b/tools/cli/go-whisk-cli/commands/flags.go
@@ -116,11 +116,6 @@ type Flags struct {
         configfile string
         resptype   string
     }
-
-    // sdk
-    sdk struct {
-        bashrc bool
-    }
 }
 
 

--- a/tools/cli/go-whisk-cli/commands/flags.go
+++ b/tools/cli/go-whisk-cli/commands/flags.go
@@ -116,6 +116,11 @@ type Flags struct {
         configfile string
         resptype   string
     }
+
+    // sdk
+    sdk struct {
+        bashrc bool
+    }
 }
 
 

--- a/tools/cli/go-whisk-cli/commands/sdk.go
+++ b/tools/cli/go-whisk-cli/commands/sdk.go
@@ -22,6 +22,8 @@ import (
     "fmt"
     "io"
     "os"
+    "os/user"
+    "io/ioutil"
     "strings"
 
     "github.com/spf13/cobra"
@@ -50,7 +52,6 @@ type sdkInfo struct {
 var sdkMap map[string]*sdkInfo
 const SDK_DOCKER_COMPONENT_NAME string = "docker"
 const SDK_IOS_COMPONENT_NAME string = "ios"
-const BASH_AUTOCOMPLETE_FILENAME string = "wsk_cli_bash_completion.sh"
 
 var sdkInstallCmd = &cobra.Command{
     Use:   "install COMPONENT",
@@ -74,17 +75,23 @@ var sdkInstallCmd = &cobra.Command{
         case "ios":
             err = iOSInstall()
         case "bashauto":
-            err = WskCmd.GenBashCompletionFile(BASH_AUTOCOMPLETE_FILENAME)
-            if (err != nil) {
-                whisk.Debug(whisk.DbgError, "GenBashCompletionFile('%s`) error: \n", BASH_AUTOCOMPLETE_FILENAME, err)
-                errStr := wski18n.T("Unable to generate '{{.name}}': {{.err}}",
-                        map[string]interface{}{"name": BASH_AUTOCOMPLETE_FILENAME, "err": err})
+            whisk.Debug(whisk.DbgInfo, "Running bashauto script\n")
+            if err = WskCmd.GenBashCompletion(os.Stdout); err != nil {
+                whisk.Debug(whisk.DbgError, "GenBashCompletion error: %s\n", err)
+                errStr := wski18n.T("Unable to generate bashauto-completion {{.err}}",
+                        map[string]interface{}{"err": err})
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return werr
             }
-            fmt.Printf(
-                wski18n.T("bash_completion_msg",
-                    map[string]interface{}{"name": BASH_AUTOCOMPLETE_FILENAME}))
+            if flags.sdk.bashrc {
+                if err := addToBash(); err != nil {
+                    whisk.Debug(whisk.DbgError, "Flag --bashrc failed: %s\n", err)
+                    errStr := wski18n.T("Unable to append .bashrc: {{.err}}",
+                        map[string]interface{}{"err": err})
+                    werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+                    return werr
+                }
+            }
         default:
             whisk.Debug(whisk.DbgError, "Invalid component argument '%s'\n", component)
             errStr := wski18n.T("The SDK component argument '{{.component}}' is invalid. Valid components are docker, ios and bashauto",
@@ -97,6 +104,58 @@ var sdkInstallCmd = &cobra.Command{
         }
         return nil
     },
+}
+
+// addToBash() attempts to find user's .bashrc and append the line
+// "eval \"`wsk sdk install bashauto`\"" to it unless the line already exists
+func addToBash() error {
+    var usr *user.User
+    var bash *os.File
+    var exists bool
+    var err error
+
+    bashCheck := "wsk sdk install bashauto"
+    bashCmd := "eval \"`wsk sdk install bashauto`\""
+
+    if usr, err = user.Current(); err != nil {
+        whisk.Debug(whisk.DbgError, "Couldn't find User Directory: %s\n", err)
+        return err
+    }
+    whisk.Debug(whisk.DbgInfo, "Found current user %s\n", usr.HomeDir)
+    bashLoc := fmt.Sprintf("%s/%s", usr.HomeDir, ".bashrc")
+    if bash, err = os.OpenFile(bashLoc, os.O_APPEND|os.O_WRONLY, 0600); err != nil {
+        whisk.Debug(whisk.DbgError, "Could not find .bashrc: %s\n", err)
+        return err
+    }
+    defer bash.Close()
+    if exists, err = lineExists(bashLoc, bashCheck); err != nil {
+        return err
+    }
+    if exists == false {
+        whisk.Debug(whisk.DbgInfo, "Attempting to append .bashrc\n")
+        if _, err :=  bash.WriteString(bashCmd); err != nil {
+            whisk.Debug(whisk.DbgError, "Could not append .bashrc: %s\n", err)
+            return err
+        }
+        whisk.Debug(whisk.DbgInfo, "Successfully appended .bashrc\n")
+    }
+
+    return nil
+}
+
+// lineExists(string, string) checks to see if a string is contained in a specified file
+// Returns a boolean (true meaning the line exists) and any errors
+func lineExists(fileLoc string , text string) (bool, error) {
+	if read, err := ioutil.ReadFile(fileLoc); err != nil {
+		whisk.Debug(whisk.DbgError, "Could not find %s due to: %s\n", fileLoc, err)
+		return false, err
+	} else if strings.Contains(string(read), text) {
+		whisk.Debug(whisk.DbgInfo, "String '%s' was found in %s\n", text, fileLoc)
+		return true, nil
+	}
+	whisk.Debug(whisk.DbgInfo, "Did not find string '%s' in %s\n", text, fileLoc)
+
+	return false, nil
 }
 
 func dockerInstall() error {
@@ -238,6 +297,8 @@ func sdkInstall(componentName string) error {
 }
 
 func init() {
+	sdkInstallCmd.Flags().BoolVarP(&flags.sdk.bashrc, "bashrc", "b", false, wski18n.T("adds bashauto-completion install command to .bashrc"))
+
     sdkCmd.AddCommand(sdkInstallCmd)
 
     sdkMap = make(map[string]*sdkInfo)

--- a/tools/cli/go-whisk-cli/commands/sdk.go
+++ b/tools/cli/go-whisk-cli/commands/sdk.go
@@ -50,6 +50,7 @@ type sdkInfo struct {
 var sdkMap map[string]*sdkInfo
 const SDK_DOCKER_COMPONENT_NAME string = "docker"
 const SDK_IOS_COMPONENT_NAME string = "ios"
+const BASH_AUTOCOMPLETE_FILENAME string = "wsk_cli_bash_completion.sh"
 
 var sdkInstallCmd = &cobra.Command{
     Use:   "install COMPONENT",
@@ -73,13 +74,27 @@ var sdkInstallCmd = &cobra.Command{
         case "ios":
             err = iOSInstall()
         case "bashauto":
-            if err = WskCmd.GenBashCompletion(os.Stdout); err != nil {
-                whisk.Debug(whisk.DbgError, "GenBashCompletion error: %s\n", err)
-                errStr := wski18n.T("Unable to output bash command completion {{.err}}",
-                        map[string]interface{}{"err": err})
-                werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-                return werr
-            }
+            if flags.sdk.stdout {
+                if err = WskCmd.GenBashCompletion(os.Stdout); err != nil {
+                    whisk.Debug(whisk.DbgError, "GenBashCompletion error: %s\n", err)
+                    errStr := wski18n.T("Unable to output bash command completion {{.err}}",
+                            map[string]interface{}{"err": err})
+                    werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+                    return werr
+                }
+             } else {
+                    err = WskCmd.GenBashCompletionFile(BASH_AUTOCOMPLETE_FILENAME)
+                    if (err != nil) {
+                        whisk.Debug(whisk.DbgError, "GenBashCompletionFile('%s`) error: \n", BASH_AUTOCOMPLETE_FILENAME, err)
+                        errStr := wski18n.T("Unable to generate '{{.name}}': {{.err}}",
+                                map[string]interface{}{"name": BASH_AUTOCOMPLETE_FILENAME, "err": err})
+                        werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+                        return werr
+                    }
+                    fmt.Printf(
+                        wski18n.T("bash_completion_msg",
+                    map[string]interface{}{"name": BASH_AUTOCOMPLETE_FILENAME}))
+             }
         default:
             whisk.Debug(whisk.DbgError, "Invalid component argument '%s'\n", component)
             errStr := wski18n.T("The SDK component argument '{{.component}}' is invalid. Valid components are docker, ios and bashauto",
@@ -233,6 +248,8 @@ func sdkInstall(componentName string) error {
 }
 
 func init() {
+    sdkInstallCmd.Flags().BoolVarP(&flags.sdk.stdout, "stdout", "s", false, wski18n.T("prints bash command completion script to stdout"))
+
     sdkCmd.AddCommand(sdkInstallCmd)
 
     sdkMap = make(map[string]*sdkInfo)

--- a/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
+++ b/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
@@ -554,14 +554,6 @@
     "translation": "The SDK component argument is missing. One component (docker, ios, or bashauto) must be specified"
   },
   {
-    "id": "Unable to generate '{{.name}}': {{.err}}",
-    "translation": "Unable to generate '{{.name}}': {{.err}}"
-  },
-  {
-    "id": "bash_completion_msg",
-    "translation": "The bash auto-completion script ({{.name}}) is installed in the current directory.\nTo enable command line completion of wsk commands, source the auto completion script into your bash environment\n"
-  },
-  {
     "id": "The SDK component argument '{{.component}}' is invalid. Valid components are docker, ios and bashauto",
     "translation": "The SDK component argument '{{.component}}' is invalid. Valid components are docker, ios and bashauto"
   },
@@ -1518,5 +1510,17 @@
   {
     "id": "get action url",
     "translation": "get action url"
+  },
+  {
+    "id": "adds bashauto-completion install command to .bashrc",
+    "translation": "adds bashauto-completion install command to .bashrc"
+  },
+  {
+    "id": "Unable to append .bashrc: {{.err}}",
+    "translation": "Unable to append .bashrc: {{.err}}"
+  },
+  {
+    "id": "Unable to generate bashauto-completion {{.err}}",
+    "translation": "Unable to generate bashauto-completion {{.err}}"
   }
 ]

--- a/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
+++ b/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
@@ -554,6 +554,14 @@
     "translation": "The SDK component argument is missing. One component (docker, ios, or bashauto) must be specified"
   },
   {
+    "id": "Unable to generate '{{.name}}': {{.err}}",
+    "translation": "Unable to generate '{{.name}}': {{.err}}"
+  },
+  {
+    "id": "bash_completion_msg",
+    "translation": "The bash auto-completion script ({{.name}}) is installed in the current directory.\nTo enable command line completion of wsk commands, source the auto completion script into your bash environment\n"
+  },
+  {
     "id": "The SDK component argument '{{.component}}' is invalid. Valid components are docker, ios and bashauto",
     "translation": "The SDK component argument '{{.component}}' is invalid. Valid components are docker, ios and bashauto"
   },
@@ -1514,5 +1522,9 @@
   {
     "id": "Unable to output bash command completion {{.err}}",
     "translation": "Unable to output bash command completion {{.err}}"
-  }
+},
+{
+    "id": "prints bash command completion script to stdout",
+    "translation": "prints bash command completion script to stdout"
+}
 ]

--- a/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
+++ b/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
@@ -1512,15 +1512,7 @@
     "translation": "get action url"
   },
   {
-    "id": "adds bashauto-completion install command to .bashrc",
-    "translation": "adds bashauto-completion install command to .bashrc"
-  },
-  {
-    "id": "Unable to append .bashrc: {{.err}}",
-    "translation": "Unable to append .bashrc: {{.err}}"
-  },
-  {
-    "id": "Unable to generate bashauto-completion {{.err}}",
-    "translation": "Unable to generate bashauto-completion {{.err}}"
+    "id": "Unable to output bash command completion {{.err}}",
+    "translation": "Unable to output bash command completion {{.err}}"
   }
 ]

--- a/tools/ubuntu-setup/bashprofile.sh
+++ b/tools/ubuntu-setup/bashprofile.sh
@@ -1,5 +1,4 @@
 # Adds openwhisk bin to bash profile
 echo 'export PATH=$HOME/openwhisk/bin:$PATH' > "$HOME/.bash_profile"
 # Adds tab completion
-echo 'eval "$(register-python-argcomplete wsk)"' >> "$HOME/.bash_profile"
 echo 'eval "$(register-python-argcomplete wskadmin)"' >> "$HOME/.bash_profile"

--- a/tools/vagrant/Vagrantfile
+++ b/tools/vagrant/Vagrantfile
@@ -155,7 +155,6 @@ $script_end = <<SCRIPT
   chmod +x ${HOME}/bin/wsk
   chown vagrant:vagrant ${HOME}/bin/wsk
   PATH=${PATH}:${HOME}/bin
-  echo 'pushd "$(mktemp -d)" > /dev/null && wsk sdk install bashauto > /dev/null && source wsk_cli_bash_completion.sh && popd > /dev/null' >> $HOME/.bashrc
 
   # Run OpenWhisk CLI
   touch $HOME/.wskprops

--- a/tools/vagrant/Vagrantfile
+++ b/tools/vagrant/Vagrantfile
@@ -155,7 +155,7 @@ $script_end = <<SCRIPT
   chmod +x ${HOME}/bin/wsk
   chown vagrant:vagrant ${HOME}/bin/wsk
   PATH=${PATH}:${HOME}/bin
-  eval "`wsk sdk install bashauto`"
+  eval "`wsk sdk install bashauto --stdout`"
 
   # Run OpenWhisk CLI
   touch $HOME/.wskprops

--- a/tools/vagrant/Vagrantfile
+++ b/tools/vagrant/Vagrantfile
@@ -155,6 +155,7 @@ $script_end = <<SCRIPT
   chmod +x ${HOME}/bin/wsk
   chown vagrant:vagrant ${HOME}/bin/wsk
   PATH=${PATH}:${HOME}/bin
+  eval "`wsk sdk install bashauto`"
 
   # Run OpenWhisk CLI
   touch $HOME/.wskprops


### PR DESCRIPTION
This change simply changes the output of the Cobra auto-completion script from a file to STDOUT. Originally, `wsk sdk install autobash` would create the file `wsk_cli_bash_completion.sh`, but now it will print the contents of the Cobra auto-completion script to the terminal. You can now use the command ``eval "`wsk sdk install autobash`"`` to automatically install the script for that instance of the terminal. Adding the eval command to your `.bashrc` or `.profile` will keep you from rerunning this command. Closes #1221