### PR TITLE
Share bookkeeping data across controllers

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -108,7 +108,7 @@ controller:
   arguments: "{{ controller_arguments | default('') }}"
   blackboxFraction: "{{ controller_blackbox_fraction | default(0.10) }}"
   instances: "{{ groups['controllers'] | length }}"
-  localBookkeeping: "{{ controller_local_bookkeeping | default('false') }}"
+  localBookkeeping: "{{ controller_local_bookkeeping | default('true') }}"
   akka:
     provider: cluster
     cluster:

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -108,6 +108,15 @@ controller:
   arguments: "{{ controller_arguments | default('') }}"
   blackboxFraction: "{{ controller_blackbox_fraction | default(0.10) }}"
   instances: "{{ groups['controllers'] | length }}"
+  localBookkeeping: "{{ controller_local_bookkeeping | default('false') }}"
+  akka:
+    provider: cluster
+    cluster:
+      basePort: 8000
+      host: "{{ groups['controllers'] | map('extract', hostvars, 'ansible_host') | list }}"
+      bindPort: 2551
+      # at this moment all controllers are seed nodes
+      seedNodes: "{{ groups['controllers'] | map('extract', hostvars, 'ansible_host') | list }}"
 
 registry:
   confdir: "{{ config_root_dir }}/registry"

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -16,6 +16,12 @@
     mode: 0777
   become: "{{ logs.dir.become }}"
 
+- name: create seed nodes list
+  set_fact:
+    seed_nodes_list: "{{ seed_nodes_list | default([]) }} + [ \"{{item.1}}:{{controller.akka.cluster.basePort+item.0}}\" ]"
+  with_indexed_items:
+  - "{{ controller.akka.cluster.seedNodes }}"
+
 - name: (re)start controller
   docker_container:
     name: controller{{ groups['controllers'].index(inventory_hostname) }}
@@ -58,11 +64,18 @@
       "LOADBALANCER_INVOKERBUSYTHRESHOLD": "{{ invoker.busyThreshold }}"
 
       "RUNTIMES_MANIFEST": "{{ runtimesManifest | to_json }}"
+      "CONTROLLER_LOCALBOOKKEEPING": "{{ controller.localBookkeeping }}"
+      "AKKA_CLUSTER_PORT": "{{ controller.akka.cluster.basePort + groups['controllers'].index(inventory_hostname) }}"
+      "AKKA_CLUSTER_HOST": "{{ controller.akka.cluster.host[groups['controllers'].index(inventory_hostname)] }}"
+      "AKKA_CLUSTER_SEED_NODES": "{{seed_nodes_list | join(' ') }}"
+      "AKKA_CLUSTER_BIND_PORT": "{{ controller.akka.cluster.bindPort }}"
+      "AKKA_ACTOR_PROVIDER": "{{ controller.akka.provider }}"
     volumes:
       - "{{ whisk_logs_dir }}/controller{{ groups['controllers'].index(inventory_hostname) }}:/logs"
     ports:
       - "{{ controller.basePort + groups['controllers'].index(inventory_hostname) }}:8080"
