### PR TITLE
Adopt gitignore to ignore generated certs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ node_modules
 ansible/environments/docker-machine/hosts
 ansible/db_local.ini*
 ansible/tmp/*
+ansible/roles/nginx/files/openwhisk-client*
 ansible/roles/nginx/files/*.csr
 ansible/roles/nginx/files/*cert.pem
 


### PR DESCRIPTION
After executing the script to create certificates, 3 files will be generated in the nginx-role folder that are currently not added to the gitignore file.