### PR TITLE
Allow multiple controllers and invokers in local environments

### DIFF
--- a/ansible/environments/distributed/hosts
+++ b/ansible/environments/distributed/hosts
@@ -1,23 +1,29 @@
-; the first parameter in a host is the inventory_hostname which has to be
-; either an ip
-; or a resolvable hostname
+; the first parameter in a host is the inventory_hostname
 
 ; used for local actions only
 ansible ansible_connection=local
+
 [registry]
-10.3.2.153
+10.3.2.153              ansible_host=10.3.2.153
+
 [edge]
-10.3.2.154
+10.3.2.154              ansible_host=10.3.2.154
+
 [apigateway:children]
 edge
+
 [redis:children]
 edge
+
 [controllers]
-10.3.2.155
+10.3.2.155              ansible_host=10.3.2.155
+
 [kafka]
-10.3.2.156
+10.3.2.156              ansible_host=10.3.2.156
+
 [invokers]
-10.3.2.158
-10.3.2.159
+10.3.2.158              ansible_host=10.3.2.158
+10.3.2.159              ansible_host=10.3.2.159
+
 [db]
-10.3.2.16
+10.3.2.16               ansible_host=10.3.2.16

--- a/ansible/environments/docker-machine/group_vars/all
+++ b/ansible/environments/docker-machine/group_vars/all
@@ -28,3 +28,5 @@ apigw_host_v2: "http://{{ groups['apigateway']|first }}:{{apigateway.port.api}}/
 
 controller_arguments: '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1098'
 invoker_arguments: "{{ controller_arguments }}"
+
+invoker_allow_multiple_instances: true

--- a/ansible/environments/docker-machine/hosts.j2.ini
+++ b/ansible/environments/docker-machine/hosts.j2.ini
@@ -1,30 +1,30 @@
-; the first parameter in a host is the inventory_hostname which has to be
-; either an ip
-; or a resolvable hostname
+; the first parameter in a host is the inventory_hostname
 
 ; used for local actions only
 ansible ansible_connection=local
 
 [edge]
-{{ docker_machine_ip }}
+{{ docker_machine_ip }}     ansible_host={{ docker_machine_ip }}
 
 [controllers]
-{{ docker_machine_ip }}
+controller0                 ansible_host={{ docker_machine_ip }}
+controller1                 ansible_host={{ docker_machine_ip }}
 
 [kafka]
-{{ docker_machine_ip }}
+{{ docker_machine_ip }}     ansible_host={{ docker_machine_ip }}
 
 [invokers]
-{{ docker_machine_ip }}
+invoker0                    ansible_host={{ docker_machine_ip }}
+invoker1                    ansible_host={{ docker_machine_ip }}
 
 [db]
-{{ docker_machine_ip }}
+{{ docker_machine_ip }}     ansible_host={{ docker_machine_ip }}
 
 [redis]
-{{ docker_machine_ip }}
+{{ docker_machine_ip }}     ansible_host={{ docker_machine_ip }}
 
 [apigateway]
-{{ docker_machine_ip }}
+{{ docker_machine_ip }}     ansible_host={{ docker_machine_ip }}
 
 ; define variables
 [all:vars]

--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -22,3 +22,5 @@ apigw_host_v2: "http://{{ groups['apigateway']|first }}:{{apigateway.port.api}}/
 
 controller_arguments: '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1098'
 invoker_arguments: "{{ controller_arguments }}"
+
+invoker_allow_multiple_instances: true

--- a/ansible/environments/local/hosts
+++ b/ansible/environments/local/hosts
@@ -1,29 +1,28 @@
-; the first parameter in a host is the inventory_hostname which has to be
-; either an ip
-; or a resolvable hostname
+; the first parameter in a host is the inventory_hostname
 
 ; used for local actions only
 ansible ansible_connection=local
 
 [edge]
-172.17.0.1 ansible_connection=local
+172.17.0.1          ansible_host=172.17.0.1 ansible_connection=local
 
 [controllers]
