### PR TITLE
Using JDK instead of JRE to provide tooling.

### DIFF
--- a/common/scala/Dockerfile
+++ b/common/scala/Dockerfile
@@ -8,15 +8,17 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 ENV VERSION 8
-ENV UPDATE 131
-ENV BUILD 11
+ENV UPDATE 141
+ENV BUILD 15
+ENV SIG 336fa29ff2bb4ef291e347e091f7f4a7
 
 ENV JAVA_HOME /usr/lib/jvm/java-${VERSION}-oracle
 ENV JRE_HOME ${JAVA_HOME}/jre
+ENV PATH $JAVA_HOME/bin:$PATH
 
 RUN curl --silent --location --retry 3 --cacert /etc/ssl/certs/GeoTrust_Global_CA.pem \
   --header "Cookie: oraclelicense=accept-securebackup-cookie;" \
-  http://download.oracle.com/otn-pub/java/jdk/"${VERSION}"u"${UPDATE}"-b"${BUILD}"/d54c1d3a095b4ff2b6607d096fa80163/server-jre-"${VERSION}"u"${UPDATE}"-linux-x64.tar.gz \
+  http://download.oracle.com/otn-pub/java/jdk/"${VERSION}"u"${UPDATE}"-b"${BUILD}"/"${SIG}"/jdk-"${VERSION}"u"${UPDATE}"-linux-x64.tar.gz \
   | tar xz -C /tmp && \
   mkdir -p /usr/lib/jvm && mv /tmp/jdk1.${VERSION}.0_${UPDATE} "${JAVA_HOME}" && \
   apt-get autoclean && apt-get --purge -y autoremove && \


### PR DESCRIPTION
Using JDK tools can be useful to debug JRE related problems. The image grows ~200MB.