### PR TITLE
remove API GW V1 group vars

### DIFF
--- a/ansible/environments/distributed/group_vars/all
+++ b/ansible/environments/distributed/group_vars/all
@@ -72,5 +72,4 @@ instances:
 # API GW connection configuration
 apigw_auth_user: ""
 apigw_auth_pwd: ""
-apigw_host: "http://{{ groups['apigateway']|first }}:{{apigateway.port.api}}/v1"
 apigw_host_v2: "http://{{ groups['apigateway']|first }}:{{apigateway.port.api}}/v2"

--- a/ansible/environments/docker-machine/group_vars/all
+++ b/ansible/environments/docker-machine/group_vars/all
@@ -23,7 +23,6 @@ db_port: "{{ lookup('ini', 'db_port section=db_creds file={{ playbook_dir }}/db_
 # API GW connection configuration
 apigw_auth_user: ""
 apigw_auth_pwd: ""
-apigw_host: "http://{{ groups['apigateway']|first }}:{{apigateway.port.api}}/v1"
 apigw_host_v2: "http://{{ groups['apigateway']|first }}:{{apigateway.port.api}}/v2"
 
 controller_arguments: '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1098'

--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -17,7 +17,6 @@ db_port: "{{ lookup('ini', 'db_port section=db_creds file={{ playbook_dir }}/db_
 # API GW connection configuration
 apigw_auth_user: ""
 apigw_auth_pwd: ""
-apigw_host: "http://{{ groups['apigateway']|first }}:{{apigateway.port.api}}/v1"
 apigw_host_v2: "http://{{ groups['apigateway']|first }}:{{apigateway.port.api}}/v2"
 
 controller_arguments: '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1098'

--- a/ansible/roles/routemgmt/files/installRouteMgmt.sh
+++ b/ansible/roles/routemgmt/files/installRouteMgmt.sh
@@ -24,7 +24,6 @@ WSK_CLI="$4"
 WHISKPROPS_FILE="$OPENWHISK_HOME/whisk.properties"
 GW_USER=`fgrep apigw.auth.user= $WHISKPROPS_FILE | cut -d'=' -f2`
 GW_PWD=`fgrep apigw.auth.pwd= $WHISKPROPS_FILE | cut -d'=' -f2-`
-GW_HOST=`fgrep apigw.host= $WHISKPROPS_FILE | cut -d'=' -f2`
 GW_HOST_V2=`fgrep apigw.host.v2= $WHISKPROPS_FILE | cut -d'=' -f2`
 
 # If the auth key file exists, read the key in the file. Otherwise, take the
@@ -40,7 +39,6 @@ $WSK_CLI -i --apihost "$APIHOST" package update --auth "$AUTH"  --shared no "$NA
 -a description "This package manages the gateway API configuration." \
 -p gwUser "$GW_USER" \
 -p gwPwd "$GW_PWD" \
--p gwUrl "$GW_HOST" \
 -p gwUrlV2 "$GW_HOST_V2"
 
 echo Creating NPM module .zip files

--- a/ansible/templates/whisk.properties.j2
+++ b/ansible/templates/whisk.properties.j2
@@ -90,7 +90,6 @@ db.whisk.auths={{ db.whisk.auth }}
 
 apigw.auth.user={{apigw_auth_user}}
 apigw.auth.pwd={{apigw_auth_pwd}}
-apigw.host={{apigw_host}}
 apigw.host.v2={{apigw_host_v2}}
 
 loadbalancer.invokerBusyThreshold={{ invoker.busyThreshold }}

--- a/docs/apigateway.md
+++ b/docs/apigateway.md
@@ -12,8 +12,6 @@ For more information on API Gateway feature you can read the [api management doc
 
 Follow the instructions in [Configure CLI](./README.md#setting-up-the-openwhisk-cli) on how to set the authentication key for your specific namespace.
 
-**Note:** The APIs you created using the `wsk api-experimental` will continue to work for a short period, however you should begin migrating your APIs to web actions and reconfigure your existing apis using the new CLI command `wsk api`.
-
 ### Create your first API using the CLI
 
 1. Create a JavaScript file with the following content. For this example, the file name is 'hello.js'.


### PR DESCRIPTION
Should I be updating all api_gw_v2 vars to exclude v2 now as well? aka api_gw