### PR TITLE
Invoker Kafka topics are created via the Invoker Docker image.

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -127,6 +127,8 @@ registry:
   confdir: "{{ config_root_dir }}/registry"
 
 kafka:
+  replication_factor: "{{ kafka_replication_factor | default(1) }}"
+  partitions: "{{ kafka_partitions | default(1) }}"
   version: 0.10.2.1
   port: 9092
   ras:

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -76,6 +76,14 @@
         -e SERVICE_CHECK_INTERVAL=15s
         -e JAVA_OPTS=-Xmx{{ invoker.heap }}
         -e INVOKER_OPTS='{{ invoker.arguments }}'
+        -e INVOKER_INDEX={{ groups['invokers'].index(inventory_hostname) }}
+        -e REPLICATION_FACTOR={{ kafka.replication_factor}}
+        -e PARTITIONS={{ kafka.partitions }}
+        -e ZOOKEEPER_HOST={{ groups['kafka']|first }}
+        -e ZOOKEEPER_PORT={{ zookeeper.port }}
+        -e KAFKA_TOPICS_INVOKER_RETENTIONBYTES={{ kafka.topics.invoker.retentionBytes }}
+        -e KAFKA_TOPICS_INVOKER_RETENTIONMS={{ kafka.topics.invoker.retentionMS }}
+        -e KAFKA_TOPICS_INVOKER_SEGMENTBYTES={{ kafka.topics.invoker.segmentBytes }}
         -v /sys/fs/cgroup:/sys/fs/cgroup
         -v /run/runc:/run/runc
         -v {{ whisk_logs_dir }}/invoker{{ groups['invokers'].index(inventory_hostname) }}:/logs
@@ -83,7 +91,7 @@
         -v {{ docker_sock | default('/var/run/docker.sock') }}:/var/run/docker.sock
         -p {{ invoker.port + groups['invokers'].index(inventory_hostname) }}:8080
         {{ docker_registry }}{{ docker.image.prefix }}/invoker:{{ docker.image.tag }}
-        /bin/sh -c "exec /invoker/bin/invoker {{ groups['invokers'].index(inventory_hostname) }} >> /logs/invoker{{ groups['invokers'].index(inventory_hostname) }}_logs.log 2>&1"
+        /bin/sh -c "/invoker.sh >> /logs/invoker{{ groups['invokers'].index(inventory_hostname) }}_logs.log 2>&1"
   when: invokerInfo.json|length == 0
 
 # todo: re-enable docker_container module once https://github.com/ansible/ansible-modules-core/issues/5054 is resolved

--- a/ansible/roles/kafka/tasks/deploy.yml
+++ b/ansible/roles/kafka/tasks/deploy.yml
@@ -62,10 +62,3 @@
   register: command_result
   failed_when: "not ('Created topic' in command_result.stdout or 'already exists' in command_result.stdout)"
   changed_when: "'Created topic' in command_result.stdout"
-
-- name: create the invoker topics
-  shell: "docker exec kafka bash -c 'unset JMX_PORT; kafka-topics.sh --create --topic invoker{{ item.0 }} --replication-factor 1 --partitions 1 --zookeeper {{ inventory_hostname }}:{{ zookeeper.port }} --config retention.bytes={{ kafka.topics.invoker.retentionBytes }} --config retention.ms={{ kafka.topics.invoker.retentionMS }} --config segment.bytes={{ kafka.topics.invoker.segmentBytes }}'"
-  with_indexed_items: "{{ groups['invokers'] }}"
-  register: command_result
-  failed_when: "not ('Created topic' in command_result.stdout or 'already exists' in command_result.stdout)"
-  changed_when: "'Created topic' in command_result.stdout"

--- a/core/invoker/Dockerfile
+++ b/core/invoker/Dockerfile
@@ -11,8 +11,24 @@ rm -f docker-${DOCKER_VERSION}.tgz && \
 chmod +x /usr/bin/docker && \
 chmod +x /usr/bin/docker-runc
 
+# Copy the Invoker built from gradle
 COPY build/distributions/invoker.tar ./
 RUN tar xf invoker.tar && \
 rm -f invoker.tar
 
 EXPOSE 8080
+
+# Download Kafka
+ENV KAFKA_VERSION=0.10.0.1
+ENV KAFKA_RELEASE=kafka_2.11-0.10.0.1.tgz
+RUN wget --no-verbose -P /tmp http://www.us.apache.org/dist/kafka/${KAFKA_VERSION}/${KAFKA_RELEASE}
+
+# untar Kafka to /kafka
+RUN mkdir /kafka
+RUN tar -xf /tmp/${KAFKA_RELEASE} -C /kafka --strip=1
+
+# remove Kafka tarball
+RUN rm /tmp/${KAFKA_RELEASE}
+
+# Copy the init script
+COPY invoker.sh /invoker.sh

--- a/core/invoker/invoker.sh
+++ b/core/invoker/invoker.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -x
+
+echo "Create invoker topics"
+OUTPUT=$(/kafka/bin/kafka-topics.sh --create --topic invoker$INVOKER_INDEX --replication-factor $REPLICATION_FACTOR --partitions $PARTITIONS --zookeeper ${ZOOKEEPER_HOST}:${ZOOKEEPER_PORT} --config retention.bytes=$KAFKA_TOPICS_INVOKER_RETENTIONBYTES --config retention.ms=$KAFKA_TOPICS_INVOKER_RETENTIONMS --config segment.bytes=$KAFKA_TOPICS_INVOKER_SEGMENTBYTES)
+
+if ! ([[ "$OUTPUT" == *"already exists"* ]] || [[ "$OUTPUT" == *"Created topic"* ]]); then
+  echo "Failed to create invoker$i topic"
+  exit 1
+fi
+
+# Start command is defined in deployment option, Ansible, Kubernetes, etc
+exec /invoker/bin/invoker $INVOKER_INDEX


### PR DESCRIPTION
This PR will move the logic for Invoker topics from the Ansible scripts to the Invoker Docker image. Keeping all of the health checks the same. 