### PR TITLE
Add the fundamental framework of REST invocation for test cases

### DIFF
--- a/tests/src/test/scala/common/TestUtils.java
+++ b/tests/src/test/scala/common/TestUtils.java
@@ -212,7 +212,7 @@ public class TestUtils {
         public final String stdout;
         public final String stderr;
 
-        private RunResult(int exitCode, String stdout, String stderr) {
+        protected RunResult(int exitCode, String stdout, String stderr) {
             this.exitCode = exitCode;
             this.stdout = stdout;
             this.stderr = stderr;

--- a/tests/src/test/scala/common/Wsk.scala
+++ b/tests/src/test/scala/common/Wsk.scala
@@ -62,14 +62,14 @@ import whisk.utils.retry
  * It also sets the apihost and apiversion explicitly to avoid ambiguity with
  * a local property file if it exists.
  */
-class Wsk() extends RunWskCmd {
-  implicit val action = new WskAction
-  implicit val trigger = new WskTrigger
-  implicit val rule = new WskRule
-  implicit val activation = new WskActivation
-  implicit val pkg = new WskPackage
-  implicit val namespace = new WskNamespace
-  implicit val api = new WskApi
+class Wsk() extends RunWskCmd with BaseWsk {
+  override implicit val action = new WskAction
+  override implicit val trigger = new WskTrigger
+  override implicit val rule = new WskRule
+  override implicit val activation = new WskActivation
+  override implicit val pkg = new WskPackage
+  override implicit val namespace = new WskNamespace
+  override implicit val api = new WskApi
 }
 
 trait ListOrGetFromCollectionCLI extends BaseListOrGetFromCollection {

--- a/tests/src/test/scala/common/rest/WskRest.scala
+++ b/tests/src/test/scala/common/rest/WskRest.scala
@@ -1,0 +1,1458 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common.rest
+
+import java.io.File
+import java.time.Clock
+import java.time.Instant
+import java.util.Base64
+
+import org.apache.commons.io.FileUtils
+import org.scalatest.Matchers
+import org.scalatest.FlatSpec
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.Span.convertDurationToSpan
+
+import scala.Left
+import scala.Right
+import scala.collection.JavaConversions.mapAsJavaMap
+import scala.collection.mutable.Buffer
+import scala.collection.immutable.Seq
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.Future
+import scala.language.postfixOps
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+import scala.util.{ Failure, Success }
+
+import akka.http.scaladsl.model.StatusCode
+import akka.http.scaladsl.model.StatusCodes.Accepted
+import akka.http.scaladsl.model.StatusCodes.NotFound
+import akka.http.scaladsl.model.StatusCodes.BadRequest
+import akka.http.scaladsl.model.StatusCodes.OK
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.HttpMethod
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.headers.Authorization
+import akka.http.scaladsl.model.HttpEntity
+import akka.http.scaladsl.model.ContentTypes
+import akka.http.scaladsl.Http
+
+import akka.http.scaladsl.model.headers.BasicHttpCredentials
+import akka.http.scaladsl.model.Uri
+import akka.http.scaladsl.model.Uri.Path
+
+import akka.http.scaladsl.model.HttpMethods.DELETE
+import akka.http.scaladsl.model.HttpMethods.GET
+import akka.http.scaladsl.model.HttpMethods.POST
+import akka.http.scaladsl.model.HttpMethods.PUT
+
+import akka.stream.ActorMaterializer
+
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+import spray.json.JsObject
+import spray.json.JsValue
+import spray.json.pimpString
+
+import common._
+import common.BaseDeleteFromCollection
+import common.BaseListOrGetFromCollection
+import common.HasActivation
+import common.RunWskCmd
+import common.TestUtils
+import common.TestUtils.SUCCESS_EXIT
+import common.TestUtils.DONTCARE_EXIT
+import common.TestUtils.ANY_ERROR_EXIT
+import common.TestUtils.DONTCARE_EXIT
+import common.TestUtils.RunResult
+import common.WaitFor
+import common.WhiskProperties
+import common.WskActorSystem
+import common.WskProps
+
+import whisk.core.entity.ByteSize
+import whisk.utils.retry
+
+class WskRest() extends RunWskRestCmd with BaseWsk {
+    override implicit val action = new WskRestAction
+    override implicit val trigger = new WskRestTrigger
+    override implicit val rule = new WskRestRule
+    override implicit val activation = new WskRestActivation
+    override implicit val pkg = new WskRestPackage
+    override implicit val namespace = new WskRestNamespace
+    override implicit val api = new WskRestApi
+}
+
+trait ListOrGetFromCollectionRest extends BaseListOrGetFromCollection {
+    self: RunWskRestCmd =>
+
+    /**
+     * List entities in collection.
+     *
+     * @param namespace (optional) if specified must be  fully qualified namespace
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    override def list(namespace: Option[String] = None,
+                      limit: Option[Int] = None,
+                      nameSort: Option[Boolean] = None,
+                      expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
+        val (ns, name) = getNamespaceActionName(resolve(namespace))
+
+        val pathToList = s"$basePath/namespaces/$ns/$noun"
+        val entPath =
+            if (name != "") Path(s"$pathToList/$name/")
+            else Path(s"$pathToList")
+        val paramMap = Map[String, String]() ++ { Map("skip" -> "0".toString, "docs" -> true.toString) } ++ {
+            limit map { l =>
+                Map("limit" -> l.toString)
+            } getOrElse Map[String, String]("limit" -> "30".toString)
+        }
+        val resp = getWhiskEntity(entPath, paramMap).futureValue
+        val r = new RestResult(resp.status, getRespData(resp))
+        validateStatusCode(expectedExitCode, r.statusCode.intValue)
+        r
+    }
+
+    /**
+     * Gets entity from collection.
+     *
+     * @param name either a fully qualified name or a simple entity name
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    override def get(name: String,
+                     expectedExitCode: Int = OK.intValue,
+                     summary: Boolean = false,
+                     fieldFilter: Option[String] = None,
+                     url: Option[Boolean] = None)(implicit wp: WskProps): RestResult = {
+        val (ns, entity) = getNamespaceActionName(name)
+        val entPath = Path(s"$basePath/namespaces/$ns/$noun/$entity")
+        val resp = getWhiskEntity(entPath)(wp).futureValue
+        val r = new RestResult(resp.status, getRespData(resp))
+        validateStatusCode(expectedExitCode, r.statusCode.intValue)
+        r
+    }
+}
+
+trait DeleteFromCollectionRest extends BaseDeleteFromCollection {
+    self: RunWskRestCmd =>
+
+    /**
+     * Deletes entity from collection.
+     *
+     * @param name either a fully qualified name or a simple entity name
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    override def delete(entity: String, expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
+        val r = deleteEntity(entity)(wp)
+        validateStatusCode(expectedExitCode, r.statusCode.intValue)
+        r
+    }
+
+    def deleteEntity(name: String)(implicit wp: WskProps): RestResult = {
+        val (ns, entity) = getNamespaceActionName(name)
+        val path = Path(s"$basePath/namespaces/$ns/$noun/$entity")
+        val resp = deleteEntity(path)(wp)
+        new RestResult(resp.status, getRespData(resp))
+    }
+
+    /**
+     * Deletes entity from collection but does not assert that the command succeeds.
+     * Use this if deleting an entity that may not exist and it is OK if it does not.
+     *
+     * @param name either a fully qualified name or a simple entity name
+     */
+    override def sanitize(name: String)(implicit wp: WskProps): RestResult = {
+        delete(name, DONTCARE_EXIT)
+    }
+}
+
+trait HasActivationRest extends HasActivation {
+
+    /**
+     * Extracts activation id from invoke (action or trigger) or activation get
+     */
+    override def extractActivationId(result: RunResult): Option[String] = {
+        extractActivationIdFromInvoke(result.asInstanceOf[RestResult])
+    }
+
+    /**
+     * Extracts activation id from 'wsk action invoke' or 'wsk trigger invoke'
+     */
+    private def extractActivationIdFromInvoke(result: RestResult): Option[String] = {
+        Try {
+            val activationID =
+                if ((result.statusCode == OK) || (result.statusCode == Accepted)) result.getField("activationId") else ""
+            activationID
+        } toOption
+    }
+}
+
+class WskRestAction
+    extends RunWskRestCmd
+    with ListOrGetFromCollectionRest
+    with DeleteFromCollectionRest
+    with HasActivationRest
+    with BaseAction {
+
+    override protected val noun = "actions"
+    override implicit val config = PatienceConfig(100 seconds, 15 milliseconds)
+
+    /**
+     * Creates action. Parameters mirror those available in the REST.
+     *
+     * @param name either a fully qualified name or a simple entity name
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    override def create(
+        name: String,
+        artifact: Option[String],
+        kind: Option[String] = None, // one of docker, copy, sequence or none for autoselect else an explicit type
+        main: Option[String] = None,
+        docker: Option[String] = None,
+        parameters: Map[String, JsValue] = Map(),
+        annotations: Map[String, JsValue] = Map(),
+        parameterFile: Option[String] = None,
+        annotationFile: Option[String] = None,
+        timeout: Option[Duration] = None,
+        memory: Option[ByteSize] = None,
+        logsize: Option[ByteSize] = None,
+        shared: Option[Boolean] = None,
+        update: Boolean = false,
+        web: Option[String] = None,
+        expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
+
+        val (namespace, actName) = getNamespaceActionName(name)
+        var exec = Map[String, JsValue]()
+        var code = ""
+        var kindType = ""
+
+        val (ext, artifactFile) = artifact map { a =>
+            (getExt(a), a)
+        } getOrElse (null, "")
+
+        ext match {
+            case ".jar" => {
+                kindType = "java:default"
+                val jar = FileUtils.readFileToByteArray(new File(artifactFile))
+                code = Base64.getEncoder.encodeToString(jar)
+            }
+            case ".zip" => {
+                val zip = FileUtils.readFileToByteArray(new File(artifactFile))
+                code = Base64.getEncoder.encodeToString(zip)
+            }
+            case ".js" => {
+                kindType = "nodejs:default"
+                code = FileUtils.readFileToString(new File(artifactFile))
+            }
+            case ".py" => {
+                kindType = "python:default"
+                code = FileUtils.readFileToString(new File(artifactFile))
+            }
+            case ".swift" => {
+                kindType = "swift:default"
+                code = FileUtils.readFileToString(new File(artifactFile))
+            }
+            case ".php" => {
+                kindType = "php:default"
+                code = FileUtils.readFileToString(new File(artifactFile))
+            }
+            case _ =>
+        }
+
+        kindType = docker map { d =>
+            "blackbox"
+        } getOrElse kindType
+
+        var (params, annos) = getParamsAnnos(parameters, annotations, parameterFile, annotationFile, web = web)
+
+        val inputKindType = kind map { k =>
+            k
+        } getOrElse null
+
+        inputKindType match {
+            case null => {
+                exec = Map("code" -> code.toJson, "kind" -> kindType.toJson)
+            }
+            case "copy" => {
+                val actName = entityName(artifactFile)
+                val actionPath = Path(s"$basePath/namespaces/$namespace/$noun/$actName")
+                val resp = getWhiskEntity(actionPath).futureValue
+                if (resp == None)
+                    return new RestResult(NotFound, null)
+                else {
+                    val result = new RestResult(resp.status, getRespData(resp))
+                    params = JsArray(result.getFieldListJsObject("parameters"))
+                    annos = JsArray(result.getFieldListJsObject("annotations"))
+                    exec = result.getFieldJsObject("exec").fields
+                }
+            }
+            case "sequence" => {
+                kindType = "sequence"
+                val comps = convertIntoComponents(artifactFile)
+                exec = Map("components" -> comps.toJson, "kind" -> kindType.toJson)
+            }
+            case "native" => {
+                exec = Map("code" -> code.toJson, "kind" -> "blackbox".toJson, "image" -> "openwhisk/dockerskeleton".toJson)
+            }
+            case _ => {
+                kindType = inputKindType
+                exec = Map("code" -> code.toJson, "kind" -> kindType.toJson)
+            }
+        }
+
+        exec = exec ++ {
+            main map { m =>
+                Map("main" -> m.toJson)
+            } getOrElse Map[String, JsValue]()
+        } ++ {
+            docker map { d =>
+                Map("kind" -> "blackbox".toJson, "image" -> d.toJson)
+            } getOrElse Map[String, JsValue]()
+        }
+
+        var bodyContent = Map("name" -> name.toJson, "namespace" -> namespace.toJson)
+
+        if (update) {
+            if ((kind != None) && ((inputKindType == "sequence") || (inputKindType == "native"))) {
+                bodyContent = bodyContent ++ Map("exec" -> exec.toJson)
+            }
+
+            bodyContent = bodyContent ++ {
+                shared map { s =>
+                    Map("publish" -> s.toJson)
+                } getOrElse Map[String, JsValue]()
+            }
+
+            val inputParams = convertMapIntoKeyValue(parameters)
+            if (inputParams.elements.size > 0) {
+                bodyContent = bodyContent ++ Map("parameters" -> params)
+            }
+            val inputAnnos = convertMapIntoKeyValue(annotations)
+            if (inputAnnos.elements.size > 0) {
+                bodyContent = bodyContent ++ Map("annotations" -> annos)
+            }
+        } else {
+            bodyContent = bodyContent ++ Map("exec" -> exec.toJson, "parameters" -> params, "annotations" -> annos)
+
+            bodyContent = bodyContent ++ {
+                timeout map { t =>
+                    Map("limits" -> JsObject("timeout" -> t.toMillis.toJson))
+                } getOrElse Map[String, JsValue]()
+            }
+        }
+
+        val path = Path(s"$basePath/namespaces/$namespace/$noun/$actName")
+        val respFuture =
+            if (update) createEntity(path, JsObject(bodyContent).toString, Map("overwrite" -> "true"))
+            else createEntity(path, JsObject(bodyContent).toString)
+        val resp = respFuture.futureValue
+        val r = new RestResult(resp.status, getRespData(resp))
+        validateStatusCode(expectedExitCode, r.statusCode.intValue)
+        r
+    }
+
+    override def invoke(name: String,
+                        parameters: Map[String, JsValue] = Map(),
+                        parameterFile: Option[String] = None,
+                        blocking: Boolean = false,
+                        result: Boolean = false,
+                        expectedExitCode: Int = Accepted.intValue)(implicit wp: WskProps): RestResult = {
+        super.invokeAction(name, parameters, parameterFile, blocking, result, expectedExitCode = expectedExitCode)
+    }
+}
+
+class WskRestTrigger
+    extends RunWskRestCmd
+    with ListOrGetFromCollectionRest
+    with DeleteFromCollectionRest
+    with HasActivationRest
+    with BaseTrigger {
+
+    override protected val noun = "triggers"
+
+    /**
+     * Creates trigger. Parameters mirror those available in the REST.
+     *
+     * @param name either a fully qualified name or a simple entity name
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    override def create(name: String,
+                        parameters: Map[String, JsValue] = Map(),
+                        annotations: Map[String, JsValue] = Map(),
+                        parameterFile: Option[String] = None,
+                        annotationFile: Option[String] = None,
+                        feed: Option[String] = None,
+                        shared: Option[Boolean] = None,
+                        update: Boolean = false,
+                        expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
+
+        val (ns, triggerName) = this.getNamespaceActionName(name)
+        val path = Path(s"$basePath/namespaces/$ns/$noun/$triggerName")
+        val (params, annos) = getParamsAnnos(parameters, annotations, parameterFile, annotationFile, feed)
+        var bodyContent = JsObject("name" -> name.toJson, "namespace" -> s"$ns".toJson)
+
+        if (!update) {
+            val published = shared map { s =>
+                s
+            } getOrElse false
+            bodyContent = JsObject(
+                bodyContent.fields + ("publish" -> published.toJson,
+                    "parameters" -> params, "annotations" -> annos))
+        } else {
+            bodyContent = shared map { s =>
+                JsObject(bodyContent.fields + ("publish" -> s.toJson))
+            } getOrElse bodyContent
+
+            val inputParams = convertMapIntoKeyValue(parameters)
+            if (inputParams.elements.size > 0) {
+                bodyContent = JsObject(bodyContent.fields + ("parameters" -> params))
+            }
+            val inputAnnos = convertMapIntoKeyValue(annotations)
+            if (inputAnnos.elements.size > 0) {
+                bodyContent = JsObject(bodyContent.fields + ("annotations" -> annos))
+            }
+        }
+
+        val respFuture =
+            if (update) createEntity(path, bodyContent.toString, Map("overwrite" -> "true"))
+            else createEntity(path, bodyContent.toString)
+        val resp = respFuture.futureValue
+        val result = new RestResult(resp.status, getRespData(resp))
+
+        val feedInput = feed map { f =>
+            f
+        } getOrElse null
+
+        if ((feed == null) || (result.statusCode != OK)) {
+            validateStatusCode(expectedExitCode, result.statusCode.intValue)
+            result
+        } else {
+            // Invoke the feed
+            val (nsFeed, feedName) = this.getNamespaceActionName(feedInput)
+            val path = Path(s"$basePath/namespaces/$nsFeed/actions/$feedName")
+            val paramMap = Map("blocking" -> "true".toString, "result" -> "false".toString)
+            var params: Map[String, JsValue] = Map(
+                "lifecycleEvent" -> "CREATE".toJson,
+                "triggerName" -> s"/$ns/$triggerName".toJson,
+                "authKey" -> s"${getAuthKey(wp)}".toJson)
+            params = params ++ parameters
+            val resp = postEntityParam(path, params.toJson.toString(), paramMap).futureValue
+            val resultInvoke = new RestResult(resp.status, getRespData(resp))
+            expectedExitCode shouldBe resultInvoke.statusCode.intValue
+            if (resultInvoke.statusCode != OK) {
+                // Remove the trigger, because the feed failed to invoke.
+                this.delete(triggerName)
+            } else {
+                result
+            }
+        }
+    }
+
+    /**
+     * Fires trigger. Parameters mirror those available in the REST.
+     *
+     * @param name either a fully qualified name or a simple entity name
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    override def fire(name: String,
+                      parameters: Map[String, JsValue] = Map(),
+                      parameterFile: Option[String] = None,
+                      expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
+        val path = getNamePath(noun, name)
+        val params = parameterFile map { l =>
+            val input = FileUtils.readFileToString(new File(l))
+            input.parseJson.convertTo[Map[String, JsValue]]
+        } getOrElse parameters
+        val resp =
+            if (params.size == 0) postEntity(path).futureValue else postEntity(path, params.toJson.toString()).futureValue
+        new RestResult(resp.status.intValue, getRespData(resp))
+    }
+}
+
+class WskRestRule
+    extends RunWskRestCmd
+    with ListOrGetFromCollectionRest
+    with DeleteFromCollectionRest
+    with WaitFor
+    with BaseRule {
+
+    override protected val noun = "rules"
+
+    /**
+     * Creates rule. Parameters mirror those available in the REST.
+     *
+     * @param name either a fully qualified name or a simple entity name
+     * @param trigger must be a simple name
+     * @param action must be a simple name
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    override def create(name: String,
+                        trigger: String,
+                        action: String,
+                        annotations: Map[String, JsValue] = Map(),
+                        shared: Option[Boolean] = None,
+                        update: Boolean = false,
+                        expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RestResult = {
+        val path = getNamePath(noun, name)
+        val annos = convertMapIntoKeyValue(annotations)
+        val published = shared map { s =>
+            s
+        } getOrElse false
+
+        val bodyContent = JsObject(
+            "trigger" -> fullEntityName(trigger).toJson,
+            "action" -> fullEntityName(action).toJson,
+            "publish" -> published.toJson,
+            "name" -> name.toJson,
+            "status" -> "".toJson,
+            "annotations" -> annos)
+
+        val respFuture =
+            if (update) createEntity(path, bodyContent.toString, Map("overwrite" -> "true"))
+            else createEntity(path, bodyContent.toString)
+        val resp = respFuture.futureValue
+        new RestResult(resp.status, getRespData(resp))
+    }
+
+    /**
+     * Enables rule.
+     *
+     * @param name either a fully qualified name or a simple entity name
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    override def enable(name: String, expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RestResult = {
+        changeRuleState(name, "active")
+    }
+
+    /**
+     * Disables rule.
+     *
+     * @param name either a fully qualified name or a simple entity name
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    override def disable(name: String, expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RestResult = {
+        changeRuleState(name, "inactive")
+    }
+
+    /**
+     * Checks state of rule.
+     *
+     * @param name either a fully qualified name or a simple entity name
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    override def state(name: String, expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
+        get(name, expectedExitCode = expectedExitCode)
+    }
+
+    def changeRuleState(ruleName: String, state: String = "active")(implicit wp: WskProps): RestResult = {
+        val enName = entityName(ruleName)
+        val path = getNamePath(noun, enName)
+        val bodyContent = JsObject("status" -> state.toJson)
+        val resp = postEntity(path, bodyContent.toString).futureValue
+        new RestResult(resp.status, getRespData(resp))
+    }
+}
+
+class WskRestActivation extends RunWskRestCmd with HasActivationRest with WaitFor with BaseActivation {
+
+    protected val noun = "activations"
+
+    /**
+     * Activation polling console.
+     *
+     * @param duration exits console after duration
+     * @param since (optional) time travels back to activation since given duration
+     */
+    override def console(duration: Duration, since: Option[Duration] = None, expectedExitCode: Int = SUCCESS_EXIT)(
+        implicit wp: WskProps): RestResult = {
+        var sinceTime = System.currentTimeMillis()
+        val utc = Instant.now(Clock.systemUTC()).toEpochMilli
+        sinceTime = since map { s =>
+            sinceTime - s.toMillis
+        } getOrElse sinceTime
+        val pollTimeout = duration.toSeconds
+        waitForActivationConsole(duration, Instant.ofEpochMilli(sinceTime))
+    }
+
+    /**
+     * Lists activations.
+     *
+     * @param filter (optional) if define, must be a simple entity name
+     * @param limit (optional) the maximum number of activation to return
+     * @param since (optional) only the activations since this timestamp are included
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    def listActivation(filter: Option[String] = None,
+                       limit: Option[Int] = None,
+                       since: Option[Instant] = None,
+                       docs: Boolean = true,
+                       expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RestResult = {
+        val entityPath = Path(s"${basePath}/namespaces/${wp.namespace}/$noun")
+        var paramMap = Map("skip" -> "0".toString, "docs" -> docs.toString) ++ {
+            limit map { l =>
+                Map("limit" -> l.toString)
+            } getOrElse Map("limit" -> "30".toString)
+        } ++ {
+            filter map { f =>
+                Map("limit" -> f.toString)
+            } getOrElse Map[String, String]()
+        } ++ {
+            since map { s =>
+                Map("limit" -> s.toEpochMilli().toString)
+            } getOrElse Map[String, String]()
+        }
+        val resp = getWhiskEntity(entityPath, paramMap).futureValue
+        new RestResult(resp.status, getRespData(resp))
+    }
+
+    /**
+     * Parses result of WskActivation.list to extract sequence of activation ids.
+     *
+     * @param rr run result, should be from WhiskActivation.list otherwise behavior is undefined
+     * @return sequence of activations
+     */
+    def idsActivation(rr: RestResult): Seq[String] = {
+        val list = rr.getBodyListJsObject()
+        var result = Seq[String]()
+        list.foreach((obj: JsObject) => result = result :+ (RestResult.getField(obj, "activationId").toString))
+        result
+    }
+
+    /**
+     * Gets activation logs by id.
+     *
+     * @param activationId the activation id
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    def activationLogs(activationId: String, expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
+        val path = Path(s"${basePath}/namespaces/${wp.namespace}/$noun/$activationId/logs")
+        val resp = getWhiskEntity(path).futureValue
+        val r = new RestResult(resp.status, getRespData(resp))
+        validateStatusCode(expectedExitCode, r.statusCode.intValue)
+        r
+    }
+
+    /**
+     * Gets activation result by id.
+     *
+     * @param activationId the activation id
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    def activationResult(activationId: String, expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
+        val path = Path(s"${basePath}/namespaces/${wp.namespace}/$noun/$activationId/result")
+        val resp = getWhiskEntity(path).futureValue
+        val r = new RestResult(resp.status, getRespData(resp))
+        validateStatusCode(expectedExitCode, r.statusCode.intValue)
+        r
+    }
+
+    /**
+     * Polls activations list for at least N activations. The activations
+     * are optionally filtered for the given entity. Will return as soon as
+     * N activations are found. If after retry budget is exhausted, N activations
+     * are still not present, will return a partial result. Hence caller must
+     * check length of the result and not assume it is >= N.
+     *
+     * @param N the number of activations desired
+     * @param entity the name of the entity to filter from activation list
+     * @param limit the maximum number of entities to list (if entity name is not unique use Some(0))
+     * @param since (optional) only the activations since this timestamp are included
+     * @param retries the maximum retries (total timeout is retries + 1 seconds)
+     * @return activation ids found, caller must check length of sequence
+     */
+    override def pollFor(N: Int,
+                         entity: Option[String],
+                         limit: Option[Int] = Some(30),
+                         since: Option[Instant] = None,
+                         retries: Int = 10,
+                         pollPeriod: Duration = 1.second)(implicit wp: WskProps): Seq[String] = {
+        Try {
+            retry({
+                val result = idsActivation(listActivation(filter = entity, limit = limit, since = since, docs = false))
+                if (result.length >= N) result else throw PartialResult(result)
+            }, retries, waitBeforeRetry = Some(pollPeriod))
+        } match {
+            case Success(ids)                => ids
+            case Failure(PartialResult(ids)) => ids
+            case _                           => Seq()
+        }
+    }
+
+    override def get(activationId: Option[String],
+                     expectedExitCode: Int = OK.intValue,
+                     fieldFilter: Option[String] = None,
+                     last: Option[Boolean] = None)(implicit wp: WskProps): RestResult = {
+        val r = activationId match {
+            case Some(id) => {
+                val resp = getWhiskEntity(getNamePath(noun, id)).futureValue
+                new RestResult(resp.status, getRespData(resp))
+            }
+            case None => {
+                new RestResult(NotFound, null)
+            }
+        }
+        validateStatusCode(expectedExitCode, r.statusCode.intValue)
+        r
+    }
+
+    /**
+     * Polls for an activation matching the given id. If found
+     * return Right(activation) else Left(result of calling REST API).
+     *
+     * @return either Left(error message) or Right(activation as JsObject)
+     */
+    override def waitForActivation(activationId: String,
+                                   initialWait: Duration = 1 second,
+                                   pollPeriod: Duration = 1 second,
+                                   totalWait: Duration = 30 seconds)(implicit wp: WskProps): Either[String, JsObject] = {
+        val activation = waitfor(() => {
+            val result = get(Some(activationId), expectedExitCode = DONTCARE_EXIT)(wp)
+            if (result.statusCode == NotFound) {
+                null
+            } else result
+        }, initialWait, pollPeriod, totalWait)
+        Try {
+            assert(activation.statusCode == OK)
+            assert(activation.getField("activationId") != "")
+            activation.respBody
+        } map {
+            Right(_)
+        } getOrElse Left(s"Cannot find activation id from '$activation'")
+
+    }
+
+    def waitForActivationConsole(totalWait: Duration = 30 seconds, sinceTime: Instant)(
+        implicit wp: WskProps): RestResult = {
+        var result = new RestResult(NotFound, null)
+        Thread.sleep(totalWait.toMillis)
+        listActivation(since = Some(sinceTime))(wp)
+    }
+
+    override def logs(activationId: Option[String] = None,
+                      expectedExitCode: Int = OK.intValue,
+                      last: Option[Boolean] = None)(implicit wp: WskProps): RestResult = {
+        val path = activationId map { id =>
+            Path(s"${basePath}/namespaces/${wp.namespace}/$noun/$id/logs")
+        } getOrElse Path("")
+        val resp = getWhiskEntity(path).futureValue
+        val r = new RestResult(resp.status, getRespData(resp))
+        validateStatusCode(expectedExitCode, r.statusCode.intValue)
+        r
+    }
+
+    override def result(activationId: Option[String] = None,
+                        expectedExitCode: Int = OK.intValue,
+                        last: Option[Boolean] = None)(implicit wp: WskProps): RestResult = {
+        val path = activationId map { id =>
+            Path(s"${basePath}/namespaces/${wp.namespace}/$noun/$id/result")
+        } getOrElse Path("")
+        val resp = getWhiskEntity(path).futureValue
+        val r = new RestResult(resp.status, getRespData(resp))
+        validateStatusCode(expectedExitCode, r.statusCode.intValue)
+        r
+    }
+
+    /** Used in polling for activations to record partial results from retry poll. */
+    private case class PartialResult(ids: Seq[String]) extends Throwable
+}
+
+class WskRestNamespace extends RunWskRestCmd with BaseNamespace {
+
+    protected val noun = "namespaces"
+
+    /**
+     * Lists available namespaces for whisk properties.
+     *
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    override def list(expectedExitCode: Int = OK.intValue, nameSort: Option[Boolean] = None)(
+        implicit wp: WskProps): RestResult = {
+        val entPath = Path(s"$basePath/namespaces")
+        val resp = getWhiskEntity(entPath).futureValue
+        val result = if (resp == None) new RestResult(NotFound, null) else new RestResult(resp.status, getRespData(resp))
+        validateStatusCode(expectedExitCode, result.statusCode.intValue)
+        result
+    }
+
+    /**
+     * Gets entities in namespace.
+     *
+     * @param namespace (optional) if specified must be  fully qualified namespace
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    override def get(namespace: Option[String] = None,
+                     expectedExitCode: Int = OK.intValue,
+                     nameSort: Option[Boolean] = None)(implicit wp: WskProps): RestResult = {
+        val (ns, _) = namespace map { this.getNamespaceActionName(_) } getOrElse (wp.namespace, "")
+        val entPath = Path(s"$basePath/namespaces/$ns/")
+        val resp = getWhiskEntity(entPath).futureValue
+        val r = new RestResult(resp.status, getRespData(resp))
+        validateStatusCode(expectedExitCode, r.statusCode.intValue)
+        r
+    }
+
+    /**
+     * Looks up namespace for whisk props.
+     *
+     * @param wskprops instance of WskProps with an auth key to lookup
+     * @return namespace as string
+     */
+    override def whois()(implicit wskprops: WskProps): String = {
+        val ns = list().getBodyListString
+        if (ns.size > 0) ns(0).toString() else ""
+    }
+}
+
+class WskRestPackage
+    extends RunWskRestCmd
+    with ListOrGetFromCollectionRest
+    with DeleteFromCollectionRest
+    with BasePackage {
+
+    override protected val noun = "packages"
+
+    /**
+     * Creates package. Parameters mirror those available in the REST.
+     *
+     * @param name either a fully qualified name or a simple entity name
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    override def create(name: String,
+                        parameters: Map[String, JsValue] = Map(),
+                        annotations: Map[String, JsValue] = Map(),
+                        parameterFile: Option[String] = None,
+                        annotationFile: Option[String] = None,
+                        shared: Option[Boolean] = None,
+                        update: Boolean = false,
+                        expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
+        val path = getNamePath(noun, name)
+        var bodyContent = JsObject("namespace" -> s"${wp.namespace}".toJson, "name" -> name.toJson)
+
+        val (params, annos) = this.getParamsAnnos(parameters, annotations, parameterFile, annotationFile)
+        if (!update) {
+            val published = shared map { s =>
+                s
+            } getOrElse false
+            bodyContent = JsObject(
+                bodyContent.fields + ("publish" -> published.toJson,
+                    "parameters" -> params, "annotations" -> annos))
+        } else {
+            if (shared != None)
+                bodyContent = shared map { s =>
+                    JsObject(bodyContent.fields + ("publish" -> s.toJson))
+                } getOrElse bodyContent
+
+            val inputParams = convertMapIntoKeyValue(parameters)
+            if (inputParams.elements.size > 0) {
+                bodyContent = JsObject(bodyContent.fields + ("parameters" -> params))
+            }
+            val inputAnnos = convertMapIntoKeyValue(annotations)
+            if (inputAnnos.elements.size > 0) {
+                bodyContent = JsObject(bodyContent.fields + ("annotations" -> annos))
+            }
+        }
+
+        val respFuture =
+            if (update) createEntity(path, bodyContent.toString, Map("overwrite" -> "true"))
+            else createEntity(path, bodyContent.toString)
+        val resp = respFuture.futureValue
+        val r = new RestResult(resp.status, getRespData(resp))
+        validateStatusCode(expectedExitCode, r.statusCode.intValue)
+        r
+    }
+
+    /**
+     * Binds package. Parameters mirror those available in the REST.
+     *
+     * @param name either a fully qualified name or a simple entity name
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    override def bind(provider: String,
+                      name: String,
+                      parameters: Map[String, JsValue] = Map(),
+                      annotations: Map[String, JsValue] = Map(),
+                      expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
+        val params = convertMapIntoKeyValue(parameters)
+        val annos = convertMapIntoKeyValue(annotations)
+
+        val (ns, packageName) = this.getNamespaceActionName(provider)
+        val path = getNamePath(noun, name)
+        val binding = JsObject("namespace" -> ns.toJson, "name" -> packageName.toJson)
+        val bodyContent = JsObject("binding" -> binding.toJson, "parameters" -> params, "annotations" -> annos)
+        val respFuture = createEntity(path, bodyContent.toString, Map("overwrite" -> "false"))
+        val resp = respFuture.futureValue
+        val r = new RestResult(resp.status, getRespData(resp))
+        validateStatusCode(expectedExitCode, r.statusCode.intValue)
+        r
+    }
+
+}
+
+class WskRestApi extends RunWskRestCmd with BaseApi {
+    protected val noun = "apis"
+
+    /**
+     * Creates and API endpoint. Parameters mirror those available in the REST.
+     *
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    override def create(basepath: Option[String] = None,
+                        relpath: Option[String] = None,
+                        operation: Option[String] = None,
+                        action: Option[String] = None,
+                        apiname: Option[String] = None,
+                        swagger: Option[String] = None,
+                        responsetype: Option[String] = None,
+                        expectedExitCode: Int = SUCCESS_EXIT,
+                        cliCfgFile: Option[String] = None)(implicit wp: WskProps): RestResult = {
+        val r = action match {
+            case Some(action) => {
+                val (ns, actionName) = this.getNamespaceActionName(action)
+                val actionUrl = s"https://${WhiskProperties.getBaseControllerHost()}$basePath/web/$ns/default/$actionName.http"
+                val actionAuthKey = this.getAuthKey(wp)
+                val testaction = Some(ApiAction(name = actionName, namespace = ns, backendUrl = actionUrl, authkey = actionAuthKey))
+
+                val parms = Map[String, JsValue]() ++ { Map("namespace" -> ns.toJson) } ++ {
+                    basepath map { b =>
+                        Map("gatewayBasePath" -> b.toJson)
+                    } getOrElse Map[String, JsValue]()
+                } ++ {
+                    relpath map { r =>
+                        Map("gatewayPath" -> r.toJson)
+                    } getOrElse Map[String, JsValue]()
+                } ++ {
+                    operation map { o =>
+                        Map("gatewayMethod" -> o.toJson)
+                    } getOrElse Map[String, JsValue]()
+                } ++ {
+                    apiname map { an =>
+                        Map("apiName" -> an.toJson)
+                    } getOrElse Map[String, JsValue]()
+                } ++ {
+                    testaction map { a =>
+                        Map("action" -> a.toJson)
+                    } getOrElse Map[String, JsValue]()
+                } ++ {
+                    swagger map { s =>
+                        val swaggerFile = FileUtils.readFileToString(new File(s))
+                        Map("swagger" -> swaggerFile.toJson)
+                    } getOrElse Map[String, JsValue]()
+                }
+
+                val parm = Map[String, JsValue]("apidoc" -> JsObject(parms)) ++ { Map("__ow_user" -> ns.toJson) } ++ {
+                    responsetype map { r =>
+                        Map("responsetype" -> r.toJson)
+                    } getOrElse Map[String, JsValue]()
+                } ++ {
+                    Map("accesstoken" -> wp.authKey.toJson)
+                } ++ {
+                    Map("spaceguid" -> wp.authKey.split(":")(0).toJson)
+                }
+
+                invokeAction(
+                    name = "apimgmt/createApi",
+                    parameters = parm,
+                    blocking = true,
+                    result = true,
+                    expectedExitCode = expectedExitCode)(wp)
+            }
+            case None => {
+                new RestResult(NotFound, null)
+            }
+        }
+        r
+    }
+
+    /**
+     * Retrieve a list of API endpoints. Parameters mirror those available in the REST.
+     *
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    override def list(basepathOrApiName: Option[String] = None,
+                      relpath: Option[String] = None,
+                      operation: Option[String] = None,
+                      limit: Option[Int] = None,
+                      since: Option[Instant] = None,
+                      full: Option[Boolean] = None,
+                      nameSort: Option[Boolean] = None,
+                      expectedExitCode: Int = SUCCESS_EXIT,
+                      cliCfgFile: Option[String] = None)(implicit wp: WskProps): RestResult = {
+
+        val parms = Map[String, JsValue]() ++
+            Map("__ow_user" -> wp.namespace.toJson) ++ {
+                basepathOrApiName map { b =>
+                    Map("basepath" -> b.toJson)
+                } getOrElse Map[String, JsValue]()
+            } ++ {
+                relpath map { r =>
+                    Map("relpath" -> r.toJson)
+                } getOrElse Map[String, JsValue]()
+            } ++ {
+                operation map { o =>
+                    Map("operation" -> o.toJson)
+                } getOrElse Map[String, JsValue]()
+            } ++ {
+                Map("accesstoken" -> wp.authKey.toJson)
+            } ++ {
+                Map("spaceguid" -> wp.authKey.split(":")(0).toJson)
+            }
+        val rr = invokeAction(
+            name = "apimgmt/getApi",
+            parameters = parms,
+            blocking = true,
+            result = true,
+            expectedExitCode = OK.intValue)(wp)
+        rr
+    }
+
+    /**
+     * Retieves an API's configuration. Parameters mirror those available in the REST.
+     * Runs a command wsk [params] where the arguments come in as a sequence.
+     *
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    override def get(basepathOrApiName: Option[String] = None,
+                     full: Option[Boolean] = None,
+                     expectedExitCode: Int = SUCCESS_EXIT,
+                     cliCfgFile: Option[String] = None,
+                     format: Option[String] = None)(implicit wp: WskProps): RestResult = {
+        val parms = Map[String, JsValue]() ++
+            Map("__ow_user" -> wp.namespace.toJson) ++ {
+                basepathOrApiName map { b =>
+                    Map("basepath" -> b.toJson)
+                } getOrElse Map[String, JsValue]()
+            } ++ {
+                Map("accesstoken" -> wp.authKey.toJson)
+            } ++ {
+                Map("spaceguid" -> wp.authKey.split(":")(0).toJson)
+            }
+
+        val result = invokeAction(
+            name = "apimgmt/getApi",
+            parameters = parms,
+            blocking = true,
+            result = true,
+            expectedExitCode = OK.intValue)(wp)
+        result
+    }
+
+    /**
+     * Delete an entire API or a subset of API endpoints. Parameters mirror those available in the REST.
+     *
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    override def delete(basepathOrApiName: String,
+                        relpath: Option[String] = None,
+                        operation: Option[String] = None,
+                        expectedExitCode: Int = SUCCESS_EXIT,
+                        cliCfgFile: Option[String] = None)(implicit wp: WskProps): RestResult = {
+        val parms = Map[String, JsValue]() ++ { Map("__ow_user" -> wp.namespace.toJson) } ++ {
+            Map("basepath" -> basepathOrApiName.toJson)
+        } ++ {
+            relpath map { r =>
+                Map("relpath" -> r.toJson)
+            } getOrElse Map[String, JsValue]()
+        } ++ {
+            operation map { o =>
+                Map("operation" -> o.toJson)
+            } getOrElse Map[String, JsValue]()
+        } ++ {
+            Map("accesstoken" -> wp.authKey.toJson)
+        } ++ {
+            Map("spaceguid" -> wp.authKey.split(":")(0).toJson)
+        }
+
+        val rr = invokeAction(
+            name = "apimgmt/deleteApi",
+            parameters = parms,
+            blocking = true,
+            result = true,
+            expectedExitCode = expectedExitCode)(wp)
+        return rr
+    }
+
+    def getApi(basepathOrApiName: String, params: Map[String, String] = null, expectedExitCode: Int = OK.intValue)(
+        implicit wp: WskProps): RestResult = {
+        val whiskUrl = Uri(s"http://${WhiskProperties.getBaseControllerHost()}:9001")
+        val path = Path(s"/api/${wp.authKey.split(":")(0)}$basepathOrApiName/path")
+        val resp = getWhiskEntity(path, params, whiskUrl = whiskUrl).futureValue
+        val result = new RestResult(resp.status, getRespData(resp))
+        result
+    }
+}
+
+class RunWskRestCmd() extends FlatSpec with RunWskCmd with Matchers with ScalaFutures with WskActorSystem {
+
+    implicit val config = PatienceConfig(10 seconds, 0 milliseconds)
+    implicit val materializer = ActorMaterializer()
+    val whiskRestUrl = Uri(s"http://${WhiskProperties.getBaseControllerAddress()}")
+    val basePath = Path("/api/v1")
+
+    def validateStatusCode(expectedExitCode: Int, statusCode: Int) = {
+        if ((expectedExitCode != DONTCARE_EXIT) && (expectedExitCode != ANY_ERROR_EXIT))
+            if (statusCode != expectedExitCode)
+                statusCode shouldBe expectedExitCode
+    }
+
+    def getNamePath(noun: String, name: String)(implicit wp: WskProps): Path = {
+        return Path(s"$basePath/namespaces/${wp.namespace}/$noun/$name")
+    }
+
+    def getExt(filePath: String)(implicit wp: WskProps) = {
+        val sep = "."
+        if (filePath.contains(sep)) filePath.substring(filePath.lastIndexOf(sep), filePath.length())
+        else null
+    }
+
+    def request(method: HttpMethod, uri: Uri, body: String = "", creds: BasicHttpCredentials): Future[HttpResponse] = {
+        val entity = HttpEntity(ContentTypes.`application/json`, body)
+        val request = HttpRequest(method, uri, List(Authorization(creds)), entity = entity)
+        Http().singleRequest(request)
+    }
+    def createEntity(path: Path, body: String, params: Map[String, String] = null, whiskUrl: Uri = whiskRestUrl)(
+        implicit wp: WskProps): Future[HttpResponse] = {
+        val creds = getBasicHttpCredentials(wp)
+        if (params != null)
+            request(PUT, whiskUrl.withPath(path).withQuery(Uri.Query(params)), body, creds = creds)
+        else
+            request(PUT, whiskUrl.withPath(path), body, creds = creds)
+    }
+
+    def postEntityParam(path: Path, body: String, params: Map[String, String] = null, whiskUrl: Uri = whiskRestUrl)(
+        implicit wp: WskProps): Future[HttpResponse] = {
+        val creds = getBasicHttpCredentials(wp)
+        if (params != null)
+            request(POST, whiskUrl.withPath(path).withQuery(Uri.Query(params)), body, creds = creds)
+        else
+            request(POST, whiskUrl.withPath(path), body, creds = creds)
+    }
+
+    def postEntity(path: Path, body: String = null, whiskUrl: Uri = whiskRestUrl)(
+        implicit wp: WskProps): Future[HttpResponse] = {
+        val creds = getBasicHttpCredentials(wp)
+        if (body != null)
+            request(POST, whiskUrl.withPath(path), body, creds = creds)
+        else
+            request(POST, whiskUrl.withPath(path), creds = creds)
+    }
+
+    def deleteEntity(path: Path, whiskUrl: Uri = whiskRestUrl)(implicit wp: WskProps): HttpResponse = {
+        val creds = getBasicHttpCredentials(wp)
+        request(DELETE, whiskUrl.withPath(path), creds = creds).futureValue
+    }
+
+    def getWhiskEntity(path: Path, params: Map[String, String] = null, whiskUrl: Uri = whiskRestUrl)(
+        implicit wp: WskProps): Future[HttpResponse] = {
+        val creds = getBasicHttpCredentials(wp)
+        if (params != null) {
+            request(GET, whiskUrl.withPath(path).withQuery(Uri.Query(params)), creds = creds)
+        } else
+            request(GET, whiskUrl.withPath(path), creds = creds)
+    }
+
+    private def getBasicHttpCredentials(wp: WskProps): BasicHttpCredentials = {
+        if (wp.authKey.contains(":")) {
+            val authKey = wp.authKey.split(":")
+            new BasicHttpCredentials(authKey(0), authKey(1))
+        } else {
+            new BasicHttpCredentials(wp.authKey, wp.authKey)
+        }
+    }
+
+    def getAuthKey(wp: WskProps): String = {
+        val authKey = wp.authKey.split(":")
+        s"${authKey(0)}:${authKey(1)}"
+    }
+
+    def getParamsAnnos(parameters: Map[String, JsValue] = Map(),
+                       annotations: Map[String, JsValue] = Map(),
+                       parameterFile: Option[String] = None,
+                       annotationFile: Option[String] = None,
+                       feed: Option[String] = None,
+                       web: Option[String] = None): (JsArray, JsArray) = {
+        val params = parameterFile map { pf =>
+            convertStringIntoKeyValue(pf)
+        } getOrElse convertMapIntoKeyValue(parameters)
+        val annos = annotationFile map { af =>
+            convertStringIntoKeyValue(af, feed, web)
+        } getOrElse convertMapIntoKeyValue(annotations, feed, web)
+        (params, annos)
+    }
+
+    def convertStringIntoKeyValue(file: String, feed: Option[String] = None, web: Option[String] = None): JsArray = {
+        var paramsList = Vector[JsObject]()
+        val input = FileUtils.readFileToString(new File(file))
+        val in = input.parseJson.convertTo[Map[String, JsValue]]
+        convertMapIntoKeyValue(in, feed, web)
+    }
+
+    def convertMapIntoKeyValue(params: Map[String, JsValue],
+                               feed: Option[String] = None,
+                               web: Option[String] = None): JsArray = {
+        var paramsList = Vector[JsObject]()
+        params foreach { case (key, value) => paramsList :+= JsObject("key" -> key.toJson, "value" -> value.toJson) }
+        paramsList = feed map { f =>
+            paramsList :+ JsObject("key" -> "feed".toJson, "value" -> f.toJson)
+        } getOrElse paramsList
+        paramsList = web map { w =>
+            paramsList :+ JsObject("key" -> "web-export".toJson, "value" -> w.toJson)
+        } getOrElse paramsList
+        JsArray(paramsList)
+    }
+
+    def entityName(name: String)(implicit wp: WskProps) = {
+        val sep = "/"
+        if (name.startsWith(sep)) name.substring(name.indexOf(sep, name.indexOf(sep) + 1) + 1, name.length())
+        else name
+    }
+
+    def fullEntityName(name: String)(implicit wp: WskProps) = {
+        val sep = "/"
+        if (name.startsWith(sep)) name
+        else s"/${wp.namespace}/$name"
+    }
+
+    def convertIntoComponents(comps: String)(implicit wp: WskProps): JsArray = {
+        var paramsList = Vector[JsString]()
+        comps.split(",") foreach {
+            case (value) =>
+                val fullName = fullEntityName(value)
+                paramsList :+= JsString(fullName)
+        }
+        JsArray(paramsList)
+    }
+
+    def getRespData(resp: HttpResponse): String = {
+        val timeout = 5.seconds
+        Try {
+            resp.entity.toStrict(timeout).map { _.data }.map(_.utf8String).futureValue
+        } getOrElse {
+            ""
+        }
+    }
+
+    def getNamespaceActionName(name: String)(implicit wp: WskProps): (String, String) = {
+        val seq = "/"
+        var ns = ""
+        var entityName = ""
+        if (name.startsWith(seq)) {
+            val eN = name.substring(1, name.length())
+            if (eN.contains(seq)) {
+                ns = eN.split(seq)(0)
+                entityName = eN.substring(eN.indexOf(seq) + 1, eN.length())
+            } else {
+                ns = eN
+            }
+        } else {
+            ns = wp.namespace
+            entityName = name
+        }
+
+        (ns, entityName)
+    }
+
+    def invokeAction(name: String,
+                     parameters: Map[String, JsValue] = Map(),
+                     parameterFile: Option[String] = None,
+                     blocking: Boolean = false,
+                     result: Boolean = false,
+                     expectedExitCode: Int = Accepted.intValue)(implicit wp: WskProps): RestResult = {
+        val (ns, actName) = this.getNamespaceActionName(name)
+        val path = Path(s"$basePath/namespaces/$ns/actions/$actName")
+        var paramMap = Map("blocking" -> blocking.toString, "result" -> result.toString)
+        val input = parameterFile map { pf =>
+            FileUtils.readFileToString(new File(pf))
+        } getOrElse parameters.toJson.toString()
+        val resp = postEntityParam(path, input, paramMap).futureValue
+        val r = new RestResult(resp.status.intValue, getRespData(resp))
+        if (blocking || result) {
+            validateStatusCode(OK.intValue, r.statusCode.intValue)
+        } else {
+            validateStatusCode(expectedExitCode, r.statusCode.intValue)
+        }
+        r
+    }
+}
+
+object WskRestAdmin {
+    private val binDir = WhiskProperties.getFileRelativeToWhiskHome("bin")
+    private val binaryName = "wskadmin"
+
+    def exists = {
+        val dir = binDir
+        val exec = new File(dir, binaryName)
+        assert(dir.exists, s"did not find $dir")
+        assert(exec.exists, s"did not find $exec")
+    }
+
+    def baseCommand = {
+        Buffer(WhiskProperties.python, new File(binDir, binaryName).toString)
+    }
+
+    def listKeys(namespace: String, pick: Integer = 1): List[(String, String)] = {
+        val wskadmin = new RunWskRestAdminCmd {}
+        wskadmin
+            .cli(Seq("user", "list", namespace, "--pick", pick.toString))
+            .stdout
+            .split("\n")
+            .map("""\s+""".r.split(_))
+            .map(parts => (parts(0), parts(1)))
+            .toList
+    }
+
+}
+
+trait RunWskRestAdminCmd extends RunWskCmd {
+    override def baseCommand = WskRestAdmin.baseCommand
+
+    def adminCommand(params: Seq[String],
+                     expectedExitCode: Int = SUCCESS_EXIT,
+                     verbose: Boolean = false,
+                     env: Map[String, String] = Map("WSK_CONFIG_FILE" -> ""),
+                     workingDir: File = new File("."),
+                     stdinFile: Option[File] = None,
+                     showCmd: Boolean = false): RunResult = {
+        val args = baseCommand
+        if (verbose) args += "--verbose"
+        if (showCmd) println(args.mkString(" ") + " " + params.mkString(" "))
+        val rr = TestUtils.runCmd(
+            DONTCARE_EXIT,
+            workingDir,
+            TestUtils.logger,
+            sys.env ++ env,
+            stdinFile.getOrElse(null),
+            args ++ params: _*)
+
+        withClue(reportFailure(args ++ params, expectedExitCode, rr)) {
+            if (expectedExitCode != TestUtils.DONTCARE_EXIT) {
+                val ok = (rr.exitCode == expectedExitCode) || (expectedExitCode == TestUtils.ANY_ERROR_EXIT && rr.exitCode != 0)
+                if (!ok) {
+                    rr.exitCode shouldBe expectedExitCode
+                }
+            }
+        }
+        rr
+    }
+}
+
+object RestResult {
+
+    val codeConversion = 256
+
+    def getField(obj: JsObject, key: String): String = {
+        obj.fields.get(key).map(_.convertTo[String]).getOrElse("")
+    }
+
+    def getFieldJsObject(obj: JsObject, key: String): JsObject = {
+        obj.fields.get(key).map(_.asJsObject).getOrElse(JsObject())
+    }
+
+    def getFieldJsValue(obj: JsObject, key: String): JsValue = {
+        obj.fields.get(key).getOrElse(JsObject())
+    }
+
+    def getFieldListJsObject(obj: JsObject, key: String): Vector[JsObject] = {
+        obj.fields.get(key).map(_.convertTo[Vector[JsObject]]).getOrElse(Vector(JsObject()))
+    }
+
+    def convertStausCodeToExitCode(statusCode: StatusCode): Int = {
+        if (statusCode == OK)
+            return 0
+        if (statusCode.intValue < BadRequest.intValue) statusCode.intValue else statusCode.intValue - codeConversion
+    }
+
+    def convertHttpResponseToStderr(respData: String): String = {
+        Try {
+            getField(respData.parseJson.asJsObject, "error")
+        } getOrElse {
+            ""
+        }
+    }
+}
+
+class RestResult(var statusCode: StatusCode, var respData: String)
+    extends RunResult(
+        RestResult.convertStausCodeToExitCode(statusCode),
+        respData,
+        RestResult.convertHttpResponseToStderr(respData)) {
+
+    def respBody: JsObject = respData.parseJson.asJsObject
+
+    def getField(key: String): String = {
+        RestResult.getField(respBody, key)
+    }
+
+    def getFieldJsObject(key: String): JsObject = {
+        RestResult.getFieldJsObject(respBody, key)
+    }
+
+    def getFieldJsValue(key: String): JsValue = {
+        RestResult.getFieldJsValue(respBody, key)
+    }
+
+    def getFieldListJsObject(key: String): Vector[JsObject] = {
+        RestResult.getFieldListJsObject(respBody, key)
+    }
+
+    def getBodyListJsObject(): Vector[JsObject] = {
+        respData.parseJson.convertTo[Vector[JsObject]]
+    }
+
+    def getBodyListString(): Vector[String] = {
+        respData.parseJson.convertTo[Vector[String]]
+    }
+}
+
+case class ApiAction(name: String,
+                     namespace: String,
+                     backendMethod: String = "POST",
+                     backendUrl: String,
+                     authkey: String) {
+    def toJson(): JsObject = {
+        return JsObject(
+            "name" -> name.toJson,
+            "namespace" -> namespace.toJson,
+            "backendMethod" -> backendMethod.toJson,
+            "backendUrl" -> backendUrl.toJson,
+            "authkey" -> authkey.toJson)
+    }
+}

--- a/tests/src/test/scala/common/rest/WskRest.scala
+++ b/tests/src/test/scala/common/rest/WskRest.scala
@@ -116,7 +116,6 @@ trait ListOrGetFromCollectionRest extends BaseListOrGetFromCollection {
                     nameSort: Option[Boolean] = None,
                     expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
     val (ns, name) = getNamespaceActionName(resolve(namespace))
-
     val pathToList = s"$basePath/namespaces/$ns/$noun"
     val entPath =
       if (name != "") Path(s"$pathToList/$name/")
@@ -275,8 +274,10 @@ class WskRestAction
             kindType = "php:default"
             code = FileUtils.readFileToString(new File(artifactFile))
           }
+          case _ =>
         }
       }
+      case None =>
     }
 
     kindType = docker map { d =>
@@ -293,7 +294,7 @@ class WskRestAction
             val actionPath = Path(s"$basePath/namespaces/$namespace/$noun/$actName")
             val resp = requestEntity(GET, actionPath)
             if (resp == None)
-              return new RestResult(NotFound, null)
+              return new RestResult(NotFound)
             else {
               val result = new RestResult(resp.status, getRespData(resp))
               params = JsArray(result.getFieldListJsObject("parameters"))
@@ -713,7 +714,7 @@ class WskRestActivation extends RunWskRestCmd with HasActivationRest with WaitFo
         new RestResult(resp.status, getRespData(resp))
       }
       case None => {
-        new RestResult(NotFound, null)
+        new RestResult(NotFound)
       }
     }
     validateStatusCode(expectedExitCode, r.statusCode.intValue)
@@ -748,7 +749,7 @@ class WskRestActivation extends RunWskRestCmd with HasActivationRest with WaitFo
 
   def waitForActivationConsole(totalWait: Duration = 30 seconds, sinceTime: Instant)(
     implicit wp: WskProps): RestResult = {
-    var result = new RestResult(NotFound, null)
+    var result = new RestResult(NotFound)
     Thread.sleep(totalWait.toMillis)
     listActivation(since = Some(sinceTime))(wp)
   }
@@ -762,7 +763,7 @@ class WskRestActivation extends RunWskRestCmd with HasActivationRest with WaitFo
         new RestResult(resp.status, getRespData(resp))
       }
       case None => {
-        new RestResult(NotFound, null)
+        new RestResult(NotFound)
       }
     }
     validateStatusCode(expectedExitCode, r.statusCode.intValue)
@@ -778,7 +779,7 @@ class WskRestActivation extends RunWskRestCmd with HasActivationRest with WaitFo
         new RestResult(resp.status, getRespData(resp))
       }
       case None => {
-        new RestResult(NotFound, null)
+        new RestResult(NotFound)
       }
     }
     validateStatusCode(expectedExitCode, r.statusCode.intValue)
@@ -803,7 +804,7 @@ class WskRestNamespace extends RunWskRestCmd with BaseNamespace {
     implicit wp: WskProps): RestResult = {
     val entPath = Path(s"$basePath/namespaces")
     val resp = requestEntity(GET, entPath)
-    val result = if (resp == None) new RestResult(NotFound, null) else new RestResult(resp.status, getRespData(resp))
+    val result = if (resp == None) new RestResult(NotFound) else new RestResult(resp.status, getRespData(resp))
     validateStatusCode(expectedExitCode, result.statusCode.intValue)
     result
   }
@@ -994,7 +995,7 @@ class WskRestApi extends RunWskRestCmd with BaseApi {
           expectedExitCode = expectedExitCode)(wp)
       }
       case None => {
-        new RestResult(NotFound, null)
+        new RestResult(NotFound)
       }
     }
     r
@@ -1141,7 +1142,7 @@ class RunWskRestCmd() extends FlatSpec with RunWskCmd with Matchers with ScalaFu
   def getExt(filePath: String)(implicit wp: WskProps) = {
     val sep = "."
     if (filePath.contains(sep)) filePath.substring(filePath.lastIndexOf(sep), filePath.length())
-    else null
+    else ""
   }
 
   def request(method: HttpMethod,
@@ -1384,7 +1385,7 @@ object RestResult {
   }
 }
 
-class RestResult(var statusCode: StatusCode, var respData: String)
+class RestResult(var statusCode: StatusCode, var respData: String = "")
     extends RunResult(
       RestResult.convertStausCodeToExitCode(statusCode),
       respData,

--- a/tests/src/test/scala/common/rest/WskRest.scala
+++ b/tests/src/test/scala/common/rest/WskRest.scala
@@ -197,11 +197,10 @@ trait HasActivationRest extends HasActivation {
    * Extracts activation id from 'wsk action invoke' or 'wsk trigger invoke'
    */
   private def extractActivationIdFromInvoke(result: RestResult): Option[String] = {
-    Try {
-      val activationID =
-        if ((result.statusCode == OK) || (result.statusCode == Accepted)) result.getField("activationId") else ""
-      activationID
-    } toOption
+    if ((result.statusCode == OK) || (result.statusCode == Accepted))
+      Some(result.getField("activationId"))
+    else
+      None
   }
 }
 
@@ -411,9 +410,7 @@ class WskRestTrigger
     var bodyContent = JsObject("name" -> name.toJson, "namespace" -> s"$ns".toJson)
 
     if (!update) {
-      val published = shared map { s =>
-        s
-      } getOrElse false
+      val published = shared.getOrElse(false)
       bodyContent = JsObject(
         bodyContent.fields + ("publish" -> published.toJson,
         "parameters" -> params, "annotations" -> annos))
@@ -516,10 +513,7 @@ class WskRestRule
                       expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RestResult = {
     val path = getNamePath(noun, name)
     val annos = convertMapIntoKeyValue(annotations)
-    val published = shared map { s =>
-      s
-    } getOrElse false
-
+    val published = shared.getOrElse(false)
     val bodyContent = JsObject(
       "trigger" -> fullEntityName(trigger).toJson,
       "action" -> fullEntityName(action).toJson,
@@ -867,9 +861,7 @@ class WskRestPackage
 
     val (params, annos) = this.getParamsAnnos(parameters, annotations, parameterFile, annotationFile)
     if (!update) {
-      val published = shared map { s =>
-        s
-      } getOrElse false
+      val published = shared.getOrElse(false)
       bodyContent = JsObject(
         bodyContent.fields + ("publish" -> published.toJson,
         "parameters" -> params, "annotations" -> annos))

--- a/tests/src/test/scala/common/rest/WskRest.scala
+++ b/tests/src/test/scala/common/rest/WskRest.scala
@@ -40,7 +40,7 @@ import scala.language.postfixOps
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
 
 import akka.http.scaladsl.model.StatusCode
 import akka.http.scaladsl.model.StatusCodes.Accepted
@@ -92,120 +92,118 @@ import whisk.core.entity.ByteSize
 import whisk.utils.retry
 
 class WskRest() extends RunWskRestCmd with BaseWsk {
-    override implicit val action = new WskRestAction
-    override implicit val trigger = new WskRestTrigger
-    override implicit val rule = new WskRestRule
-    override implicit val activation = new WskRestActivation
-    override implicit val pkg = new WskRestPackage
-    override implicit val namespace = new WskRestNamespace
-    override implicit val api = new WskRestApi
+  override implicit val action = new WskRestAction
+  override implicit val trigger = new WskRestTrigger
+  override implicit val rule = new WskRestRule
+  override implicit val activation = new WskRestActivation
+  override implicit val pkg = new WskRestPackage
+  override implicit val namespace = new WskRestNamespace
+  override implicit val api = new WskRestApi
 }
 
 trait ListOrGetFromCollectionRest extends BaseListOrGetFromCollection {
-    self: RunWskRestCmd =>
+  self: RunWskRestCmd =>
 
-    /**
-     * List entities in collection.
-     *
-     * @param namespace (optional) if specified must be  fully qualified namespace
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    override def list(namespace: Option[String] = None,
-                      limit: Option[Int] = None,
-                      nameSort: Option[Boolean] = None,
-                      expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
-        val (ns, name) = getNamespaceActionName(resolve(namespace))
+  /**
+   * List entities in collection.
+   *
+   * @param namespace (optional) if specified must be  fully qualified namespace
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  override def list(namespace: Option[String] = None,
+                    limit: Option[Int] = None,
+                    nameSort: Option[Boolean] = None,
+                    expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
+    val (ns, name) = getNamespaceActionName(resolve(namespace))
 
-        val pathToList = s"$basePath/namespaces/$ns/$noun"
-        val entPath =
-            if (name != "") Path(s"$pathToList/$name/")
-            else Path(s"$pathToList")
-        val paramMap = Map[String, String]() ++ { Map("skip" -> "0".toString, "docs" -> true.toString) } ++ {
-            limit map { l =>
-                Map("limit" -> l.toString)
-            } getOrElse Map[String, String]("limit" -> "30".toString)
-        }
-        val resp = getWhiskEntity(entPath, paramMap).futureValue
-        val r = new RestResult(resp.status, getRespData(resp))
-        validateStatusCode(expectedExitCode, r.statusCode.intValue)
-        r
+    val pathToList = s"$basePath/namespaces/$ns/$noun"
+    val entPath =
+      if (name != "") Path(s"$pathToList/$name/")
+      else Path(s"$pathToList")
+    val paramMap = Map[String, String]() ++ { Map("skip" -> "0".toString, "docs" -> true.toString) } ++ {
+      limit map { l =>
+        Map("limit" -> l.toString)
+      } getOrElse Map[String, String]("limit" -> "30".toString)
     }
+    val resp = requestEntity(GET, entPath, paramMap)
+    val r = new RestResult(resp.status, getRespData(resp))
+    validateStatusCode(expectedExitCode, r.statusCode.intValue)
+    r
+  }
 
-    /**
-     * Gets entity from collection.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    override def get(name: String,
-                     expectedExitCode: Int = OK.intValue,
-                     summary: Boolean = false,
-                     fieldFilter: Option[String] = None,
-                     url: Option[Boolean] = None)(implicit wp: WskProps): RestResult = {
-        val (ns, entity) = getNamespaceActionName(name)
-        val entPath = Path(s"$basePath/namespaces/$ns/$noun/$entity")
-        val resp = getWhiskEntity(entPath)(wp).futureValue
-        val r = new RestResult(resp.status, getRespData(resp))
-        validateStatusCode(expectedExitCode, r.statusCode.intValue)
-        r
-    }
+  /**
+   * Gets entity from collection.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  override def get(name: String,
+                   expectedExitCode: Int = OK.intValue,
+                   summary: Boolean = false,
+                   fieldFilter: Option[String] = None,
+                   url: Option[Boolean] = None,
+                   save: Option[Boolean] = None,
+                   saveAs: Option[String] = None)(implicit wp: WskProps): RestResult = {
+    val (ns, entity) = getNamespaceActionName(name)
+    val entPath = Path(s"$basePath/namespaces/$ns/$noun/$entity")
+    val resp = requestEntity(GET, entPath)(wp)
+    val r = new RestResult(resp.status, getRespData(resp))
+    validateStatusCode(expectedExitCode, r.statusCode.intValue)
+    r
+  }
 }
 
 trait DeleteFromCollectionRest extends BaseDeleteFromCollection {
-    self: RunWskRestCmd =>
+  self: RunWskRestCmd =>
 
-    /**
-     * Deletes entity from collection.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    override def delete(entity: String, expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
-        val r = deleteEntity(entity)(wp)
-        validateStatusCode(expectedExitCode, r.statusCode.intValue)
-        r
-    }
+  /**
+   * Deletes entity from collection.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  override def delete(entity: String, expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
+    val (ns, entityName) = getNamespaceActionName(entity)
+    val path = Path(s"$basePath/namespaces/$ns/$noun/$entityName")
+    val resp = requestEntity(DELETE, path)(wp)
+    val r = new RestResult(resp.status, getRespData(resp))
+    validateStatusCode(expectedExitCode, r.statusCode.intValue)
+    r
+  }
 
-    def deleteEntity(name: String)(implicit wp: WskProps): RestResult = {
-        val (ns, entity) = getNamespaceActionName(name)
-        val path = Path(s"$basePath/namespaces/$ns/$noun/$entity")
-        val resp = deleteEntity(path)(wp)
-        new RestResult(resp.status, getRespData(resp))
-    }
-
-    /**
-     * Deletes entity from collection but does not assert that the command succeeds.
-     * Use this if deleting an entity that may not exist and it is OK if it does not.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     */
-    override def sanitize(name: String)(implicit wp: WskProps): RestResult = {
-        delete(name, DONTCARE_EXIT)
-    }
+  /**
+   * Deletes entity from collection but does not assert that the command succeeds.
+   * Use this if deleting an entity that may not exist and it is OK if it does not.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   */
+  override def sanitize(name: String)(implicit wp: WskProps): RestResult = {
+    delete(name, DONTCARE_EXIT)
+  }
 }
 
 trait HasActivationRest extends HasActivation {
 
-    /**
-     * Extracts activation id from invoke (action or trigger) or activation get
-     */
-    override def extractActivationId(result: RunResult): Option[String] = {
-        extractActivationIdFromInvoke(result.asInstanceOf[RestResult])
-    }
+  /**
+   * Extracts activation id from invoke (action or trigger) or activation get
+   */
+  override def extractActivationId(result: RunResult): Option[String] = {
+    extractActivationIdFromInvoke(result.asInstanceOf[RestResult])
+  }
 
-    /**
-     * Extracts activation id from 'wsk action invoke' or 'wsk trigger invoke'
-     */
-    private def extractActivationIdFromInvoke(result: RestResult): Option[String] = {
-        Try {
-            val activationID =
-                if ((result.statusCode == OK) || (result.statusCode == Accepted)) result.getField("activationId") else ""
-            activationID
-        } toOption
-    }
+  /**
+   * Extracts activation id from 'wsk action invoke' or 'wsk trigger invoke'
+   */
+  private def extractActivationIdFromInvoke(result: RestResult): Option[String] = {
+    Try {
+      val activationID =
+        if ((result.statusCode == OK) || (result.statusCode == Accepted)) result.getField("activationId") else ""
+      activationID
+    } toOption
+  }
 }
 
 class WskRestAction
@@ -215,172 +213,171 @@ class WskRestAction
     with HasActivationRest
     with BaseAction {
 
-    override protected val noun = "actions"
-    override implicit val config = PatienceConfig(100 seconds, 15 milliseconds)
+  override protected val noun = "actions"
+  override implicit val config = PatienceConfig(100 seconds, 15 milliseconds)
 
-    /**
-     * Creates action. Parameters mirror those available in the REST.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    override def create(
-        name: String,
-        artifact: Option[String],
-        kind: Option[String] = None, // one of docker, copy, sequence or none for autoselect else an explicit type
-        main: Option[String] = None,
-        docker: Option[String] = None,
-        parameters: Map[String, JsValue] = Map(),
-        annotations: Map[String, JsValue] = Map(),
-        parameterFile: Option[String] = None,
-        annotationFile: Option[String] = None,
-        timeout: Option[Duration] = None,
-        memory: Option[ByteSize] = None,
-        logsize: Option[ByteSize] = None,
-        shared: Option[Boolean] = None,
-        update: Boolean = false,
-        web: Option[String] = None,
-        expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
+  /**
+   * Creates action. Parameters mirror those available in the REST.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  override def create(
+    name: String,
+    artifact: Option[String],
+    kind: Option[String] = None, // one of docker, copy, sequence or none for autoselect else an explicit type
+    main: Option[String] = None,
+    docker: Option[String] = None,
+    parameters: Map[String, JsValue] = Map(),
+    annotations: Map[String, JsValue] = Map(),
+    parameterFile: Option[String] = None,
+    annotationFile: Option[String] = None,
+    timeout: Option[Duration] = None,
+    memory: Option[ByteSize] = None,
+    logsize: Option[ByteSize] = None,
+    shared: Option[Boolean] = None,
+    update: Boolean = false,
+    web: Option[String] = None,
+    expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
 
-        val (namespace, actName) = getNamespaceActionName(name)
-        var exec = Map[String, JsValue]()
-        var code = ""
-        var kindType = ""
+    val (namespace, actName) = getNamespaceActionName(name)
+    var exec = Map[String, JsValue]()
+    var code = ""
+    var kindType = ""
 
-        val (ext, artifactFile) = artifact map { a =>
-            (getExt(a), a)
-        } getOrElse (null, "")
+    val (ext, artifactFile) = artifact map { a =>
+      (getExt(a), a)
+    } getOrElse (null, "")
 
-        ext match {
-            case ".jar" => {
-                kindType = "java:default"
-                val jar = FileUtils.readFileToByteArray(new File(artifactFile))
-                code = Base64.getEncoder.encodeToString(jar)
-            }
-            case ".zip" => {
-                val zip = FileUtils.readFileToByteArray(new File(artifactFile))
-                code = Base64.getEncoder.encodeToString(zip)
-            }
-            case ".js" => {
-                kindType = "nodejs:default"
-                code = FileUtils.readFileToString(new File(artifactFile))
-            }
-            case ".py" => {
-                kindType = "python:default"
-                code = FileUtils.readFileToString(new File(artifactFile))
-            }
-            case ".swift" => {
-                kindType = "swift:default"
-                code = FileUtils.readFileToString(new File(artifactFile))
-            }
-            case ".php" => {
-                kindType = "php:default"
-                code = FileUtils.readFileToString(new File(artifactFile))
-            }
-            case _ =>
-        }
-
-        kindType = docker map { d =>
-            "blackbox"
-        } getOrElse kindType
-
-        var (params, annos) = getParamsAnnos(parameters, annotations, parameterFile, annotationFile, web = web)
-
-        val inputKindType = kind map { k =>
-            k
-        } getOrElse null
-
-        inputKindType match {
-            case null => {
-                exec = Map("code" -> code.toJson, "kind" -> kindType.toJson)
-            }
-            case "copy" => {
-                val actName = entityName(artifactFile)
-                val actionPath = Path(s"$basePath/namespaces/$namespace/$noun/$actName")
-                val resp = getWhiskEntity(actionPath).futureValue
-                if (resp == None)
-                    return new RestResult(NotFound, null)
-                else {
-                    val result = new RestResult(resp.status, getRespData(resp))
-                    params = JsArray(result.getFieldListJsObject("parameters"))
-                    annos = JsArray(result.getFieldListJsObject("annotations"))
-                    exec = result.getFieldJsObject("exec").fields
-                }
-            }
-            case "sequence" => {
-                kindType = "sequence"
-                val comps = convertIntoComponents(artifactFile)
-                exec = Map("components" -> comps.toJson, "kind" -> kindType.toJson)
-            }
-            case "native" => {
-                exec = Map("code" -> code.toJson, "kind" -> "blackbox".toJson, "image" -> "openwhisk/dockerskeleton".toJson)
-            }
-            case _ => {
-                kindType = inputKindType
-                exec = Map("code" -> code.toJson, "kind" -> kindType.toJson)
-            }
-        }
-
-        exec = exec ++ {
-            main map { m =>
-                Map("main" -> m.toJson)
-            } getOrElse Map[String, JsValue]()
-        } ++ {
-            docker map { d =>
-                Map("kind" -> "blackbox".toJson, "image" -> d.toJson)
-            } getOrElse Map[String, JsValue]()
-        }
-
-        var bodyContent = Map("name" -> name.toJson, "namespace" -> namespace.toJson)
-
-        if (update) {
-            if ((kind != None) && ((inputKindType == "sequence") || (inputKindType == "native"))) {
-                bodyContent = bodyContent ++ Map("exec" -> exec.toJson)
-            }
-
-            bodyContent = bodyContent ++ {
-                shared map { s =>
-                    Map("publish" -> s.toJson)
-                } getOrElse Map[String, JsValue]()
-            }
-
-            val inputParams = convertMapIntoKeyValue(parameters)
-            if (inputParams.elements.size > 0) {
-                bodyContent = bodyContent ++ Map("parameters" -> params)
-            }
-            val inputAnnos = convertMapIntoKeyValue(annotations)
-            if (inputAnnos.elements.size > 0) {
-                bodyContent = bodyContent ++ Map("annotations" -> annos)
-            }
-        } else {
-            bodyContent = bodyContent ++ Map("exec" -> exec.toJson, "parameters" -> params, "annotations" -> annos)
-
-            bodyContent = bodyContent ++ {
-                timeout map { t =>
-                    Map("limits" -> JsObject("timeout" -> t.toMillis.toJson))
-                } getOrElse Map[String, JsValue]()
-            }
-        }
-
-        val path = Path(s"$basePath/namespaces/$namespace/$noun/$actName")
-        val respFuture =
-            if (update) createEntity(path, JsObject(bodyContent).toString, Map("overwrite" -> "true"))
-            else createEntity(path, JsObject(bodyContent).toString)
-        val resp = respFuture.futureValue
-        val r = new RestResult(resp.status, getRespData(resp))
-        validateStatusCode(expectedExitCode, r.statusCode.intValue)
-        r
+    ext match {
+      case ".jar" => {
+        kindType = "java:default"
+        val jar = FileUtils.readFileToByteArray(new File(artifactFile))
+        code = Base64.getEncoder.encodeToString(jar)
+      }
+      case ".zip" => {
+        val zip = FileUtils.readFileToByteArray(new File(artifactFile))
+        code = Base64.getEncoder.encodeToString(zip)
+      }
+      case ".js" => {
+        kindType = "nodejs:default"
+        code = FileUtils.readFileToString(new File(artifactFile))
+      }
+      case ".py" => {
+        kindType = "python:default"
+        code = FileUtils.readFileToString(new File(artifactFile))
+      }
+      case ".swift" => {
+        kindType = "swift:default"
+        code = FileUtils.readFileToString(new File(artifactFile))
+      }
+      case ".php" => {
+        kindType = "php:default"
+        code = FileUtils.readFileToString(new File(artifactFile))
+      }
+      case _ =>
     }
 
-    override def invoke(name: String,
-                        parameters: Map[String, JsValue] = Map(),
-                        parameterFile: Option[String] = None,
-                        blocking: Boolean = false,
-                        result: Boolean = false,
-                        expectedExitCode: Int = Accepted.intValue)(implicit wp: WskProps): RestResult = {
-        super.invokeAction(name, parameters, parameterFile, blocking, result, expectedExitCode = expectedExitCode)
+    kindType = docker map { d =>
+      "blackbox"
+    } getOrElse kindType
+
+    var (params, annos) = getParamsAnnos(parameters, annotations, parameterFile, annotationFile, web = web)
+
+    val inputKindType = kind map { k =>
+      k
+    } getOrElse null
+
+    inputKindType match {
+      case null => {
+        exec = Map("code" -> code.toJson, "kind" -> kindType.toJson)
+      }
+      case "copy" => {
+        val actName = entityName(artifactFile)
+        val actionPath = Path(s"$basePath/namespaces/$namespace/$noun/$actName")
+        val resp = requestEntity(GET, actionPath)
+        if (resp == None)
+          return new RestResult(NotFound, null)
+        else {
+          val result = new RestResult(resp.status, getRespData(resp))
+          params = JsArray(result.getFieldListJsObject("parameters"))
+          annos = JsArray(result.getFieldListJsObject("annotations"))
+          exec = result.getFieldJsObject("exec").fields
+        }
+      }
+      case "sequence" => {
+        kindType = "sequence"
+        val comps = convertIntoComponents(artifactFile)
+        exec = Map("components" -> comps.toJson, "kind" -> kindType.toJson)
+      }
+      case "native" => {
+        exec = Map("code" -> code.toJson, "kind" -> "blackbox".toJson, "image" -> "openwhisk/dockerskeleton".toJson)
+      }
+      case _ => {
+        kindType = inputKindType
+        exec = Map("code" -> code.toJson, "kind" -> kindType.toJson)
+      }
     }
+
+    exec = exec ++ {
+      main map { m =>
+        Map("main" -> m.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      docker map { d =>
+        Map("kind" -> "blackbox".toJson, "image" -> d.toJson)
+      } getOrElse Map[String, JsValue]()
+    }
+
+    var bodyContent = Map("name" -> name.toJson, "namespace" -> namespace.toJson)
+
+    if (update) {
+      if ((kind != None) && ((inputKindType == "sequence") || (inputKindType == "native"))) {
+        bodyContent = bodyContent ++ Map("exec" -> exec.toJson)
+      }
+
+      bodyContent = bodyContent ++ {
+        shared map { s =>
+          Map("publish" -> s.toJson)
+        } getOrElse Map[String, JsValue]()
+      }
+
+      val inputParams = convertMapIntoKeyValue(parameters)
+      if (inputParams.elements.size > 0) {
+        bodyContent = bodyContent ++ Map("parameters" -> params)
+      }
+      val inputAnnos = convertMapIntoKeyValue(annotations)
+      if (inputAnnos.elements.size > 0) {
+        bodyContent = bodyContent ++ Map("annotations" -> annos)
+      }
+    } else {
+      bodyContent = bodyContent ++ Map("exec" -> exec.toJson, "parameters" -> params, "annotations" -> annos)
+
+      bodyContent = bodyContent ++ {
+        timeout map { t =>
+          Map("limits" -> JsObject("timeout" -> t.toMillis.toJson))
+        } getOrElse Map[String, JsValue]()
+      }
+    }
+
+    val path = Path(s"$basePath/namespaces/$namespace/$noun/$actName")
+    val resp =
+      if (update) requestEntity(PUT, path, Map("overwrite" -> "true"), Some(JsObject(bodyContent).toString))
+      else requestEntity(PUT, path, body = Some(JsObject(bodyContent).toString))
+    val r = new RestResult(resp.status, getRespData(resp))
+    validateStatusCode(expectedExitCode, r.statusCode.intValue)
+    r
+  }
+
+  override def invoke(name: String,
+                      parameters: Map[String, JsValue] = Map(),
+                      parameterFile: Option[String] = None,
+                      blocking: Boolean = false,
+                      result: Boolean = false,
+                      expectedExitCode: Int = Accepted.intValue)(implicit wp: WskProps): RestResult = {
+    super.invokeAction(name, parameters, parameterFile, blocking, result, expectedExitCode = expectedExitCode)
+  }
 }
 
 class WskRestTrigger
@@ -390,107 +387,107 @@ class WskRestTrigger
     with HasActivationRest
     with BaseTrigger {
 
-    override protected val noun = "triggers"
+  override protected val noun = "triggers"
 
-    /**
-     * Creates trigger. Parameters mirror those available in the REST.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    override def create(name: String,
-                        parameters: Map[String, JsValue] = Map(),
-                        annotations: Map[String, JsValue] = Map(),
-                        parameterFile: Option[String] = None,
-                        annotationFile: Option[String] = None,
-                        feed: Option[String] = None,
-                        shared: Option[Boolean] = None,
-                        update: Boolean = false,
-                        expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
-
-        val (ns, triggerName) = this.getNamespaceActionName(name)
-        val path = Path(s"$basePath/namespaces/$ns/$noun/$triggerName")
-        val (params, annos) = getParamsAnnos(parameters, annotations, parameterFile, annotationFile, feed)
-        var bodyContent = JsObject("name" -> name.toJson, "namespace" -> s"$ns".toJson)
-
-        if (!update) {
-            val published = shared map { s =>
-                s
-            } getOrElse false
-            bodyContent = JsObject(
-                bodyContent.fields + ("publish" -> published.toJson,
-                    "parameters" -> params, "annotations" -> annos))
-        } else {
-            bodyContent = shared map { s =>
-                JsObject(bodyContent.fields + ("publish" -> s.toJson))
-            } getOrElse bodyContent
-
-            val inputParams = convertMapIntoKeyValue(parameters)
-            if (inputParams.elements.size > 0) {
-                bodyContent = JsObject(bodyContent.fields + ("parameters" -> params))
-            }
-            val inputAnnos = convertMapIntoKeyValue(annotations)
-            if (inputAnnos.elements.size > 0) {
-                bodyContent = JsObject(bodyContent.fields + ("annotations" -> annos))
-            }
-        }
-
-        val respFuture =
-            if (update) createEntity(path, bodyContent.toString, Map("overwrite" -> "true"))
-            else createEntity(path, bodyContent.toString)
-        val resp = respFuture.futureValue
-        val result = new RestResult(resp.status, getRespData(resp))
-
-        val feedInput = feed map { f =>
-            f
-        } getOrElse null
-
-        if ((feed == null) || (result.statusCode != OK)) {
-            validateStatusCode(expectedExitCode, result.statusCode.intValue)
-            result
-        } else {
-            // Invoke the feed
-            val (nsFeed, feedName) = this.getNamespaceActionName(feedInput)
-            val path = Path(s"$basePath/namespaces/$nsFeed/actions/$feedName")
-            val paramMap = Map("blocking" -> "true".toString, "result" -> "false".toString)
-            var params: Map[String, JsValue] = Map(
-                "lifecycleEvent" -> "CREATE".toJson,
-                "triggerName" -> s"/$ns/$triggerName".toJson,
-                "authKey" -> s"${getAuthKey(wp)}".toJson)
-            params = params ++ parameters
-            val resp = postEntityParam(path, params.toJson.toString(), paramMap).futureValue
-            val resultInvoke = new RestResult(resp.status, getRespData(resp))
-            expectedExitCode shouldBe resultInvoke.statusCode.intValue
-            if (resultInvoke.statusCode != OK) {
-                // Remove the trigger, because the feed failed to invoke.
-                this.delete(triggerName)
-            } else {
-                result
-            }
-        }
-    }
-
-    /**
-     * Fires trigger. Parameters mirror those available in the REST.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    override def fire(name: String,
+  /**
+   * Creates trigger. Parameters mirror those available in the REST.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  override def create(name: String,
                       parameters: Map[String, JsValue] = Map(),
+                      annotations: Map[String, JsValue] = Map(),
                       parameterFile: Option[String] = None,
+                      annotationFile: Option[String] = None,
+                      feed: Option[String] = None,
+                      shared: Option[Boolean] = None,
+                      update: Boolean = false,
                       expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
-        val path = getNamePath(noun, name)
-        val params = parameterFile map { l =>
-            val input = FileUtils.readFileToString(new File(l))
-            input.parseJson.convertTo[Map[String, JsValue]]
-        } getOrElse parameters
-        val resp =
-            if (params.size == 0) postEntity(path).futureValue else postEntity(path, params.toJson.toString()).futureValue
-        new RestResult(resp.status.intValue, getRespData(resp))
+
+    val (ns, triggerName) = this.getNamespaceActionName(name)
+    val path = Path(s"$basePath/namespaces/$ns/$noun/$triggerName")
+    val (params, annos) = getParamsAnnos(parameters, annotations, parameterFile, annotationFile, feed)
+    var bodyContent = JsObject("name" -> name.toJson, "namespace" -> s"$ns".toJson)
+
+    if (!update) {
+      val published = shared map { s =>
+        s
+      } getOrElse false
+      bodyContent = JsObject(
+        bodyContent.fields + ("publish" -> published.toJson,
+        "parameters" -> params, "annotations" -> annos))
+    } else {
+      bodyContent = shared map { s =>
+        JsObject(bodyContent.fields + ("publish" -> s.toJson))
+      } getOrElse bodyContent
+
+      val inputParams = convertMapIntoKeyValue(parameters)
+      if (inputParams.elements.size > 0) {
+        bodyContent = JsObject(bodyContent.fields + ("parameters" -> params))
+      }
+      val inputAnnos = convertMapIntoKeyValue(annotations)
+      if (inputAnnos.elements.size > 0) {
+        bodyContent = JsObject(bodyContent.fields + ("annotations" -> annos))
+      }
     }
+
+    val resp =
+      if (update) requestEntity(PUT, path, Map("overwrite" -> "true"), Some(bodyContent.toString))
+      else requestEntity(PUT, path, body = Some(bodyContent.toString))
+    val result = new RestResult(resp.status, getRespData(resp))
+
+    val feedInput = feed map { f =>
+      f
+    } getOrElse null
+
+    if ((feed == null) || (result.statusCode != OK)) {
+      validateStatusCode(expectedExitCode, result.statusCode.intValue)
+      result
+    } else {
+      // Invoke the feed
+      val (nsFeed, feedName) = this.getNamespaceActionName(feedInput)
+      val path = Path(s"$basePath/namespaces/$nsFeed/actions/$feedName")
+      val paramMap = Map("blocking" -> "true".toString, "result" -> "false".toString)
+      var body: Map[String, JsValue] = Map(
+        "lifecycleEvent" -> "CREATE".toJson,
+        "triggerName" -> s"/$ns/$triggerName".toJson,
+        "authKey" -> s"${getAuthKey(wp)}".toJson)
+      body = body ++ parameters
+      val resp = requestEntity(POST, path, paramMap, Some(body.toJson.toString()))
+      val resultInvoke = new RestResult(resp.status, getRespData(resp))
+      expectedExitCode shouldBe resultInvoke.statusCode.intValue
+      if (resultInvoke.statusCode != OK) {
+        // Remove the trigger, because the feed failed to invoke.
+        this.delete(triggerName)
+      } else {
+        result
+      }
+    }
+  }
+
+  /**
+   * Fires trigger. Parameters mirror those available in the REST.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  override def fire(name: String,
+                    parameters: Map[String, JsValue] = Map(),
+                    parameterFile: Option[String] = None,
+                    expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
+    val path = getNamePath(noun, name)
+    val params = parameterFile map { l =>
+      val input = FileUtils.readFileToString(new File(l))
+      input.parseJson.convertTo[Map[String, JsValue]]
+    } getOrElse parameters
+    val resp =
+      if (params.size == 0) requestEntity(POST, path)
+      else requestEntity(POST, path, body = Some(params.toJson.toString()))
+    new RestResult(resp.status.intValue, getRespData(resp))
+  }
 }
 
 class WskRestRule
@@ -500,340 +497,347 @@ class WskRestRule
     with WaitFor
     with BaseRule {
 
-    override protected val noun = "rules"
+  override protected val noun = "rules"
 
-    /**
-     * Creates rule. Parameters mirror those available in the REST.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     * @param trigger must be a simple name
-     * @param action must be a simple name
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    override def create(name: String,
-                        trigger: String,
-                        action: String,
-                        annotations: Map[String, JsValue] = Map(),
-                        shared: Option[Boolean] = None,
-                        update: Boolean = false,
-                        expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RestResult = {
-        val path = getNamePath(noun, name)
-        val annos = convertMapIntoKeyValue(annotations)
-        val published = shared map { s =>
-            s
-        } getOrElse false
+  /**
+   * Creates rule. Parameters mirror those available in the REST.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   * @param trigger must be a simple name
+   * @param action must be a simple name
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  override def create(name: String,
+                      trigger: String,
+                      action: String,
+                      annotations: Map[String, JsValue] = Map(),
+                      shared: Option[Boolean] = None,
+                      update: Boolean = false,
+                      expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RestResult = {
+    val path = getNamePath(noun, name)
+    val annos = convertMapIntoKeyValue(annotations)
+    val published = shared map { s =>
+      s
+    } getOrElse false
 
-        val bodyContent = JsObject(
-            "trigger" -> fullEntityName(trigger).toJson,
-            "action" -> fullEntityName(action).toJson,
-            "publish" -> published.toJson,
-            "name" -> name.toJson,
-            "status" -> "".toJson,
-            "annotations" -> annos)
+    val bodyContent = JsObject(
+      "trigger" -> fullEntityName(trigger).toJson,
+      "action" -> fullEntityName(action).toJson,
+      "publish" -> published.toJson,
+      "name" -> name.toJson,
+      "status" -> "".toJson,
+      "annotations" -> annos)
 
-        val respFuture =
-            if (update) createEntity(path, bodyContent.toString, Map("overwrite" -> "true"))
-            else createEntity(path, bodyContent.toString)
-        val resp = respFuture.futureValue
-        new RestResult(resp.status, getRespData(resp))
-    }
+    val resp =
+      if (update) requestEntity(PUT, path, Map("overwrite" -> "true"), Some(bodyContent.toString))
+      else requestEntity(PUT, path, body = Some(bodyContent.toString))
+    new RestResult(resp.status, getRespData(resp))
+  }
 
-    /**
-     * Enables rule.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    override def enable(name: String, expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RestResult = {
-        changeRuleState(name, "active")
-    }
+  /**
+   * Enables rule.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  override def enable(name: String, expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RestResult = {
+    changeRuleState(name, "active")
+  }
 
-    /**
-     * Disables rule.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    override def disable(name: String, expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RestResult = {
-        changeRuleState(name, "inactive")
-    }
+  /**
+   * Disables rule.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  override def disable(name: String, expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RestResult = {
+    changeRuleState(name, "inactive")
+  }
 
-    /**
-     * Checks state of rule.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    override def state(name: String, expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
-        get(name, expectedExitCode = expectedExitCode)
-    }
+  /**
+   * Checks state of rule.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  override def state(name: String, expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
+    get(name, expectedExitCode = expectedExitCode)
+  }
 
-    def changeRuleState(ruleName: String, state: String = "active")(implicit wp: WskProps): RestResult = {
-        val enName = entityName(ruleName)
-        val path = getNamePath(noun, enName)
-        val bodyContent = JsObject("status" -> state.toJson)
-        val resp = postEntity(path, bodyContent.toString).futureValue
-        new RestResult(resp.status, getRespData(resp))
-    }
+  def changeRuleState(ruleName: String, state: String = "active")(implicit wp: WskProps): RestResult = {
+    val enName = entityName(ruleName)
+    val path = getNamePath(noun, enName)
+    val bodyContent = JsObject("status" -> state.toJson)
+    val resp = requestEntity(POST, path, body = Some(bodyContent.toString))
+    new RestResult(resp.status, getRespData(resp))
+  }
 }
 
 class WskRestActivation extends RunWskRestCmd with HasActivationRest with WaitFor with BaseActivation {
 
-    protected val noun = "activations"
+  protected val noun = "activations"
 
-    /**
-     * Activation polling console.
-     *
-     * @param duration exits console after duration
-     * @param since (optional) time travels back to activation since given duration
-     */
-    override def console(duration: Duration, since: Option[Duration] = None, expectedExitCode: Int = SUCCESS_EXIT)(
-        implicit wp: WskProps): RestResult = {
-        var sinceTime = System.currentTimeMillis()
-        val utc = Instant.now(Clock.systemUTC()).toEpochMilli
-        sinceTime = since map { s =>
-            sinceTime - s.toMillis
-        } getOrElse sinceTime
-        val pollTimeout = duration.toSeconds
-        waitForActivationConsole(duration, Instant.ofEpochMilli(sinceTime))
+  /**
+   * Activation polling console.
+   *
+   * @param duration exits console after duration
+   * @param since (optional) time travels back to activation since given duration
+   */
+  override def console(duration: Duration, since: Option[Duration] = None, expectedExitCode: Int = SUCCESS_EXIT)(
+    implicit wp: WskProps): RestResult = {
+    var sinceTime = System.currentTimeMillis()
+    val utc = Instant.now(Clock.systemUTC()).toEpochMilli
+    sinceTime = since map { s =>
+      sinceTime - s.toMillis
+    } getOrElse sinceTime
+    val pollTimeout = duration.toSeconds
+    waitForActivationConsole(duration, Instant.ofEpochMilli(sinceTime))
+  }
+
+  /**
+   * Lists activations.
+   *
+   * @param filter (optional) if define, must be a simple entity name
+   * @param limit (optional) the maximum number of activation to return
+   * @param since (optional) only the activations since this timestamp are included
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  def listActivation(filter: Option[String] = None,
+                     limit: Option[Int] = None,
+                     since: Option[Instant] = None,
+                     docs: Boolean = true,
+                     expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RestResult = {
+    val entityPath = Path(s"${basePath}/namespaces/${wp.namespace}/$noun")
+    var paramMap = Map("skip" -> "0".toString, "docs" -> docs.toString) ++ {
+      limit map { l =>
+        Map("limit" -> l.toString)
+      } getOrElse Map("limit" -> "30".toString)
+    } ++ {
+      filter map { f =>
+        Map("limit" -> f.toString)
+      } getOrElse Map[String, String]()
+    } ++ {
+      since map { s =>
+        Map("limit" -> s.toEpochMilli().toString)
+      } getOrElse Map[String, String]()
     }
+    val resp = requestEntity(GET, entityPath, paramMap)
+    new RestResult(resp.status, getRespData(resp))
+  }
 
-    /**
-     * Lists activations.
-     *
-     * @param filter (optional) if define, must be a simple entity name
-     * @param limit (optional) the maximum number of activation to return
-     * @param since (optional) only the activations since this timestamp are included
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def listActivation(filter: Option[String] = None,
-                       limit: Option[Int] = None,
+  /**
+   * Parses result of WskActivation.list to extract sequence of activation ids.
+   *
+   * @param rr run result, should be from WhiskActivation.list otherwise behavior is undefined
+   * @return sequence of activations
+   */
+  def idsActivation(rr: RestResult): Seq[String] = {
+    val list = rr.getBodyListJsObject()
+    var result = Seq[String]()
+    list.foreach((obj: JsObject) => result = result :+ (RestResult.getField(obj, "activationId").toString))
+    result
+  }
+
+  /**
+   * Gets activation logs by id.
+   *
+   * @param activationId the activation id
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  def activationLogs(activationId: String, expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
+    val path = Path(s"${basePath}/namespaces/${wp.namespace}/$noun/$activationId/logs")
+    val resp = requestEntity(GET, path)
+    val r = new RestResult(resp.status, getRespData(resp))
+    validateStatusCode(expectedExitCode, r.statusCode.intValue)
+    r
+  }
+
+  /**
+   * Gets activation result by id.
+   *
+   * @param activationId the activation id
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  def activationResult(activationId: String, expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
+    val path = Path(s"${basePath}/namespaces/${wp.namespace}/$noun/$activationId/result")
+    val resp = requestEntity(GET, path)
+    val r = new RestResult(resp.status, getRespData(resp))
+    validateStatusCode(expectedExitCode, r.statusCode.intValue)
+    r
+  }
+
+  /**
+   * Polls activations list for at least N activations. The activations
+   * are optionally filtered for the given entity. Will return as soon as
+   * N activations are found. If after retry budget is exhausted, N activations
+   * are still not present, will return a partial result. Hence caller must
+   * check length of the result and not assume it is >= N.
+   *
+   * @param N the number of activations desired
+   * @param entity the name of the entity to filter from activation list
+   * @param limit the maximum number of entities to list (if entity name is not unique use Some(0))
+   * @param since (optional) only the activations since this timestamp are included
+   * @param retries the maximum retries (total timeout is retries + 1 seconds)
+   * @return activation ids found, caller must check length of sequence
+   */
+  override def pollFor(N: Int,
+                       entity: Option[String],
+                       limit: Option[Int] = Some(30),
                        since: Option[Instant] = None,
-                       docs: Boolean = true,
-                       expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RestResult = {
-        val entityPath = Path(s"${basePath}/namespaces/${wp.namespace}/$noun")
-        var paramMap = Map("skip" -> "0".toString, "docs" -> docs.toString) ++ {
-            limit map { l =>
-                Map("limit" -> l.toString)
-            } getOrElse Map("limit" -> "30".toString)
-        } ++ {
-            filter map { f =>
-                Map("limit" -> f.toString)
-            } getOrElse Map[String, String]()
-        } ++ {
-            since map { s =>
-                Map("limit" -> s.toEpochMilli().toString)
-            } getOrElse Map[String, String]()
-        }
-        val resp = getWhiskEntity(entityPath, paramMap).futureValue
+                       retries: Int = 10,
+                       pollPeriod: Duration = 1.second)(implicit wp: WskProps): Seq[String] = {
+    Try {
+      retry({
+        val result = idsActivation(listActivation(filter = entity, limit = limit, since = since, docs = false))
+        if (result.length >= N) result else throw PartialResult(result)
+      }, retries, waitBeforeRetry = Some(pollPeriod))
+    } match {
+      case Success(ids)                => ids
+      case Failure(PartialResult(ids)) => ids
+      case _                           => Seq()
+    }
+  }
+
+  override def get(activationId: Option[String],
+                   expectedExitCode: Int = OK.intValue,
+                   fieldFilter: Option[String] = None,
+                   last: Option[Boolean] = None)(implicit wp: WskProps): RestResult = {
+    val r = activationId match {
+      case Some(id) => {
+        val resp = requestEntity(GET, getNamePath(noun, id))
         new RestResult(resp.status, getRespData(resp))
+      }
+      case None => {
+        new RestResult(NotFound, null)
+      }
     }
+    validateStatusCode(expectedExitCode, r.statusCode.intValue)
+    r
+  }
 
-    /**
-     * Parses result of WskActivation.list to extract sequence of activation ids.
-     *
-     * @param rr run result, should be from WhiskActivation.list otherwise behavior is undefined
-     * @return sequence of activations
-     */
-    def idsActivation(rr: RestResult): Seq[String] = {
-        val list = rr.getBodyListJsObject()
-        var result = Seq[String]()
-        list.foreach((obj: JsObject) => result = result :+ (RestResult.getField(obj, "activationId").toString))
-        result
+  /**
+   * Polls for an activation matching the given id. If found
+   * return Right(activation) else Left(result of calling REST API).
+   *
+   * @return either Left(error message) or Right(activation as JsObject)
+   */
+  override def waitForActivation(activationId: String,
+                                 initialWait: Duration = 1 second,
+                                 pollPeriod: Duration = 1 second,
+                                 totalWait: Duration = 30 seconds)(implicit wp: WskProps): Either[String, JsObject] = {
+    val activation = waitfor(() => {
+      val result = get(Some(activationId), expectedExitCode = DONTCARE_EXIT)(wp)
+      if (result.statusCode == NotFound) {
+        null
+      } else result
+    }, initialWait, pollPeriod, totalWait)
+    Try {
+      assert(activation.statusCode == OK)
+      assert(activation.getField("activationId") != "")
+      activation.respBody
+    } map {
+      Right(_)
+    } getOrElse Left(s"Cannot find activation id from '$activation'")
+
+  }
+
+  def waitForActivationConsole(totalWait: Duration = 30 seconds, sinceTime: Instant)(
+    implicit wp: WskProps): RestResult = {
+    var result = new RestResult(NotFound, null)
+    Thread.sleep(totalWait.toMillis)
+    listActivation(since = Some(sinceTime))(wp)
+  }
+
+  override def logs(activationId: Option[String] = None,
+                    expectedExitCode: Int = OK.intValue,
+                    last: Option[Boolean] = None)(implicit wp: WskProps): RestResult = {
+    val r = activationId match {
+      case Some(id) => {
+        val resp = requestEntity(GET, getNamePath(noun, s"$id/logs"))
+        new RestResult(resp.status, getRespData(resp))
+      }
+      case None => {
+        new RestResult(NotFound, null)
+      }
     }
+    validateStatusCode(expectedExitCode, r.statusCode.intValue)
+    r
+  }
 
-    /**
-     * Gets activation logs by id.
-     *
-     * @param activationId the activation id
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def activationLogs(activationId: String, expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
-        val path = Path(s"${basePath}/namespaces/${wp.namespace}/$noun/$activationId/logs")
-        val resp = getWhiskEntity(path).futureValue
-        val r = new RestResult(resp.status, getRespData(resp))
-        validateStatusCode(expectedExitCode, r.statusCode.intValue)
-        r
-    }
-
-    /**
-     * Gets activation result by id.
-     *
-     * @param activationId the activation id
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def activationResult(activationId: String, expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
-        val path = Path(s"${basePath}/namespaces/${wp.namespace}/$noun/$activationId/result")
-        val resp = getWhiskEntity(path).futureValue
-        val r = new RestResult(resp.status, getRespData(resp))
-        validateStatusCode(expectedExitCode, r.statusCode.intValue)
-        r
-    }
-
-    /**
-     * Polls activations list for at least N activations. The activations
-     * are optionally filtered for the given entity. Will return as soon as
-     * N activations are found. If after retry budget is exhausted, N activations
-     * are still not present, will return a partial result. Hence caller must
-     * check length of the result and not assume it is >= N.
-     *
-     * @param N the number of activations desired
-     * @param entity the name of the entity to filter from activation list
-     * @param limit the maximum number of entities to list (if entity name is not unique use Some(0))
-     * @param since (optional) only the activations since this timestamp are included
-     * @param retries the maximum retries (total timeout is retries + 1 seconds)
-     * @return activation ids found, caller must check length of sequence
-     */
-    override def pollFor(N: Int,
-                         entity: Option[String],
-                         limit: Option[Int] = Some(30),
-                         since: Option[Instant] = None,
-                         retries: Int = 10,
-                         pollPeriod: Duration = 1.second)(implicit wp: WskProps): Seq[String] = {
-        Try {
-            retry({
-                val result = idsActivation(listActivation(filter = entity, limit = limit, since = since, docs = false))
-                if (result.length >= N) result else throw PartialResult(result)
-            }, retries, waitBeforeRetry = Some(pollPeriod))
-        } match {
-            case Success(ids)                => ids
-            case Failure(PartialResult(ids)) => ids
-            case _                           => Seq()
-        }
-    }
-
-    override def get(activationId: Option[String],
-                     expectedExitCode: Int = OK.intValue,
-                     fieldFilter: Option[String] = None,
-                     last: Option[Boolean] = None)(implicit wp: WskProps): RestResult = {
-        val r = activationId match {
-            case Some(id) => {
-                val resp = getWhiskEntity(getNamePath(noun, id)).futureValue
-                new RestResult(resp.status, getRespData(resp))
-            }
-            case None => {
-                new RestResult(NotFound, null)
-            }
-        }
-        validateStatusCode(expectedExitCode, r.statusCode.intValue)
-        r
-    }
-
-    /**
-     * Polls for an activation matching the given id. If found
-     * return Right(activation) else Left(result of calling REST API).
-     *
-     * @return either Left(error message) or Right(activation as JsObject)
-     */
-    override def waitForActivation(activationId: String,
-                                   initialWait: Duration = 1 second,
-                                   pollPeriod: Duration = 1 second,
-                                   totalWait: Duration = 30 seconds)(implicit wp: WskProps): Either[String, JsObject] = {
-        val activation = waitfor(() => {
-            val result = get(Some(activationId), expectedExitCode = DONTCARE_EXIT)(wp)
-            if (result.statusCode == NotFound) {
-                null
-            } else result
-        }, initialWait, pollPeriod, totalWait)
-        Try {
-            assert(activation.statusCode == OK)
-            assert(activation.getField("activationId") != "")
-            activation.respBody
-        } map {
-            Right(_)
-        } getOrElse Left(s"Cannot find activation id from '$activation'")
-
-    }
-
-    def waitForActivationConsole(totalWait: Duration = 30 seconds, sinceTime: Instant)(
-        implicit wp: WskProps): RestResult = {
-        var result = new RestResult(NotFound, null)
-        Thread.sleep(totalWait.toMillis)
-        listActivation(since = Some(sinceTime))(wp)
-    }
-
-    override def logs(activationId: Option[String] = None,
+  override def result(activationId: Option[String] = None,
                       expectedExitCode: Int = OK.intValue,
                       last: Option[Boolean] = None)(implicit wp: WskProps): RestResult = {
-        val path = activationId map { id =>
-            Path(s"${basePath}/namespaces/${wp.namespace}/$noun/$id/logs")
-        } getOrElse Path("")
-        val resp = getWhiskEntity(path).futureValue
-        val r = new RestResult(resp.status, getRespData(resp))
-        validateStatusCode(expectedExitCode, r.statusCode.intValue)
-        r
+    val r = activationId match {
+      case Some(id) => {
+        val resp = requestEntity(GET, getNamePath(noun, s"$id/result"))
+        new RestResult(resp.status, getRespData(resp))
+      }
+      case None => {
+        new RestResult(NotFound, null)
+      }
     }
+    validateStatusCode(expectedExitCode, r.statusCode.intValue)
+    r
+  }
 
-    override def result(activationId: Option[String] = None,
-                        expectedExitCode: Int = OK.intValue,
-                        last: Option[Boolean] = None)(implicit wp: WskProps): RestResult = {
-        val path = activationId map { id =>
-            Path(s"${basePath}/namespaces/${wp.namespace}/$noun/$id/result")
-        } getOrElse Path("")
-        val resp = getWhiskEntity(path).futureValue
-        val r = new RestResult(resp.status, getRespData(resp))
-        validateStatusCode(expectedExitCode, r.statusCode.intValue)
-        r
-    }
-
-    /** Used in polling for activations to record partial results from retry poll. */
-    private case class PartialResult(ids: Seq[String]) extends Throwable
+  /** Used in polling for activations to record partial results from retry poll. */
+  private case class PartialResult(ids: Seq[String]) extends Throwable
 }
 
 class WskRestNamespace extends RunWskRestCmd with BaseNamespace {
 
-    protected val noun = "namespaces"
+  protected val noun = "namespaces"
 
-    /**
-     * Lists available namespaces for whisk properties.
-     *
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    override def list(expectedExitCode: Int = OK.intValue, nameSort: Option[Boolean] = None)(
-        implicit wp: WskProps): RestResult = {
-        val entPath = Path(s"$basePath/namespaces")
-        val resp = getWhiskEntity(entPath).futureValue
-        val result = if (resp == None) new RestResult(NotFound, null) else new RestResult(resp.status, getRespData(resp))
-        validateStatusCode(expectedExitCode, result.statusCode.intValue)
-        result
-    }
+  /**
+   * Lists available namespaces for whisk properties.
+   *
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  override def list(expectedExitCode: Int = OK.intValue, nameSort: Option[Boolean] = None)(
+    implicit wp: WskProps): RestResult = {
+    val entPath = Path(s"$basePath/namespaces")
+    val resp = requestEntity(GET, entPath)
+    val result = if (resp == None) new RestResult(NotFound, null) else new RestResult(resp.status, getRespData(resp))
+    validateStatusCode(expectedExitCode, result.statusCode.intValue)
+    result
+  }
 
-    /**
-     * Gets entities in namespace.
-     *
-     * @param namespace (optional) if specified must be  fully qualified namespace
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    override def get(namespace: Option[String] = None,
-                     expectedExitCode: Int = OK.intValue,
-                     nameSort: Option[Boolean] = None)(implicit wp: WskProps): RestResult = {
-        val (ns, _) = namespace map { this.getNamespaceActionName(_) } getOrElse (wp.namespace, "")
-        val entPath = Path(s"$basePath/namespaces/$ns/")
-        val resp = getWhiskEntity(entPath).futureValue
-        val r = new RestResult(resp.status, getRespData(resp))
-        validateStatusCode(expectedExitCode, r.statusCode.intValue)
-        r
-    }
+  /**
+   * Gets entities in namespace.
+   *
+   * @param namespace (optional) if specified must be  fully qualified namespace
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  override def get(namespace: Option[String] = None,
+                   expectedExitCode: Int = OK.intValue,
+                   nameSort: Option[Boolean] = None)(implicit wp: WskProps): RestResult = {
+    val (ns, _) = namespace map { this.getNamespaceActionName(_) } getOrElse (wp.namespace, "")
+    val entPath = Path(s"$basePath/namespaces/$ns/")
+    val resp = requestEntity(GET, entPath)
+    val r = new RestResult(resp.status, getRespData(resp))
+    validateStatusCode(expectedExitCode, r.statusCode.intValue)
+    r
+  }
 
-    /**
-     * Looks up namespace for whisk props.
-     *
-     * @param wskprops instance of WskProps with an auth key to lookup
-     * @return namespace as string
-     */
-    override def whois()(implicit wskprops: WskProps): String = {
-        val ns = list().getBodyListString
-        if (ns.size > 0) ns(0).toString() else ""
-    }
+  /**
+   * Looks up namespace for whisk props.
+   *
+   * @param wskprops instance of WskProps with an auth key to lookup
+   * @return namespace as string
+   */
+  override def whois()(implicit wskprops: WskProps): String = {
+    val ns = list().getBodyListString
+    if (ns.size > 0) ns(0).toString() else ""
+  }
 }
 
 class WskRestPackage
@@ -842,604 +846,577 @@ class WskRestPackage
     with DeleteFromCollectionRest
     with BasePackage {
 
-    override protected val noun = "packages"
+  override protected val noun = "packages"
 
-    /**
-     * Creates package. Parameters mirror those available in the REST.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    override def create(name: String,
-                        parameters: Map[String, JsValue] = Map(),
-                        annotations: Map[String, JsValue] = Map(),
-                        parameterFile: Option[String] = None,
-                        annotationFile: Option[String] = None,
-                        shared: Option[Boolean] = None,
-                        update: Boolean = false,
-                        expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
-        val path = getNamePath(noun, name)
-        var bodyContent = JsObject("namespace" -> s"${wp.namespace}".toJson, "name" -> name.toJson)
-
-        val (params, annos) = this.getParamsAnnos(parameters, annotations, parameterFile, annotationFile)
-        if (!update) {
-            val published = shared map { s =>
-                s
-            } getOrElse false
-            bodyContent = JsObject(
-                bodyContent.fields + ("publish" -> published.toJson,
-                    "parameters" -> params, "annotations" -> annos))
-        } else {
-            if (shared != None)
-                bodyContent = shared map { s =>
-                    JsObject(bodyContent.fields + ("publish" -> s.toJson))
-                } getOrElse bodyContent
-
-            val inputParams = convertMapIntoKeyValue(parameters)
-            if (inputParams.elements.size > 0) {
-                bodyContent = JsObject(bodyContent.fields + ("parameters" -> params))
-            }
-            val inputAnnos = convertMapIntoKeyValue(annotations)
-            if (inputAnnos.elements.size > 0) {
-                bodyContent = JsObject(bodyContent.fields + ("annotations" -> annos))
-            }
-        }
-
-        val respFuture =
-            if (update) createEntity(path, bodyContent.toString, Map("overwrite" -> "true"))
-            else createEntity(path, bodyContent.toString)
-        val resp = respFuture.futureValue
-        val r = new RestResult(resp.status, getRespData(resp))
-        validateStatusCode(expectedExitCode, r.statusCode.intValue)
-        r
-    }
-
-    /**
-     * Binds package. Parameters mirror those available in the REST.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    override def bind(provider: String,
-                      name: String,
+  /**
+   * Creates package. Parameters mirror those available in the REST.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  override def create(name: String,
                       parameters: Map[String, JsValue] = Map(),
                       annotations: Map[String, JsValue] = Map(),
+                      parameterFile: Option[String] = None,
+                      annotationFile: Option[String] = None,
+                      shared: Option[Boolean] = None,
+                      update: Boolean = false,
                       expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
-        val params = convertMapIntoKeyValue(parameters)
-        val annos = convertMapIntoKeyValue(annotations)
+    val path = getNamePath(noun, name)
+    var bodyContent = JsObject("namespace" -> s"${wp.namespace}".toJson, "name" -> name.toJson)
 
-        val (ns, packageName) = this.getNamespaceActionName(provider)
-        val path = getNamePath(noun, name)
-        val binding = JsObject("namespace" -> ns.toJson, "name" -> packageName.toJson)
-        val bodyContent = JsObject("binding" -> binding.toJson, "parameters" -> params, "annotations" -> annos)
-        val respFuture = createEntity(path, bodyContent.toString, Map("overwrite" -> "false"))
-        val resp = respFuture.futureValue
-        val r = new RestResult(resp.status, getRespData(resp))
-        validateStatusCode(expectedExitCode, r.statusCode.intValue)
-        r
+    val (params, annos) = this.getParamsAnnos(parameters, annotations, parameterFile, annotationFile)
+    if (!update) {
+      val published = shared map { s =>
+        s
+      } getOrElse false
+      bodyContent = JsObject(
+        bodyContent.fields + ("publish" -> published.toJson,
+        "parameters" -> params, "annotations" -> annos))
+    } else {
+      if (shared != None)
+        bodyContent = shared map { s =>
+          JsObject(bodyContent.fields + ("publish" -> s.toJson))
+        } getOrElse bodyContent
+
+      val inputParams = convertMapIntoKeyValue(parameters)
+      if (inputParams.elements.size > 0) {
+        bodyContent = JsObject(bodyContent.fields + ("parameters" -> params))
+      }
+      val inputAnnos = convertMapIntoKeyValue(annotations)
+      if (inputAnnos.elements.size > 0) {
+        bodyContent = JsObject(bodyContent.fields + ("annotations" -> annos))
+      }
     }
+
+    val resp =
+      if (update) requestEntity(PUT, path, Map("overwrite" -> "true"), Some(bodyContent.toString))
+      else requestEntity(PUT, path, body = Some(bodyContent.toString))
+    val r = new RestResult(resp.status, getRespData(resp))
+    validateStatusCode(expectedExitCode, r.statusCode.intValue)
+    r
+  }
+
+  /**
+   * Binds package. Parameters mirror those available in the REST.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  override def bind(provider: String,
+                    name: String,
+                    parameters: Map[String, JsValue] = Map(),
+                    annotations: Map[String, JsValue] = Map(),
+                    expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
+    val params = convertMapIntoKeyValue(parameters)
+    val annos = convertMapIntoKeyValue(annotations)
+
+    val (ns, packageName) = this.getNamespaceActionName(provider)
+    val path = getNamePath(noun, name)
+    val binding = JsObject("namespace" -> ns.toJson, "name" -> packageName.toJson)
+    val bodyContent = JsObject("binding" -> binding.toJson, "parameters" -> params, "annotations" -> annos)
+    val resp = requestEntity(PUT, path, Map("overwrite" -> "false"), Some(bodyContent.toString))
+    val r = new RestResult(resp.status, getRespData(resp))
+    validateStatusCode(expectedExitCode, r.statusCode.intValue)
+    r
+  }
 
 }
 
 class WskRestApi extends RunWskRestCmd with BaseApi {
-    protected val noun = "apis"
+  protected val noun = "apis"
 
-    /**
-     * Creates and API endpoint. Parameters mirror those available in the REST.
-     *
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    override def create(basepath: Option[String] = None,
-                        relpath: Option[String] = None,
-                        operation: Option[String] = None,
-                        action: Option[String] = None,
-                        apiname: Option[String] = None,
-                        swagger: Option[String] = None,
-                        responsetype: Option[String] = None,
-                        expectedExitCode: Int = SUCCESS_EXIT,
-                        cliCfgFile: Option[String] = None)(implicit wp: WskProps): RestResult = {
-        val r = action match {
-            case Some(action) => {
-                val (ns, actionName) = this.getNamespaceActionName(action)
-                val actionUrl = s"https://${WhiskProperties.getBaseControllerHost()}$basePath/web/$ns/default/$actionName.http"
-                val actionAuthKey = this.getAuthKey(wp)
-                val testaction = Some(ApiAction(name = actionName, namespace = ns, backendUrl = actionUrl, authkey = actionAuthKey))
-
-                val parms = Map[String, JsValue]() ++ { Map("namespace" -> ns.toJson) } ++ {
-                    basepath map { b =>
-                        Map("gatewayBasePath" -> b.toJson)
-                    } getOrElse Map[String, JsValue]()
-                } ++ {
-                    relpath map { r =>
-                        Map("gatewayPath" -> r.toJson)
-                    } getOrElse Map[String, JsValue]()
-                } ++ {
-                    operation map { o =>
-                        Map("gatewayMethod" -> o.toJson)
-                    } getOrElse Map[String, JsValue]()
-                } ++ {
-                    apiname map { an =>
-                        Map("apiName" -> an.toJson)
-                    } getOrElse Map[String, JsValue]()
-                } ++ {
-                    testaction map { a =>
-                        Map("action" -> a.toJson)
-                    } getOrElse Map[String, JsValue]()
-                } ++ {
-                    swagger map { s =>
-                        val swaggerFile = FileUtils.readFileToString(new File(s))
-                        Map("swagger" -> swaggerFile.toJson)
-                    } getOrElse Map[String, JsValue]()
-                }
-
-                val parm = Map[String, JsValue]("apidoc" -> JsObject(parms)) ++ { Map("__ow_user" -> ns.toJson) } ++ {
-                    responsetype map { r =>
-                        Map("responsetype" -> r.toJson)
-                    } getOrElse Map[String, JsValue]()
-                } ++ {
-                    Map("accesstoken" -> wp.authKey.toJson)
-                } ++ {
-                    Map("spaceguid" -> wp.authKey.split(":")(0).toJson)
-                }
-
-                invokeAction(
-                    name = "apimgmt/createApi",
-                    parameters = parm,
-                    blocking = true,
-                    result = true,
-                    expectedExitCode = expectedExitCode)(wp)
-            }
-            case None => {
-                new RestResult(NotFound, null)
-            }
-        }
-        r
-    }
-
-    /**
-     * Retrieve a list of API endpoints. Parameters mirror those available in the REST.
-     *
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    override def list(basepathOrApiName: Option[String] = None,
+  /**
+   * Creates and API endpoint. Parameters mirror those available in the REST.
+   *
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  override def create(basepath: Option[String] = None,
                       relpath: Option[String] = None,
                       operation: Option[String] = None,
-                      limit: Option[Int] = None,
-                      since: Option[Instant] = None,
-                      full: Option[Boolean] = None,
-                      nameSort: Option[Boolean] = None,
+                      action: Option[String] = None,
+                      apiname: Option[String] = None,
+                      swagger: Option[String] = None,
+                      responsetype: Option[String] = None,
                       expectedExitCode: Int = SUCCESS_EXIT,
                       cliCfgFile: Option[String] = None)(implicit wp: WskProps): RestResult = {
+    val r = action match {
+      case Some(action) => {
+        val (ns, actionName) = this.getNamespaceActionName(action)
+        val actionUrl = s"https://${WhiskProperties.getBaseControllerHost()}$basePath/web/$ns/default/$actionName.http"
+        val actionAuthKey = this.getAuthKey(wp)
+        val testaction = Some(
+          ApiAction(name = actionName, namespace = ns, backendUrl = actionUrl, authkey = actionAuthKey))
 
-        val parms = Map[String, JsValue]() ++
-            Map("__ow_user" -> wp.namespace.toJson) ++ {
-                basepathOrApiName map { b =>
-                    Map("basepath" -> b.toJson)
-                } getOrElse Map[String, JsValue]()
-            } ++ {
-                relpath map { r =>
-                    Map("relpath" -> r.toJson)
-                } getOrElse Map[String, JsValue]()
-            } ++ {
-                operation map { o =>
-                    Map("operation" -> o.toJson)
-                } getOrElse Map[String, JsValue]()
-            } ++ {
-                Map("accesstoken" -> wp.authKey.toJson)
-            } ++ {
-                Map("spaceguid" -> wp.authKey.split(":")(0).toJson)
-            }
-        val rr = invokeAction(
-            name = "apimgmt/getApi",
-            parameters = parms,
-            blocking = true,
-            result = true,
-            expectedExitCode = OK.intValue)(wp)
-        rr
-    }
-
-    /**
-     * Retieves an API's configuration. Parameters mirror those available in the REST.
-     * Runs a command wsk [params] where the arguments come in as a sequence.
-     *
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    override def get(basepathOrApiName: Option[String] = None,
-                     full: Option[Boolean] = None,
-                     expectedExitCode: Int = SUCCESS_EXIT,
-                     cliCfgFile: Option[String] = None,
-                     format: Option[String] = None)(implicit wp: WskProps): RestResult = {
-        val parms = Map[String, JsValue]() ++
-            Map("__ow_user" -> wp.namespace.toJson) ++ {
-                basepathOrApiName map { b =>
-                    Map("basepath" -> b.toJson)
-                } getOrElse Map[String, JsValue]()
-            } ++ {
-                Map("accesstoken" -> wp.authKey.toJson)
-            } ++ {
-                Map("spaceguid" -> wp.authKey.split(":")(0).toJson)
-            }
-
-        val result = invokeAction(
-            name = "apimgmt/getApi",
-            parameters = parms,
-            blocking = true,
-            result = true,
-            expectedExitCode = OK.intValue)(wp)
-        result
-    }
-
-    /**
-     * Delete an entire API or a subset of API endpoints. Parameters mirror those available in the REST.
-     *
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    override def delete(basepathOrApiName: String,
-                        relpath: Option[String] = None,
-                        operation: Option[String] = None,
-                        expectedExitCode: Int = SUCCESS_EXIT,
-                        cliCfgFile: Option[String] = None)(implicit wp: WskProps): RestResult = {
-        val parms = Map[String, JsValue]() ++ { Map("__ow_user" -> wp.namespace.toJson) } ++ {
-            Map("basepath" -> basepathOrApiName.toJson)
+        val parms = Map[String, JsValue]() ++ { Map("namespace" -> ns.toJson) } ++ {
+          basepath map { b =>
+            Map("gatewayBasePath" -> b.toJson)
+          } getOrElse Map[String, JsValue]()
         } ++ {
-            relpath map { r =>
-                Map("relpath" -> r.toJson)
-            } getOrElse Map[String, JsValue]()
+          relpath map { r =>
+            Map("gatewayPath" -> r.toJson)
+          } getOrElse Map[String, JsValue]()
         } ++ {
-            operation map { o =>
-                Map("operation" -> o.toJson)
-            } getOrElse Map[String, JsValue]()
+          operation map { o =>
+            Map("gatewayMethod" -> o.toJson)
+          } getOrElse Map[String, JsValue]()
         } ++ {
-            Map("accesstoken" -> wp.authKey.toJson)
+          apiname map { an =>
+            Map("apiName" -> an.toJson)
+          } getOrElse Map[String, JsValue]()
         } ++ {
-            Map("spaceguid" -> wp.authKey.split(":")(0).toJson)
+          testaction map { a =>
+            Map("action" -> a.toJson)
+          } getOrElse Map[String, JsValue]()
+        } ++ {
+          swagger map { s =>
+            val swaggerFile = FileUtils.readFileToString(new File(s))
+            Map("swagger" -> swaggerFile.toJson)
+          } getOrElse Map[String, JsValue]()
         }
 
-        val rr = invokeAction(
-            name = "apimgmt/deleteApi",
-            parameters = parms,
-            blocking = true,
-            result = true,
-            expectedExitCode = expectedExitCode)(wp)
-        return rr
+        val parm = Map[String, JsValue]("apidoc" -> JsObject(parms)) ++ { Map("__ow_user" -> ns.toJson) } ++ {
+          responsetype map { r =>
+            Map("responsetype" -> r.toJson)
+          } getOrElse Map[String, JsValue]()
+        } ++ {
+          Map("accesstoken" -> wp.authKey.toJson)
+        } ++ {
+          Map("spaceguid" -> wp.authKey.split(":")(0).toJson)
+        }
+
+        invokeAction(
+          name = "apimgmt/createApi",
+          parameters = parm,
+          blocking = true,
+          result = true,
+          expectedExitCode = expectedExitCode)(wp)
+      }
+      case None => {
+        new RestResult(NotFound, null)
+      }
+    }
+    r
+  }
+
+  /**
+   * Retrieve a list of API endpoints. Parameters mirror those available in the REST.
+   *
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  override def list(basepathOrApiName: Option[String] = None,
+                    relpath: Option[String] = None,
+                    operation: Option[String] = None,
+                    limit: Option[Int] = None,
+                    since: Option[Instant] = None,
+                    full: Option[Boolean] = None,
+                    nameSort: Option[Boolean] = None,
+                    expectedExitCode: Int = SUCCESS_EXIT,
+                    cliCfgFile: Option[String] = None)(implicit wp: WskProps): RestResult = {
+
+    val parms = Map[String, JsValue]() ++
+      Map("__ow_user" -> wp.namespace.toJson) ++ {
+      basepathOrApiName map { b =>
+        Map("basepath" -> b.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      relpath map { r =>
+        Map("relpath" -> r.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      operation map { o =>
+        Map("operation" -> o.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      Map("accesstoken" -> wp.authKey.toJson)
+    } ++ {
+      Map("spaceguid" -> wp.authKey.split(":")(0).toJson)
+    }
+    val rr = invokeAction(
+      name = "apimgmt/getApi",
+      parameters = parms,
+      blocking = true,
+      result = true,
+      expectedExitCode = OK.intValue)(wp)
+    rr
+  }
+
+  /**
+   * Retieves an API's configuration. Parameters mirror those available in the REST.
+   * Runs a command wsk [params] where the arguments come in as a sequence.
+   *
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  override def get(basepathOrApiName: Option[String] = None,
+                   full: Option[Boolean] = None,
+                   expectedExitCode: Int = SUCCESS_EXIT,
+                   cliCfgFile: Option[String] = None,
+                   format: Option[String] = None)(implicit wp: WskProps): RestResult = {
+    val parms = Map[String, JsValue]() ++
+      Map("__ow_user" -> wp.namespace.toJson) ++ {
+      basepathOrApiName map { b =>
+        Map("basepath" -> b.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      Map("accesstoken" -> wp.authKey.toJson)
+    } ++ {
+      Map("spaceguid" -> wp.authKey.split(":")(0).toJson)
     }
 
-    def getApi(basepathOrApiName: String, params: Map[String, String] = null, expectedExitCode: Int = OK.intValue)(
-        implicit wp: WskProps): RestResult = {
-        val whiskUrl = Uri(s"http://${WhiskProperties.getBaseControllerHost()}:9001")
-        val path = Path(s"/api/${wp.authKey.split(":")(0)}$basepathOrApiName/path")
-        val resp = getWhiskEntity(path, params, whiskUrl = whiskUrl).futureValue
-        val result = new RestResult(resp.status, getRespData(resp))
-        result
+    val result = invokeAction(
+      name = "apimgmt/getApi",
+      parameters = parms,
+      blocking = true,
+      result = true,
+      expectedExitCode = OK.intValue)(wp)
+    result
+  }
+
+  /**
+   * Delete an entire API or a subset of API endpoints. Parameters mirror those available in the REST.
+   *
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  override def delete(basepathOrApiName: String,
+                      relpath: Option[String] = None,
+                      operation: Option[String] = None,
+                      expectedExitCode: Int = SUCCESS_EXIT,
+                      cliCfgFile: Option[String] = None)(implicit wp: WskProps): RestResult = {
+    val parms = Map[String, JsValue]() ++ { Map("__ow_user" -> wp.namespace.toJson) } ++ {
+      Map("basepath" -> basepathOrApiName.toJson)
+    } ++ {
+      relpath map { r =>
+        Map("relpath" -> r.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      operation map { o =>
+        Map("operation" -> o.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      Map("accesstoken" -> wp.authKey.toJson)
+    } ++ {
+      Map("spaceguid" -> wp.authKey.split(":")(0).toJson)
     }
+
+    val rr = invokeAction(
+      name = "apimgmt/deleteApi",
+      parameters = parms,
+      blocking = true,
+      result = true,
+      expectedExitCode = expectedExitCode)(wp)
+    return rr
+  }
+
+  def getApi(basepathOrApiName: String, params: Map[String, String] = null, expectedExitCode: Int = OK.intValue)(
+    implicit wp: WskProps): RestResult = {
+    val whiskUrl = Uri(s"http://${WhiskProperties.getBaseControllerHost()}:9001")
+    val path = Path(s"/api/${wp.authKey.split(":")(0)}$basepathOrApiName/path")
+    val resp = requestEntity(GET, path, params, whiskUrl = whiskUrl)
+    val result = new RestResult(resp.status, getRespData(resp))
+    result
+  }
 }
 
 class RunWskRestCmd() extends FlatSpec with RunWskCmd with Matchers with ScalaFutures with WskActorSystem {
 
-    implicit val config = PatienceConfig(10 seconds, 0 milliseconds)
-    implicit val materializer = ActorMaterializer()
-    val whiskRestUrl = Uri(s"http://${WhiskProperties.getBaseControllerAddress()}")
-    val basePath = Path("/api/v1")
+  implicit val config = PatienceConfig(10 seconds, 0 milliseconds)
+  implicit val materializer = ActorMaterializer()
+  val whiskRestUrl = Uri(s"http://${WhiskProperties.getBaseControllerAddress()}")
+  val basePath = Path("/api/v1")
 
-    def validateStatusCode(expectedExitCode: Int, statusCode: Int) = {
-        if ((expectedExitCode != DONTCARE_EXIT) && (expectedExitCode != ANY_ERROR_EXIT))
-            if (statusCode != expectedExitCode)
-                statusCode shouldBe expectedExitCode
+  def validateStatusCode(expectedExitCode: Int, statusCode: Int) = {
+    if ((expectedExitCode != DONTCARE_EXIT) && (expectedExitCode != ANY_ERROR_EXIT))
+      if (statusCode != expectedExitCode)
+        statusCode shouldBe expectedExitCode
+  }
+
+  def getNamePath(noun: String, name: String)(implicit wp: WskProps): Path = {
+    return Path(s"$basePath/namespaces/${wp.namespace}/$noun/$name")
+  }
+
+  def getExt(filePath: String)(implicit wp: WskProps) = {
+    val sep = "."
+    if (filePath.contains(sep)) filePath.substring(filePath.lastIndexOf(sep), filePath.length())
+    else null
+  }
+
+  def request(method: HttpMethod,
+              uri: Uri,
+              body: Option[String] = None,
+              creds: BasicHttpCredentials): Future[HttpResponse] = {
+    val entity = body map { b =>
+      HttpEntity(ContentTypes.`application/json`, b)
+    } getOrElse HttpEntity(ContentTypes.`application/json`, "")
+    val request = HttpRequest(method, uri, List(Authorization(creds)), entity = entity)
+    Http().singleRequest(request)
+  }
+
+  def requestEntity(method: HttpMethod,
+                    path: Path,
+                    params: Map[String, String] = Map(),
+                    body: Option[String] = None,
+                    whiskUrl: Uri = whiskRestUrl)(implicit wp: WskProps): HttpResponse = {
+    val creds = getBasicHttpCredentials(wp)
+    request(method, whiskUrl.withPath(path).withQuery(Uri.Query(params)), body, creds = creds).futureValue
+  }
+
+  private def getBasicHttpCredentials(wp: WskProps): BasicHttpCredentials = {
+    if (wp.authKey.contains(":")) {
+      val authKey = wp.authKey.split(":")
+      new BasicHttpCredentials(authKey(0), authKey(1))
+    } else {
+      new BasicHttpCredentials(wp.authKey, wp.authKey)
     }
+  }
 
-    def getNamePath(noun: String, name: String)(implicit wp: WskProps): Path = {
-        return Path(s"$basePath/namespaces/${wp.namespace}/$noun/$name")
-    }
+  def getAuthKey(wp: WskProps): String = {
+    val authKey = wp.authKey.split(":")
+    s"${authKey(0)}:${authKey(1)}"
+  }
 
-    def getExt(filePath: String)(implicit wp: WskProps) = {
-        val sep = "."
-        if (filePath.contains(sep)) filePath.substring(filePath.lastIndexOf(sep), filePath.length())
-        else null
-    }
-
-    def request(method: HttpMethod, uri: Uri, body: String = "", creds: BasicHttpCredentials): Future[HttpResponse] = {
-        val entity = HttpEntity(ContentTypes.`application/json`, body)
-        val request = HttpRequest(method, uri, List(Authorization(creds)), entity = entity)
-        Http().singleRequest(request)
-    }
-    def createEntity(path: Path, body: String, params: Map[String, String] = null, whiskUrl: Uri = whiskRestUrl)(
-        implicit wp: WskProps): Future[HttpResponse] = {
-        val creds = getBasicHttpCredentials(wp)
-        if (params != null)
-            request(PUT, whiskUrl.withPath(path).withQuery(Uri.Query(params)), body, creds = creds)
-        else
-            request(PUT, whiskUrl.withPath(path), body, creds = creds)
-    }
-
-    def postEntityParam(path: Path, body: String, params: Map[String, String] = null, whiskUrl: Uri = whiskRestUrl)(
-        implicit wp: WskProps): Future[HttpResponse] = {
-        val creds = getBasicHttpCredentials(wp)
-        if (params != null)
-            request(POST, whiskUrl.withPath(path).withQuery(Uri.Query(params)), body, creds = creds)
-        else
-            request(POST, whiskUrl.withPath(path), body, creds = creds)
-    }
-
-    def postEntity(path: Path, body: String = null, whiskUrl: Uri = whiskRestUrl)(
-        implicit wp: WskProps): Future[HttpResponse] = {
-        val creds = getBasicHttpCredentials(wp)
-        if (body != null)
-            request(POST, whiskUrl.withPath(path), body, creds = creds)
-        else
-            request(POST, whiskUrl.withPath(path), creds = creds)
-    }
-
-    def deleteEntity(path: Path, whiskUrl: Uri = whiskRestUrl)(implicit wp: WskProps): HttpResponse = {
-        val creds = getBasicHttpCredentials(wp)
-        request(DELETE, whiskUrl.withPath(path), creds = creds).futureValue
-    }
-
-    def getWhiskEntity(path: Path, params: Map[String, String] = null, whiskUrl: Uri = whiskRestUrl)(
-        implicit wp: WskProps): Future[HttpResponse] = {
-        val creds = getBasicHttpCredentials(wp)
-        if (params != null) {
-            request(GET, whiskUrl.withPath(path).withQuery(Uri.Query(params)), creds = creds)
-        } else
-            request(GET, whiskUrl.withPath(path), creds = creds)
-    }
-
-    private def getBasicHttpCredentials(wp: WskProps): BasicHttpCredentials = {
-        if (wp.authKey.contains(":")) {
-            val authKey = wp.authKey.split(":")
-            new BasicHttpCredentials(authKey(0), authKey(1))
-        } else {
-            new BasicHttpCredentials(wp.authKey, wp.authKey)
-        }
-    }
-
-    def getAuthKey(wp: WskProps): String = {
-        val authKey = wp.authKey.split(":")
-        s"${authKey(0)}:${authKey(1)}"
-    }
-
-    def getParamsAnnos(parameters: Map[String, JsValue] = Map(),
-                       annotations: Map[String, JsValue] = Map(),
-                       parameterFile: Option[String] = None,
-                       annotationFile: Option[String] = None,
-                       feed: Option[String] = None,
-                       web: Option[String] = None): (JsArray, JsArray) = {
-        val params = parameterFile map { pf =>
-            convertStringIntoKeyValue(pf)
-        } getOrElse convertMapIntoKeyValue(parameters)
-        val annos = annotationFile map { af =>
-            convertStringIntoKeyValue(af, feed, web)
-        } getOrElse convertMapIntoKeyValue(annotations, feed, web)
-        (params, annos)
-    }
-
-    def convertStringIntoKeyValue(file: String, feed: Option[String] = None, web: Option[String] = None): JsArray = {
-        var paramsList = Vector[JsObject]()
-        val input = FileUtils.readFileToString(new File(file))
-        val in = input.parseJson.convertTo[Map[String, JsValue]]
-        convertMapIntoKeyValue(in, feed, web)
-    }
-
-    def convertMapIntoKeyValue(params: Map[String, JsValue],
-                               feed: Option[String] = None,
-                               web: Option[String] = None): JsArray = {
-        var paramsList = Vector[JsObject]()
-        params foreach { case (key, value) => paramsList :+= JsObject("key" -> key.toJson, "value" -> value.toJson) }
-        paramsList = feed map { f =>
-            paramsList :+ JsObject("key" -> "feed".toJson, "value" -> f.toJson)
-        } getOrElse paramsList
-        paramsList = web map { w =>
-            paramsList :+ JsObject("key" -> "web-export".toJson, "value" -> w.toJson)
-        } getOrElse paramsList
-        JsArray(paramsList)
-    }
-
-    def entityName(name: String)(implicit wp: WskProps) = {
-        val sep = "/"
-        if (name.startsWith(sep)) name.substring(name.indexOf(sep, name.indexOf(sep) + 1) + 1, name.length())
-        else name
-    }
-
-    def fullEntityName(name: String)(implicit wp: WskProps) = {
-        val sep = "/"
-        if (name.startsWith(sep)) name
-        else s"/${wp.namespace}/$name"
-    }
-
-    def convertIntoComponents(comps: String)(implicit wp: WskProps): JsArray = {
-        var paramsList = Vector[JsString]()
-        comps.split(",") foreach {
-            case (value) =>
-                val fullName = fullEntityName(value)
-                paramsList :+= JsString(fullName)
-        }
-        JsArray(paramsList)
-    }
-
-    def getRespData(resp: HttpResponse): String = {
-        val timeout = 5.seconds
-        Try {
-            resp.entity.toStrict(timeout).map { _.data }.map(_.utf8String).futureValue
-        } getOrElse {
-            ""
-        }
-    }
-
-    def getNamespaceActionName(name: String)(implicit wp: WskProps): (String, String) = {
-        val seq = "/"
-        var ns = ""
-        var entityName = ""
-        if (name.startsWith(seq)) {
-            val eN = name.substring(1, name.length())
-            if (eN.contains(seq)) {
-                ns = eN.split(seq)(0)
-                entityName = eN.substring(eN.indexOf(seq) + 1, eN.length())
-            } else {
-                ns = eN
-            }
-        } else {
-            ns = wp.namespace
-            entityName = name
-        }
-
-        (ns, entityName)
-    }
-
-    def invokeAction(name: String,
-                     parameters: Map[String, JsValue] = Map(),
+  def getParamsAnnos(parameters: Map[String, JsValue] = Map(),
+                     annotations: Map[String, JsValue] = Map(),
                      parameterFile: Option[String] = None,
-                     blocking: Boolean = false,
-                     result: Boolean = false,
-                     expectedExitCode: Int = Accepted.intValue)(implicit wp: WskProps): RestResult = {
-        val (ns, actName) = this.getNamespaceActionName(name)
-        val path = Path(s"$basePath/namespaces/$ns/actions/$actName")
-        var paramMap = Map("blocking" -> blocking.toString, "result" -> result.toString)
-        val input = parameterFile map { pf =>
-            FileUtils.readFileToString(new File(pf))
-        } getOrElse parameters.toJson.toString()
-        val resp = postEntityParam(path, input, paramMap).futureValue
-        val r = new RestResult(resp.status.intValue, getRespData(resp))
-        if (blocking || result) {
-            validateStatusCode(OK.intValue, r.statusCode.intValue)
-        } else {
-            validateStatusCode(expectedExitCode, r.statusCode.intValue)
-        }
-        r
+                     annotationFile: Option[String] = None,
+                     feed: Option[String] = None,
+                     web: Option[String] = None): (JsArray, JsArray) = {
+    val params = parameterFile map { pf =>
+      convertStringIntoKeyValue(pf)
+    } getOrElse convertMapIntoKeyValue(parameters)
+    val annos = annotationFile map { af =>
+      convertStringIntoKeyValue(af, feed, web)
+    } getOrElse convertMapIntoKeyValue(annotations, feed, web)
+    (params, annos)
+  }
+
+  def convertStringIntoKeyValue(file: String, feed: Option[String] = None, web: Option[String] = None): JsArray = {
+    var paramsList = Vector[JsObject]()
+    val input = FileUtils.readFileToString(new File(file))
+    val in = input.parseJson.convertTo[Map[String, JsValue]]
+    convertMapIntoKeyValue(in, feed, web)
+  }
+
+  def convertMapIntoKeyValue(params: Map[String, JsValue],
+                             feed: Option[String] = None,
+                             web: Option[String] = None): JsArray = {
+    var paramsList = Vector[JsObject]()
+    params foreach { case (key, value) => paramsList :+= JsObject("key" -> key.toJson, "value" -> value.toJson) }
+    paramsList = feed map { f =>
+      paramsList :+ JsObject("key" -> "feed".toJson, "value" -> f.toJson)
+    } getOrElse paramsList
+    paramsList = web map { w =>
+      paramsList :+ JsObject("key" -> "web-export".toJson, "value" -> w.toJson)
+    } getOrElse paramsList
+    JsArray(paramsList)
+  }
+
+  def entityName(name: String)(implicit wp: WskProps) = {
+    val sep = "/"
+    if (name.startsWith(sep)) name.substring(name.indexOf(sep, name.indexOf(sep) + 1) + 1, name.length())
+    else name
+  }
+
+  def fullEntityName(name: String)(implicit wp: WskProps) = {
+    val sep = "/"
+    if (name.startsWith(sep)) name
+    else s"/${wp.namespace}/$name"
+  }
+
+  def convertIntoComponents(comps: String)(implicit wp: WskProps): JsArray = {
+    var paramsList = Vector[JsString]()
+    comps.split(",") foreach {
+      case (value) =>
+        val fullName = fullEntityName(value)
+        paramsList :+= JsString(fullName)
     }
+    JsArray(paramsList)
+  }
+
+  def getRespData(resp: HttpResponse): String = {
+    val timeout = 5.seconds
+    Try {
+      resp.entity.toStrict(timeout).map { _.data }.map(_.utf8String).futureValue
+    } getOrElse {
+      ""
+    }
+  }
+
+  def getNamespaceActionName(name: String)(implicit wp: WskProps): (String, String) = {
+    val seq = "/"
+    var ns = ""
+    var entityName = ""
+    if (name.startsWith(seq)) {
+      val eN = name.substring(1, name.length())
+      if (eN.contains(seq)) {
+        ns = eN.split(seq)(0)
+        entityName = eN.substring(eN.indexOf(seq) + 1, eN.length())
+      } else {
+        ns = eN
+      }
+    } else {
+      ns = wp.namespace
+      entityName = name
+    }
+
+    (ns, entityName)
+  }
+
+  def invokeAction(name: String,
+                   parameters: Map[String, JsValue] = Map(),
+                   parameterFile: Option[String] = None,
+                   blocking: Boolean = false,
+                   result: Boolean = false,
+                   expectedExitCode: Int = Accepted.intValue)(implicit wp: WskProps): RestResult = {
+    val (ns, actName) = this.getNamespaceActionName(name)
+    val path = Path(s"$basePath/namespaces/$ns/actions/$actName")
+    var paramMap = Map("blocking" -> blocking.toString, "result" -> result.toString)
+    val input = parameterFile map { pf =>
+      Some(FileUtils.readFileToString(new File(pf)))
+    } getOrElse Some(parameters.toJson.toString())
+    val resp = requestEntity(POST, path, paramMap, input)
+    val r = new RestResult(resp.status.intValue, getRespData(resp))
+    if (blocking || result) {
+      validateStatusCode(OK.intValue, r.statusCode.intValue)
+    } else {
+      validateStatusCode(expectedExitCode, r.statusCode.intValue)
+    }
+    r
+  }
 }
 
 object WskRestAdmin {
-    private val binDir = WhiskProperties.getFileRelativeToWhiskHome("bin")
-    private val binaryName = "wskadmin"
+  private val binDir = WhiskProperties.getFileRelativeToWhiskHome("bin")
+  private val binaryName = "wskadmin"
 
-    def exists = {
-        val dir = binDir
-        val exec = new File(dir, binaryName)
-        assert(dir.exists, s"did not find $dir")
-        assert(exec.exists, s"did not find $exec")
-    }
+  def exists = {
+    val dir = binDir
+    val exec = new File(dir, binaryName)
+    assert(dir.exists, s"did not find $dir")
+    assert(exec.exists, s"did not find $exec")
+  }
 
-    def baseCommand = {
-        Buffer(WhiskProperties.python, new File(binDir, binaryName).toString)
-    }
+  def baseCommand = {
+    Buffer(WhiskProperties.python, new File(binDir, binaryName).toString)
+  }
 
-    def listKeys(namespace: String, pick: Integer = 1): List[(String, String)] = {
-        val wskadmin = new RunWskRestAdminCmd {}
-        wskadmin
-            .cli(Seq("user", "list", namespace, "--pick", pick.toString))
-            .stdout
-            .split("\n")
-            .map("""\s+""".r.split(_))
-            .map(parts => (parts(0), parts(1)))
-            .toList
-    }
+  def listKeys(namespace: String, pick: Integer = 1): List[(String, String)] = {
+    val wskadmin = new RunWskRestAdminCmd {}
+    wskadmin
+      .cli(Seq("user", "list", namespace, "--pick", pick.toString))
+      .stdout
+      .split("\n")
+      .map("""\s+""".r.split(_))
+      .map(parts => (parts(0), parts(1)))
+      .toList
+  }
 
 }
 
 trait RunWskRestAdminCmd extends RunWskCmd {
-    override def baseCommand = WskRestAdmin.baseCommand
+  override def baseCommand = WskRestAdmin.baseCommand
 
-    def adminCommand(params: Seq[String],
-                     expectedExitCode: Int = SUCCESS_EXIT,
-                     verbose: Boolean = false,
-                     env: Map[String, String] = Map("WSK_CONFIG_FILE" -> ""),
-                     workingDir: File = new File("."),
-                     stdinFile: Option[File] = None,
-                     showCmd: Boolean = false): RunResult = {
-        val args = baseCommand
-        if (verbose) args += "--verbose"
-        if (showCmd) println(args.mkString(" ") + " " + params.mkString(" "))
-        val rr = TestUtils.runCmd(
-            DONTCARE_EXIT,
-            workingDir,
-            TestUtils.logger,
-            sys.env ++ env,
-            stdinFile.getOrElse(null),
-            args ++ params: _*)
+  def adminCommand(params: Seq[String],
+                   expectedExitCode: Int = SUCCESS_EXIT,
+                   verbose: Boolean = false,
+                   env: Map[String, String] = Map("WSK_CONFIG_FILE" -> ""),
+                   workingDir: File = new File("."),
+                   stdinFile: Option[File] = None,
+                   showCmd: Boolean = false): RunResult = {
+    val args = baseCommand
+    if (verbose) args += "--verbose"
+    if (showCmd) println(args.mkString(" ") + " " + params.mkString(" "))
+    val rr = TestUtils.runCmd(
+      DONTCARE_EXIT,
+      workingDir,
+      TestUtils.logger,
+      sys.env ++ env,
+      stdinFile.getOrElse(null),
+      args ++ params: _*)
 
-        withClue(reportFailure(args ++ params, expectedExitCode, rr)) {
-            if (expectedExitCode != TestUtils.DONTCARE_EXIT) {
-                val ok = (rr.exitCode == expectedExitCode) || (expectedExitCode == TestUtils.ANY_ERROR_EXIT && rr.exitCode != 0)
-                if (!ok) {
-                    rr.exitCode shouldBe expectedExitCode
-                }
-            }
+    withClue(reportFailure(args ++ params, expectedExitCode, rr)) {
+      if (expectedExitCode != TestUtils.DONTCARE_EXIT) {
+        val ok = (rr.exitCode == expectedExitCode) || (expectedExitCode == TestUtils.ANY_ERROR_EXIT && rr.exitCode != 0)
+        if (!ok) {
+          rr.exitCode shouldBe expectedExitCode
         }
-        rr
+      }
     }
+    rr
+  }
 }
 
 object RestResult {
 
-    val codeConversion = 256
+  val codeConversion = 256
 
-    def getField(obj: JsObject, key: String): String = {
-        obj.fields.get(key).map(_.convertTo[String]).getOrElse("")
-    }
+  def getField(obj: JsObject, key: String): String = {
+    obj.fields.get(key).map(_.convertTo[String]).getOrElse("")
+  }
 
-    def getFieldJsObject(obj: JsObject, key: String): JsObject = {
-        obj.fields.get(key).map(_.asJsObject).getOrElse(JsObject())
-    }
+  def getFieldJsObject(obj: JsObject, key: String): JsObject = {
+    obj.fields.get(key).map(_.asJsObject).getOrElse(JsObject())
+  }
 
-    def getFieldJsValue(obj: JsObject, key: String): JsValue = {
-        obj.fields.get(key).getOrElse(JsObject())
-    }
+  def getFieldJsValue(obj: JsObject, key: String): JsValue = {
+    obj.fields.get(key).getOrElse(JsObject())
+  }
 
-    def getFieldListJsObject(obj: JsObject, key: String): Vector[JsObject] = {
-        obj.fields.get(key).map(_.convertTo[Vector[JsObject]]).getOrElse(Vector(JsObject()))
-    }
+  def getFieldListJsObject(obj: JsObject, key: String): Vector[JsObject] = {
+    obj.fields.get(key).map(_.convertTo[Vector[JsObject]]).getOrElse(Vector(JsObject()))
+  }
 
-    def convertStausCodeToExitCode(statusCode: StatusCode): Int = {
-        if (statusCode == OK)
-            return 0
-        if (statusCode.intValue < BadRequest.intValue) statusCode.intValue else statusCode.intValue - codeConversion
-    }
+  def convertStausCodeToExitCode(statusCode: StatusCode): Int = {
+    if (statusCode == OK)
+      return 0
+    if (statusCode.intValue < BadRequest.intValue) statusCode.intValue else statusCode.intValue - codeConversion
+  }
 
-    def convertHttpResponseToStderr(respData: String): String = {
-        Try {
-            getField(respData.parseJson.asJsObject, "error")
-        } getOrElse {
-            ""
-        }
+  def convertHttpResponseToStderr(respData: String): String = {
+    Try {
+      getField(respData.parseJson.asJsObject, "error")
+    } getOrElse {
+      ""
     }
+  }
 }
 
 class RestResult(var statusCode: StatusCode, var respData: String)
     extends RunResult(
-        RestResult.convertStausCodeToExitCode(statusCode),
-        respData,
-        RestResult.convertHttpResponseToStderr(respData)) {
+      RestResult.convertStausCodeToExitCode(statusCode),
+      respData,
+      RestResult.convertHttpResponseToStderr(respData)) {
 
-    def respBody: JsObject = respData.parseJson.asJsObject
+  def respBody: JsObject = respData.parseJson.asJsObject
 
-    def getField(key: String): String = {
-        RestResult.getField(respBody, key)
-    }
+  def getField(key: String): String = {
+    RestResult.getField(respBody, key)
+  }
 
-    def getFieldJsObject(key: String): JsObject = {
-        RestResult.getFieldJsObject(respBody, key)
-    }
+  def getFieldJsObject(key: String): JsObject = {
+    RestResult.getFieldJsObject(respBody, key)
+  }
 
-    def getFieldJsValue(key: String): JsValue = {
-        RestResult.getFieldJsValue(respBody, key)
-    }
+  def getFieldJsValue(key: String): JsValue = {
+    RestResult.getFieldJsValue(respBody, key)
+  }
 
-    def getFieldListJsObject(key: String): Vector[JsObject] = {
-        RestResult.getFieldListJsObject(respBody, key)
-    }
+  def getFieldListJsObject(key: String): Vector[JsObject] = {
+    RestResult.getFieldListJsObject(respBody, key)
+  }
 
-    def getBodyListJsObject(): Vector[JsObject] = {
-        respData.parseJson.convertTo[Vector[JsObject]]
-    }
+  def getBodyListJsObject(): Vector[JsObject] = {
+    respData.parseJson.convertTo[Vector[JsObject]]
+  }
 
-    def getBodyListString(): Vector[String] = {
-        respData.parseJson.convertTo[Vector[String]]
-    }
+  def getBodyListString(): Vector[String] = {
+    respData.parseJson.convertTo[Vector[String]]
+  }
 }
 
 case class ApiAction(name: String,
@@ -1447,12 +1424,12 @@ case class ApiAction(name: String,
                      backendMethod: String = "POST",
                      backendUrl: String,
                      authkey: String) {
-    def toJson(): JsObject = {
-        return JsObject(
-            "name" -> name.toJson,
-            "namespace" -> namespace.toJson,
-            "backendMethod" -> backendMethod.toJson,
-            "backendUrl" -> backendUrl.toJson,
-            "authkey" -> authkey.toJson)
-    }
+  def toJson(): JsObject = {
+    return JsObject(
+      "name" -> name.toJson,
+      "namespace" -> namespace.toJson,
+      "backendMethod" -> backendMethod.toJson,
+      "backendUrl" -> backendUrl.toJson,
+      "authkey" -> authkey.toJson)
+  }
 }


### PR DESCRIPTION
Almost all the test cases in OpenWhisk are currently running based
on the wsk CLI binary. In order to separate the CLI out of OpenWhisk
core repository, we need to call REST API of OpenWhisk to access
OpenWhisk services instead of calling the wsk CLI binary command.

This PR adds the basic REST implementation for all the test cases
to use. One basic principle is to keep the changes to the existing
test cases as few as possible, so we add WskRest.scala as an equivalent
class to Wsk.scala and WskRestTestHelpers.scala as an equivalent file
to WskTestHelpers.scala for REST.

All the replacement of binary with REST will happen in an increamental fashion.
This PR only changes one existing test case in WskActionTests.scala, and
reimplements it in WskRestActionTests.scala. All the other test cases can follow
the same way to change the test cases one by one. New changes may be necessary
to the basic REST implementation as well in future to accommodate the test cases.

Partially-closes-bug: #2430