### PR TITLE
Change controller cluster work mode configurable

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -111,6 +111,8 @@ controller:
   arguments: "{{ controller_arguments | default('') }}"
   blackboxFraction: 0.10
   instances: "{{ groups['controllers'] | length }}"
+  # active/slave mode: 'backup', active/active mode:''
+  workMode: "{{ controller_cluster_work_mode | default('backup') }}"
 
 registry:
   confdir: "{{ config_root_dir }}/registry"

--- a/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/ansible/roles/nginx/templates/nginx.conf.j2
@@ -21,11 +21,12 @@ http {
         # Mark the controller as unavailable for at least 60 seconds, to not get any requests during restart.
         # Otherwise, nginx would dispatch requests when the container is up, but the backend in the container not.
         # From the docs:
-        # "normally, requests with a non-idempotent method (POST, LOCK, PATCH) are not passed to the next server if a request has been sent to an upstream server"
+        # "normally, if use active/slave mode, requests with a non-idempotent method (POST, LOCK, PATCH) are not passed to the next server if a request has been sent to an upstream server"
+        # "if use active/active mode, both of them will receive the requests on average"
         server {{ groups['controllers'] | first }}:{{ controller.basePort }} fail_timeout=60s;
 {% for ip in groups['controllers'] %}
     {% if groups['controllers'].index(ip) > 0 %}
-        server {{ ip }}:{{ controller.basePort + groups['controllers'].index(ip) }} backup;
+        server {{ ip }}:{{ controller.basePort + groups['controllers'].index(ip) }} fail_timeout=60s {{ controller.workMode }};
     {% endif %}
 {% endfor %}
     }


### PR DESCRIPTION
Currently, the default controller cluster work mode is `active/slave`.
if use `active/active` mode, can share more pressure on the request.
So i think it is necessary to change the controller cluster work mode configurable