### PR TITLE
experimental web apigw cleanup

### DIFF
--- a/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
@@ -178,9 +178,9 @@ class RestAPIVersion(config: WhiskConfig, apiPath: String, apiVersion: String)(
                 // web actions are distinct to separate the cors header
                 // and allow the actions themselves to respond to options
                 basicAuth(validateCredentials) { user =>
-                    web.routes(user) ~ webexp.routes(user)
+                    web.routes(user)
                 } ~ {
-                    web.routes() ~ webexp.routes()
+                    web.routes()
                 } ~ options {
                     sendCorsHeaders {
                         complete(OK)
@@ -197,8 +197,8 @@ class RestAPIVersion(config: WhiskConfig, apiPath: String, apiVersion: String)(
     private val triggers = new TriggersApi(apiPath, apiVersion)
     private val activations = new ActivationsApi(apiPath, apiVersion)
     private val rules = new RulesApi(apiPath, apiVersion)
-    private val webexp = new WebActionsApi(Seq("experimental", "web"), WebApiDirectives.exp)
-    private val web = new WebActionsApi(Seq("web"), WebApiDirectives.web)
+    private val WebApiDirectives = new WebApiDirectives()
+    private val web = new WebActionsApi(Seq("web"), this.WebApiDirectives)
 
     class NamespacesApi(
        val apiPath: String,

--- a/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
@@ -59,7 +59,7 @@ import whisk.http.ErrorResponse.terminate
 import whisk.http.Messages
 import whisk.utils.JsHelpers._
 
-protected[controller] sealed class WebApiDirectives private (prefix: String) {
+protected[controller] sealed class WebApiDirectives (prefix: String = "__ow_") {
     // enforce the presence of an extension (e.g., .http) in the URI path
     val enforceExtension = false
 
@@ -76,20 +76,6 @@ protected[controller] sealed class WebApiDirectives private (prefix: String) {
 
     lazy val reservedProperties: Set[String] = Set(method, headers, path, namespace, query, body)
     protected final def fields(f: String) = s"$prefix$f"
-}
-
-// field names for /web with raw-http action
-protected[controller] object WebApiDirectives {
-    // field names for /web
-    val web = new WebApiDirectives("__ow_")
-
-    // field names used for /experimental/web
-    val exp = new WebApiDirectives("__ow_meta_") {
-        override val enforceExtension = true
-        override val method = fields("verb")
-        override val namespace = fields("namespace")
-        override val statusCode = "code"
-    }
 }
 
 private case class Context(
@@ -372,7 +358,7 @@ trait WhiskWebActionsApi
     /**
      * Adds route to web based activations. Actions invoked this way are anonymous in that the
      * caller is not authenticated. The intended action must be named in the path as a fully qualified
-     * name as in /experimental/web/some-namespace/some-package/some-action. The package is optional
+     * name as in /web/some-namespace/some-package/some-action. The package is optional
      * in that the action may be in the default package, in which case, the string "default" must be used.
      * If the action doesn't exist (or the namespace is not valid) NotFound is generated. Following the
      * action name, an "extension" is required to specify the desired content type for the response. This
@@ -380,7 +366,7 @@ trait WhiskWebActionsApi
      * an text/html response.
      *
      * Optionally, the result form the action may be projected based on a named property. As in
-     * /experimental/web/some-namespace/some-package/some-action/some-property. If the property
+     * /web/some-namespace/some-package/some-action/some-property. If the property
      * does not exist in the result then a NotFound error is generated. A path of properties may
      * be supplied to project nested properties.
      *

--- a/tests/src/test/scala/common/Wsk.scala
+++ b/tests/src/test/scala/common/Wsk.scala
@@ -97,7 +97,6 @@ class Wsk() extends RunWskCmd {
     implicit val pkg = new WskPackage
     implicit val namespace = new WskNamespace
     implicit val api = new WskApi
-    implicit val apiexperimental = new WskApiExperimental
 }
 
 trait FullyQualifiedNames {
@@ -784,98 +783,6 @@ class WskPackage()
             { parameters flatMap { p => Seq("-p", p._1, p._2.compactPrint) } } ++
             { annotations flatMap { p => Seq("-a", p._1, p._2.compactPrint) } }
         cli(wp.overrides ++ params, expectedExitCode)
-    }
-}
-
-class WskApiExperimental extends RunWskCmd {
-    protected val noun = "api-experimental"
-
-    /**
-     * Creates and API endpoint. Parameters mirror those available in the CLI.
-     *
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def create(
-        basepath: Option[String] = None,
-        relpath: Option[String] = None,
-        operation: Option[String] = None,
-        action: Option[String] = None,
-        apiname: Option[String] = None,
-        swagger: Option[String] = None,
-        expectedExitCode: Int = SUCCESS_EXIT)(
-            implicit wp: WskProps): RunResult = {
-        val params = Seq(noun, "create", "--auth", wp.authKey) ++
-            { basepath map { b => Seq(b) } getOrElse Seq() } ++
-            { relpath map { r => Seq(r) } getOrElse Seq() } ++
-            { operation map { o => Seq(o) } getOrElse Seq() } ++
-            { action map { aa => Seq(aa) } getOrElse Seq() } ++
-            { apiname map { a => Seq("--apiname", a) } getOrElse Seq() } ++
-            { swagger map { s => Seq("--config-file", s) } getOrElse Seq() }
-        cli(wp.overrides ++ params, expectedExitCode, showCmd = true)
-    }
-
-    /**
-     * Retrieve a list of API endpoints. Parameters mirror those available in the CLI.
-     *
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def list(
-        basepathOrApiName: Option[String] = None,
-        relpath: Option[String] = None,
-        operation: Option[String] = None,
-        limit: Option[Int] = None,
-        since: Option[Instant] = None,
-        full: Option[Boolean] = None,
-        nameSort: Option[Boolean] = None,
-        expectedExitCode: Int = SUCCESS_EXIT)(
-            implicit wp: WskProps): RunResult = {
-        val params = Seq(noun, "list", "--auth", wp.authKey) ++
-            { basepathOrApiName map { b => Seq(b) } getOrElse Seq() } ++
-            { relpath map { r => Seq(r) } getOrElse Seq() } ++
-            { operation map { o => Seq(o) } getOrElse Seq() } ++
-            { limit map { l => Seq("--limit", l.toString) } getOrElse Seq() } ++
-            { since map { i => Seq("--since", i.toEpochMilli.toString) } getOrElse Seq() } ++
-            { full map { r => Seq("--full") } getOrElse Seq() } ++
-            { nameSort map { n => Seq("--name-sort") } getOrElse Seq() }
-        cli(wp.overrides ++ params, expectedExitCode, showCmd = true)
-    }
-
-    /**
-     * Retieves an API's configuration. Parameters mirror those available in the CLI.
-     * Runs a command wsk [params] where the arguments come in as a sequence.
-     *
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def get(
-        basepathOrApiName: Option[String] = None,
-        full: Option[Boolean] = None,
-        expectedExitCode: Int = SUCCESS_EXIT)(
-            implicit wp: WskProps): RunResult = {
-        val params = Seq(noun, "get", "--auth", wp.authKey) ++
-            { basepathOrApiName map { b => Seq(b) } getOrElse Seq() } ++
-            { full map { f => if (f) Seq("--full") else Seq() } getOrElse Seq() }
-        cli(wp.overrides ++ params, expectedExitCode, showCmd = true)
-    }
-
-    /**
-     * Delete an entire API or a subset of API endpoints. Parameters mirror those available in the CLI.
-     *
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def delete(
-        basepathOrApiName: String,
-        relpath: Option[String] = None,
-        operation: Option[String] = None,
-        expectedExitCode: Int = SUCCESS_EXIT)(
-            implicit wp: WskProps): RunResult = {
-        val params = Seq(noun, "delete", "--auth", wp.authKey, basepathOrApiName) ++
-            { relpath map { r => Seq(r) } getOrElse Seq() } ++
-            { operation map { o => Seq(o) } getOrElse Seq() }
-        cli(wp.overrides ++ params, expectedExitCode, showCmd = true)
     }
 }
 

--- a/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
@@ -79,30 +79,9 @@ import whisk.http.Messages
  */
 
 @RunWith(classOf[JUnitRunner])
-class WebActionsApiTestsV1 extends FlatSpec with Matchers with WebActionsApiTests {
-    override lazy val webInvokePathSegments = Seq("experimental", "web")
-    override lazy val webApiDirectives = WebApiDirectives.exp
-
-    "properties" should "match verion" in {
-        webApiDirectives.method shouldBe "__ow_meta_verb"
-        webApiDirectives.headers shouldBe "__ow_meta_headers"
-        webApiDirectives.path shouldBe "__ow_meta_path"
-        webApiDirectives.namespace shouldBe "__ow_meta_namespace"
-        webApiDirectives.query shouldBe "__ow_meta_query"
-        webApiDirectives.body shouldBe "__ow_meta_body"
-        webApiDirectives.statusCode shouldBe "code"
-        webApiDirectives.enforceExtension shouldBe true
-        webApiDirectives.reservedProperties shouldBe {
-            Set("__ow_meta_verb", "__ow_meta_headers", "__ow_meta_path", "__ow_meta_namespace",
-                "__ow_meta_query", "__ow_meta_body")
-        }
-    }
-}
-
-@RunWith(classOf[JUnitRunner])
-class WebActionsApiTestsV2 extends FlatSpec with Matchers with WebActionsApiTests {
+class WebActionsApiPropertiesTests extends FlatSpec with Matchers with WebActionsApiTests {
     override lazy val webInvokePathSegments = Seq("web")
-    override lazy val webApiDirectives = WebApiDirectives.web
+    override lazy val webApiDirectives = new WebApiDirectives()
 
     "properties" should "match verion" in {
         webApiDirectives.method shouldBe "__ow_method"


### PR DESCRIPTION
I was planning on consolidating things like the following into a single var accross the entire project:
```
apigw_host: "http://{{ groups['apigateway']|first }}:{{apigateway.port.api}}/v1"
apigw_host_v2: "http://{{ groups['apigateway']|first }}:{{apigateway.port.api}}/v2"
```

However, the implications seems to be far reaching, and I am not sure the most efficient way to go about it.

Should I be retaining the v1 in all the routes? should it be all updated to v2? or the version removed entirely?

@csantanapr @mdeuser 