-172.17.0.1 ansible_connection=local
+controller0         ansible_host=172.17.0.1 ansible_connection=local
+controller1         ansible_host=172.17.0.1 ansible_connection=local
 
 [kafka]
-172.17.0.1 ansible_connection=local
+172.17.0.1          ansible_host=172.17.0.1 ansible_connection=local
 
 [invokers]
-172.17.0.1 ansible_connection=local
+invoker0            ansible_host=172.17.0.1 ansible_connection=local
+invoker1            ansible_host=172.17.0.1 ansible_connection=local
 
 ; db group is only used if db_provider is CouchDB
 [db]
-172.17.0.1 ansible_connection=local
+172.17.0.1          ansible_host=172.17.0.1 ansible_connection=local
 
 [redis]
-172.17.0.1 ansible_connection=local
+172.17.0.1          ansible_host=172.17.0.1 ansible_connection=local
 
 [apigateway]
-172.17.0.1 ansible_connection=local
-
+172.17.0.1          ansible_host=172.17.0.1 ansible_connection=local

--- a/ansible/environments/mac/group_vars/all
+++ b/ansible/environments/mac/group_vars/all
@@ -22,3 +22,5 @@ apigw_host_v2: "http://{{ groups['apigateway']|first }}:{{apigateway.port.api}}/
 
 controller_arguments: '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1098'
 invoker_arguments: "{{ controller_arguments }}"
+
+invoker_allow_multiple_instances: true

--- a/ansible/environments/mac/hosts
+++ b/ansible/environments/mac/hosts
@@ -1,29 +1,28 @@
-; the first parameter in a host is the inventory_hostname which has to be
-; either an ip
-; or a resolvable hostname
+; the first parameter in a host is the inventory_hostname
 
 ; used for local actions only
 ansible ansible_connection=local
 
 [edge]
-172.17.0.1 ansible_connection=local
+172.17.0.1          ansible_host=172.17.0.1 ansible_connection=local
 
 [controllers]
-172.17.0.1 ansible_connection=local
+controller0         ansible_host=172.17.0.1 ansible_connection=local
+controller1         ansible_host=172.17.0.1 ansible_connection=local
 
 [kafka]
-172.17.0.1 ansible_connection=local
+172.17.0.1          ansible_host=172.17.0.1 ansible_connection=local
 
 [invokers]
-172.17.0.1 ansible_connection=local
+invoker0            ansible_host=172.17.0.1 ansible_connection=local
+invoker1            ansible_host=172.17.0.1 ansible_connection=local
 
 ; db group is only used if db_provider is CouchDB
 [db]
-172.17.0.1 ansible_connection=local
+172.17.0.1          ansible_host=172.17.0.1 ansible_connection=local
 
 [redis]
-172.17.0.1 ansible_connection=local
+172.17.0.1          ansible_host=172.17.0.1 ansible_connection=local
 
 [apigateway]
-172.17.0.1 ansible_connection=local
-
+172.17.0.1          ansible_host=172.17.0.1 ansible_connection=local

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -142,6 +142,8 @@ invoker:
   coreshare: 2
   busyThreshold: "{{ invoker_busy_threshold | default(16) }}"
   instances: "{{ groups['invokers'] | length }}"
+  # Specify if it is allowed to deploy more than 1 invoker on a single machine.
+  allowMultipleInstances: "{{ invoker_allow_multiple_instances | default(false) }}"
 
 nginx:
   confdir: "{{ config_root_dir }}/nginx"

--- a/ansible/logs.yml
+++ b/ansible/logs.yml
@@ -24,13 +24,14 @@
         - subjects
       when: "'db' not in exclude_logs_from"
 
-- hosts: shared,core,invokers
+- hosts: all:!ansible
+  serial: 1
   tasks:
   - name: get all docker containers
-    local_action: shell docker --host tcp://{{inventory_hostname}}:{{docker.port}} ps -a --format="{% raw %}{{.Names}}{% endraw %}"
+    local_action: shell docker --host tcp://{{ ansible_host }}:{{ docker.port }} ps -a --format="{% raw %}{{.Names}}{% endraw %}"
     register: container_names
   - name: get logs from all containers
