### PR TITLE
Support multiple response header values in raw web actions

### DIFF
--- a/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
@@ -215,9 +215,9 @@ protected[core] object WhiskWebActionsApi extends Directives {
         Try {
             val JsObject(fields) = result
             val headers = fields.get("headers").map {
-                case JsObject(hs) => hs.map {
+                case JsObject(hs) => hs.flatMap {
                     case (k, v) => headersFromJson(k, v)
-                }.flatten.toList
+                }.toList
 
                 case _ => throw new Throwable("Invalid header")
             } getOrElse List()
@@ -252,7 +252,7 @@ protected[core] object WhiskWebActionsApi extends Directives {
         case JsString(v)  => Seq(RawHeader(k, v))
         case JsBoolean(v) => Seq(RawHeader(k, v.toString))
         case JsNumber(v)  => Seq(RawHeader(k, v.toString))
-        case JsArray(v)   => v.map(headersFromJson(k, _:JsValue)).flatten
+        case JsArray(v)   => v.flatMap(inner => headersFromJson(k, inner))
         case _            => throw new Throwable("Invalid header")
     }
 

--- a/docs/webactions.md
+++ b/docs/webactions.md
@@ -70,6 +70,22 @@ function main() {
 }
 ```
 
+Or sets multiple cookies:
+```javascript
+function main() {
+  return { 
+    headers: { 
+      'Set-Cookie': [
+        'UserID=Jane; Max-Age=3600; Version=',
+        'SessionID=asdfgh123456; Path = /'
+      ],
+      'Content-Type': 'text/html'
+    }, 
+    statusCode: 200,
+    body: '<html><body><h3>hello</h3></body></html>' }
+}
+```
+
 Or returns an `image/png`:
 ```javascript
 function main() {
@@ -97,7 +113,7 @@ It is important to be aware of the [response size limit](reference.md) for actio
 
 An OpenWhisk action that is not a web action requires both authentication and must respond with a JSON object. In contrast, web actions may be invoked without authentication, and may be used to implement HTTP handlers that respond with _headers_, _statusCode_, and _body_ content of different types. The web action must still return a JSON object, but the OpenWhisk system (namely the `controller`) will treat a web action differently if its result includes one or more of the following as top level JSON properties:
 
-1. `headers`: a JSON object where the keys are header-names and the values are string values for those headers (default is no headers).
+1. `headers`: a JSON object where the keys are header-names and the values are string, number, or boolean values for those headers (default is no headers). To send multiple values for a single header, the header's value should be a JSON array of values.
 2. `statusCode`: a valid HTTP status code (default is 200 OK).
 3. `body`: a string which is either plain text or a base64 encoded string for binary data (default is empty response).
 

--- a/tests/dat/actions/multipleHeaders.js
+++ b/tests/dat/actions/multipleHeaders.js
@@ -1,0 +1,8 @@
+function main() {
+    return {
+        headers: {
+            "Set-Cookie": ["a=b", "c=d"]
+        },
+        code: 200
+    }
+}

--- a/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
@@ -27,6 +27,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.junit.JUnitRunner
 
 import com.jayway.restassured.RestAssured
+import com.jayway.restassured.response.Header
 
 import common.TestHelpers
 import common.TestUtils
@@ -313,8 +314,9 @@ trait WskWebActionsTests
 
             response.statusCode shouldBe 200
             val cookieHeaders = response.headers.getList("Set-Cookie")
-            cookieHeaders.size shouldBe 2
-            cookieHeaders.get(0).getValue shouldBe "a=b"
-            cookieHeaders.get(1).getValue shouldBe "c=d"
+            cookieHeaders should contain allOf (
+                new Header("Set-Cookie", "a=b"),
+                new Header("Set-Cookie", "c=d")
+            )
     }
 }

--- a/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
@@ -1127,6 +1127,27 @@ trait WebActionsApiTests extends ControllerTestCommon with BeforeAndAfterEach wi
                 }
         }
 
+        it should s"support multiple values for headers (auth? ${creds.isDefined})" in {
+            implicit val tid = transid()
+
+            Seq(s"$systemId/proxy/export_c.http").
+                foreach { path =>
+                    invocationsAllowed += 1
+                    actionResult = Some(
+                        JsObject(
+                            "headers" -> JsObject(
+                                "Set-Cookie" -> JsArray(JsString("a=b"), JsString("c=d; Path = /")))))
+
+                    Options(s"$testRoutePath/$path") ~> sealRoute(routes(creds)) ~> check {
+                        withClue(headers) {
+                            headers.length shouldBe 2
+                            headers(0).toString shouldBe "Set-Cookie: a=b"
+                            headers(1).toString shouldBe "Set-Cookie: c=d; Path = /"
+                        }
+                    }
+                }
+        }
+
         it should s"invoke action with options verb without custom options (auth? ${creds.isDefined})" in {
             implicit val tid = transid()
             customOptions = false

--- a/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
@@ -1139,11 +1139,10 @@ trait WebActionsApiTests extends ControllerTestCommon with BeforeAndAfterEach wi
                                 "Set-Cookie" -> JsArray(JsString("a=b"), JsString("c=d; Path = /")))))
 
                     Options(s"$testRoutePath/$path") ~> sealRoute(routes(creds)) ~> check {
-                        withClue(headers) {
-                            headers.length shouldBe 2
-                            headers(0).toString shouldBe "Set-Cookie: a=b"
-                            headers(1).toString shouldBe "Set-Cookie: c=d; Path = /"
-                        }
+                        headers should contain allOf (
+                            HttpHeaders.RawHeader("Set-Cookie", "a=b"),
+                            HttpHeaders.RawHeader("Set-Cookie", "c=d; Path = /")
+                        )
                     }
                 }
         }


### PR DESCRIPTION
This change allows multiple response header values to be set in raw
web actions by using a JSON array as the header value. For example:

```
function main() {
  return {
    headers: {
      "Set-Cookie": ["a=b", "c=d"]
    },
    code: 200
  }
}
```

I have signed the Apache CLA as "Benjamin M. Browning".