### PR TITLE
Add number of controller instances again to the controller

### DIFF
--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -27,6 +27,7 @@
     env:
       "JAVA_OPTS": "-Xmx{{ controller.heap }}"
       "CONTROLLER_OPTS": "{{ controller.arguments }}"
+      "CONTROLLER_INSTANCES": "{{ controller.instances }}"
 
       "COMPONENT_NAME": "controller{{ groups['controllers'].index(inventory_hostname) }}"
       "PORT": 8080

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -157,7 +157,7 @@ object Controller {
     // a value, and whose values are default values.   A null value in the Map means there is
     // no default value specified, so it must appear in the properties file
     def requiredProperties = Map(WhiskConfig.servicePort -> 8080.toString) ++
-        Map(WhiskConfig.controllerInstances -> 1.toString) ++
+        Map(WhiskConfig.controllerInstances -> null) ++
         ExecManifest.requiredProperties ++
         RestApiCommons.requiredProperties ++
         LoadBalancerService.requiredProperties ++


### PR DESCRIPTION
Readd the number of controllers to the controller.
This value is needed to genrate unique tids across all controllers.

PG4#652 is running.