### PR TITLE
Bump toStrictEntity timeout to 30 seconds.

### DIFF
--- a/common/scala/src/main/scala/whisk/http/BasicHttpService.scala
+++ b/common/scala/src/main/scala/whisk/http/BasicHttpService.scala
@@ -92,7 +92,7 @@ trait BasicHttpService extends Directives with TransactionCounter {
                 prioritizeRejections {
                     DebuggingDirectives.logRequest(logRequestInfo _) {
                         DebuggingDirectives.logRequestResult(logResponseInfo _) {
-                            toStrictEntity(1.second) {
+                            toStrictEntity(30.seconds) {
                                 routes
                             }
                         }


### PR DESCRIPTION
1 second is a rather small timeout for `toStrictEntity`. If a garbage collection hits around it, requests might randomly and unnecessary fail. Bumping that timeout to something quite high shouldn't impact general operations at all.