### PR TITLE
Fix bug on set_fact relative ansible task

### DIFF
--- a/ansible/roles/cli/tasks/download_openwhisk_cli.yml
+++ b/ansible/roles/cli/tasks/download_openwhisk_cli.yml
@@ -37,9 +37,10 @@
     headers=""
   when: openwhisk_cli.remote.headers is not defined
 
-- name: "set the instance volume_dir"
-  set_fact:
+- name: "set the volume_dir"
+  vars:
     instance: "{{instances | selectattr('name', 'equalto', 'db') | list | first}}"
+  set_fact:
     volume_dir: "{{ instance.volume.fsmount | default( '/mnt/' + group_names|first, true ) }}:/usr/local/var/lib/couchdb"
   when: (block_device is defined) and (block_device in disk_status.stdout)
 

--- a/ansible/roles/couchdb/tasks/deploy.yml
+++ b/ansible/roles/couchdb/tasks/deploy.yml
@@ -10,8 +10,10 @@
   register: disk_status
   when: block_device is defined
 
-- set_fact:
+- name: "set the volume_dir"
+  vars:
     instance: "{{instances | selectattr('name', 'equalto', 'db') | list | first}}"
+  set_fact:
     volume_dir: "{{ instance.volume.fsmount | default( '/mnt/' + group_names|first, true ) }}:/usr/local/var/lib/couchdb"
   when: (block_device is defined) and (block_device in disk_status.stdout)
 


### PR DESCRIPTION
Fix bug that one variable can't use another variable which is defined
in same set_fact statement.

ansible version: 2.3.0.0
bug description:

fatal: [172.17.0.1]: FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'instance' is undefined\n\nThe error appears to have been in '/home/irteam/jenkins/workspace/lambda/ansible/roles/couchdb/tasks/deploy.yml': line 13, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- set_fact:\n  ^ here\n"}


above error's codes as followings:
```
- set_fact:
    instance: "{{instances | selectattr('name', 'equalto', 'db') | list | first}}"
    volume_dir: "{{ instance.volume.fsmount | default( '/mnt/' + group_names|first, true ) }}:/usr/local/var/lib/couchdb"
  when: (block_device is defined) and (block_device in disk_status.stdout)
```
It seesm the `volume_dir` can't use variable `instance` which is defined in same set_fact statement.