### PR TITLE
don't attempt to run registrator if already running

### DIFF
--- a/ansible/roles/consul/tasks/deploy.yml
+++ b/ansible/roles/consul/tasks/deploy.yml
@@ -79,6 +79,7 @@
 
 - name: start registrator using docker cli
   shell: >
+        docker top registrator ||
         docker run -d
         --name registrator
         --hostname registrator


### PR DESCRIPTION
While attempting to redeploy after a reload of my Vagrant machine, I was encountering trouble.

It appears the `openwhisk` playbook cannot be run twice in succession, because if the `registrator` container is running, `docker run ...` will fail due to a name collision.  I found this frustrating while attempting to debug the issue (#2539).

This change checks to see if the `registrator` container is running, and if so, skips the attempt to manually start it.