### PR TITLE
Clean up limit records

### DIFF
--- a/tests/src/test/scala/limits/ThrottleTests.scala
+++ b/tests/src/test/scala/limits/ThrottleTests.scala
@@ -307,9 +307,13 @@ class NamespaceSpecificThrottleTests
     wskadmin.cli(Seq("limits", "set", oneProps.namespace, "--invocationsPerMinute", "1", "--firesPerMinute", "1"))
 
     override def afterAll() = {
-        disposeAdditionalTestSubject(zeroProps.namespace)
-        disposeAdditionalTestSubject(zeroConcProps.namespace)
-        disposeAdditionalTestSubject(oneProps.namespace)
+        Seq(zeroProps, zeroConcProps, oneProps).foreach { wp =>
+            val ns = wp.namespace
+            disposeAdditionalTestSubject(ns)
+            withClue(s"failed to delete temporary limits for $ns") {
+                wskadmin.cli(Seq("limits", "delete", ns))
+            }
+        }
     }
 
     behavior of "Namespace-specific throttles"

--- a/tests/src/test/scala/whisk/core/admin/WskAdminTests.scala
+++ b/tests/src/test/scala/whisk/core/admin/WskAdminTests.scala
@@ -153,4 +153,21 @@ class WskAdminTests
             wskadmin.cli(Seq("user", "delete", subject)).stdout should include("Subject deleted")
         }
     }
+
+    it should "adjust throttles for namespace" in {
+        val wskadmin = new RunWskAdminCmd {}
+        val subject = Subject().asString
+        try {
+            // set some limits
+            wskadmin.cli(Seq("limits", "set", subject, "--invocationsPerMinute", "1", "--firesPerMinute", "2", "--concurrentInvocations", "3"))
+            // check correctly set
+            val lines = wskadmin.cli(Seq("limits", "get", subject)).stdout.lines.toSeq
+            lines should have size 3
+            lines(0) shouldBe "invocationsPerMinute = 1"
+            lines(1) shouldBe "firesPerMinute = 2"
+            lines(2) shouldBe "concurrentInvocations = 3"
+        } finally {
+            wskadmin.cli(Seq("limits", "delete", subject)).stdout should include("Limits deleted")
+        }
+    }
 }

--- a/tools/admin/wskadmin
+++ b/tools/admin/wskadmin
@@ -127,6 +127,12 @@ def parseArgs():
     subcmd.add_argument('--firesPerMinute', help='trigger fires per minute allowed', type=int)
     subcmd.add_argument('--concurrentInvocations', help='concurrent invocations allowed for this namespace', type=int)
 
+    subcmd = subparser.add_parser('get', help='get limits for a given namespace (if none exist, system defaults apply)')
+    subcmd.add_argument('namespace', help='the namespace to get limits for')
+
+    subcmd = subparser.add_parser('delete', help='delete limits for a given namespace (system defaults apply)')
+    subcmd.add_argument('namespace', help='the namespace to delete limits for')
+
     propmenu = subparsers.add_parser('db', help='work with dbs')
     subparser = propmenu.add_subparsers(title='available commands', dest='subcmd')
 
@@ -183,6 +189,10 @@ def syslogCmd(args, props):
 def limitsCmd(args, props):
     if args.subcmd == 'set':
         return setLimitsCmd(args, props)
+    elif args.subcmd == 'get':
+        return getLimitsCmd(args, props)
+    elif args.subcmd == 'delete':
+        return deleteLimitsCmd(args, props)
     else:
         print('unknown command')
         return 2
@@ -498,6 +508,57 @@ def setLimitsCmd(args, props):
         print('Limits successfully set for "%s"' % args.namespace)
     else:
         print('Failed to set limits (%s)' % res.read().strip())
+        return 1
+
+def getLimitsCmd(args, props):
+    argsDict = vars(args)
+    docId = args.namespace + "/limits"
+    (dbDoc, res) = getDocumentFromDb(props, urllib.quote_plus(docId), args.verbose)
+
+    if dbDoc is not None:
+        limits = ['invocationsPerMinute', 'firesPerMinute', 'concurrentInvocations']
+        for limit in limits:
+            givenLimit = dbDoc.get(limit)
+            if givenLimit != None:
+                print('%s = %s' % (limit, givenLimit))
+    else:
+        print('Failed to get limits (%s)' % res.read().strip())
+        return 1
+
+def deleteLimitsCmd(args, props):
+    argsDict = vars(args)
+    docId = urllib.quote_plus(args.namespace + "/limits")
+    (dbDoc, res) = getDocumentFromDb(props, docId, args.verbose)
+
+    if dbDoc is None:
+        print('Failed to delete limits (%s)' % res.read().strip())
+        return 1
+
+    protocol = props[DB_PROTOCOL]
+    host     = props[DB_HOST]
+    port     = props[DB_PORT]
+    username = props[DB_USERNAME]
+    password = props[DB_PASSWORD]
+    database = props[DB_WHISK_AUTHS]
+
+    url = '%(protocol)s://%(host)s:%(port)s/%(database)s/%(docid)s?rev=%(rev)s' % {
+        'protocol': protocol,
+        'host'    : host,
+        'port'    : port,
+        'database': database,
+        'docid'   : docId,
+        'rev'     : dbDoc['_rev']
+    }
+
+    headers = {
+        'Content-Type': 'application/json',
+    }
+
+    res = request('DELETE', url, headers=headers, auth='%s:%s' % (username, password), verbose=args.verbose)
+    if res.status in [200, 202]:
+        print('Limits deleted')
+    else:
+        print('Failed to delete limits (%s)' % res.read().strip())
         return 1
 
 def getDbCmd(args, props):


### PR DESCRIPTION
I noticed that the new throttle tests don't clean up correctly - the limits docs are left in the database. This patch adds `wskadmin limits [get, delete]`, updates the tests to delete the limits after testing, and adds tests for the new admin functions.

PG2/1889 🔵 
Can verify cleanup https://app.box.com/v/openwhisk-travis-logs/file/205104572185.