### PR TITLE
Fix bug on ansible variable db_prefix

### DIFF
--- a/ansible/environments/distributed/group_vars/all
+++ b/ansible/environments/distributed/group_vars/all
@@ -5,7 +5,7 @@ db_protocol: http
 db_username: couch_user
 db_password: couch_password
 db_host: "{{ groups['db'] | first }}"
-db_prefix: "{{ ansible_user_id|lower }}_{{ ansible_hostname|lower }}_"
+db_prefix: whisk_distributed_
 
 whisk_version_name: local
 config_root_dir: /tmp

--- a/ansible/environments/docker-machine/group_vars/all
+++ b/ansible/environments/docker-machine/group_vars/all
@@ -10,7 +10,7 @@ docker_dns: ""
 whisk_api_localhost_name: "openwhisk"
 
 # Hardcoded for docker-machine since db init runs on host not inside VM
-db_prefix: dockermachine_
+db_prefix: whisk_dockermachine_
 
 # Auto lookup to find the db credentials
 db_provider: "{{ lookup('ini', 'db_provider section=db_creds file={{ playbook_dir }}/db_local.ini') }}"

--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -4,7 +4,7 @@ whisk_logs_dir: /tmp/wsklogs
 docker_registry: ""
 docker_dns: ""
 
-db_prefix: "{{ ansible_user_id|lower }}_{{ ansible_hostname|lower }}_"
+db_prefix: whisk_local_
 
 # Auto lookup to find the db credentials
 db_provider: "{{ lookup('ini', 'db_provider section=db_creds file={{ playbook_dir }}/db_local.ini') }}"

--- a/ansible/environments/mac/group_vars/all
+++ b/ansible/environments/mac/group_vars/all
@@ -4,7 +4,7 @@ whisk_logs_dir: /Users/Shared/wsklogs
 docker_registry: ""
 docker_dns: ""
 
-db_prefix: "{{ ansible_user_id|lower }}_{{ ansible_hostname|lower }}_"
+db_prefix: whisk_mac_
 
 # Auto lookup to find the db credentials
 db_provider: "{{ lookup('ini', 'db_provider section=db_creds file={{ playbook_dir }}/db_local.ini') }}"


### PR DESCRIPTION
if `ansible node` and `target node` is not the same node, it will have problem.
```
- include: db/recreateDb.yml
  vars:
    dbName: "{{ db.whisk.auth }}"
    forceRecreation: False
```
the `db.whisk.auth` references varaible : `db_prefix`, above ansible task's `db_prefix` value is `ansible node`'s  `{{ ansible_user_id|lower }}_{{ ansible_hostname|lower }}_`  (Note: it will get `ansible node`'s `user_id` and `hostname`)

```
- name: (re)start controller
  docker_container:
    name: controller{{ groups['controllers'].index(inventory_hostname) }}
    env:
       "DB_WHISK_AUTHS": "{{ db.whisk.auth }}"
       ...
       ...
 ```
But above ansible task's  `db.whisk.auth`'s `db_prefix` value is `controller node`'s  `{{ ansible_user_id|lower }}_{{ ansible_hostname|lower }}_`  (Note: it will get `controller node`'s `user_id` and `hostname`)

So if `ansible node` is not same as `controller node`, the controller's ENV `DB_WHISK_AUTHS` will reference a `not exist auth db address`. 

So it is better to write the `db_prefix` value to hardcode to keep the default running env well.
If you don't like the `db_prefix` value, can change it what you like.