### PR TITLE
Update README.md with instructions to get nginx container running

### DIFF
--- a/tools/ubuntu-setup/README.md
+++ b/tools/ubuntu-setup/README.md
@@ -37,6 +37,14 @@ Follow the instructions in [ansible/README.md](../../ansible/README.md) to deplo
 Once deployed, several Docker containers will be running in your machine.
 You can check that containers are running by using the docker cli with the command `docker ps`.
 
+## Run wskdev edge
+
+At this point, you should have all the docker containers running except for the nginx container.  To launch the nginx container, run:
+
+```
+$ ./bin/wskdev edge
+```
+
 ### Configure the CLI
 Follow instructions in [Configure CLI](../../docs/cli.md). The API host
 should be `172.17.0.1` or more formally, the IP of the `edge` host from the


### PR DESCRIPTION
I needed to follow the instructions in https://github.com/apache/incubator-openwhisk/issues/2304#issuecomment-304560475 to get it fully working.  Before running this, I was getting errors connecting to port 443, since there was no nginx container.