### PR TITLE
Align await timeout for docker test 

### DIFF
--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
@@ -271,13 +271,14 @@ class DockerContainerTests extends FlatSpec
         implicit val docker = stub[DockerApiWithFileAccess]
         implicit val runc = stub[RuncApi]
 
+        val initTimeout = 1.second
         val interval = intervalOf(1.millisecond)
         val container = dockerContainer() {
             Future.successful(RunResult(interval, Right(ContainerResponse(true, "", None))))
         }
 
-        val initInterval = container.initialize(JsObject(), 1.second)
-        await(initInterval) shouldBe interval
+        val initInterval = container.initialize(JsObject(), initTimeout)
+        await(initInterval, initTimeout) shouldBe interval
 
         // assert the starting log is there
         val start = LogMarker.parse(logLines.head)
@@ -302,7 +303,7 @@ class DockerContainerTests extends FlatSpec
 
         val init = container.initialize(JsObject(), initTimeout)
 
-        val error = the[InitializationError] thrownBy await(init)
+        val error = the[InitializationError] thrownBy await(init, initTimeout)
         error.interval shouldBe interval
         error.response.statusCode shouldBe ActivationResponse.ApplicationError
 


### PR DESCRIPTION
The await could have timed out before docker init operation is finished. 
Align both timeouts. 