-    local_action: shell docker --host tcp://{{inventory_hostname}}:{{docker.port}} logs {{ item }} > "{{ openwhisk_home }}/logs/{{ item }}.log"; exit 0
+    local_action: shell docker --host tcp://{{ ansible_host }}:{{ docker.port }} logs {{ item }} > "{{ openwhisk_home }}/logs/{{ item }}.log"; exit 0
     with_items: "{{ container_names.stdout_lines | difference('whisk_docker_registry') }}"
     when: "'docker' not in exclude_logs_from"
   - name: workaround to make synchronize work

--- a/ansible/provision_env_dist.yml
+++ b/ansible/provision_env_dist.yml
@@ -5,7 +5,7 @@
   tasks:
     - name: add header to hosts file
       copy:
-        content: "; the first parameter in a host is the inventory_hostname which has to be\n; either an ip\n; or a resolvable hostname\n\n; used for local actions only\nansible ansible_connection=local\n"
+        content: "; the first parameter in a host is the inventory_hostname\n\nansible ansible_connection=local\n"
         dest: "{{inventory_dir}}/hosts"
 
     - name: Create instances

--- a/ansible/roles/apigateway/tasks/deploy.yml
+++ b/ansible/roles/apigateway/tasks/deploy.yml
@@ -19,7 +19,7 @@
     env:
       "REDIS_HOST": "{{ groups['redis'] | first }}"
       "REDIS_PORT": "{{ redis.port }}"
-      "PUBLIC_MANAGEDURL_HOST": "{{ inventory_hostname }}"
+      "PUBLIC_MANAGEDURL_HOST": "{{ ansible_host }}"
       "PUBLIC_MANAGEDURL_PORT": "{{ apigateway.port.mgmt }}"
     ports:
       - "{{ apigateway.port.mgmt }}:8080"

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -65,7 +65,7 @@
 
 - name: wait until the Controller in this host is up and running
   uri:
-    url: "http://{{ inventory_hostname }}:{{ controller.basePort + groups['controllers'].index(inventory_hostname) }}/ping"
+    url: "http://{{ ansible_host }}:{{ controller.basePort + groups['controllers'].index(inventory_hostname) }}/ping"
   register: result
   until: result.status == 200
   retries: 12

--- a/ansible/roles/couchdb/tasks/deploy.yml
+++ b/ansible/roles/couchdb/tasks/deploy.yml
@@ -36,13 +36,13 @@
 - name: wait until the CouchDB in this host is up and running
   wait_for:
     delay: 2
-    host: "{{ inventory_hostname }}"
+    host: "{{ ansible_host }}"
     port: "{{ db_port }}"
     timeout: 60
 
 - name: create admin user
   uri:
-    url: "{{ db_protocol }}://{{ inventory_hostname }}:{{ db_port }}/_config/admins/{{ db_username }}"
+    url: "{{ db_protocol }}://{{ ansible_host }}:{{ db_port }}/_config/admins/{{ db_username }}"
     method: PUT
     body: >
         "{{ db_password }}"
@@ -51,7 +51,7 @@
 
 - name: disable reduce limit on views
   uri:
-    url: "{{ db_protocol }}://{{ inventory_hostname }}:{{ db_port }}/_config/query_server_config/reduce_limit"
+    url: "{{ db_protocol }}://{{ ansible_host }}:{{ db_port }}/_config/query_server_config/reduce_limit"
     method: PUT
     body: >
         "false"

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -27,7 +27,7 @@
   delay: "{{ docker.pull.delay }}"
 
 - name: determine docker root dir
-  uri:  url="http://{{ inventory_hostname }}:{{ docker.port }}/info" return_content=yes
+  uri:  url="http://{{ ansible_host }}:{{ docker.port }}/info" return_content=yes
   register: dockerInfo
 
 - name: ensure invoker log directory is created with permissions
@@ -43,18 +43,21 @@
   when: whisk_version_name != "mac"
 
 - name: get running invoker information
