### PR TITLE
Add the image filter when get invoker info

### DIFF
--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -43,7 +43,7 @@
   when: whisk_version_name != "mac"
 
 - name: get running invoker information
-  uri: url="http://{{ inventory_hostname }}:{{ docker.port }}/containers/json?filters={{ '{"name":[ "invoker" ]}' | urlencode }}" return_content=yes
+  uri: url="http://{{ inventory_hostname }}:{{ docker.port }}/containers/json?filters={{ '{"name":[ "invoker" ],"ancestor":[ "invoker" ]}' | urlencode }}" return_content=yes
   register: invokerInfo
 
 - name: determine if more than one invoker is running


### PR DESCRIPTION
The `nodejs6action` container is created by invoker which test the invoker whether worked well, sometimes, 
its name may has `invoker` substring, for example as below
```
37d73d962120        whisk/nodejs6action:latest   "/bin/sh -c 'node --e"   13 minutes ago      Up 13 minutes                                                                          wsk0_3_whisksystem_invokerHealthTestAction0
2581c86d6ada        whisk/invoker:latest         "/bin/sh -c 'exec /in"   13 minutes ago      Up 13 minutes       0.0.0.0:12001->8080/tcp                                            invoker0
```
If above situation happens, and execute `ansible-playbook -i environments/<env>  invoker.yml` again in this node, below ansible task's revokerInfo's length will be greater than 1
```
- name: get running invoker information
  uri: url="http://{{ inventory_hostname }}:{{ docker.port }}/containers/json?filters={{ '{"name":[ "invoker" ],"ancestor":[ "invoker" ]}' | urlencode }}" return_content=yes
  register: invokerInfo
```
then, below ansible task will be failed
```
TASK [invoker : determine if more than one invoker is running] ******************************************************************************
Monday 07 August 2017  22:15:36 -0400 (0:00:00.314)       0:00:02.154 ********* 
fatal: [10.34.135.216]: FAILED! => {"changed": false, "failed": true, "msg": "more than one invoker is running"}
```

How to solve this problem, i think the best way is `add image filter` to search exactly 