### PR TITLE
Clean Up CLI Tests (Review)

### DIFF
--- a/tests/src/test/scala/common/Wsk.scala
+++ b/tests/src/test/scala/common/Wsk.scala
@@ -1006,17 +1006,13 @@ trait WaitFor {
 
 object Wsk {
     private val binaryName = "wsk"
-    private val cliPath = getCLIPath
+    private val cliPath = if (WhiskProperties.useCLIDownload) getDownloadedGoCLIPath else WhiskProperties.getCLIPath
 
     assert((new File(cliPath)).exists, s"did not find $cliPath")
 
     /** What is the path to a downloaded CLI? **/
     private def getDownloadedGoCLIPath = {
         s"${System.getProperty("user.home")}${File.separator}.local${File.separator}bin${File.separator}${binaryName}"
-    }
-
-    private def getCLIPath = {
-        if (WhiskProperties.useCLIDownload) getDownloadedGoCLIPath else WhiskProperties.getCLIPath
     }
 
     def baseCommand = Buffer(cliPath)

--- a/tests/src/test/scala/common/Wsk.scala
+++ b/tests/src/test/scala/common/Wsk.scala
@@ -94,7 +94,7 @@ case class WskPropsV2(
     }
 }
 
-class Wsk() extends RunWskCmd {
+class Wsk extends RunWskCmd {
     implicit val action = new WskAction
     implicit val trigger = new WskTrigger
     implicit val rule = new WskRule
@@ -276,7 +276,6 @@ class WskAction()
     with HasActivation {
 
     override protected val noun = "action"
-    override def baseCommand = Wsk.baseCommand
 
     /**
      * Creates action. Parameters mirror those available in the CLI.
@@ -1007,19 +1006,24 @@ trait WaitFor {
 
 object Wsk {
     private val binaryName = "wsk"
+    private val cliPath = getCLIPath
+
+    exists
 
     /** What is the path to a downloaded CLI? **/
     private def getDownloadedGoCLIPath = {
         s"${System.getProperty("user.home")}${File.separator}.local${File.separator}bin${File.separator}${binaryName}"
     }
 
-    def exists() = {
-        val cliPath = if (WhiskProperties.useCLIDownload) getDownloadedGoCLIPath else WhiskProperties.getCLIPath
+    private def getCLIPath = {
+        if (WhiskProperties.useCLIDownload) getDownloadedGoCLIPath else WhiskProperties.getCLIPath
+    }
+
+    private def exists = {
         assert((new File(cliPath)).exists, s"did not find $cliPath")
     }
 
-    def baseCommand() =
-        if (WhiskProperties.useCLIDownload) Buffer(getDownloadedGoCLIPath) else Buffer(WhiskProperties.getCLIPath)
+    def baseCommand = Buffer(cliPath)
 }
 
 trait RunWskCmd extends Matchers {

--- a/tests/src/test/scala/common/Wsk.scala
+++ b/tests/src/test/scala/common/Wsk.scala
@@ -94,7 +94,7 @@ case class WskPropsV2(
     }
 }
 
-class Wsk extends RunWskCmd {
+class Wsk() extends RunWskCmd {
     implicit val action = new WskAction
     implicit val trigger = new WskTrigger
     implicit val rule = new WskRule
@@ -1008,7 +1008,7 @@ object Wsk {
     private val binaryName = "wsk"
     private val cliPath = getCLIPath
 
-    exists
+    assert((new File(cliPath)).exists, s"did not find $cliPath")
 
     /** What is the path to a downloaded CLI? **/
     private def getDownloadedGoCLIPath = {
@@ -1017,10 +1017,6 @@ object Wsk {
 
     private def getCLIPath = {
         if (WhiskProperties.useCLIDownload) getDownloadedGoCLIPath else WhiskProperties.getCLIPath
-    }
-
-    private def exists = {
-        assert((new File(cliPath)).exists, s"did not find $cliPath")
     }
 
     def baseCommand = Buffer(cliPath)

--- a/tests/src/test/scala/system/basic/WskBasicTests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicTests.scala
@@ -46,10 +46,6 @@ class WskBasicTests
 
     behavior of "Wsk CLI"
 
-    it should "confirm wsk exists" in {
-        Wsk.exists
-    }
-
     it should "reject creating duplicate entity" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             val name = "testDuplicateCreate"

--- a/tests/src/test/scala/system/basic/WskPackageTests.scala
+++ b/tests/src/test/scala/system/basic/WskPackageTests.scala
@@ -44,10 +44,6 @@ class WskPackageTests
 
     behavior of "Wsk Package"
 
-    it should "confirm wsk exists" in {
-        Wsk.exists
-    }
-
     it should "allow creation and deletion of a package" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             val name = "simplepackage"

--- a/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -65,10 +65,6 @@ class WskBasicUsageTests
 
     behavior of "Wsk CLI usage"
 
-    it should "confirm wsk exists" in {
-        Wsk.exists
-    }
-
     it should "show help and usage info" in {
         val stdout = wsk.cli(Seq()).stdout
         stdout should include regex ("""(?i)Usage:""")


### PR DESCRIPTION
Remove unnecessary baseCommand override in WskAction and always ensure that the CLI exists instead of just doing so in a few test suites.