### PR TITLE
Reuse namespace in the Python 3 action runtime

### DIFF
--- a/core/pythonAction/pythonrunner.py
+++ b/core/pythonAction/pythonrunner.py
@@ -32,7 +32,7 @@ class PythonRunner(ActionRunner):
         ActionRunner.__init__(self, '/action/__main__.py')
         self.fn = None
         self.mainFn = 'main'
-        self.namespace = {}
+        self.global_context = {}
 
     def initCodeFromString(self, message):
         # do nothing, defer to build step
@@ -83,10 +83,10 @@ class PythonRunner(ActionRunner):
         result = None
         try:
             os.environ = env
-            self.namespace['param'] = args
-            exec(self.fn, self.namespace)
-            exec('fun = %s(param)' % self.mainFn, self.namespace)
-            result = self.namespace['fun']
+            self.global_context['param'] = args
+            exec(self.fn, self.global_context)
+            exec('fun = %s(param)' % self.mainFn, self.global_context)
+            result = self.global_context['fun']
         except Exception:
             traceback.print_exc(file=sys.stderr)
 

--- a/core/pythonAction/pythonrunner.py
+++ b/core/pythonAction/pythonrunner.py
@@ -32,6 +32,7 @@ class PythonRunner(ActionRunner):
         ActionRunner.__init__(self, '/action/__main__.py')
         self.fn = None
         self.mainFn = 'main'
+        self.namespace = {}
 
     def initCodeFromString(self, message):
         # do nothing, defer to build step
@@ -79,15 +80,13 @@ class PythonRunner(ActionRunner):
         return self.fn is not None
 
     def run(self, args, env):
-        # initialize the namespace for the execution
-        namespace = {}
         result = None
         try:
             os.environ = env
-            namespace['param'] = args
-            exec(self.fn, namespace)
-            exec('fun = %s(param)' % self.mainFn, namespace)
-            result = namespace['fun']
+            self.namespace['param'] = args
+            exec(self.fn, self.namespace)
+            exec('fun = %s(param)' % self.mainFn, self.namespace)
+            result = self.namespace['fun']
         except Exception:
             traceback.print_exc(file=sys.stderr)
 


### PR DESCRIPTION
This allows actions to set/retrieve global variables as an additional optimization during container reuse.