### PR TITLE
Add the ability to define user-specific throttles.

### DIFF
--- a/ansible/files/auth_index.json
+++ b/ansible/files/auth_index.json
@@ -2,7 +2,7 @@
   "_id":"_design/subjects",
   "views": {
     "identities": {
-      "map": "function (doc) {\n  if(doc.uuid && doc.key && !doc.blocked) {\n    var v = {namespace: doc.subject, uuid: doc.uuid, key: doc.key};\n    emit([doc.subject], v);\n    emit([doc.uuid, doc.key], v);\n  }\n  if(doc.namespaces && !doc.blocked) {\n    doc.namespaces.forEach(function(namespace) {\n      var v = {namespace: namespace.name, uuid: namespace.uuid, key: namespace.key};\n      emit([namespace.name], v);\n      emit([namespace.uuid, namespace.key], v);\n    });\n  }\n}"
+      "map": "function (doc) {\n  if(doc.uuid && doc.key && !doc.blocked) {\n    var v = {namespace: doc.subject, uuid: doc.uuid, key: doc.key};\n    emit([doc.subject], v);\n    emit([doc.uuid, doc.key], v);\n  }\n  if(doc.namespaces && !doc.blocked) {\n    doc.namespaces.forEach(function(namespace) {\n      var v = {_id: namespace.name + '/limits', namespace: namespace.name, uuid: namespace.uuid, key: namespace.key};\n      emit([namespace.name], v);\n      emit([namespace.uuid, namespace.key], v);\n    });\n  }\n}"
     }
   },
   "language":"javascript",