-  uri: url="http://{{ inventory_hostname }}:{{ docker.port }}/containers/json?filters={{ '{"name":[ "invoker" ],"ancestor":[ "invoker" ]}' | urlencode }}" return_content=yes
+  uri:
+    url: "http://{{ ansible_host }}:{{ docker.port }}/containers/json?filters={{ '{\"name\":[ \"invoker\" ],\"ancestor\":[ \"invoker\" ]}' | urlencode }}"
+    return_content: yes
   register: invokerInfo
 
 - name: determine if more than one invoker is running
-  fail: msg="more than one invoker is running"
-  when: invokerInfo.json|length > 1
+  fail:
+    msg: "more than one invoker is running"
+  when: not invoker.allowMultipleInstances and invokerInfo.json|length > 1
 
 - name: determine if index of invoker is same with index of inventory host
   fail:
     msg: "invoker index is invalid. expected: /invoker{{ groups['invokers'].index(inventory_hostname) }} found: {{ item.Names[0] }}"
   with_items: "{{ invokerInfo.json }}"
-  when: item.Names[0] != "/invoker{{ groups['invokers'].index(inventory_hostname) }}"
+  when: not invoker.allowMultipleInstances and item.Names[0] != "/invoker{{ groups['invokers'].index(inventory_hostname) }}"
 
 - name: start invoker using docker cli
   shell: >
@@ -101,13 +104,12 @@
         -p {{ invoker.port + groups['invokers'].index(inventory_hostname) }}:8080
         {{ docker_registry }}{{ docker.image.prefix }}/invoker:{{ docker.image.tag }}
         /bin/sh -c "exec /invoker/bin/invoker {{ groups['invokers'].index(inventory_hostname) }} >> /logs/invoker{{ groups['invokers'].index(inventory_hostname) }}_logs.log 2>&1"
-  when: invokerInfo.json|length == 0
 
 # todo: re-enable docker_container module once https://github.com/ansible/ansible-modules-core/issues/5054 is resolved
 
 - name: wait until Invoker is up and running
   uri:
-    url: "http://{{ inventory_hostname }}:{{ invoker.port + groups['invokers'].index(inventory_hostname) }}/ping"
+    url: "http://{{ ansible_host }}:{{ invoker.port + groups['invokers'].index(inventory_hostname) }}/ping"
   register: result
   until: result.status == 200
   retries: 12

--- a/ansible/roles/kafka/tasks/deploy.yml
+++ b/ansible/roles/kafka/tasks/deploy.yml
@@ -17,7 +17,7 @@
       - "{{ zookeeper.port }}:2181"
 
 - name: wait until the Zookeeper in this host is up and running
-  action: shell (echo ruok; sleep 1) | nc {{ inventory_hostname }} {{ zookeeper.port }}
+  action: shell (echo ruok; sleep 1) | nc {{ ansible_host }} {{ zookeeper.port }}
   register: result
   until: (result.rc == 0) and (result.stdout == 'imok')
   retries: 36
@@ -38,7 +38,7 @@
     links:
       - "zookeeper:zookeeper"
     env:
-      "KAFKA_ADVERTISED_HOST_NAME": "{{ inventory_hostname }}"
+      "KAFKA_ADVERTISED_HOST_NAME": "{{ ansible_host }}"
       "KAFKA_HEAP_OPTS": "-Xmx{{ kafka.heap }} -Xms{{ kafka.heap }}"
     ports:
       - "{{ kafka.port }}:9092"
@@ -51,20 +51,20 @@
   delay: 5
 
 - name: create the health topic
