### PR TITLE
Execute stat command on localhost

### DIFF
--- a/ansible/roles/cli/tasks/copy_local_openwhisk_cli.yml
+++ b/ansible/roles/cli/tasks/copy_local_openwhisk_cli.yml
@@ -3,6 +3,7 @@
 # Copy the cli binaries to Nginx directory
 
 - stat: path={{ openwhisk_cli.local.location }}/{{ item }}
+  delegate_to: localhost
   register: binary_path
 
 - name: "copy the local binaries from a local directory to Nginx directory"


### PR DESCRIPTION
This closes #2560

`stat` command runs on the target host.
In local deployment, it's not a problem. But in distributed environment, this command, `stat: path={{ openwhisk_cli.local.location }}/{{ item }}` will run on target host and be failed.

We need to force this command to run on localhost(Ansible host).