### PR TITLE
Make the result of response consistent for both Wsk CLI and REST

### DIFF
--- a/tests/src/test/scala/system/basic/WskActionTests.scala
+++ b/tests/src/test/scala/system/basic/WskActionTests.scala
@@ -20,6 +20,7 @@ package system.basic
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
+import common.ActivationResult
 import common.JsHelpers
 import common.TestHelpers
 import common.TestUtils
@@ -289,7 +290,7 @@ class WskActionTests
             }
 
             val run = wsk.action.invoke(name, Map("payload" -> testString.toJson), blocking = true)
-            val activation = wsk.parseJsonString(run.stdout).convertTo[CliActivation]
+            val activation = wsk.parseJsonString(run.stdout).convertTo[ActivationResult]
 
             withClue(s"check failed for activation: $activation") {
                 val wordCount = testString.split(" ").length
@@ -305,7 +306,7 @@ class WskActionTests
             }
 
             val run = wsk.action.invoke(name, Map("payload" -> testString.toJson), blocking = true)
-            val activation = wsk.parseJsonString(run.stdout).convertTo[CliActivation]
+            val activation = wsk.parseJsonString(run.stdout).convertTo[ActivationResult]
 
             withClue(s"check failed for activation: $activation") {
                 activation.response.status shouldBe "success"

--- a/tests/src/test/scala/system/basic/WskBasicTests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicTests.scala
@@ -25,6 +25,7 @@ import scala.language.postfixOps
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
+import common.ActivationResult
 import common.TestHelpers
 import common.TestUtils
 import common.TestUtils._
@@ -370,7 +371,7 @@ class WskBasicTests
             }
 
             val stderr = wsk.action.invoke(name, blocking = true, expectedExitCode = 246).stderr
-            CliActivation.serdes.read(removeCLIHeader(stderr).parseJson).response.result shouldBe Some {
+            ActivationResult.serdes.read(removeCLIHeader(stderr).parseJson).response.result shouldBe Some {
                 JsObject("error" -> JsObject("msg" -> "failed activation on purpose".toJson))
             }
     }

--- a/tests/src/test/scala/system/basic/WskSequenceTests.scala
+++ b/tests/src/test/scala/system/basic/WskSequenceTests.scala
@@ -27,6 +27,7 @@ import scala.util.matching.Regex
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
+import common.ActivationResult
 import common.StreamLogging
 import common.TestHelpers
 import common.TestUtils
@@ -478,7 +479,7 @@ class WskSequenceTests
      * checks duration
      * checks memory
      */
-    private def checkSequenceLogsAndAnnotations(activation: CliActivation, size: Int) = {
+    private def checkSequenceLogsAndAnnotations(activation: ActivationResult, size: Int) = {
         activation.logs shouldBe defined
         // check that the logs are what they are supposed to be (activation ids)
         // check that the cause field is properly set for these activations
@@ -523,7 +524,7 @@ class WskSequenceTests
         }
     }
 
-    private def extractMemoryAnnotation(activation: CliActivation): Long = {
+    private def extractMemoryAnnotation(activation: ActivationResult): Long = {
         val limits = activation.getAnnotationValue("limits")
         limits shouldBe defined
         limits.get.asJsObject.getFields("memory")(0).convertTo[Long]

--- a/tests/src/test/scala/whisk/core/limits/ActionLimitsTests.scala
+++ b/tests/src/test/scala/whisk/core/limits/ActionLimitsTests.scala
@@ -26,6 +26,7 @@ import scala.language.postfixOps
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
+import common.ActivationResult
 import common.TestHelpers
 import common.TestUtils
 import common.TestUtils.TOO_LARGE
@@ -133,7 +134,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers {
 
                 val allowedSize = ActivationEntityLimit.MAX_ACTIVATION_ENTITY_LIMIT.toBytes
 
-                def checkResponse(activation: CliActivation) = {
+                def checkResponse(activation: ActivationResult) = {
                     val response = activation.response
                     response.success shouldBe false
                     response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ContainerError)
@@ -150,7 +151,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers {
                 val code = if (blocking) TestUtils.APP_ERROR else TestUtils.SUCCESS_EXIT
                 val rr = wsk.action.invoke(name, args, blocking = blocking, expectedExitCode = code)
                 if (blocking) {
-                    checkResponse(wsk.parseJsonString(rr.stderr).convertTo[CliActivation])
+                    checkResponse(wsk.parseJsonString(rr.stderr).convertTo[ActivationResult])
                 } else {
                     withActivation(wsk.activation, rr, totalWait = 120 seconds) { checkResponse(_) }
                 }


### PR DESCRIPTION
Rename CliActivationResponse & CliActivation, and change them from inner classes to classes

This PR renames the class CliActivation and CliActivationResponse
and makes them available to be accessed from another package, because
REST call can use both of the classes as well.

The PR also creates RestResult class to save the results of HTTP reopnses for REST.

Partially-closes-bug: #2430