-  shell: "docker exec kafka bash -c 'unset JMX_PORT; kafka-topics.sh --create --topic health --replication-factor 1 --partitions 1 --zookeeper {{ inventory_hostname }}:{{ zookeeper.port }} --config retention.bytes={{ kafka.topics.health.retentionBytes }} --config retention.ms={{ kafka.topics.health.retentionMS }} --config segment.bytes={{ kafka.topics.health.segmentBytes }}'"
+  shell: "docker exec kafka bash -c 'unset JMX_PORT; kafka-topics.sh --create --topic health --replication-factor 1 --partitions 1 --zookeeper {{ ansible_host }}:{{ zookeeper.port }} --config retention.bytes={{ kafka.topics.health.retentionBytes }} --config retention.ms={{ kafka.topics.health.retentionMS }} --config segment.bytes={{ kafka.topics.health.segmentBytes }}'"
   register: command_result
   failed_when: "not ('Created topic' in command_result.stdout or 'already exists' in command_result.stdout)"
   changed_when: "'Created topic' in command_result.stdout"
 
 - name: create the active-ack topics
-  shell: "docker exec kafka bash -c 'unset JMX_PORT; kafka-topics.sh --create --topic completed{{ item.0 }} --replication-factor 1 --partitions 1 --zookeeper {{ inventory_hostname }}:{{ zookeeper.port }} --config retention.bytes={{ kafka.topics.completed.retentionBytes }} --config retention.ms={{ kafka.topics.completed.retentionMS }} --config segment.bytes={{ kafka.topics.completed.segmentBytes }}'"
+  shell: "docker exec kafka bash -c 'unset JMX_PORT; kafka-topics.sh --create --topic completed{{ item.0 }} --replication-factor 1 --partitions 1 --zookeeper {{ ansible_host }}:{{ zookeeper.port }} --config retention.bytes={{ kafka.topics.completed.retentionBytes }} --config retention.ms={{ kafka.topics.completed.retentionMS }} --config segment.bytes={{ kafka.topics.completed.segmentBytes }}'"
   with_indexed_items: "{{ groups['controllers'] }}"
   register: command_result
   failed_when: "not ('Created topic' in command_result.stdout or 'already exists' in command_result.stdout)"
   changed_when: "'Created topic' in command_result.stdout"
 
 - name: create the invoker topics
-  shell: "docker exec kafka bash -c 'unset JMX_PORT; kafka-topics.sh --create --topic invoker{{ item.0 }} --replication-factor 1 --partitions 1 --zookeeper {{ inventory_hostname }}:{{ zookeeper.port }} --config retention.bytes={{ kafka.topics.invoker.retentionBytes }} --config retention.ms={{ kafka.topics.invoker.retentionMS }} --config segment.bytes={{ kafka.topics.invoker.segmentBytes }}'"
+  shell: "docker exec kafka bash -c 'unset JMX_PORT; kafka-topics.sh --create --topic invoker{{ item.0 }} --replication-factor 1 --partitions 1 --zookeeper {{ ansible_host }}:{{ zookeeper.port }} --config retention.bytes={{ kafka.topics.invoker.retentionBytes }} --config retention.ms={{ kafka.topics.invoker.retentionMS }} --config segment.bytes={{ kafka.topics.invoker.segmentBytes }}'"
   with_indexed_items: "{{ groups['invokers'] }}"
   register: command_result
   failed_when: "not ('Created topic' in command_result.stdout or 'already exists' in command_result.stdout)"

--- a/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/ansible/roles/nginx/templates/nginx.conf.j2
@@ -22,11 +22,11 @@ http {
         # Otherwise, nginx would dispatch requests when the container is up, but the backend in the container not.
         # From the docs:
         # "normally, requests with a non-idempotent method (POST, LOCK, PATCH) are not passed to the next server if a request has been sent to an upstream server"
-        server {{ groups['controllers'] | first }}:{{ controller.basePort }} fail_timeout=60s;
+        server {{ hostvars[groups['controllers'] | first].ansible_host }}:{{ controller.basePort }} fail_timeout=60s;
 {% for ip in groups['controllers'] %}
-    {% if groups['controllers'].index(ip) > 0 %}
-        server {{ ip }}:{{ controller.basePort + groups['controllers'].index(ip) }} backup;
-    {% endif %}
+{% if groups['controllers'].index(ip) > 0 %}
+        server {{ hostvars[ip].ansible_host }}:{{ controller.basePort + groups['controllers'].index(ip) }} backup;
+{% endif %}
 {% endfor %}
     }
 

