### PR TITLE
Enable reactive containerpool for all open environments.

### DIFF
--- a/ansible/environments/docker-machine/group_vars/all
+++ b/ansible/environments/docker-machine/group_vars/all
@@ -37,4 +37,4 @@ apigw_host_v2: "http://{{ groups['apigateway']|first }}:{{apigateway.port.api}}/
 
 # RunC enablement
 invoker_use_runc: true
-invoker_use_reactive_pool: false
+invoker_use_reactive_pool: true

--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -32,7 +32,7 @@ apigw_host_v2: "http://{{ groups['apigateway']|first }}:{{apigateway.port.api}}/
 
 # RunC enablement
 invoker_use_runc: true
-invoker_use_reactive_pool: false
+invoker_use_reactive_pool: true
 
 controller_arguments: '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1098'
 invoker_arguments: "{{ controller_arguments }}"

--- a/ansible/environments/mac/group_vars/all
+++ b/ansible/environments/mac/group_vars/all
@@ -32,7 +32,7 @@ apigw_host_v2: "http://{{ groups['apigateway']|first }}:{{apigateway.port.api}}/
 
 # RunC enablement
 invoker_use_runc: true
-invoker_use_reactive_pool: false
+invoker_use_reactive_pool: true
 
 controller_arguments: '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1098'
 invoker_arguments: "{{ controller_arguments }}"


### PR DESCRIPTION
This is a stepping stone to make the new pool the default for everything.

Communication will be done via dev list.