### PR TITLE
Remove databases of old ReplicatorTests that failed

### DIFF
--- a/tools/db/replicateDbs.py
+++ b/tools/db/replicateDbs.py
@@ -27,7 +27,7 @@ import couchdb.client
 
 def retry(fn, retries):
     try:
-        return fn
+        return fn()
     except:
         if (retries > 0):
             time.sleep(1)


### PR DESCRIPTION
This PR does a cleanup before the ReplicatorTests starts.

In addition, it fixes the retry method in the replicator-script.

PG4#661 started.