--- a/ansible/roles/redis/tasks/deploy.yml
+++ b/ansible/roles/redis/tasks/deploy.yml
@@ -17,7 +17,7 @@
       - "{{ redis.port }}:6379"
 
 - name: wait until redis is up and running
-  action: shell (echo PING; sleep 1) | nc {{ inventory_hostname }} {{ redis.port }}
+  action: shell (echo PING; sleep 1) | nc {{ ansible_host }} {{ redis.port }}
   register: result
   until: (result.rc == 0) and (result.stdout == '+PONG')
   retries: 12

--- a/ansible/roles/registry/tasks/deploy.yml
+++ b/ansible/roles/registry/tasks/deploy.yml
@@ -6,7 +6,7 @@
   retries: "{{ docker.pull.retries }}"
   delay: "{{ docker.pull.delay }}"
 
-- name: "create {{ registry.confdir }} on registry {{ inventory_hostname }}"
+- name: "create {{ registry.confdir }} on registry {{ ansible_host }}"
   file:
     path: "{{ registry.confdir }}/certs"
     state: directory
@@ -54,7 +54,7 @@
 - name: wait until registry in this host is up and running
   wait_for:
     delay: 2
-    host: "{{ ansible_host|default('inventory_hostname') }}"
+    host: "{{ ansible_host }}"
     port: "{{ registry.port }}"
     timeout: 60
 

--- a/ansible/roles/whiskhost/tasks/patchKernel.yml
+++ b/ansible/roles/whiskhost/tasks/patchKernel.yml
@@ -33,9 +33,14 @@
   become: true
 
 - name: wait until host comes back up, timeout after 10 minutes
-  local_action: wait_for host={{ inventory_hostname }} port=22 state=started delay=10 timeout=600
+  local_action:
+    wait_for host: "{{ ansible_host }}"
+    port: 22
+    state: started
+    delay: 10
+    timeout: 600
 
 # can not use apt module because of https://github.com/ansible/ansible-modules-core/issues/4029
 - name: remove old kernels
-  shell: apt-get -y autoremove --purge 
+  shell: apt-get -y autoremove --purge
   become: true

--- a/ansible/templates/whisk.properties.j2
+++ b/ansible/templates/whisk.properties.j2
@@ -45,7 +45,7 @@ edge.host={{ groups["edge"]|first }}
 kafka.host={{ groups["kafka"]|first }}
 router.host={{ groups["edge"]|first }}
 zookeeper.host={{ groups["kafka"]|first }}
-invoker.hosts={{ groups["invokers"] | join(",") }}
+invoker.hosts={{ groups["invokers"] | map('extract', hostvars, 'ansible_host') | list | join(",") }}
 
 edge.host.apiport=443
 zookeeper.host.port={{ zookeeper.port }}
@@ -53,7 +53,7 @@ kafka.host.port={{ kafka.port }}
 kafkaras.host.port={{ kafka.ras.port }}
 invoker.hosts.baseport={{ invoker.port }}
 
-controller.hosts={{ groups["controllers"] | join(",") }}
+controller.hosts={{ groups["controllers"] | map('extract', hostvars, 'ansible_host') | list | join(",") }}
 controller.host.basePort={{ controller.basePort }}
 controller.instances={{ controller.instances }}
 
@@ -64,7 +64,7 @@ invoker.numcore={{ invoker.numcore }}
 invoker.coreshare={{ invoker.coreshare }}
 invoker.instances={{ invoker.instances }}
 
-main.docker.endpoint={{ groups["controllers"]|first }}:{{ docker.port }}
+main.docker.endpoint={{ hostvars[groups["controllers"]|first].ansible_host }}:{{ docker.port }}
 
 docker.registry={{ docker_registry }}
 docker.image.prefix={{ docker.image.prefix }}


### PR DESCRIPTION
Signed-off-by: Markus Thoemmes <markus.thoemmes@de.ibm.com>

This allows deploying multiple controllers and invokers locally to be able to test their scaleout ability.
This PR replaces #2527 