### PR TITLE
Make reactive containerpool default for all environments.

### DIFF
--- a/ansible/environments/docker-machine/group_vars/all
+++ b/ansible/environments/docker-machine/group_vars/all
@@ -38,4 +38,3 @@ apigw_host_v2: "http://{{ groups['apigateway']|first }}:{{apigateway.port.api}}/
 
 # RunC enablement
 invoker_use_runc: true
-invoker_use_reactive_pool: true

--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -32,7 +32,6 @@ apigw_host_v2: "http://{{ groups['apigateway']|first }}:{{apigateway.port.api}}/
 
 # RunC enablement
 invoker_use_runc: true
-invoker_use_reactive_pool: true
 
 controller_arguments: '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1098'
 invoker_arguments: "{{ controller_arguments }}"

--- a/ansible/environments/mac/group_vars/all
+++ b/ansible/environments/mac/group_vars/all
@@ -32,7 +32,6 @@ apigw_host_v2: "http://{{ groups['apigateway']|first }}:{{apigateway.port.api}}/
 
 # RunC enablement
 invoker_use_runc: true
-invoker_use_reactive_pool: true
 
 controller_arguments: '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1098'
 invoker_arguments: "{{ controller_arguments }}"

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -149,7 +149,7 @@ invoker:
   serializeDockerOp: true
   serializeDockerPull: true
   useRunc: false
-  useReactivePool: "{{ invoker_use_reactive_pool | default(false) }}"
+  useReactivePool: "{{ invoker_use_reactive_pool | default(true) }}"
   instances: "{{ groups['invokers'] | length }}"
 
 nginx:


### PR DESCRIPTION
Custom environments now need to opt-in to the old pool by using `invoker_use_reactive_pool: false` explicitly.