-    command: /bin/sh -c "controller/bin/controller {{ groups['controllers'].index(inventory_hostname) }} >> /logs/controller{{ groups['controllers'].index(inventory_hostname) }}_logs.log 2>&1"
+      - "{{ controller.akka.cluster.basePort + groups['controllers'].index(inventory_hostname) }}:{{ controller.akka.cluster.bindPort }}"
+    command: /bin/sh -c "export CONTAINER_IP=$(hostname -I); controller/bin/controller {{ groups['controllers'].index(inventory_hostname) }} >> /logs/controller{{ groups['controllers'].index(inventory_hostname) }}_logs.log 2>&1"
 
 - name: wait until the Controller in this host is up and running
   uri:

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -13,8 +13,9 @@ dependencies {
 
     compile 'io.spray:spray-json_2.11:1.3.3'
 
-    compile 'com.typesafe.akka:akka-actor_2.11:2.4.16'
-    compile 'com.typesafe.akka:akka-slf4j_2.11:2.4.16'
+    compile 'com.typesafe.akka:akka-actor_2.11:2.5.3'
+    compile 'com.typesafe.akka:akka-stream_2.11:2.5.3'
+    compile 'com.typesafe.akka:akka-slf4j_2.11:2.4.19'
     compile 'com.typesafe.akka:akka-http-core_2.11:10.0.10'
     compile 'com.typesafe.akka:akka-http-spray-json_2.11:10.0.10'
 

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -13,8 +13,8 @@ dependencies {
 
     compile 'io.spray:spray-json_2.11:1.3.3'
 
-    compile 'com.typesafe.akka:akka-actor_2.11:2.5.3'
-    compile 'com.typesafe.akka:akka-stream_2.11:2.5.3'
+    compile 'com.typesafe.akka:akka-actor_2.11:2.5.4'
+    compile 'com.typesafe.akka:akka-stream_2.11:2.5.4'
     compile 'com.typesafe.akka:akka-slf4j_2.11:2.5.4'
     compile 'com.typesafe.akka:akka-http-core_2.11:10.0.10'
     compile 'com.typesafe.akka:akka-http-spray-json_2.11:10.0.10'

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
     compile 'com.typesafe.akka:akka-actor_2.11:2.5.3'
     compile 'com.typesafe.akka:akka-stream_2.11:2.5.3'
-    compile 'com.typesafe.akka:akka-slf4j_2.11:2.4.19'
+    compile 'com.typesafe.akka:akka-slf4j_2.11:2.5.4'
     compile 'com.typesafe.akka:akka-http-core_2.11:10.0.10'
     compile 'com.typesafe.akka:akka-http-spray-json_2.11:10.0.10'
 

--- a/common/scala/src/main/scala/whisk/common/Config.scala
+++ b/common/scala/src/main/scala/whisk/common/Config.scala
@@ -95,6 +95,16 @@ class Config(requiredProperties: Map[String, String], optionalProperties: Set[St
   }
 
   /**
+   * Returns the value of a given key parsed as a boolean.
+   * If parsing fails, return the default value.
+   *
+   * @param key the property that has to be returned.
+   */
+  def getAsBoolean(key: String, defaultValue: Boolean): Boolean = {
+    Try(getProperty(key).toBoolean).getOrElse(defaultValue)
+  }
+
+  /**
    * Converts the set of property to a string for debugging.
    */
   def mkString: String = settings.mkString("\n")
@@ -134,6 +144,7 @@ object Config {
       val envp = p.replace('.', '_').toUpperCase
       val envv = env.get(envp)
       if (envv.isDefined) {
+        println(s"environment set value for $p")
         properties += p -> envv.get.trim
       }
     }
@@ -148,6 +159,7 @@ object Config {
   def validateProperties(required: Map[String, String], properties: Map[String, String]): Boolean = {
     required.keys.forall { key =>
       val value = properties(key)
+      if (value == null) println(s"required property $key still not set")
       value != null
     }
   }

--- a/common/scala/src/main/scala/whisk/common/Config.scala
+++ b/common/scala/src/main/scala/whisk/common/Config.scala
@@ -43,7 +43,7 @@ import scala.util.Try
  * @param env an optional environment to read from (defaults to sys.env).
  */
 class Config(requiredProperties: Map[String, String], optionalProperties: Set[String] = Set())(
-  env: Map[String, String] = sys.env)(implicit logging: Logging) {
+  env: Map[String, String] = sys.env) {
 
   private val settings = getProperties().toMap.filter {
     case (k, v) =>
@@ -128,13 +128,12 @@ object Config {
    * Reads a Map of key-value pairs from the environment -- store them in the
    * mutable properties object.
    */
-  def readPropertiesFromEnvironment(properties: scala.collection.mutable.Map[String, String], env: Map[String, String])(
-    implicit logging: Logging) = {
+  def readPropertiesFromEnvironment(properties: scala.collection.mutable.Map[String, String],
+                                    env: Map[String, String]) = {
     for (p <- properties.keys) {
       val envp = p.replace('.', '_').toUpperCase
       val envv = env.get(envp)
       if (envv.isDefined) {
-        logging.info(this, s"environment set value for $p")
         properties += p -> envv.get.trim
       }
     }
@@ -146,11 +145,9 @@ object Config {
    * @param required a key-value map where the keys are required properties
    * @param properties a set of properties to check
    */
-  def validateProperties(required: Map[String, String], properties: Map[String, String])(
-    implicit logging: Logging): Boolean = {
+  def validateProperties(required: Map[String, String], properties: Map[String, String]): Boolean = {
     required.keys.forall { key =>
       val value = properties(key)
-      if (value == null) logging.error(this, s"required property $key still not set")
       value != null
     }
   }

--- a/common/scala/src/main/scala/whisk/common/Config.scala
+++ b/common/scala/src/main/scala/whisk/common/Config.scala
@@ -43,7 +43,7 @@ import scala.util.Try
  * @param env an optional environment to read from (defaults to sys.env).
  */
 class Config(requiredProperties: Map[String, String], optionalProperties: Set[String] = Set())(
-  env: Map[String, String] = sys.env) {
+  env: Map[String, String] = sys.env)(implicit logging: Logging) {
 
   private val settings = getProperties().toMap.filter {
     case (k, v) =>
@@ -138,13 +138,13 @@ object Config {
    * Reads a Map of key-value pairs from the environment -- store them in the
    * mutable properties object.
    */
-  def readPropertiesFromEnvironment(properties: scala.collection.mutable.Map[String, String],
-                                    env: Map[String, String]) = {
+  def readPropertiesFromEnvironment(properties: scala.collection.mutable.Map[String, String], env: Map[String, String])(
+    implicit logging: Logging) = {
     for (p <- properties.keys) {
       val envp = p.replace('.', '_').toUpperCase
       val envv = env.get(envp)
       if (envv.isDefined) {
-        println(s"environment set value for $p")
+        logging.info(this, s"environment set value for $p")
         properties += p -> envv.get.trim
       }
     }
@@ -156,10 +156,11 @@ object Config {
    * @param required a key-value map where the keys are required properties
    * @param properties a set of properties to check
    */
-  def validateProperties(required: Map[String, String], properties: Map[String, String]): Boolean = {
+  def validateProperties(required: Map[String, String], properties: Map[String, String])(
+    implicit logging: Logging): Boolean = {
     required.keys.forall { key =>
       val value = properties(key)
-      if (value == null) println(s"required property $key still not set")
+      if (value == null) logging.error(this, s"required property $key still not set")
       value != null
     }
   }

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -22,8 +22,6 @@ import java.io.File
 import scala.io.Source
 import whisk.common.Config
 
-import scala.util.Try
-
 /**
  * A set of properties which might be needed to run a whisk microservice implemented
  * in scala.
@@ -49,10 +47,6 @@ class WhiskConfig(requiredProperties: Map[String, String],
     val properties = super.getProperties()
     WhiskConfig.readPropertiesFromFile(properties, Option(propertiesFile) getOrElse (WhiskConfig.whiskPropertiesFile))
     properties
-  }
-
-  def getAsBoolean(key: String, defaultValaue :Boolean) :Boolean = {
-    Try(getProperty(key).toBoolean).getOrElse(defaultValaue)
   }
 
   val servicePort = this(WhiskConfig.servicePort)

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -20,8 +20,9 @@ package whisk.core
 import java.io.File
 
 import scala.io.Source
-
 import whisk.common.Config
+
+import scala.util.Try
 
 /**
  * A set of properties which might be needed to run a whisk microservice implemented
@@ -48,6 +49,10 @@ class WhiskConfig(requiredProperties: Map[String, String],
     val properties = super.getProperties()
     WhiskConfig.readPropertiesFromFile(properties, Option(propertiesFile) getOrElse (WhiskConfig.whiskPropertiesFile))
     properties
+  }
+
+  def getAsBoolean(key: String, defaultValaue :Boolean) :Boolean = {
+    Try(getProperty(key).toBoolean).getOrElse(defaultValaue)
   }
 
   val servicePort = this(WhiskConfig.servicePort)
@@ -94,14 +99,13 @@ class WhiskConfig(requiredProperties: Map[String, String],
   val mainDockerEndpoint = this(WhiskConfig.mainDockerEndpoint)
 
   val runtimesManifest = this(WhiskConfig.runtimesManifest)
-
   val actionInvokePerMinuteLimit = this(WhiskConfig.actionInvokePerMinuteLimit)
   val actionInvokeConcurrentLimit = this(WhiskConfig.actionInvokeConcurrentLimit)
   val triggerFirePerMinuteLimit = this(WhiskConfig.triggerFirePerMinuteLimit)
   val actionInvokeSystemOverloadLimit = this(WhiskConfig.actionInvokeSystemOverloadLimit)
   val actionSequenceLimit = this(WhiskConfig.actionSequenceMaxLimit)
   val controllerSeedNodes = this(WhiskConfig.controllerSeedNodes)
-  val controllerLocalBookkeeping = this(WhiskConfig.controllerLocalBookkeeping)
+  val controllerLocalBookkeeping = getAsBoolean(WhiskConfig.controllerLocalBookkeeping, false)
 
 }
 

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -22,7 +22,6 @@ import java.io.File
 import scala.io.Source
 
 import whisk.common.Config
-import whisk.common.Logging
 
 /**
  * A set of properties which might be needed to run a whisk microservice implemented
@@ -37,7 +36,7 @@ import whisk.common.Logging
 class WhiskConfig(requiredProperties: Map[String, String],
                   optionalProperties: Set[String] = Set(),
                   propertiesFile: File = null,
-                  env: Map[String, String] = sys.env)(implicit val logging: Logging)
+                  env: Map[String, String] = sys.env)
     extends Config(requiredProperties, optionalProperties)(env) {
 
   /**
@@ -101,6 +100,9 @@ class WhiskConfig(requiredProperties: Map[String, String],
   val triggerFirePerMinuteLimit = this(WhiskConfig.triggerFirePerMinuteLimit)
   val actionInvokeSystemOverloadLimit = this(WhiskConfig.actionInvokeSystemOverloadLimit)
   val actionSequenceLimit = this(WhiskConfig.actionSequenceMaxLimit)
+  val controllerSeedNodes = this(WhiskConfig.controllerSeedNodes)
+  val controllerLocalBookkeeping = this(WhiskConfig.controllerLocalBookkeeping)
+
 }
 
 object WhiskConfig {
@@ -129,10 +131,8 @@ object WhiskConfig {
    * Reads a Map of key-value pairs from the environment (sys.env) -- store them in the
    * mutable properties object.
    */
-  def readPropertiesFromFile(properties: scala.collection.mutable.Map[String, String], file: File)(
-    implicit logging: Logging) = {
+  def readPropertiesFromFile(properties: scala.collection.mutable.Map[String, String], file: File) = {
     if (file != null && file.exists) {
-      logging.info(this, s"reading properties from file $file")
       for (line <- Source.fromFile(file).getLines if line.trim != "") {
         val parts = line.split('=')
         if (parts.length >= 1) {
@@ -140,10 +140,7 @@ object WhiskConfig {
           val v = if (parts.length == 2) parts(1).trim else ""
           if (properties.contains(p)) {
             properties += p -> v
-            logging.debug(this, s"properties file set value for $p")
           }
-        } else {
-          logging.warn(this, s"ignoring properties $line")
         }
       }
     }
@@ -221,4 +218,6 @@ object WhiskConfig {
   val actionInvokeConcurrentLimit = "limits.actions.invokes.concurrent"
   val actionInvokeSystemOverloadLimit = "limits.actions.invokes.concurrentInSystem"
   val triggerFirePerMinuteLimit = "limits.triggers.fires.perMinute"
+  val controllerSeedNodes = "akka.cluster.seed.nodes"
+  val controllerLocalBookkeeping = "controller.localBookkeeping"
 }

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -20,7 +20,7 @@ package whisk.core
 import java.io.File
 
 import scala.io.Source
-import whisk.common.Config
+import whisk.common.{Config, Logging}
 
 /**
  * A set of properties which might be needed to run a whisk microservice implemented
@@ -35,7 +35,7 @@ import whisk.common.Config
 class WhiskConfig(requiredProperties: Map[String, String],
                   optionalProperties: Set[String] = Set(),
                   propertiesFile: File = null,
-                  env: Map[String, String] = sys.env)
+                  env: Map[String, String] = sys.env)(implicit val logging: Logging)
     extends Config(requiredProperties, optionalProperties)(env) {
 
   /**
@@ -129,8 +129,10 @@ object WhiskConfig {
    * Reads a Map of key-value pairs from the environment (sys.env) -- store them in the
    * mutable properties object.
    */
-  def readPropertiesFromFile(properties: scala.collection.mutable.Map[String, String], file: File) = {
+  def readPropertiesFromFile(properties: scala.collection.mutable.Map[String, String], file: File)(
+    implicit logging: Logging) = {
     if (file != null && file.exists) {
+      logging.info(this, s"reading properties from file $file")
       for (line <- Source.fromFile(file).getLines if line.trim != "") {
         val parts = line.split('=')
         if (parts.length >= 1) {
@@ -138,7 +140,10 @@ object WhiskConfig {
           val v = if (parts.length == 2) parts(1).trim else ""
           if (properties.contains(p)) {
             properties += p -> v
+            logging.debug(this, s"properties file set value for $p")
           }
+        } else {
+          logging.warn(this, s"ignoring properties $line")
         }
       }
     }

--- a/core/controller/build.gradle
+++ b/core/controller/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.typesafe.akka:akka-distributed-data_2.11:2.5.3'
+    compile 'com.typesafe.akka:akka-distributed-data_2.11:2.5.4'
     compile "org.scala-lang:scala-library:${gradle.scala.version}"
     compile project(':common:scala')
 }

--- a/core/controller/build.gradle
+++ b/core/controller/build.gradle
@@ -11,6 +11,9 @@ repositories {
 }
 
 dependencies {
+    compile 'com.typesafe.akka:akka-distributed-data_2.11:2.5.3'
+    compile 'com.typesafe.akka:akka-cluster-metrics_2.11:2.5.3'
+    compile 'org.scalatest:scalatest_2.11:3.0.1'
     compile "org.scala-lang:scala-library:${gradle.scala.version}"
     compile project(':common:scala')
 }

--- a/core/controller/build.gradle
+++ b/core/controller/build.gradle
@@ -12,8 +12,6 @@ repositories {
 
 dependencies {
     compile 'com.typesafe.akka:akka-distributed-data_2.11:2.5.3'
-    compile 'com.typesafe.akka:akka-cluster-metrics_2.11:2.5.3'
-    compile 'org.scalatest:scalatest_2.11:3.0.1'
     compile "org.scala-lang:scala-library:${gradle.scala.version}"
     compile project(':common:scala')
 }

--- a/core/controller/src/main/resources/application.conf
+++ b/core/controller/src/main/resources/application.conf
@@ -56,8 +56,8 @@ akka.http {
   }
 }
 
-# Check out all akka-remote-2.5.3 options here:
-# http://doc.akka.io/docs/akka/2.5.3/scala/general/configuration.html#config-akka-remote
+# Check out all akka-remote-2.5.4 options here:
+# http://doc.akka.io/docs/akka/2.5.4/scala/general/configuration.html#config-akka-remote
 akka {
   actor {
     provider = ${?AKKA_ACTOR_PROVIDER}
@@ -77,12 +77,6 @@ akka {
   cluster {
     # Disable legacy metrics in akka-cluster.
     metrics.enabled=off
-
-    # Sigar native library extract location during tests.
-    # Note: use per-jvm-instance folder when running multiple jvm on one host.
-    metrics.native-library-extract-folder=${user.dir}/target/native
-    
-    auto-down-unreachable-after = 10s
 
     #distributed-data.notify-subscribers-interval = 0.01
   }

--- a/core/controller/src/main/resources/application.conf
+++ b/core/controller/src/main/resources/application.conf
@@ -78,6 +78,7 @@ akka {
     # Disable legacy metrics in akka-cluster.
     metrics.enabled=off
 
+    auto-down-unreachable-after = ${?AUTO_DOWN_UNREACHABLE_AFTER}
     #distributed-data.notify-subscribers-interval = 0.01
   }
 }

--- a/core/controller/src/main/resources/application.conf
+++ b/core/controller/src/main/resources/application.conf
@@ -68,7 +68,6 @@ akka {
     log-sent-messages = on
 
     netty.tcp {
-      maximum-frame-size=1280000000b
       hostname = ${?AKKA_CLUSTER_HOST}
       port = ${?AKKA_CLUSTER_PORT}
       bind-port = ${?AKKA_CLUSTER_BIND_PORT}
@@ -84,9 +83,6 @@ akka {
     metrics.native-library-extract-folder=${user.dir}/target/native
     
     auto-down-unreachable-after = 10s
-
-    # Enable metrics extension in akka-cluster-metrics.
-    #akka.extensions=["akka.cluster.metrics.ClusterMetricsExtension"]
 
     #distributed-data.notify-subscribers-interval = 0.01
   }

--- a/core/controller/src/main/resources/application.conf
+++ b/core/controller/src/main/resources/application.conf
@@ -55,3 +55,39 @@ akka.http {
     }
   }
 }
+
+# Check out all akka-remote-2.5.3 options here:
+# http://doc.akka.io/docs/akka/2.5.3/scala/general/configuration.html#config-akka-remote
+akka {
+  actor {
+    provider = ${?AKKA_ACTOR_PROVIDER}
+  }
+  remote {
+    log-remote-lifecycle-events = DEBUG
+    log-received-messages = on
+    log-sent-messages = on
+
+    netty.tcp {
+      maximum-frame-size=1280000000b
+      hostname = ${?AKKA_CLUSTER_HOST}
+      port = ${?AKKA_CLUSTER_PORT}
+      bind-port = ${?AKKA_CLUSTER_BIND_PORT}
+      bind-hostname = ${?CONTAINER_IP}
+    }
+  }
+  cluster {
+    # Disable legacy metrics in akka-cluster.
+    metrics.enabled=off
+
+    # Sigar native library extract location during tests.
+    # Note: use per-jvm-instance folder when running multiple jvm on one host.
+    metrics.native-library-extract-folder=${user.dir}/target/native
+    
+    auto-down-unreachable-after = 10s
+
+    # Enable metrics extension in akka-cluster-metrics.
+    #akka.extensions=["akka.cluster.metrics.ClusterMetricsExtension"]
+
+    #distributed-data.notify-subscribers-interval = 0.01
+  }
+}

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -39,7 +39,7 @@ import whisk.core.entitlement._
 import whisk.core.entity._
 import whisk.core.entity.ActivationId.ActivationIdGenerator
 import whisk.core.entity.ExecManifest.Runtimes
-import whisk.core.loadBalancer.{LoadBalancerService, SharedDataService}
+import whisk.core.loadBalancer.{LoadBalancerService}
 import whisk.http.BasicHttpService
 import whisk.http.BasicRasService
 
@@ -152,8 +152,7 @@ object Controller {
       ExecManifest.requiredProperties ++
       RestApiCommons.requiredProperties ++
       LoadBalancerService.requiredProperties ++
-      EntitlementProvider.requiredProperties ++
-      SharedDataService.requiredProperties
+      EntitlementProvider.requiredProperties
 
   private def info(config: WhiskConfig, runtimes: Runtimes, apis: List[String]) =
     JsObject(
@@ -169,13 +168,11 @@ object Controller {
       "runtimes" -> runtimes.toJson)
 
   def main(args: Array[String]): Unit = {
+    implicit val actorSystem = ActorSystem("controller-actor-system")
+    implicit val logger = new AkkaLogging(akka.event.Logging.getLogger(actorSystem, this))
 
     // extract configuration data from the environment
     val config = new WhiskConfig(requiredProperties)
-
-    implicit val actorSystem = ActorSystem("controller-actor-system", SharedDataService.addAkkaSeedNodesToConf(config))
-    implicit val logger = new AkkaLogging(akka.event.Logging.getLogger(actorSystem, this))
-
     val port = config.servicePort.toInt
 
     // if deploying multiple instances (scale out), must pass the instance number as the

--- a/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
@@ -23,8 +23,7 @@ import whisk.core.entity.Identity
 import whisk.core.loadBalancer.LoadBalancer
 import whisk.http.Messages
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
  * Determines user limits and activation counts as seen by the invoker and the loadbalancer
@@ -37,7 +36,7 @@ import scala.concurrent.Future
  * @param systemOverloadLimit the limit when the system is considered overloaded
  */
 class ActivationThrottler(loadBalancer: LoadBalancer, defaultConcurrencyLimit: Int, systemOverloadLimit: Int)(
-  implicit logging: Logging) {
+  implicit logging: Logging, executionContext: ExecutionContext) {
 
   logging.info(this, s"concurrencyLimit = $defaultConcurrencyLimit, systemOverloadLimit = $systemOverloadLimit")(
     TransactionId.controller)

--- a/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
@@ -36,7 +36,8 @@ import scala.concurrent.{ExecutionContext, Future}
  * @param systemOverloadLimit the limit when the system is considered overloaded
  */
 class ActivationThrottler(loadBalancer: LoadBalancer, defaultConcurrencyLimit: Int, systemOverloadLimit: Int)(
-  implicit logging: Logging, executionContext: ExecutionContext) {
+  implicit logging: Logging,
+  executionContext: ExecutionContext) {
 
   logging.info(this, s"concurrencyLimit = $defaultConcurrencyLimit, systemOverloadLimit = $systemOverloadLimit")(
     TransactionId.controller)

--- a/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
@@ -23,6 +23,9 @@ import whisk.core.entity.Identity
 import whisk.core.loadBalancer.LoadBalancer
 import whisk.http.Messages
 
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
 /**
  * Determines user limits and activation counts as seen by the invoker and the loadbalancer
  * in a scheduled, repeating task for other services to get the cached information to be able
@@ -42,22 +45,26 @@ class ActivationThrottler(loadBalancer: LoadBalancer, defaultConcurrencyLimit: I
   /**
    * Checks whether the operation should be allowed to proceed.
    */
-  def check(user: Identity)(implicit tid: TransactionId): RateLimit = {
-    val concurrentActivations = loadBalancer.activeActivationsFor(user.uuid)
-    val concurrencyLimit = user.limits.concurrentInvocations.getOrElse(defaultConcurrencyLimit)
-    logging.info(
-      this,
-      s"namespace = ${user.uuid.asString}, concurrent activations = $concurrentActivations, limit = $concurrencyLimit")
-    ConcurrentRateLimit(concurrentActivations, concurrencyLimit)
+  def check(user: Identity)(implicit tid: TransactionId): Future[RateLimit] = {
+    loadBalancer.activeActivationsFor(user.uuid).map { concurrentActivations =>
+      val concurrencyLimit = user.limits.concurrentInvocations.getOrElse(defaultConcurrencyLimit)
+      logging.info(
+        this,
+        s"namespace = ${user.uuid.asString}, concurrent activations = $concurrentActivations, below limit = $concurrencyLimit")
+      ConcurrentRateLimit(concurrentActivations, concurrencyLimit)
+    }
   }
 
   /**
    * Checks whether the system is in a generally overloaded state.
    */
-  def isOverloaded()(implicit tid: TransactionId): Boolean = {
-    val concurrentActivations = loadBalancer.totalActiveActivations
-    logging.info(this, s"concurrent activations in system = $concurrentActivations, below limit = $systemOverloadLimit")
-    concurrentActivations > systemOverloadLimit
+  def isOverloaded()(implicit tid: TransactionId): Future[Boolean] = {
+    loadBalancer.totalActiveActivations.map { concurrentActivations =>
+      logging.info(
+        this,
+        s"concurrent activations in system = $concurrentActivations, below limit = $systemOverloadLimit")
+      concurrentActivations > systemOverloadLimit
+    }
   }
 }
 

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -130,7 +130,7 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
 
     logging.info(this, s"checking user '${user.subject}' has not exceeded activation quota")
     checkSystemOverload(ACTIVATE)
-      .flatMap(_ => checkThrottleOverload(invokeRateThrottler.check(user)))
+      .flatMap(_ => checkThrottleOverload(Future(invokeRateThrottler.check(user))))
       .flatMap(_ => checkThrottleOverload(concurrentInvokeThrottler.check(user)))
   }
 
@@ -184,7 +184,6 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
     } else {
       Future.successful(false)
     }
-
     entitlementCheck andThen {
       case Success(r) if resources.nonEmpty =>
         logging.info(this, if (r) "authorized" else "not authorized")
@@ -231,11 +230,13 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
    * @return future completing successfully if system is not overloaded else failing with a rejection
    */
   protected def checkSystemOverload(right: Privilege)(implicit transid: TransactionId): Future[Unit] = {
-    val systemOverload = right == ACTIVATE && concurrentInvokeThrottler.isOverloaded
-    if (systemOverload) {
-      logging.error(this, "system is overloaded")
-      Future.failed(RejectRequest(TooManyRequests, systemOverloaded))
-    } else Future.successful(())
+    concurrentInvokeThrottler.isOverloaded.flatMap { isOverloaded =>
+      val systemOverload = right == ACTIVATE && isOverloaded
+      if (systemOverload) {
+        logging.error(this, "system is overloaded")
+        Future.failed(RejectRequest(TooManyRequests, systemOverloaded))
+      } else Future.successful(())
+    }
   }
 
   /**
@@ -253,9 +254,9 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
     implicit transid: TransactionId): Future[Unit] = {
     if (right == ACTIVATE) {
       if (resources.exists(_.collection.path == Collection.ACTIONS)) {
-        checkThrottleOverload(invokeRateThrottler.check(user))
+        checkThrottleOverload(Future(invokeRateThrottler.check(user)))
       } else if (resources.exists(_.collection.path == Collection.TRIGGERS)) {
-        checkThrottleOverload(triggerRateThrottler.check(user))
+        checkThrottleOverload(Future(triggerRateThrottler.check(user)))
       } else Future.successful(())
     } else Future.successful(())
   }
@@ -278,11 +279,13 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
     } else Future.successful(())
   }
 
-  private def checkThrottleOverload(throttle: RateLimit)(implicit transid: TransactionId): Future[Unit] = {
-    if (throttle.ok) {
-      Future.successful(())
-    } else {
-      Future.failed(RejectRequest(TooManyRequests, throttle.errorMsg))
+  private def checkThrottleOverload(throttle: Future[RateLimit])(implicit transid: TransactionId): Future[Unit] = {
+    throttle.flatMap { limit =>
+      if (limit.ok) {
+        Future.successful(())
+      } else {
+        Future.failed(RejectRequest(TooManyRequests, limit.errorMsg))
+      }
     }
   }
 }

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -130,7 +130,7 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
 
     logging.info(this, s"checking user '${user.subject}' has not exceeded activation quota")
     checkSystemOverload(ACTIVATE)
-      .flatMap(_ => checkThrottleOverload(Future(invokeRateThrottler.check(user))))
+      .flatMap(_ => checkThrottleOverload(Future.successful(invokeRateThrottler.check(user))))
       .flatMap(_ => checkThrottleOverload(concurrentInvokeThrottler.check(user)))
   }
 
@@ -254,9 +254,9 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
     implicit transid: TransactionId): Future[Unit] = {
     if (right == ACTIVATE) {
       if (resources.exists(_.collection.path == Collection.ACTIONS)) {
-        checkThrottleOverload(Future(invokeRateThrottler.check(user)))
+        checkThrottleOverload(Future.successful(invokeRateThrottler.check(user)))
       } else if (resources.exists(_.collection.path == Collection.TRIGGERS)) {
-        checkThrottleOverload(Future(triggerRateThrottler.check(user)))
+        checkThrottleOverload(Future.successful(triggerRateThrottler.check(user)))
       } else Future.successful(())
     } else Future.successful(())
   }

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/DistributedLoadBalancerData.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/DistributedLoadBalancerData.scala
@@ -20,8 +20,9 @@ package whisk.core.loadBalancer
 import akka.actor.ActorSystem
 import akka.util.Timeout
 import akka.pattern.ask
-import akka.event.Logging
+import whisk.common.Logging
 import whisk.core.entity.{ActivationId, UUID}
+
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -32,7 +33,7 @@ import scala.concurrent.duration._
  * Note: The state keeping is backed by distributed akka actors. All CRUDs operations are done on local values, thus
  * a stale value might be read.
  */
-class DistributedLoadBalancerData(implicit val actorSystem: ActorSystem) extends LoadBalancerData {
+class DistributedLoadBalancerData(implicit actorSystem: ActorSystem, logging: Logging) extends LoadBalancerData {
 
   implicit val timeout = Timeout(5.seconds)
   implicit val executionContext = actorSystem.dispatcher
@@ -46,14 +47,13 @@ class DistributedLoadBalancerData(implicit val actorSystem: ActorSystem) extends
     name =
       "SharedDataServiceNamespaces" + UUID())
 
-  val logging = Logging(actorSystem, sharedStateInvokers)
-
   def totalActivationCount =
-    (sharedStateNamespaces ? GetMap).mapTo[Map[String, BigInt]].map(_.values.sum.toInt)
+    (sharedStateInvokers ? GetMap).mapTo[Map[String, BigInt]].map(_.values.sum.toInt)
 
   def activationCountOn(namespace: UUID): Future[Int] = {
     (sharedStateNamespaces ? GetMap)
-        .mapTo[Map[String, BigInt]].map(_.mapValues(_.toInt).getOrElse(namespace.toString, 0))
+      .mapTo[Map[String, BigInt]]
+      .map(_.mapValues(_.toInt).getOrElse(namespace.toString, 0))
   }
 
   def activationCountPerInvoker: Future[Map[String, Int]] = {
@@ -69,17 +69,17 @@ class DistributedLoadBalancerData(implicit val actorSystem: ActorSystem) extends
       val entry = update
       sharedStateNamespaces ! IncreaseCounter(entry.namespaceId.asString, 1)
       sharedStateInvokers ! IncreaseCounter(entry.invokerName.toString, 1)
-      logging.debug(s"increased shared counters")
+      logging.debug(this, "increased shared counters")
       entry
     })
   }
 
   def removeActivation(entry: ActivationEntry): Option[ActivationEntry] = {
-    activationsById.remove(entry.id).map { x =>
+    activationsById.remove(entry.id).map { activationEntry =>
       sharedStateInvokers ! DecreaseCounter(entry.invokerName.toString, 1)
       sharedStateNamespaces ! DecreaseCounter(entry.namespaceId.asString, 1)
-      logging.debug(s"decreased shared counters")
-      x
+      logging.debug(this, "decreased shared counters")
+      activationEntry
     }
   }
 

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/DistributedLoadBalancerData.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/DistributedLoadBalancerData.scala
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.loadBalancer
+
+import akka.actor.ActorSystem
+import akka.util.Timeout
+import akka.pattern.ask
+import akka.event.Logging
+import whisk.core.entity.{ActivationId, UUID}
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+/**
+ * Encapsulates data used for loadbalancer and active-ack bookkeeping.
+ *
+ * Note: The state keeping is backed by distributed akka actors. All CRUDs operations are done on local values, thus
+ * a stale value might be read.
+ */
+class DistributedLoadBalancerData(implicit val actorSystem: ActorSystem) extends LoadBalancerData {
+
+  implicit val timeout = Timeout(5.seconds)
+  implicit val executionContext = actorSystem.dispatcher
+  private val activationsById = TrieMap[ActivationId, ActivationEntry]()
+  private val sharedStateInvokers = actorSystem.actorOf(
+    SharedDataService.props("Invokers"),
+    name =
+      "SharedDataServiceInvokers" + UUID())
+  private val sharedStateNamespaces = actorSystem.actorOf(
+    SharedDataService.props("Namespaces"),
+    name =
+      "SharedDataServiceNamespaces" + UUID())
+
+  val logging = Logging(actorSystem, sharedStateInvokers)
+
+  def totalActivationCount =
+    (sharedStateNamespaces ? GetMap).mapTo[Map[String, BigInt]].map(_.values.sum.toInt)
+
+  def activationCountOn(namespace: UUID): Future[Int] = {
+    (sharedStateNamespaces ? GetMap)
+        .mapTo[Map[String, BigInt]].map(_.mapValues(_.toInt).getOrElse(namespace.toString, 0))
+  }
+
+  def activationCountPerInvoker: Future[Map[String, Int]] = {
+    (sharedStateInvokers ? GetMap).mapTo[Map[String, BigInt]].map(_.mapValues(_.toInt))
+  }
+
+  def activationById(activationId: ActivationId): Option[ActivationEntry] = {
+    activationsById.get(activationId)
+  }
+
+  def putActivation(id: ActivationId, update: => ActivationEntry): ActivationEntry = {
+    activationsById.getOrElseUpdate(id, {
+      val entry = update
+      sharedStateNamespaces ! IncreaseCounter(entry.namespaceId.asString, 1)
+      sharedStateInvokers ! IncreaseCounter(entry.invokerName.toString, 1)
+      logging.debug(s"increased shared counters")
+      entry
+    })
+  }
+
+  def removeActivation(entry: ActivationEntry): Option[ActivationEntry] = {
+    activationsById.remove(entry.id).map { x =>
+      sharedStateInvokers ! DecreaseCounter(entry.invokerName.toString, 1)
+      sharedStateNamespaces ! DecreaseCounter(entry.namespaceId.asString, 1)
+      logging.debug(s"decreased shared counters")
+      x
+    }
+  }
+
+  def removeActivation(aid: ActivationId): Option[ActivationEntry] = {
+    activationsById.get(aid).flatMap(removeActivation)
+  }
+}

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/DistributedLoadBalancerData.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/DistributedLoadBalancerData.scala
@@ -33,35 +33,18 @@ import scala.concurrent.duration._
  * Note: The state keeping is backed by distributed akka actors. All CRUDs operations are done on local values, thus
  * a stale value might be read.
  */
-class DistributedLoadBalancerData(seedNodesProvider: SeedNodesProvider,
-                                  implicit val actorSystem: ActorSystem,
-                                  logging: Logging)
-    extends LoadBalancerData {
+class DistributedLoadBalancerData(implicit actorSystem: ActorSystem, logging: Logging) extends LoadBalancerData {
 
   implicit val timeout = Timeout(5.seconds)
   implicit val executionContext = actorSystem.dispatcher
   private val activationsById = TrieMap[ActivationId, ActivationEntry]()
 
-  private val seedNodes = {
-    val nodes = seedNodesProvider.getSeedNodes()
-    if (nodes.size > 0)
-      nodes
-    else {
-      logging.error(
-        this,
-        "Either seed nodes were not provided or not specified in the correct " +
-          "format, e.g. whitespace " +
-          "separated <IP:PORT>")
-      sys.exit(1)
-    }
-  }
-
   private val sharedStateInvokers = actorSystem.actorOf(
-    SharedDataService.props("Invokers", seedNodes),
+    SharedDataService.props("Invokers"),
     name =
       "SharedDataServiceInvokers" + UUID())
   private val sharedStateNamespaces = actorSystem.actorOf(
-    SharedDataService.props("Namespaces", seedNodes),
+    SharedDataService.props("Namespaces"),
     name =
       "SharedDataServiceNamespaces" + UUID())
 

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerData.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerData.scala
@@ -17,131 +17,64 @@
 
 package whisk.core.loadBalancer
 
-import akka.actor.ActorSystem
-import akka.util.Timeout
-import akka.pattern.ask
-import akka.event.Logging
 import whisk.core.entity.{ActivationId, UUID}
-import scala.collection.concurrent.TrieMap
-import scala.concurrent.Future
-import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
 
-trait BookkeepingData {
+import scala.concurrent.Future
+
+
+trait LoadBalancerData {
 
   /** Get the number of activations across all namespaces. */
   def totalActivationCount: Future[Int]
 
   /**
-   * Get the number of activations for a specific namespace.
-   *
-   * @param namespace The namespace to get the activation count for
-   * @return a map (namespace -> number of activations in the system)
-   */
+    * Get the number of activations for a specific namespace.
+    *
+    * @param namespace The namespace to get the activation count for
+    * @return a map (namespace -> number of activations in the system)
+    */
   def activationCountOn(namespace: UUID): Future[Int]
 
   /**
-   * Get the number of activations for each invoker.
-   *
-   * @return a map (invoker -> number of activations queued for the invoker)
-   */
+    * Get the number of activations for each invoker.
+    *
+    * @return a map (invoker -> number of activations queued for the invoker)
+    */
   def activationCountPerInvoker: Future[Map[String, Int]]
 
   /**
-   * Get an activation entry for a given activation id.
-   *
-   * @param activationId activation id to get data for
-   * @return the respective activation or None if it doesn't exist
-   */
+    * Get an activation entry for a given activation id.
+    *
+    * @param activationId activation id to get data for
+    * @return the respective activation or None if it doesn't exist
+    */
   def activationById(activationId: ActivationId): Option[ActivationEntry]
 
   /**
-   * Adds an activation entry.
-   *
-   * @param id     identifier to deduplicate the entry
-   * @param update block calculating the entry to add.
-   *               Note: This is evaluated iff the entry
-   *               didn't exist before.
-   * @return the entry calculated by the block or iff it did
-   *         exist before the entry from the state
-   */
+    * Adds an activation entry.
+    *
+    * @param id     identifier to deduplicate the entry
+    * @param update block calculating the entry to add.
+    *               Note: This is evaluated iff the entry
+    *               didn't exist before.
+    * @return the entry calculated by the block or iff it did
+    *         exist before the entry from the state
+    */
   def putActivation(id: ActivationId, update: => ActivationEntry): ActivationEntry
 
   /**
-   * Removes the given entry.
-   *
-   * @param entry the entry to remove
-   * @return The deleted entry or None if nothing got deleted
-   */
+    * Removes the given entry.
+    *
+    * @param entry the entry to remove
+    * @return The deleted entry or None if nothing got deleted
+    */
   def removeActivation(entry: ActivationEntry): Option[ActivationEntry]
 
   /**
-   * Removes the activation identified by the given activation id.
-   *
-   * @param aid activation id to remove
-   * @return The deleted entry or None if nothing got deleted
-   */
+    * Removes the activation identified by the given activation id.
+    *
+    * @param aid activation id to remove
+    * @return The deleted entry or None if nothing got deleted
+    */
   def removeActivation(aid: ActivationId): Option[ActivationEntry]
-}
-
-/**
- * Encapsulates data used for loadbalancer and active-ack bookkeeping.
- *
- * Note: The state keeping is backed by distributed akka actors. All CRUDs operations are done on local values, thus
- * a stale value might be read.
- */
-class LoadBalancerData(implicit val actorSystem: ActorSystem) extends BookkeepingData {
-
-  implicit val timeout = Timeout(5.seconds)
-  private val activationsById = TrieMap[ActivationId, ActivationEntry]()
-  private val sharedStateInvokers = actorSystem.actorOf(
-    SharedDataService.props("Invokers"),
-    name =
-      "SharedDataServiceInvokers" + UUID())
-  private val sharedStateNamespaces = actorSystem.actorOf(
-    SharedDataService.props("Namespaces"),
-    name =
-      "SharedDataServiceNamespaces" + UUID())
-
-  val logging = Logging(actorSystem, sharedStateInvokers)
-
-  def totalActivationCount =
-    (sharedStateNamespaces ? GetTheMap()).mapTo[MapWithCounters].map(_.dataMap.values.sum.toInt)
-
-  def activationCountOn(namespace: UUID): Future[Int] = {
-    (sharedStateNamespaces ? GetTheMap())
-      .mapTo[MapWithCounters]
-      .map(_.dataMap.mapValues(_.toInt).getOrElse(namespace.toString, 0))
-  }
-
-  def activationCountPerInvoker: Future[Map[String, Int]] = {
-    (sharedStateInvokers ? GetTheMap()).mapTo[MapWithCounters].map(_.dataMap.mapValues(_.toInt))
-  }
-
-  def activationById(activationId: ActivationId): Option[ActivationEntry] = {
-    activationsById.get(activationId)
-  }
-
-  def putActivation(id: ActivationId, update: => ActivationEntry): ActivationEntry = {
-    activationsById.getOrElseUpdate(id, {
-      val entry = update
-      sharedStateNamespaces ! IncreaseCounter(entry.namespaceId.asString, 1)
-      sharedStateInvokers ! IncreaseCounter(entry.invokerName.toString, 1)
-      logging.info(s"increased shared counters")
-      entry
-    })
-  }
-
-  def removeActivation(entry: ActivationEntry): Option[ActivationEntry] = {
-    activationsById.remove(entry.id).map { x =>
-      sharedStateInvokers ! DecreaseCounter(entry.invokerName.toString, 1)
-      sharedStateNamespaces ! DecreaseCounter(entry.namespaceId.asString, 1)
-      logging.info(s"decreased shared counters")
-      x
-    }
-  }
-
-  def removeActivation(aid: ActivationId): Option[ActivationEntry] = {
-    activationsById.get(aid).flatMap(removeActivation)
-  }
 }

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerData.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerData.scala
@@ -17,64 +17,67 @@
 
 package whisk.core.loadBalancer
 
-import whisk.core.entity.{ActivationId, UUID}
+import whisk.core.entity.{ActivationId, InstanceId, UUID, WhiskActivation}
 
-import scala.concurrent.Future
+import scala.concurrent.{Future, Promise}
 
-
+case class ActivationEntry(id: ActivationId,
+                           namespaceId: UUID,
+                           invokerName: InstanceId,
+                           promise: Promise[Either[ActivationId, WhiskActivation]])
 trait LoadBalancerData {
 
   /** Get the number of activations across all namespaces. */
   def totalActivationCount: Future[Int]
 
   /**
-    * Get the number of activations for a specific namespace.
-    *
-    * @param namespace The namespace to get the activation count for
-    * @return a map (namespace -> number of activations in the system)
-    */
+   * Get the number of activations for a specific namespace.
+   *
+   * @param namespace The namespace to get the activation count for
+   * @return a map (namespace -> number of activations in the system)
+   */
   def activationCountOn(namespace: UUID): Future[Int]
 
   /**
-    * Get the number of activations for each invoker.
-    *
-    * @return a map (invoker -> number of activations queued for the invoker)
-    */
+   * Get the number of activations for each invoker.
+   *
+   * @return a map (invoker -> number of activations queued for the invoker)
+   */
   def activationCountPerInvoker: Future[Map[String, Int]]
 
   /**
-    * Get an activation entry for a given activation id.
-    *
-    * @param activationId activation id to get data for
-    * @return the respective activation or None if it doesn't exist
-    */
+   * Get an activation entry for a given activation id.
+   *
+   * @param activationId activation id to get data for
+   * @return the respective activation or None if it doesn't exist
+   */
   def activationById(activationId: ActivationId): Option[ActivationEntry]
 
   /**
-    * Adds an activation entry.
-    *
-    * @param id     identifier to deduplicate the entry
-    * @param update block calculating the entry to add.
-    *               Note: This is evaluated iff the entry
-    *               didn't exist before.
-    * @return the entry calculated by the block or iff it did
-    *         exist before the entry from the state
-    */
+   * Adds an activation entry.
+   *
+   * @param id     identifier to deduplicate the entry
+   * @param update block calculating the entry to add.
+   *               Note: This is evaluated iff the entry
+   *               didn't exist before.
+   * @return the entry calculated by the block or iff it did
+   *         exist before the entry from the state
+   */
   def putActivation(id: ActivationId, update: => ActivationEntry): ActivationEntry
 
   /**
-    * Removes the given entry.
-    *
-    * @param entry the entry to remove
-    * @return The deleted entry or None if nothing got deleted
-    */
+   * Removes the given entry.
+   *
+   * @param entry the entry to remove
+   * @return The deleted entry or None if nothing got deleted
+   */
   def removeActivation(entry: ActivationEntry): Option[ActivationEntry]
 
   /**
-    * Removes the activation identified by the given activation id.
-    *
-    * @param aid activation id to remove
-    * @return The deleted entry or None if nothing got deleted
-    */
+   * Removes the activation identified by the given activation id.
+   *
+   * @param aid activation id to remove
+   * @return The deleted entry or None if nothing got deleted
+   */
   def removeActivation(aid: ActivationId): Option[ActivationEntry]
 }

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerDataLocal.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerDataLocal.scala
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.loadBalancer
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.Future
+import whisk.core.entity.{ActivationId, UUID}
+import whisk.core.entity.InstanceId
+
+/**
+ * Loadbalancer bookkeeping data which are stored locally,
+ * e.g. not shared with other controller instances.
+ *
+ * Note: The state keeping is backed by concurrent data-structures. As such,
+ * concurrent reads can return stale values (especially the counters returned).
+ */
+class LoadBalancerDataLocal() extends BookkeepingData {
+
+  private val activationByInvoker = TrieMap[InstanceId, AtomicInteger]()
+  private val activationByNamespaceId = TrieMap[UUID, AtomicInteger]()
+  private val activationsById = TrieMap[ActivationId, ActivationEntry]()
+  private val totalActivations = new AtomicInteger(0)
+
+  override def totalActivationCount: Future[Int] = Future.successful(totalActivations.get)
+
+  override def activationCountOn(namespace: UUID): Future[Int] = {
+    Future.successful(activationByNamespaceId.get(namespace).map(_.get).getOrElse(0))
+  }
+
+  override def activationCountPerInvoker: Future[Map[String, Int]] = {
+    Future.successful(activationByInvoker.map(x => (x._1.toString, x._2.get)).toMap)
+  }
+
+  override def activationById(activationId: ActivationId): Option[ActivationEntry] = {
+    activationsById.get(activationId)
+  }
+
+  override def putActivation(id: ActivationId, update: => ActivationEntry): ActivationEntry = {
+    activationsById.getOrElseUpdate(id, {
+      val entry = update
+      totalActivations.incrementAndGet()
+      activationByNamespaceId.getOrElseUpdate(entry.namespaceId, new AtomicInteger(0)).incrementAndGet()
+      activationByInvoker.getOrElseUpdate(entry.invokerName, new AtomicInteger(0)).incrementAndGet()
+      entry
+    })
+  }
+
+  override def removeActivation(entry: ActivationEntry): Option[ActivationEntry] = {
+    activationsById.remove(entry.id).map { x =>
+      totalActivations.decrementAndGet()
+      activationByNamespaceId.getOrElseUpdate(entry.namespaceId, new AtomicInteger(0)).decrementAndGet()
+      activationByInvoker.getOrElseUpdate(entry.invokerName, new AtomicInteger(0)).decrementAndGet()
+      x
+    }
+  }
+
+  override def removeActivation(aid: ActivationId): Option[ActivationEntry] = {
+    activationsById.get(aid).flatMap(removeActivation)
+  }
+}

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -61,10 +61,10 @@ trait LoadBalancer {
   val activeAckTimeoutGrace = 1.minute
 
   /** Gets the number of in-flight activations for a specific user. */
-  def activeActivationsFor(namspace: UUID): Int
+  def activeActivationsFor(namespace: UUID): Future[Int]
 
   /** Gets the number of in-flight activations in the system. */
-  def totalActiveActivations: Int
+  def totalActiveActivations: Future[Int]
 
   /**
    * Publishes activation message on internal bus for an invoker to pick up.
@@ -83,6 +83,11 @@ trait LoadBalancer {
 
 }
 
+case class ActivationEntry(id: ActivationId,
+                           namespaceId: UUID,
+                           invokerName: InstanceId,
+                           promise: Promise[Either[ActivationId, WhiskActivation]])
+
 class LoadBalancerService(config: WhiskConfig, instance: InstanceId, entityStore: EntityStore)(
   implicit val actorSystem: ActorSystem,
   logging: Logging)
@@ -95,7 +100,12 @@ class LoadBalancerService(config: WhiskConfig, instance: InstanceId, entityStore
   private val blackboxFraction: Double = Math.max(0.0, Math.min(1.0, config.controllerBlackboxFraction))
   logging.info(this, s"blackboxFraction = $blackboxFraction")(TransactionId.loadbalancer)
 
-  private val loadBalancerData = new LoadBalancerData()
+  /** Feature switch for shared load balancer data **/
+  private val loadBalancerData = {
+    if (config.controllerLocalBookkeeping.equalsIgnoreCase("true")) {
+      new LoadBalancerDataLocal()
+    } else new LoadBalancerData()
+  }
 
   override def activeActivationsFor(namespace: UUID) = loadBalancerData.activationCountOn(namespace)
 
@@ -206,7 +216,6 @@ class LoadBalancerService(config: WhiskConfig, instance: InstanceId, entityStore
       case Failure(e) => transid.failed(this, start, s"error on posting to topic $topic")
     }
   }
-
   private val invokerPool = {
     // Do not create the invokerPool if it is not possible to create the health test action to recover the invokers.
     InvokerPool
@@ -290,18 +299,20 @@ class LoadBalancerService(config: WhiskConfig, instance: InstanceId, entityStore
   private def chooseInvoker(user: Identity, action: ExecutableWhiskAction): Future[InstanceId] = {
     val hash = generateHash(user.namespace, action)
 
-    allInvokers.flatMap { invokers =>
-      val invokersToUse = if (action.exec.pull) blackboxInvokers(invokers) else managedInvokers(invokers)
-      val invokersWithUsage = invokersToUse.view.map {
-        // Using a view defers the comparably expensive lookup to actual access of the element
-        case (instance, state) => (instance, state, loadBalancerData.activationCountOn(instance))
-      }
+    loadBalancerData.activationCountPerInvoker.flatMap { currentActivations =>
+      allInvokers.flatMap { invokers =>
+        val invokersToUse = if (action.exec.pull) blackboxInvokers(invokers) else managedInvokers(invokers)
+        val invokersWithUsage = invokersToUse.view.map {
+          // Using a view defers the comparably expensive lookup to actual access of the element
+          case (instance, state) => (instance, state, currentActivations.getOrElse(instance.toString, 0))
+        }
 
-      LoadBalancerService.schedule(invokersWithUsage, config.loadbalancerInvokerBusyThreshold, hash) match {
-        case Some(invoker) => Future.successful(invoker)
-        case None =>
-          logging.error(this, s"all invokers down")(TransactionId.invokerHealth)
-          Future.failed(new LoadBalancerException("no invokers available"))
+        LoadBalancerService.schedule(invokersWithUsage, config.loadbalancerInvokerBusyThreshold, hash) match {
+          case Some(invoker) => Future.successful(invoker)
+          case None =>
+            logging.error(this, s"all invokers down")(TransactionId.invokerHealth)
+            Future.failed(new LoadBalancerException("no invokers available"))
+        }
       }
     }
   }
@@ -314,7 +325,10 @@ class LoadBalancerService(config: WhiskConfig, instance: InstanceId, entityStore
 
 object LoadBalancerService {
   def requiredProperties =
-    kafkaHost ++ Map(loadbalancerInvokerBusyThreshold -> null, controllerBlackboxFraction -> null)
+    kafkaHost ++ Map(
+      loadbalancerInvokerBusyThreshold -> null,
+      controllerBlackboxFraction -> null,
+      controllerLocalBookkeeping -> null)
 
   /** Memoizes the result of `f` for later use. */
   def memoize[I, O](f: I => O): I => O = new scala.collection.mutable.HashMap[I, O]() {

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -27,15 +27,13 @@ import scala.concurrent.Promise
 import scala.concurrent.duration.DurationInt
 import scala.util.Failure
 import scala.util.Success
-
 import org.apache.kafka.clients.producer.RecordMetadata
-
 import akka.actor.ActorRefFactory
 import akka.actor.ActorSystem
 import akka.actor.Props
+import akka.cluster.Cluster
 import akka.util.Timeout
 import akka.pattern.ask
-
 import whisk.common.Logging
 import whisk.common.LoggingMarkers
 import whisk.common.TransactionId
@@ -103,7 +101,8 @@ class LoadBalancerService(config: WhiskConfig, instance: InstanceId, entityStore
 
       /** Specify how seed nodes are generated */
       val seedNodesProvider = new StaticSeedNodesProvider(config.controllerSeedNodes, actorSystem.name)
-      new DistributedLoadBalancerData(seedNodesProvider, actorSystem, logging)
+      Cluster(actorSystem).joinSeedNodes(seedNodesProvider.getSeedNodes())
+      new DistributedLoadBalancerData()
     }
   }
 

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -83,11 +83,6 @@ trait LoadBalancer {
 
 }
 
-case class ActivationEntry(id: ActivationId,
-                           namespaceId: UUID,
-                           invokerName: InstanceId,
-                           promise: Promise[Either[ActivationId, WhiskActivation]])
-
 class LoadBalancerService(config: WhiskConfig, instance: InstanceId, entityStore: EntityStore)(
   implicit val actorSystem: ActorSystem,
   logging: Logging)

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -102,9 +102,9 @@ class LoadBalancerService(config: WhiskConfig, instance: InstanceId, entityStore
 
   /** Feature switch for shared load balancer data **/
   private val loadBalancerData = {
-    if (config.controllerLocalBookkeeping.equalsIgnoreCase("true")) {
-      new LoadBalancerDataLocal()
-    } else new LoadBalancerData()
+    if (config.controllerLocalBookkeeping) {
+      new LocalLoadBalancerData()
+    } else new DistributedLoadBalancerData()
   }
 
   override def activeActivationsFor(namespace: UUID) = loadBalancerData.activationCountOn(namespace)

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LocalLoadBalancerData.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LocalLoadBalancerData.scala
@@ -31,7 +31,7 @@ import whisk.core.entity.InstanceId
  * Note: The state keeping is backed by concurrent data-structures. As such,
  * concurrent reads can return stale values (especially the counters returned).
  */
-class LoadBalancerDataLocal() extends BookkeepingData {
+class LocalLoadBalancerData() extends LoadBalancerData {
 
   private val activationByInvoker = TrieMap[InstanceId, AtomicInteger]()
   private val activationByNamespaceId = TrieMap[UUID, AtomicInteger]()

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/SeedNodesProvider.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/SeedNodesProvider.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.loadBalancer
+
+import akka.actor.Address
+
+import scala.collection.immutable.Seq
+
+trait SeedNodesProvider {
+  def getSeedNodes(): Seq[Address]
+}
+
+class StaticSeedNodesProvider(seedNodes: String, actorSystemName: String) extends SeedNodesProvider {
+  def getSeedNodes(): Seq[Address] = {
+    seedNodes
+      .split(' ')
+      .flatMap { rawNodes =>
+        val ipWithPort = rawNodes.split(":")
+        ipWithPort match {
+          case Array(host, port) => Seq(Address("akka.tcp", actorSystemName, host, port.toInt))
+          case _                 => Seq.empty[Address]
+        }
+      }
+      .toIndexedSeq
+  }
+}

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/SharedDataService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/SharedDataService.scala
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.loadBalancer
+
+import akka.actor.{Actor, ActorLogging, ActorRef, Props}
+import akka.cluster.Cluster
+import akka.cluster.ClusterEvent.{InitialStateAsEvents, MemberEvent, MemberRemoved, MemberUp, UnreachableMember}
+import akka.cluster.ddata.{DistributedData, PNCounterMap, PNCounterMapKey}
+import akka.cluster.ddata.Replicator._
+import whisk.common.AkkaLogging
+import whisk.core.WhiskConfig
+import com.typesafe.config.{Config, ConfigFactory}
+
+case class IncreaseCounter(key: String, value: Long)
+case class DecreaseCounter(key: String, value: Long)
+case class ReadCounter(key: String)
+case class RemoveCounter(key: String)
+case class GetTheMap()
+case class MapWithCounters(dataMap: Map[String, BigInt])
+case class InSync()
+
+/**
+ * Companion object to specify actor properties from the outside, e.g. name of the shared map
+ */
+object SharedDataService {
+  val requiredProperties = Map(WhiskConfig.controllerSeedNodes -> null)
+  def props(storageName: String): Props = Props(new SharedDataService(storageName))
+
+  /**
+   * Add seed nodes if cluster provider is specified, otherwhise return the existing config.
+   * Parse akka seed nodes this way until either of these 2 issues is resolved:
+   * https://github.com/akka/akka/issues/23600
+   * https://github.com/typesafehub/config/issues/69
+   * @return Updated Config
+   */
+  def addAkkaSeedNodesToConf(whiskConf: WhiskConfig): Config = {
+    val conf = ConfigFactory.load()
+
+    val cluster = conf.getString("akka.actor.provider")
+
+    if (cluster == "cluster") {
+      val seedNodes = whiskConf.controllerSeedNodes
+      val nodes = seedNodes.split(' ').map(x => "\"akka.tcp://controller-actor-system@" + x + "\"")
+      val configWithSeedNodes = ConfigFactory.parseString(s"akka.cluster.seed-nodes=[${nodes.mkString(",")}]")
+      configWithSeedNodes.withFallback(conf)
+    } else conf
+  }
+}
+
+class SharedDataService(storageName: String) extends Actor with ActorLogging {
+
+  val replicator = DistributedData(context.system).replicator
+
+  val logging = new AkkaLogging(context.system.log)
+
+  val storage = PNCounterMapKey[String](storageName)
+
+  implicit val node = Cluster(context.system)
+
+  /**
+   * Subscribe this node for the changes in the Map, initialize the Map
+   */
+  override def preStart(): Unit = {
+    replicator ! Subscribe(storage, self)
+    node.subscribe(self, initialStateMode = InitialStateAsEvents, classOf[MemberEvent], classOf[UnreachableMember])
+    replicator ! Update(storage, PNCounterMap.empty[String], writeLocal)(_.remove(node, "0"))
+  }
+  override def postStop(): Unit = node.unsubscribe(self)
+
+  /**
+   * CRUD operations on the counter, process cluster member events for logging
+   * @return
+   */
+  def receive = {
+
+    case (IncreaseCounter(key, increment)) => {
+      replicator ! Update(storage, PNCounterMap.empty[String], writeLocal)(_.increment(key, increment))
+    }
+    case (DecreaseCounter(key, decrement)) => {
+      replicator ! Update(storage, PNCounterMap[String], writeLocal)(_.decrement(key, decrement))
+    }
+
+    case ReadCounter(key) => {
+      replicator ! Get(storage, readLocal, request = Some((sender(), key)))
+    }
+    case RemoveCounter(key) => {
+      replicator ! Update(storage, PNCounterMap[String], writeLocal)(_.remove(node, key))
+    }
+
+    case GetTheMap() => {
+      replicator ! Get(storage, readLocal, request = Some((sender())))
+    }
+    case MemberUp(member) =>
+      logging.info(this, "Member is Up: " + member.address)
+
+    case MemberRemoved(member, previousStatus) =>
+      logging.warn(this, s"Member is Removed: ${member.address} after $previousStatus")
+
+    case c @ Changed(_) =>
+      logging.debug(this, "Current elements: " + c.dataValue)
+
+    case g @ GetSuccess(_, Some((replyTo: ActorRef))) =>
+      val map = g.get(storage).entries
+      replyTo ! MapWithCounters(map.asInstanceOf[Map[String, BigInt]])
+
+    case g @ GetSuccess(_, Some((replyTo: ActorRef, key: String))) =>
+      if (g.get(storage).contains(key)) {
+        val response = g.get(storage).getValue(key).intValue()
+        replyTo ! response
+      } else
+        //      todo: consider returning 0 instead of none
+        replyTo ! None
+
+    case _ => // ignore
+  }
+}

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/SharedDataService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/SharedDataService.scala
@@ -38,8 +38,7 @@ case object GetMap
 object SharedDataService {
   val requiredProperties = Map(WhiskConfig.controllerSeedNodes -> null)
 
-  def props(storageName: String): Props = Props(new SharedDataService
-  (storageName))
+  def props(storageName: String): Props = Props(new SharedDataService(storageName))
 
   /**
    * Add seed nodes if cluster provider is specified, otherwhise return the existing config.
@@ -88,23 +87,15 @@ class SharedDataService(storageName: String) extends Actor with ActorLogging {
    */
   def receive = {
 
-    case (IncreaseCounter(key, increment)) => {
+    case (IncreaseCounter(key, increment)) =>
       replicator ! Update(storage, PNCounterMap.empty[String], writeLocal)(_.increment(key, increment))
-    }
-    case (DecreaseCounter(key, decrement)) => {
+
+    case (DecreaseCounter(key, decrement)) =>
       replicator ! Update(storage, PNCounterMap[String], writeLocal)(_.decrement(key, decrement))
-    }
 
-    case ReadCounter(key) => {
-      replicator ! Get(storage, readLocal, request = Some((sender(), key)))
-    }
-    case RemoveCounter(key) => {
-      replicator ! Update(storage, PNCounterMap[String], writeLocal)(_.remove(node, key))
-    }
-
-    case GetMap => {
+    case GetMap =>
       replicator ! Get(storage, readLocal, request = Some((sender())))
-    }
+
     case MemberUp(member) =>
       logging.info(this, "Member is Up: " + member.address)
 
@@ -123,7 +114,6 @@ class SharedDataService(storageName: String) extends Actor with ActorLogging {
         val response = g.get(storage).getValue(key).intValue()
         replyTo ! response
       } else
-        //      todo: consider returning 0 instead of none
         replyTo ! None
 
     case _ => // ignore

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@ This programming model is a perfect match for microservices, mobile, IoT and man
 
 ## Programming model
 - [System details](./reference.md)
+- [Component clustering](./deploy.md)
 - [Catalog of OpenWhisk provided services](./catalog.md)
 - [Actions](./actions.md)
 - [Triggers and Rules](./triggers_rules.md)

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,16 @@
+# Requirements for controller clustering
+
+This page describes requirements related to the introduction of akka clustering in Controller. There are cases where its usage requires special treatment wrt to the underlying infrastructure/deployment model. Please carefully read it before you decide to enable it.
+
+
+## Controller nodes must have static IPs/Port combination.
+
+It guarantees that failed nodes are able to join the cluster again.
+This limitation refers to the fact that Akka clustering doesn't allow to add new nodes when one of the existing members is unreachable (e.g. JVM failure). If each container receives a its ip and port dynamically upon the restart, in case of controller failure, it could come back online under a new ip/port combination which makes cluster consider it as a new member and it won't be added to the cluster (in certain cases it could join as a weeklyUp member). However, the cluster will still replicate the state across the online nodes, it will have trouble to get back to the previous state with desired number of members until the old member is explicitly "downed".
+
+How to down the members.
+1. manually (sending an HTTP or JMX request to the controller). For this case an external supervisor for the cluster is required, which will down the nodes and provide an up-to-date list of seed nodes.
+2. automatically by setting the "auto-down-property" in controller that will allow the leader to down the node after a certain timeout. In order to mitigate brain split one could define a list of seed nodes which are reachable under static IPs or have static DNS entries.
+
+Link to akka clustering documentation:
+https://doc.akka.io/docs/akka/2.5.4/scala/cluster-usage.html

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     compile 'junit:junit:4.11'
     compile 'com.jayway.restassured:rest-assured:2.6.0'
     compile 'org.scalatest:scalatest_2.11:3.0.1'
-    compile 'com.typesafe.akka:akka-testkit_2.11:2.5.3'
+    compile 'com.typesafe.akka:akka-testkit_2.11:2.5.4'
     compile 'com.google.code.gson:gson:2.3.1'
     compile 'org.scalamock:scalamock-scalatest-support_2.11:3.4.2'
     compile 'com.typesafe.akka:akka-testkit_2.11:2.4.16'

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     compile 'junit:junit:4.11'
     compile 'com.jayway.restassured:rest-assured:2.6.0'
     compile 'org.scalatest:scalatest_2.11:3.0.1'
+    compile 'com.typesafe.akka:akka-testkit_2.11:2.5.3'
     compile 'com.google.code.gson:gson:2.3.1'
     compile 'org.scalamock:scalamock-scalatest-support_2.11:3.4.2'
     compile 'com.typesafe.akka:akka-testkit_2.11:2.4.16'

--- a/tests/src/test/scala/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ControllerTestCommon.scala
@@ -21,20 +21,15 @@ import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.language.postfixOps
-
 import org.scalatest.BeforeAndAfter
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
-
 import common.StreamLogging
-
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.http.scaladsl.testkit.RouteTestTimeout
-
 import spray.json.DefaultJsonProtocol
 import spray.json.JsString
-
 import whisk.common.TransactionCounter
 import whisk.common.TransactionId
 import whisk.core.WhiskConfig
@@ -183,8 +178,8 @@ class DegenerateLoadBalancerService(config: WhiskConfig)(implicit ec: ExecutionC
   // unit tests that need an activation via active ack/fast path should set this to value expected
   var whiskActivationStub: Option[(FiniteDuration, WhiskActivation)] = None
 
-  override def totalActiveActivations = 0
-  override def activeActivationsFor(namespace: UUID) = 0
+  override def totalActiveActivations = Future.successful(0)
+  override def activeActivationsFor(namespace: UUID) = Future.successful(0)
 
   override def publish(action: ExecutableWhiskAction, msg: ActivationMessage)(
     implicit transid: TransactionId): Future[Future[Either[ActivationId, WhiskActivation]]] =

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/LoadBalancerDataTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/LoadBalancerDataTests.scala
@@ -22,12 +22,7 @@ import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import common.StreamLogging
 import org.scalatest.{FlatSpec, Matchers}
 import whisk.core.entity.{ActivationId, UUID, WhiskActivation}
-import whisk.core.loadBalancer.{
-  ActivationEntry,
-  DistributedLoadBalancerData,
-  LocalLoadBalancerData,
-  StaticSeedNodesProvider
-}
+import whisk.core.loadBalancer.{ActivationEntry, DistributedLoadBalancerData, LocalLoadBalancerData}
 
 import scala.concurrent.{Await, Future, Promise}
 import whisk.core.entity.InstanceId
@@ -52,14 +47,12 @@ class LoadBalancerDataTests extends FlatSpec with Matchers with StreamLogging {
 
   implicit val actorSystem = ActorSystem(actorSystemName, config)
 
-  val seedNodesProvider = new StaticSeedNodesProvider(s"$host:$port", actorSystemName)
-
   def await[A](f: Future[A], timeout: FiniteDuration = 1.second) = Await.result(f, timeout)
 
   behavior of "LoadBalancerData"
 
   it should "return the number of activations for a namespace" in {
-    val distributedLoadBalancerData = new DistributedLoadBalancerData(seedNodesProvider, actorSystem, logging)
+    val distributedLoadBalancerData = new DistributedLoadBalancerData()
     val localLoadBalancerData = new LocalLoadBalancerData()
 //    test all implementations
     val loadBalancerDataArray = Array(localLoadBalancerData, distributedLoadBalancerData)
@@ -76,7 +69,7 @@ class LoadBalancerDataTests extends FlatSpec with Matchers with StreamLogging {
 
   it should "return the number of activations for each invoker" in {
 
-    val distributedLoadBalancerData = new DistributedLoadBalancerData(seedNodesProvider, actorSystem, logging)
+    val distributedLoadBalancerData = new DistributedLoadBalancerData()
     val localLoadBalancerData = new LocalLoadBalancerData()
 
     val loadBalancerDataArray = Array(localLoadBalancerData, distributedLoadBalancerData)
@@ -101,7 +94,7 @@ class LoadBalancerDataTests extends FlatSpec with Matchers with StreamLogging {
 
   it should "remove activations and reflect that accordingly" in {
 
-    val distributedLoadBalancerData = new DistributedLoadBalancerData(seedNodesProvider, actorSystem, logging)
+    val distributedLoadBalancerData = new DistributedLoadBalancerData()
     val localLoadBalancerData = new LocalLoadBalancerData()
 
     val loadBalancerDataArray = Array(localLoadBalancerData, distributedLoadBalancerData)
@@ -125,7 +118,7 @@ class LoadBalancerDataTests extends FlatSpec with Matchers with StreamLogging {
 
   it should "remove activations from all 3 maps by activation id" in {
 
-    val distributedLoadBalancerData = new DistributedLoadBalancerData(seedNodesProvider, actorSystem, logging)
+    val distributedLoadBalancerData = new DistributedLoadBalancerData()
     val localLoadBalancerData = new LocalLoadBalancerData()
 
     val loadBalancerDataArray = Array(localLoadBalancerData, distributedLoadBalancerData)
@@ -144,7 +137,7 @@ class LoadBalancerDataTests extends FlatSpec with Matchers with StreamLogging {
   }
 
   it should "return None if the entry doesn't exist when we remove it" in {
-    val distributedLoadBalancerData = new DistributedLoadBalancerData(seedNodesProvider, actorSystem, logging)
+    val distributedLoadBalancerData = new DistributedLoadBalancerData()
     val localLoadBalancerData = new LocalLoadBalancerData()
 
     val loadBalancerDataArray = Array(localLoadBalancerData, distributedLoadBalancerData)
@@ -160,7 +153,7 @@ class LoadBalancerDataTests extends FlatSpec with Matchers with StreamLogging {
     val entrySameInvokerAndNamespace = entry.copy(id = ActivationId())
     val entrySameInvoker = entry.copy(id = ActivationId(), namespaceId = UUID())
 
-    val distributedLoadBalancerData = new DistributedLoadBalancerData(seedNodesProvider, actorSystem, logging)
+    val distributedLoadBalancerData = new DistributedLoadBalancerData()
     val localLoadBalancerData = new LocalLoadBalancerData()
 
     val loadBalancerDataArray = Array(localLoadBalancerData, distributedLoadBalancerData)
@@ -201,7 +194,7 @@ class LoadBalancerDataTests extends FlatSpec with Matchers with StreamLogging {
 
   it should "not add the same entry more then once" in {
 
-    val distributedLoadBalancerData = new DistributedLoadBalancerData(seedNodesProvider, actorSystem, logging)
+    val distributedLoadBalancerData = new DistributedLoadBalancerData()
     val localLoadBalancerData = new LocalLoadBalancerData()
 
     val loadBalancerDataArray = Array(localLoadBalancerData, distributedLoadBalancerData)
@@ -224,7 +217,7 @@ class LoadBalancerDataTests extends FlatSpec with Matchers with StreamLogging {
 
   it should "not evaluate the given block if an entry already exists" in {
 
-    val distributedLoadBalancerData = new DistributedLoadBalancerData(seedNodesProvider, actorSystem, logging)
+    val distributedLoadBalancerData = new DistributedLoadBalancerData()
     val localLoadBalancerData = new LocalLoadBalancerData()
 
     val loadBalancerDataArray = Array(localLoadBalancerData, distributedLoadBalancerData)
@@ -255,7 +248,7 @@ class LoadBalancerDataTests extends FlatSpec with Matchers with StreamLogging {
 
   it should "not evaluate the given block even if an entry is different (but has the same id)" in {
 
-    val distributedLoadBalancerData = new DistributedLoadBalancerData(seedNodesProvider, actorSystem, logging)
+    val distributedLoadBalancerData = new DistributedLoadBalancerData()
     val localLoadBalancerData = new LocalLoadBalancerData()
 
     val loadBalancerDataArray = Array(localLoadBalancerData, distributedLoadBalancerData)

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/LoadBalancerDataTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/LoadBalancerDataTests.scala
@@ -17,12 +17,16 @@
 
 package whisk.core.loadBalancer.test
 
+import akka.actor.{ActorSystem}
+import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import org.scalatest.{FlatSpec, Matchers}
 import whisk.core.entity.{ActivationId, UUID, WhiskActivation}
 import whisk.core.loadBalancer.{ActivationEntry, LoadBalancerData}
 
-import scala.concurrent.{Promise}
+import scala.concurrent.{Await, Promise}
 import whisk.core.entity.InstanceId
+
+import scala.concurrent.duration._
 
 class LoadBalancerDataTests extends FlatSpec with Matchers {
 
@@ -30,16 +34,32 @@ class LoadBalancerDataTests extends FlatSpec with Matchers {
   val firstEntry: ActivationEntry = ActivationEntry(ActivationId(), UUID(), InstanceId(0), activationIdPromise)
   val secondEntry: ActivationEntry = ActivationEntry(ActivationId(), UUID(), InstanceId(1), activationIdPromise)
 
+  val port = 2552
+  val config = ConfigFactory
+    .parseString("akka.cluster { seed-nodes = [\"akka.tcp://controller-actor-system@127.0.0" +
+      s".1:$port" + "\"] }")
+    .withValue("akka.remote.netty.tcp.hostname", ConfigValueFactory.fromAnyRef("127.0.0.1"))
+    .withValue("akka.remote.netty.tcp.port", ConfigValueFactory.fromAnyRef(port))
+    .withValue("akka.cluster.auto-down-unreachable-after", ConfigValueFactory.fromAnyRef("10s"))
+    .withValue("akka.actor.provider", ConfigValueFactory.fromAnyRef("cluster"))
+    .withValue("akka.remote.log-remote-lifecycle-events", ConfigValueFactory.fromAnyRef("off"))
+    .withFallback(ConfigFactory.load())
+
+  implicit val actorSystem = ActorSystem("controller-actor-system", config)
+
   behavior of "LoadBalancerData"
 
   it should "return the number of activations for a namespace" in {
-
     val loadBalancerData = new LoadBalancerData()
     loadBalancerData.putActivation(firstEntry.id, firstEntry)
 
-    loadBalancerData.activationCountOn(firstEntry.namespaceId) shouldBe 1
-    loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 1
+    Await.result(loadBalancerData.activationCountOn(firstEntry.namespaceId), 1.second) shouldBe 1
+    Await.result(loadBalancerData.activationCountPerInvoker, 1.second) shouldBe Map(
+      firstEntry.invokerName.toString -> 1)
     loadBalancerData.activationById(firstEntry.id) shouldBe Some(firstEntry)
+
+    // clean up after yourself
+    loadBalancerData.removeActivation(firstEntry.id)
   }
 
   it should "return the number of activations for each invoker" in {
@@ -48,35 +68,51 @@ class LoadBalancerDataTests extends FlatSpec with Matchers {
     loadBalancerData.putActivation(firstEntry.id, firstEntry)
     loadBalancerData.putActivation(secondEntry.id, secondEntry)
 
-    loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 1
-    loadBalancerData.activationCountOn(secondEntry.invokerName) shouldBe 1
+    val res = Await.result(loadBalancerData.activationCountPerInvoker, 1.second)
+
+    res.get(firstEntry.invokerName.toString()) shouldBe Some(1)
+    res.get(secondEntry.invokerName.toString()) shouldBe Some(1)
+
     loadBalancerData.activationById(firstEntry.id) shouldBe Some(firstEntry)
     loadBalancerData.activationById(secondEntry.id) shouldBe Some(secondEntry)
+
+    // clean up after yourself
+    loadBalancerData.removeActivation(firstEntry.id)
+    loadBalancerData.removeActivation(secondEntry.id)
   }
 
   it should "remove activations and reflect that accordingly" in {
 
     val loadBalancerData = new LoadBalancerData()
     loadBalancerData.putActivation(firstEntry.id, firstEntry)
-    loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 1
-    loadBalancerData.activationCountOn(firstEntry.namespaceId) shouldBe 1
+    val res = Await.result(loadBalancerData.activationCountPerInvoker, 1.second)
+    res.get(firstEntry.invokerName.toString()) shouldBe Some(1)
+
+    Await.result(loadBalancerData.activationCountOn(firstEntry.namespaceId), 1.second) shouldBe 1
 
     loadBalancerData.removeActivation(firstEntry)
 
-    loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 0
-    loadBalancerData.activationCountOn(firstEntry.namespaceId) shouldBe 0
+    val resAfterRemoval = Await.result(loadBalancerData.activationCountPerInvoker, 1.second)
+    resAfterRemoval.get(firstEntry.invokerName.toString()) shouldBe Some(0)
+
+    Await.result(loadBalancerData.activationCountOn(firstEntry.namespaceId), 1.second) shouldBe 0
     loadBalancerData.activationById(firstEntry.id) shouldBe None
+
   }
 
   it should "remove activations from all 3 maps by activation id" in {
 
     val loadBalancerData = new LoadBalancerData()
     loadBalancerData.putActivation(firstEntry.id, firstEntry)
-    loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 1
+
+    val res = Await.result(loadBalancerData.activationCountPerInvoker, 1.second)
+    res.get(firstEntry.invokerName.toString()) shouldBe Some(1)
 
     loadBalancerData.removeActivation(firstEntry.id)
 
-    loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 0
+    val resAfterRemoval = Await.result(loadBalancerData.activationCountPerInvoker, 1.second)
+    resAfterRemoval.get(firstEntry.invokerName.toString()) shouldBe Some(0)
+
   }
 
   it should "return None if the entry doesn't exist when we remove it" in {
@@ -92,26 +128,35 @@ class LoadBalancerDataTests extends FlatSpec with Matchers {
 
     val loadBalancerData = new LoadBalancerData()
     loadBalancerData.putActivation(entry.id, entry)
-    loadBalancerData.activationCountOn(entry.namespaceId) shouldBe 1
-    loadBalancerData.activationCountOn(entry.invokerName) shouldBe 1
+
+    Await.result(loadBalancerData.activationCountOn(entry.namespaceId), 1.second) shouldBe 1
+    var res = Await.result(loadBalancerData.activationCountPerInvoker, 1.second)
+    res.get(entry.invokerName.toString()) shouldBe Some(1)
 
     loadBalancerData.putActivation(entrySameInvokerAndNamespace.id, entrySameInvokerAndNamespace)
-    loadBalancerData.activationCountOn(entry.namespaceId) shouldBe 2
-    loadBalancerData.activationCountOn(entry.invokerName) shouldBe 2
+    Await.result(loadBalancerData.activationCountOn(entry.namespaceId), 1.second) shouldBe 2
+    res = Await.result(loadBalancerData.activationCountPerInvoker, 1.second)
+    res.get(entry.invokerName.toString()) shouldBe Some(2)
 
     loadBalancerData.putActivation(entrySameInvoker.id, entrySameInvoker)
-    loadBalancerData.activationCountOn(entry.namespaceId) shouldBe 2
-    loadBalancerData.activationCountOn(entry.invokerName) shouldBe 3
+    Await.result(loadBalancerData.activationCountOn(entry.namespaceId), 1.second) shouldBe 2
+    res = Await.result(loadBalancerData.activationCountPerInvoker, 1.second)
+    res.get(entry.invokerName.toString()) shouldBe Some(3)
 
     loadBalancerData.removeActivation(entrySameInvokerAndNamespace)
-    loadBalancerData.activationCountOn(entry.namespaceId) shouldBe 1
-    loadBalancerData.activationCountOn(entry.invokerName) shouldBe 2
+    Await.result(loadBalancerData.activationCountOn(entry.namespaceId), 1.second) shouldBe 1
+    res = Await.result(loadBalancerData.activationCountPerInvoker, 1.second)
+    res.get(entry.invokerName.toString()) shouldBe Some(2)
 
     // removing non existing entry doesn't mess up
     loadBalancerData.removeActivation(entrySameInvokerAndNamespace)
-    loadBalancerData.activationCountOn(entry.namespaceId) shouldBe 1
-    loadBalancerData.activationCountOn(entry.invokerName) shouldBe 2
+    Await.result(loadBalancerData.activationCountOn(entry.namespaceId), 1.second) shouldBe 1
+    res = Await.result(loadBalancerData.activationCountPerInvoker, 1.second)
+    res.get(entry.invokerName.toString()) shouldBe Some(2)
 
+    // clean up
+    loadBalancerData.removeActivation(entry)
+    loadBalancerData.removeActivation(entrySameInvoker.id)
   }
 
   it should "not add the same entry more then once" in {
@@ -119,12 +164,17 @@ class LoadBalancerDataTests extends FlatSpec with Matchers {
     val loadBalancerData = new LoadBalancerData()
 
     loadBalancerData.putActivation(firstEntry.id, firstEntry)
-    loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 1
-    loadBalancerData.activationCountOn(firstEntry.namespaceId) shouldBe 1
+    val res = Await.result(loadBalancerData.activationCountPerInvoker, 1.second)
+    res.get(firstEntry.invokerName.toString()) shouldBe Some(1)
+    Await.result(loadBalancerData.activationCountOn(firstEntry.namespaceId), 1.second) shouldBe 1
 
     loadBalancerData.putActivation(firstEntry.id, firstEntry)
-    loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 1
-    loadBalancerData.activationCountOn(firstEntry.namespaceId) shouldBe 1
+    val resAfterAddingTheSameEntry = Await.result(loadBalancerData.activationCountPerInvoker, 1.second)
+    resAfterAddingTheSameEntry.get(firstEntry.invokerName.toString()) shouldBe Some(1)
+    Await.result(loadBalancerData.activationCountOn(firstEntry.namespaceId), 1.second) shouldBe 1
+
+    loadBalancerData.removeActivation(firstEntry)
+    loadBalancerData.removeActivation(firstEntry)
   }
 
   it should "not evaluate the given block if an entry already exists" in {
@@ -147,6 +197,9 @@ class LoadBalancerDataTests extends FlatSpec with Matchers {
 
     called shouldBe 1
     entry shouldBe entryAfterSecond
+
+    // clean up after yourself
+    loadBalancerData.removeActivation(firstEntry)
   }
 
   it should "not evaluate the given block even if an entry is different (but has the same id)" in {
@@ -161,8 +214,10 @@ class LoadBalancerDataTests extends FlatSpec with Matchers {
     })
 
     called shouldBe 1
-    loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 1
-    loadBalancerData.activationCountOn(firstEntry.namespaceId) shouldBe 1
+
+    val res = Await.result(loadBalancerData.activationCountPerInvoker, 1.second)
+    res.get(firstEntry.invokerName.toString()) shouldBe Some(1)
+    Await.result(loadBalancerData.activationCountOn(firstEntry.namespaceId), 1.second) shouldBe 1
 
     // entry already exists, should not evaluate the block and change the state
     val entryAfterSecond = loadBalancerData.putActivation(entrySameId.id, {
@@ -172,8 +227,10 @@ class LoadBalancerDataTests extends FlatSpec with Matchers {
 
     called shouldBe 1
     entry shouldBe entryAfterSecond
-    loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 1
-    loadBalancerData.activationCountOn(firstEntry.namespaceId) shouldBe 1
+    val resAfterAddingTheSameEntry = Await.result(loadBalancerData.activationCountPerInvoker, 1.second)
+    resAfterAddingTheSameEntry.get(firstEntry.invokerName.toString()) shouldBe Some(1)
+    Await.result(loadBalancerData.activationCountOn(firstEntry.namespaceId), 1.second) shouldBe 1
+
   }
 
 }

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/SeedNodesProviderTest.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/SeedNodesProviderTest.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.loadBalancer.test
+
+import akka.actor.Address
+import org.scalatest.{FlatSpec, Matchers}
+import whisk.core.loadBalancer.{StaticSeedNodesProvider}
+
+class SeedNodesProviderTest extends FlatSpec with Matchers {
+
+  val actorSystemName = "controller-actor-system"
+  val host = "192.168.99.100"
+  val port = 8000
+  val oneFakeSeedNode = s"$host:$port"
+  val twoFakeSeedNodes = s"$host:$port $host:${port + 1}"
+  val twoFakeSeedNodesWithoutWhitespace = s"$host:$port$host:${port + 1}"
+
+  behavior of "StaticSeedNodesProvider"
+
+  it should "return a sequence with a single seed node" in {
+    val seedNodesProvider = new StaticSeedNodesProvider(oneFakeSeedNode, actorSystemName)
+    val seqWithOneSeedNode = seedNodesProvider.getSeedNodes()
+    seqWithOneSeedNode shouldBe IndexedSeq(Address("akka.tcp", actorSystemName, host, port))
+  }
+  it should "return a sequence with more then one seed node" in {
+    val seedNodesProvider = new StaticSeedNodesProvider(twoFakeSeedNodes, actorSystemName)
+    val seqWithTwoSeedNodes = seedNodesProvider.getSeedNodes()
+    seqWithTwoSeedNodes shouldBe IndexedSeq(
+      Address("akka.tcp", actorSystemName, host, port),
+      Address("akka.tcp", actorSystemName, host, port + 1))
+  }
+  it should "return an empty sequence if seed nodes are provided in the wrong format" in {
+    val seedNodesProvider = new StaticSeedNodesProvider(twoFakeSeedNodesWithoutWhitespace, actorSystemName)
+    val noneResponse = seedNodesProvider.getSeedNodes()
+    noneResponse shouldBe IndexedSeq.empty[Address]
+  }
+  it should "return an empty sequence if no seed nodes specified" in {
+    val seedNodesProvider = new StaticSeedNodesProvider("", actorSystemName)
+    val noneResponse = seedNodesProvider.getSeedNodes()
+    noneResponse shouldBe IndexedSeq.empty[Address]
+  }
+
+}

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/SharedDataServiceTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/SharedDataServiceTests.scala
@@ -44,8 +44,7 @@ class SharedDataServiceTests()
     with ImplicitSender
     with FlatSpecLike
     with Matchers
-    with BeforeAndAfterAll
-    with BeforeAndAfterEach {
+    with BeforeAndAfterAll {
 
   override def afterAll {
     TestKit.shutdownActorSystem(system)
@@ -53,54 +52,43 @@ class SharedDataServiceTests()
 
   behavior of "SharedDataService"
 
-    val port = 2552
-    val config = ConfigFactory
-      .parseString("akka.cluster { seed-nodes = [\"akka.tcp://controller-actor-system@127.0.0.1:"+ port + "\"] }")
-      .withValue("akka.remote.netty.tcp.hostname", ConfigValueFactory.fromAnyRef("127.0.0.1"))
-      .withValue("akka.remote.netty.tcp.port", ConfigValueFactory.fromAnyRef(port))
-      .withValue("akka.cluster.auto-down-unreachable-after", ConfigValueFactory.fromAnyRef("10s"))
-      .withValue("akka.actor.provider", ConfigValueFactory.fromAnyRef("cluster"))
-      .withValue("akka.remote.log-remote-lifecycle-events", ConfigValueFactory.fromAnyRef("off"))
-      .withFallback(ConfigFactory.load())
+  val port = 2552
+  val config = ConfigFactory
+    .parseString("akka.cluster { seed-nodes = [\"akka.tcp://controller-actor-system@127.0.0.1:" + port + "\"] }")
+    .withValue("akka.remote.netty.tcp.hostname", ConfigValueFactory.fromAnyRef("127.0.0.1"))
+    .withValue("akka.remote.netty.tcp.port", ConfigValueFactory.fromAnyRef(port))
+    .withValue("akka.cluster.auto-down-unreachable-after", ConfigValueFactory.fromAnyRef("10s"))
+    .withValue("akka.actor.provider", ConfigValueFactory.fromAnyRef("cluster"))
+    .withValue("akka.remote.log-remote-lifecycle-events", ConfigValueFactory.fromAnyRef("off"))
+    .withFallback(ConfigFactory.load())
 
-    val s = ActorSystem("controller-actor-system", config)
+  val s = ActorSystem("controller-actor-system", config)
 
-    val sharedDataService = s.actorOf(SharedDataService.props("Candidates"), name = "busyMan")
-    implicit val timeout = Timeout(5.seconds)
+  val sharedDataService = s.actorOf(SharedDataService.props("Candidates"), name = "busyMan")
+  implicit val timeout = Timeout(5.seconds)
 
-    it should "retrieve an empty map after initialization" in {
-      sharedDataService ! GetMap
-      expectMsgPF() {
-        case x: Map[String, BigInt] if x.size == 0 => true
-      }
-    }
-    it should "increase the counter" in {
-      sharedDataService ! (IncreaseCounter("Donald", 1))
-      sharedDataService ! ReadCounter("Donald")
-      expectMsg(1)
-    }
-    it should "decrease the counter" in {
-      sharedDataService ! (IncreaseCounter("Donald", 2))
-      sharedDataService ! (DecreaseCounter("Donald", 2))
-      sharedDataService ! ReadCounter("Donald")
-      expectMsg(1)
-    }
-    it should "return None for non existing keys" in {
-      sharedDataService ! (IncreaseCounter("Donald", 1))
-      sharedDataService ! (ReadCounter("Hilary"))
-      expectMsg(None)
-    }
-    it should "remove the entry from the map" in {
-      sharedDataService ! (IncreaseCounter("Fifi", 2))
-      sharedDataService ! (RemoveCounter("Fifi"))
-      sharedDataService ! (ReadCounter("Fifi"))
-      expectMsg(None)
-    }
-    it should "receive the map with all counters" in {
-      sharedDataService ! (IncreaseCounter("Hilary", 1))
-      sharedDataService ! GetMap
-      expectMsgPF() {
-        case x: Map[String, BigInt] if x.size == 2 => true
-      }
-    }
+  it should "retrieve an empty map after initialization" in {
+    sharedDataService ! GetMap
+    val msg = Map()
+    expectMsg(msg)
+  }
+  it should "increase the counter" in {
+    sharedDataService ! (IncreaseCounter("Donald", 1))
+    sharedDataService ! GetMap
+    val msg = Map("Donald" -> 1)
+    expectMsg(msg)
+  }
+  it should "decrease the counter" in {
+    sharedDataService ! (IncreaseCounter("Donald", 2))
+    sharedDataService ! (DecreaseCounter("Donald", 2))
+    sharedDataService ! GetMap
+    val msg = Map("Donald" -> 1)
+    expectMsg(msg)
+  }
+  it should "receive the map with all counters" in {
+    sharedDataService ! (IncreaseCounter("Hilary", 1))
+    sharedDataService ! GetMap
+    val msg = Map("Hilary" -> 1, "Donald" -> 1)
+    expectMsg(msg)
+  }
 }

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/SharedDataServiceTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/SharedDataServiceTests.scala
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.loadBalancer.test
+
+import akka.actor.ActorSystem
+import akka.testkit.{ImplicitSender, TestKit}
+import akka.util.Timeout
+import com.typesafe.config.ConfigValueFactory
+import com.typesafe.config.ConfigFactory
+import org.scalatest._
+import whisk.core.loadBalancer._
+
+import scala.concurrent.duration._
+
+// Define your test specific configuration here
+
+object TestKitConfig {
+  val config = """
+    akka.remote.netty.tcp {
+      hostname = "127.0.0.1"
+      port = 2555
+    }
+    """
+}
+
+class SharedDataServiceTests()
+    extends TestKit(ActorSystem("ControllerCluster", ConfigFactory.parseString(TestKitConfig.config)))
+    with ImplicitSender
+    with WordSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with BeforeAndAfterEach {
+
+  override def afterAll {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  "A Shared Data Service" must {
+
+    val port = 2552
+    val config = ConfigFactory
+      .parseString("akka.cluster { seed-nodes = [\"akka.tcp://controller-actor-system@127.0.0" +
+        s".1:$port" + "\"] }")
+      .withValue("akka.remote.netty.tcp.hostname", ConfigValueFactory.fromAnyRef("127.0.0.1"))
+      .withValue("akka.remote.netty.tcp.port", ConfigValueFactory.fromAnyRef(port))
+      .withValue("akka.cluster.auto-down-unreachable-after", ConfigValueFactory.fromAnyRef("10s"))
+      .withValue("akka.actor.provider", ConfigValueFactory.fromAnyRef("cluster"))
+      .withValue("akka.remote.log-remote-lifecycle-events", ConfigValueFactory.fromAnyRef("off"))
+      .withFallback(ConfigFactory.load())
+
+    val system = ActorSystem("controller-actor-system", config)
+
+    val sharedDataService = system.actorOf(SharedDataService.props("Candidates"), name = "busyMan")
+    implicit val timeout = Timeout(5.seconds)
+
+    "retrieve an empty map after initialization" in {
+      sharedDataService ! GetTheMap()
+      expectMsgPF() {
+        case x: MapWithCounters if x.dataMap.size == 0 => true
+      }
+    }
+    "increase the counter" in {
+      sharedDataService ! (IncreaseCounter("Donald", 1))
+      sharedDataService ! ReadCounter("Donald")
+      expectMsg(1)
+    }
+    "decrease the counter" in {
+      sharedDataService ! (IncreaseCounter("Donald", 2))
+      sharedDataService ! (DecreaseCounter("Donald", 2))
+      Thread.sleep(500)
+      sharedDataService ! ReadCounter("Donald")
+      Thread.sleep(500)
+      expectMsg(1)
+    }
+    "return None for non existing keys" in {
+      sharedDataService ! (IncreaseCounter("Donald", 1))
+      Thread.sleep(500)
+      sharedDataService ! (ReadCounter("Hilary"))
+      expectMsg(None)
+    }
+    "remove the entry from the map" in {
+      sharedDataService ! (IncreaseCounter("Fifi", 2))
+      sharedDataService ! (RemoveCounter("Fifi"))
+      Thread.sleep(500)
+      sharedDataService ! (ReadCounter("Fifi"))
+      expectMsg(None)
+    }
+    "receive the map with all counters" in {
+      sharedDataService ! (IncreaseCounter("Hilary", 1))
+      sharedDataService ! (GetTheMap())
+      Thread.sleep(500)
+      expectMsgPF() {
+        case x: MapWithCounters if x.dataMap.size == 2 => true
+      }
+    }
+  }
+
+}

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/SharedDataServiceTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/SharedDataServiceTests.scala
@@ -17,7 +17,7 @@
 
 package whisk.core.loadBalancer.test
 
-import akka.actor.{ActorSystem, Address}
+import akka.actor.ActorSystem
 import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.Timeout
 import com.typesafe.config.ConfigValueFactory
@@ -25,7 +25,6 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest._
 import whisk.core.loadBalancer._
 import org.scalatest.FlatSpecLike
-import scala.collection.immutable.Seq
 
 import scala.concurrent.duration._
 
@@ -62,8 +61,7 @@ class SharedDataServiceTests()
     .withFallback(ConfigFactory.load())
 
   val s = ActorSystem("controller-actor-system", config)
-  val seedNode = Seq(Address("akka.tcp:", "controller-actor-system", host, port))
-  val sharedDataService = s.actorOf(SharedDataService.props("Candidates", seedNode), name = "busyMan")
+  val sharedDataService = s.actorOf(SharedDataService.props("Candidates"), name = "busyMan")
   implicit val timeout = Timeout(5.seconds)
 
   it should "retrieve an empty map after initialization" in {


### PR DESCRIPTION
Hello, 

this PR is a WIP to share the state across multiple controllers to scale out the controllers in OpenWhisk. 
It will allow us to share Activations per namespaces and invokers across several controllers using [Akka Distributed framework](http://doc.akka.io/docs/akka/snapshot/scala/distributed-data.html). The TrieMaps were replaced by PNCounterMaps, which are updated locally without waiting for the replication across other nodes in the cluster. 

UPDATED.
I have a couple of things to mention:
* Parsing of the seed-nodes is defined in a separate method due to a well known akka config issue https://github.com/akka/akka/issues/23600. 
* The old LoadBalancerData implementation is still in place, so in case of emergency we can turn off akka replication across Controllers. 

Any other todos and comments are welcome. 

@cbickel @markusthoemmes @rabbah 

regards, 
Vadim. 