### PR TITLE
Install composer in its own layer

### DIFF
--- a/core/php7.1Action/Dockerfile
+++ b/core/php7.1Action/Dockerfile
@@ -27,12 +27,12 @@ RUN \
        bcmath \
        zip \
        gd \
-       soap \
+       soap
 
-   && \
-
-    # install Composer
-    cd /tmp && curl -sS https://getcomposer.org/installer | php  -- --install-dir=/usr/bin --filename=composer
+# install composer
+RUN curl -s -f -L -o /tmp/installer.php https://getcomposer.org/installer \
+    && php /tmp/installer.php --no-ansi --install-dir=/usr/bin --filename=composer \
+    && composer --ansi --version --no-interaction
 
 # create src directory to store action files
 RUN mkdir -p /action/src


### PR DESCRIPTION
Composer installation seems to fail sometimes in the CI build
environment. Move the installation of composer to a separate layer and
separate the download of the file via curl from the installation
process. Finally, run `composer --version` to ensure that it has been
installed correctly.