### PR TITLE
Jinja2 version 2.9.6 required for Ansible template processing

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -10,6 +10,7 @@ If you want to deploy OpenWhisk locally using Ansible, you first need to install
 ```
 sudo apt-get install python-pip
 sudo pip install ansible==2.3.0.0
+sudo pip install jinja2==2.9.6
 ```
 
 #### Vagrant users
@@ -21,9 +22,10 @@ You may jump directly to [Deploying Using CouchDB](#deploying-using-couchdb)
 ```
 sudo easy_install pip
 sudo pip install ansible==2.3.0.0
+pip install jinja2==2.9.6
 ```
 Docker for Mac does not provide any official ways to meet some requirements for OpenWhisk.
-You need to depends on the workarounds until Docker provides official methods.
+You need to depend on the workarounds until Docker provides official methods.
 
 If you prefer [Docker-machine](https://docs.docker.com/machine/) to [Docker for mac](https://docs.docker.com/docker-for-mac/), you can follow instructions in [docker-machine/README.md](../tools/macos/docker-machine/README.md).
 

--- a/tools/macos/README.md
+++ b/tools/macos/README.md
@@ -32,7 +32,7 @@ sudo easy_install pip
 # install docker for python
 /usr/local/bin/pip install docker==2.2.1
 # install script prerequisites
-sudo -H pip install ansible==2.3.0.0 jsonschema couchdb' | bash
+sudo -H pip install ansible==2.3.0.0 jinja2==2.9.6 jsonschema couchdb' | bash
 ```
 
 # Build

--- a/tools/macos/docker-machine/README.md
+++ b/tools/macos/docker-machine/README.md
@@ -37,7 +37,7 @@ brew install scala
 # install pip
 sudo easy_install pip
 # install script prerequisites
-sudo -H pip install ansible==2.3.0.0 jsonschema couchdb' | bash
+sudo -H pip install ansible==2.3.0.0 jinja2==2.9.6 jsonschema couchdb' | bash
 ```
 
 # Create and configure Docker machine
@@ -112,6 +112,7 @@ cd /your/path/to/openwhisk
 ```
 brew install python
 pip install ansible==2.3.0.0
+pip install jinja2==2.9.6
 
 cd ansible
 ansible-playbook -i environments/docker-machine setup.yml [-e docker_machine_name=whisk]

--- a/tools/ubuntu-setup/ansible.sh
+++ b/tools/ubuntu-setup/ansible.sh
@@ -9,6 +9,7 @@ sudo apt-get install -y python-dev libffi-dev libssl-dev
 sudo pip install markupsafe
 sudo pip install ansible==2.3.0.0
 sudo pip install docker==2.2.1
+sudo pip install jinja2==2.9.6
 
 ansible --version
 ansible-playbook --version


### PR DESCRIPTION
With an older version of `jinja2`, deployment with Ansible fails.