--- a/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
@@ -203,9 +203,7 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](
             case Right(response) =>
                 val rows = response.fields("rows").convertTo[List[JsObject]]
 
-                val out = if (includeDocs) {
-                    rows.map(_.fields("doc").asJsObject)
-                } else if (reduce && !rows.isEmpty) {
+                val out = if (reduce && !rows.isEmpty) {
                     assert(rows.length == 1, s"result of reduced view contains more than one value: '$rows'")
                     rows.head.fields("value").convertTo[List[JsObject]]
                 } else if (reduce) {

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
@@ -294,7 +294,7 @@ object WhiskEntityQueries {
         db.query(view, startKey, endKey, skip, limit, includeDocs, true, reduce) map {
             rows =>
                 convert map { fn =>
-                    Right(rows flatMap { fn(_) toOption })
+                    Right(rows flatMap { row => fn(row.fields("doc").asJsObject) toOption })
                 } getOrElse {
                     Left(rows flatMap { normalizeRow(_, reduce) toOption })
                 }

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -82,8 +82,8 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
 
     private implicit val executionContext = actorSystem.dispatcher
 
-    private val invokeRateThrottler = new RateThrottler("actions per minute", config.actionInvokePerMinuteLimit.toInt)
-    private val triggerRateThrottler = new RateThrottler("triggers per minute", config.triggerFirePerMinuteLimit.toInt)
+    private val invokeRateThrottler = new RateThrottler("actions per minute", config.actionInvokePerMinuteLimit.toInt, _.limits.invocationsPerMinute)
+    private val triggerRateThrottler = new RateThrottler("triggers per minute", config.triggerFirePerMinuteLimit.toInt, _.limits.firesPerMinute)
     private val concurrentInvokeThrottler = new ActivationThrottler(config.consulServer, loadBalancer, config.actionInvokeConcurrentLimit.toInt, config.actionInvokeSystemOverloadLimit.toInt)
 
     /**

--- a/tests/src/test/scala/whisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/SchemaTests.scala
@@ -42,7 +42,6 @@ import whisk.core.entity.size.SizeInt
 import whisk.http.Messages
 import whisk.utils.JsHelpers
 
-
 @RunWith(classOf[JUnitRunner])
 class SchemaTests
     extends FlatSpec
@@ -84,7 +83,8 @@ class SchemaTests
             "subject" -> i.subject.asString.toJson,
             "namespace" -> i.namespace.toJson,
             "authkey" -> i.authkey.compact.toJson,
-            "rights" -> Array("READ", "PUT", "DELETE", "ACTIVATE").toJson)
+            "rights" -> Array("READ", "PUT", "DELETE", "ACTIVATE").toJson,
+            "limits" -> JsObject())
         Identity.serdes.write(i) shouldBe expected
         Identity.serdes.read(expected) shouldBe i
     }

--- a/tools/admin/wskadmin
+++ b/tools/admin/wskadmin
@@ -32,6 +32,7 @@ import sys
 import traceback
 import uuid
 import wskprop
+import urllib
 try:
     import argcomplete
 except ImportError:
@@ -72,7 +73,8 @@ def main():
             exitCode = {
               'user' : userCmd,
               'db'   : dbCmd,
-              'syslog' : syslogCmd
+              'syslog' : syslogCmd,
+              'limits': limitsCmd
             }[args.cmd](args, props)
         except Exception as e:
             print('Exception: ', e)
@@ -115,6 +117,15 @@ def parseArgs():
     subcmd.add_argument('namespace', help='the namespace to lookup')
     subcmd.add_argument('-p', '--pick', metavar='N', help='show no more than N identities', type=int, default=1)
     subcmd.add_argument('-k', '--key', help='show only the keys', action='store_true')
+
+    propmenu = subparsers.add_parser('limits', help='manage namespace-specific limits')
+    subparser = propmenu.add_subparsers(title='available commands', dest='subcmd')
+
+    subcmd = subparser.add_parser('set', help='set limits for a given namespace')
+    subcmd.add_argument('namespace', help='the namespace to set limits for')
+    subcmd.add_argument('--invocationsPerMinute', help='invocations per minute allowed', type=int)
+    subcmd.add_argument('--firesPerMinute', help='trigger fires per minute allowed', type=int)
+    subcmd.add_argument('--concurrentInvocations', help='concurrent invocations allowed for this namespace', type=int)
 
     propmenu = subparsers.add_parser('db', help='work with dbs')
     subparser = propmenu.add_subparsers(title='available commands', dest='subcmd')
@@ -165,6 +176,13 @@ def dbCmd(args, props):
 def syslogCmd(args, props):
     if args.subcmd == 'get':
         return getLogsCmd(args, props)
+    else:
+        print('unknown command')
+        return 2
+
+def limitsCmd(args, props):
+    if args.subcmd == 'set':
+        return setLimitsCmd(args, props)
     else:
         print('unknown command')
         return 2
@@ -275,6 +293,9 @@ def listUserCmd(args, props):
         return 1
 
 def getSubjectFromDb(args, props):
+    return getDocumentFromDb(props, args.subject, args.verbose)
+
+def getDocumentFromDb(props, doc, verbose):
     protocol = props[DB_PROTOCOL]
     host     = props[DB_HOST]
     port     = props[DB_PORT]
@@ -287,14 +308,14 @@ def getSubjectFromDb(args, props):
         'host'    : host,
         'port'    : port,
         'database': database,
-        'subject' : args.subject
+        'subject' : doc
     }
 
     headers = {
         'Content-Type': 'application/json',
     }
 
-    res = request('GET', url, headers=headers, auth='%s:%s' % (username, password), verbose=args.verbose)
+    res = request('GET', url, headers=headers, auth='%s:%s' % (username, password), verbose=verbose)
     if res.status == 200:
         doc = json.loads(res.read())
         return (doc, res)
@@ -457,6 +478,26 @@ def unblockUserCmd(args, props):
             return 1
     else:
         print('Failed to get subject (%s)' % res.read().strip())
+        return 1
+
+def setLimitsCmd(args, props):
+    argsDict = vars(args)
+    docId = args.namespace + "/limits"
+    (dbDoc, res) = getDocumentFromDb(props, urllib.quote_plus(docId), args.verbose)
+    doc = dbDoc or {'_id': docId}
+
+    limits = ['invocationsPerMinute', 'firesPerMinute', 'concurrentInvocations']
+    for limit in limits:
+        givenLimit = argsDict.get(limit)
+        toSet = givenLimit if givenLimit != None else doc.get(limit)
+        if toSet != None:
+            doc[limit] = toSet
+
+    res = insertIntoDatabase(props, doc, args.verbose)
+    if res.status in [201, 202]:
+        print('Limits successfully set for "%s"' % args.namespace)
+    else:
+        print('Failed to set limits (%s)' % res.read().strip())
         return 1
 
 def getDbCmd(args, props):


### PR DESCRIPTION
This adds the ability to override the rate/concurrency related limits of the system on a per-namespace basis to be able to adapt to specific user needs.

Implementation:
User defined throttles are placed in an extra document in couchdb, $namespace/limits. That document is automatically processed by the existing view, thus no extra request is needed. If no such document exist, default limits will apply.

**Todo:**

- [x] Tests
- [x] Add admin functionality to `wskadmin`