### PR TITLE
Apply standard scala formatting.

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,6 @@
+style = intellij
+danglingParentheses = false
+maxColumn = 120
+docstrings = JavaDoc
+rewrite.rules = [SortImports]
+project.git = true

--- a/build.gradle
+++ b/build.gradle
@@ -6,3 +6,8 @@ buildscript {
         classpath "cz.alenkacz:gradle-scalafmt:${gradle.scalafmt.version}"
     }
 }
+
+subprojects {
+    apply plugin: 'scalafmt'
+    scalafmt.configFilePath = gradle.scalafmt.config
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,8 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath "cz.alenkacz:gradle-scalafmt:${gradle.scalafmt.version}"
+    }
+}

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -1,8 +1,5 @@
 apply plugin: 'scala'
 apply plugin: 'eclipse'
-apply plugin: 'scalafmt'
-
-scalafmt.configFilePath = gradle.scalafmt.config
 
 ext.dockerImageName = 'scala'
 apply from: '../../gradle/docker.gradle'

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -1,12 +1,3 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath "cz.alenkacz:gradle-scalafmt:${gradle.scalafmt.version}"
-    }
-}
-
 apply plugin: 'scala'
 apply plugin: 'eclipse'
 apply plugin: 'scalafmt'

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -1,5 +1,17 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath "cz.alenkacz:gradle-scalafmt:${gradle.scalafmt.version}"
+    }
+}
+
 apply plugin: 'scala'
 apply plugin: 'eclipse'
+apply plugin: 'scalafmt'
+
+scalafmt.configFilePath = gradle.scalafmt.config
 
 ext.dockerImageName = 'scala'
 apply from: '../../gradle/docker.gradle'

--- a/common/scala/src/main/scala/whisk/common/Counter.scala
+++ b/common/scala/src/main/scala/whisk/common/Counter.scala
@@ -23,25 +23,25 @@ import java.util.concurrent.atomic.AtomicLong
  * A simple thread-safe counter.
  */
 class Counter {
-    private val cnt = new AtomicLong(0L)
-    def cur = cnt.get()
+  private val cnt = new AtomicLong(0L)
+  def cur = cnt.get()
 
-    /**
-     * Increments and gets the current value.
-     */
-    def next(): Long = {
-        cnt.incrementAndGet()
-    }
+  /**
+   * Increments and gets the current value.
+   */
+  def next(): Long = {
+    cnt.incrementAndGet()
+  }
 
-    /**
-     * Decrements and gets the current value.
-     */
-    def prev(): Long = {
-        cnt.decrementAndGet()
-    }
+  /**
+   * Decrements and gets the current value.
+   */
+  def prev(): Long = {
+    cnt.decrementAndGet()
+  }
 
-    /**
-     * Sets the value
-     */
-    def set(i: Long) = cnt.set(i)
+  /**
+   * Sets the value
+   */
+  def set(i: Long) = cnt.set(i)
 }

--- a/common/scala/src/main/scala/whisk/common/DateUtil.scala
+++ b/common/scala/src/main/scala/whisk/common/DateUtil.scala
@@ -27,26 +27,26 @@ import java.lang.System
  */
 object DateUtil {
 
-    /**
-     * Returns the current time as a string in yyyy-MM-dd'T'HH:mm:ss.SSSZ format.
-     */
-    def getTimeString(): String = {
-        val now = new Date(System.currentTimeMillis())
-        timeFormat.synchronized {
-            timeFormat.format(now)
-        }
+  /**
+   * Returns the current time as a string in yyyy-MM-dd'T'HH:mm:ss.SSSZ format.
+   */
+  def getTimeString(): String = {
+    val now = new Date(System.currentTimeMillis())
+    timeFormat.synchronized {
+      timeFormat.format(now)
     }
+  }
 
-    /**
-     * Takes a string in a format given by getTimeString and returns time in epoch millis.
-     */
-    def parseToMilli(dateStr: String): Long = {
-        val date = timeFormat.synchronized {
-            timeFormat.parse(dateStr, new java.text.ParsePosition(0))
-        }
-        date.getTime()
+  /**
+   * Takes a string in a format given by getTimeString and returns time in epoch millis.
+   */
+  def parseToMilli(dateStr: String): Long = {
+    val date = timeFormat.synchronized {
+      timeFormat.parse(dateStr, new java.text.ParsePosition(0))
     }
+    date.getTime()
+  }
 
-    private val timeFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+  private val timeFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
 
 }

--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -23,103 +23,104 @@ import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
-import akka.event.Logging.{ DebugLevel, InfoLevel, WarningLevel, ErrorLevel }
+import akka.event.Logging.{DebugLevel, ErrorLevel, InfoLevel, WarningLevel}
 import akka.event.Logging.LogLevel
 import akka.event.LoggingAdapter
 
 trait Logging {
-    /**
-     * Prints a message on DEBUG level
-     *
-     * @param from Reference, where the method was called from.
-     * @param message Message to write to the log
-     */
-    def debug(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) = {
-        emit(DebugLevel, id, from, message)
-    }
 
-    /**
-     * Prints a message on INFO level
-     *
-     * @param from Reference, where the method was called from.
-     * @param message Message to write to the log
-     */
-    def info(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) = {
-        emit(InfoLevel, id, from, message)
-    }
+  /**
+   * Prints a message on DEBUG level
+   *
+   * @param from Reference, where the method was called from.
+   * @param message Message to write to the log
+   */
+  def debug(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) = {
+    emit(DebugLevel, id, from, message)
+  }
 
-    /**
-     * Prints a message on WARN level
-     *
-     * @param from Reference, where the method was called from.
-     * @param message Message to write to the log
-     */
-    def warn(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) = {
-        emit(WarningLevel, id, from, message)
-    }
+  /**
+   * Prints a message on INFO level
+   *
+   * @param from Reference, where the method was called from.
+   * @param message Message to write to the log
+   */
+  def info(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) = {
+    emit(InfoLevel, id, from, message)
+  }
 
-    /**
-     * Prints a message on ERROR level
-     *
-     * @param from Reference, where the method was called from.
-     * @param message Message to write to the log
-     */
-    def error(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) = {
-        emit(ErrorLevel, id, from, message)
-    }
+  /**
+   * Prints a message on WARN level
+   *
+   * @param from Reference, where the method was called from.
+   * @param message Message to write to the log
+   */
+  def warn(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) = {
+    emit(WarningLevel, id, from, message)
+  }
 
-    /**
-     * Prints a message to the output.
-     *
-     * @param loglevel The level to log on
-     * @param id <code>TransactionId</code> to include in the log
-     * @param from Reference, where the method was called from.
-     * @param message Message to write to the log
-     */
-    def emit(loglevel: LogLevel, id: TransactionId, from: AnyRef, message: String)
+  /**
+   * Prints a message on ERROR level
+   *
+   * @param from Reference, where the method was called from.
+   * @param message Message to write to the log
+   */
+  def error(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) = {
+    emit(ErrorLevel, id, from, message)
+  }
+
+  /**
+   * Prints a message to the output.
+   *
+   * @param loglevel The level to log on
+   * @param id <code>TransactionId</code> to include in the log
+   * @param from Reference, where the method was called from.
+   * @param message Message to write to the log
+   */
+  def emit(loglevel: LogLevel, id: TransactionId, from: AnyRef, message: String)
 }
 
 /**
  * Implementaion of Logging, that uses akka logging.
  */
 class AkkaLogging(loggingAdapter: LoggingAdapter) extends Logging {
-    def emit(loglevel: LogLevel, id: TransactionId, from: AnyRef, message: String) = {
-        val name = if (from.isInstanceOf[String]) from else Logging.getCleanSimpleClassName(from.getClass)
+  def emit(loglevel: LogLevel, id: TransactionId, from: AnyRef, message: String) = {
+    val name = if (from.isInstanceOf[String]) from else Logging.getCleanSimpleClassName(from.getClass)
 
-        val logMessage = Seq(message).collect {
-            case msg if msg.nonEmpty =>
-                msg.split('\n').map(_.trim).mkString(" ")
-        }
-
-        val parts = Seq(s"[$id]") ++ Seq(s"[$name]") ++ logMessage
-        loggingAdapter.log(loglevel, parts.mkString(" "))
+    val logMessage = Seq(message).collect {
+      case msg if msg.nonEmpty =>
+        msg.split('\n').map(_.trim).mkString(" ")
     }
+
+    val parts = Seq(s"[$id]") ++ Seq(s"[$name]") ++ logMessage
+    loggingAdapter.log(loglevel, parts.mkString(" "))
+  }
 }
 
 /**
  * Implementaion of Logging, that uses the output stream.
  */
 class PrintStreamLogging(outputStream: PrintStream = Console.out) extends Logging {
-    def emit(loglevel: LogLevel, id: TransactionId, from: AnyRef, message: String) = {
-        val now = Instant.now(Clock.systemUTC)
-        val time = Emitter.timeFormat.format(now)
-        val name = if (from.isInstanceOf[String]) from else Logging.getCleanSimpleClassName(from.getClass)
+  def emit(loglevel: LogLevel, id: TransactionId, from: AnyRef, message: String) = {
+    val now = Instant.now(Clock.systemUTC)
+    val time = Emitter.timeFormat.format(now)
+    val name = if (from.isInstanceOf[String]) from else Logging.getCleanSimpleClassName(from.getClass)
 
-        val level = loglevel match {
-            case DebugLevel   => "DEBUG"
-            case InfoLevel    => "INFO"
-            case WarningLevel => "WARN"
-            case ErrorLevel   => "ERROR"
-        }
-
-        val logMessage = Seq(message).collect {
-            case msg if msg.nonEmpty =>
-                msg.split('\n').map(_.trim).mkString(" ")
-        }
-
-        val parts = Seq(s"[$time]", s"[$level]", s"[$id]") ++ Seq(s"[$name]") ++ logMessage
-        outputStream.println(parts.mkString(" "))
+    val level = loglevel match {
+      case DebugLevel   => "DEBUG"
+      case InfoLevel    => "INFO"
+      case WarningLevel => "WARN"
+      case ErrorLevel   => "ERROR"
     }
+
+    val logMessage = Seq(message).collect {
+      case msg if msg.nonEmpty =>
+        msg.split('\n').map(_.trim).mkString(" ")
+    }
+
+    val parts = Seq(s"[$time]", s"[$level]", s"[$id]") ++ Seq(s"[$name]") ++ logMessage
+    outputStream.println(parts.mkString(" "))
+  }
 }
 
 /**
@@ -132,115 +133,114 @@ class PrintStreamLogging(outputStream: PrintStream = Console.out) extends Loggin
  * @param deltaToMarkerStart if this is an end marker, this is the time difference to the start marker
  */
 case class LogMarker(token: LogMarkerToken, deltaToTransactionStart: Long, deltaToMarkerStart: Option[Long] = None) {
-    override def toString() = {
-        val parts = Seq(LogMarker.keyword, token.toString, deltaToTransactionStart) ++ deltaToMarkerStart
-        "[" + parts.mkString(":") + "]"
-    }
+  override def toString() = {
+    val parts = Seq(LogMarker.keyword, token.toString, deltaToTransactionStart) ++ deltaToMarkerStart
+    "[" + parts.mkString(":") + "]"
+  }
 }
 
 object LogMarker {
 
-    val keyword = "marker"
+  val keyword = "marker"
 
-    /** Convenience method for parsing log markers in unit tests. */
-    def parse(s: String) = {
-        val logmarker = raw"\[${keyword}:([^\s:]+):(\d+)(?::(\d+))?\]".r.unanchored
-        val logmarker(token, deltaToTransactionStart, deltaToMarkerStart) = s
-        LogMarker(LogMarkerToken.parse(token), deltaToTransactionStart.toLong, Option(deltaToMarkerStart).map(_.toLong))
-    }
+  /** Convenience method for parsing log markers in unit tests. */
+  def parse(s: String) = {
+    val logmarker = raw"\[${keyword}:([^\s:]+):(\d+)(?::(\d+))?\]".r.unanchored
+    val logmarker(token, deltaToTransactionStart, deltaToMarkerStart) = s
+    LogMarker(LogMarkerToken.parse(token), deltaToTransactionStart.toLong, Option(deltaToMarkerStart).map(_.toLong))
+  }
 }
 
 private object Logging {
-    /**
-     * Given a class object, return its simple name less the trailing dollar sign.
-     */
-    def getCleanSimpleClassName(clz: Class[_]) = {
-        val simpleName = clz.getSimpleName
-        if (simpleName.endsWith("$")) simpleName.dropRight(1)
-        else simpleName
-    }
+
+  /**
+   * Given a class object, return its simple name less the trailing dollar sign.
+   */
+  def getCleanSimpleClassName(clz: Class[_]) = {
+    val simpleName = clz.getSimpleName
+    if (simpleName.endsWith("$")) simpleName.dropRight(1)
+    else simpleName
+  }
 }
 
 private object Emitter {
-    val timeFormat = DateTimeFormatter.
-        ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").
-        withZone(ZoneId.of("UTC"))
+  val timeFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneId.of("UTC"))
 }
 
 case class LogMarkerToken(component: String, action: String, state: String) {
-    override def toString() = component + "_" + action + "_" + state
+  override def toString() = component + "_" + action + "_" + state
 
-    def asFinish = copy(state = LoggingMarkers.finish)
-    def asError = copy(state = LoggingMarkers.error)
+  def asFinish = copy(state = LoggingMarkers.finish)
+  def asError = copy(state = LoggingMarkers.error)
 }
 
 object LogMarkerToken {
-    def parse(s: String) = {
-        // Per convention the components are guaranteed to not contain '_'
-        // thus it's safe to split at '_' to get the components
-        val Array(component, action, state) = s.split("_")
-        LogMarkerToken(component, action, state)
-    }
+  def parse(s: String) = {
+    // Per convention the components are guaranteed to not contain '_'
+    // thus it's safe to split at '_' to get the components
+    val Array(component, action, state) = s.split("_")
+    LogMarkerToken(component, action, state)
+  }
 }
 
 object LoggingMarkers {
 
-    val start = "start"
-    val finish = "finish"
-    val error = "error"
-    val count = "count"
+  val start = "start"
+  val finish = "finish"
+  val error = "error"
+  val count = "count"
 
-    private val controller = "controller"
-    private val invoker = "invoker"
-    private val database = "database"
-    private val activation = "activation"
-    private val kafka = "kafka"
-    private val loadbalancer = "loadbalancer"
+  private val controller = "controller"
+  private val invoker = "invoker"
+  private val database = "database"
+  private val activation = "activation"
+  private val kafka = "kafka"
+  private val loadbalancer = "loadbalancer"
 
-    /*
-     * Controller related markers
-     */
-    def CONTROLLER_STARTUP(i: Int) = LogMarkerToken(controller, s"startup$i", count)
+  /*
+   * Controller related markers
+   */
+  def CONTROLLER_STARTUP(i: Int) = LogMarkerToken(controller, s"startup$i", count)
 
-    // Time of the activation in controller until it is delivered to Kafka
-    val CONTROLLER_ACTIVATION = LogMarkerToken(controller, activation, start)
-    val CONTROLLER_ACTIVATION_BLOCKING = LogMarkerToken(controller, "blockingActivation", start)
+  // Time of the activation in controller until it is delivered to Kafka
+  val CONTROLLER_ACTIVATION = LogMarkerToken(controller, activation, start)
+  val CONTROLLER_ACTIVATION_BLOCKING = LogMarkerToken(controller, "blockingActivation", start)
 
-    // Time that is needed load balance the activation
-    val CONTROLLER_LOADBALANCER = LogMarkerToken(controller, loadbalancer, start)
+  // Time that is needed load balance the activation
+  val CONTROLLER_LOADBALANCER = LogMarkerToken(controller, loadbalancer, start)
 
-    // Time that is needed to produce message in kafka
-    val CONTROLLER_KAFKA = LogMarkerToken(controller, kafka, start)
+  // Time that is needed to produce message in kafka
+  val CONTROLLER_KAFKA = LogMarkerToken(controller, kafka, start)
 
-    /*
-     * Invoker related markers
-     */
-    def INVOKER_STARTUP(i: Int) = LogMarkerToken(invoker, s"startup$i", count)
+  /*
+   * Invoker related markers
+   */
+  def INVOKER_STARTUP(i: Int) = LogMarkerToken(invoker, s"startup$i", count)
 
-    // Check invoker healthy state from loadbalancer
-    val LOADBALANCER_INVOKER_OFFLINE = LogMarkerToken(loadbalancer, "invokerOffline", count)
-    val LOADBALANCER_INVOKER_UNHEALTHY = LogMarkerToken(loadbalancer, "invokerUnhealthy", count)
+  // Check invoker healthy state from loadbalancer
+  val LOADBALANCER_INVOKER_OFFLINE = LogMarkerToken(loadbalancer, "invokerOffline", count)
+  val LOADBALANCER_INVOKER_UNHEALTHY = LogMarkerToken(loadbalancer, "invokerUnhealthy", count)
 
-    // Time that is needed to execute the action
-    val INVOKER_ACTIVATION_RUN = LogMarkerToken(invoker, "activationRun", start)
+  // Time that is needed to execute the action
+  val INVOKER_ACTIVATION_RUN = LogMarkerToken(invoker, "activationRun", start)
 
-    // Time that is needed to init the action
-    val INVOKER_ACTIVATION_INIT = LogMarkerToken(invoker, "activationInit", start)
+  // Time that is needed to init the action
+  val INVOKER_ACTIVATION_INIT = LogMarkerToken(invoker, "activationInit", start)
 
-    // Time in invoker
-    val INVOKER_ACTIVATION = LogMarkerToken(invoker, activation, start)
-    def INVOKER_DOCKER_CMD(cmd: String) = LogMarkerToken(invoker, s"docker.$cmd", start)
-    def INVOKER_RUNC_CMD(cmd: String) = LogMarkerToken(invoker, s"runc.$cmd", start)
+  // Time in invoker
+  val INVOKER_ACTIVATION = LogMarkerToken(invoker, activation, start)
+  def INVOKER_DOCKER_CMD(cmd: String) = LogMarkerToken(invoker, s"docker.$cmd", start)
+  def INVOKER_RUNC_CMD(cmd: String) = LogMarkerToken(invoker, s"runc.$cmd", start)
 
-    /*
-     * General markers
-     */
-    val DATABASE_CACHE_HIT = LogMarkerToken(database, "cacheHit", count)
-    val DATABASE_CACHE_MISS = LogMarkerToken(database, "cacheMiss", count)
-    val DATABASE_SAVE = LogMarkerToken(database, "saveDocument", start)
-    val DATABASE_DELETE = LogMarkerToken(database, "deleteDocument", start)
-    val DATABASE_GET = LogMarkerToken(database, "getDocument", start)
-    val DATABASE_QUERY = LogMarkerToken(database, "queryView", start)
-    val DATABASE_ATT_GET = LogMarkerToken(database, "getDocumentAttachment", start)
-    val DATABASE_ATT_SAVE = LogMarkerToken(database, "saveDocumentAttachment", start)
+  /*
+   * General markers
+   */
+  val DATABASE_CACHE_HIT = LogMarkerToken(database, "cacheHit", count)
+  val DATABASE_CACHE_MISS = LogMarkerToken(database, "cacheMiss", count)
+  val DATABASE_SAVE = LogMarkerToken(database, "saveDocument", start)
+  val DATABASE_DELETE = LogMarkerToken(database, "deleteDocument", start)
+  val DATABASE_GET = LogMarkerToken(database, "getDocument", start)
+  val DATABASE_QUERY = LogMarkerToken(database, "queryView", start)
+  val DATABASE_ATT_GET = LogMarkerToken(database, "getDocumentAttachment", start)
+  val DATABASE_ATT_SAVE = LogMarkerToken(database, "saveDocumentAttachment", start)
 }

--- a/common/scala/src/main/scala/whisk/common/RingBuffer.scala
+++ b/common/scala/src/main/scala/whisk/common/RingBuffer.scala
@@ -20,13 +20,13 @@ package whisk.common
 import org.apache.commons.collections.buffer.CircularFifoBuffer
 
 object RingBuffer {
-    def apply[T](size: Int) = new RingBuffer[T](size)
+  def apply[T](size: Int) = new RingBuffer[T](size)
 }
 
 class RingBuffer[T](size: Int) {
-    private val inner = new CircularFifoBuffer(size)
+  private val inner = new CircularFifoBuffer(size)
 
-    def add(el: T) = inner.add(el)
+  def add(el: T) = inner.add(el)
 
-    def toList() = inner.toArray().asInstanceOf[Array[T]].toList
+  def toList() = inner.toArray().asInstanceOf[Array[T]].toList
 }

--- a/common/scala/src/main/scala/whisk/common/SimpleExec.scala
+++ b/common/scala/src/main/scala/whisk/common/SimpleExec.scala
@@ -24,35 +24,34 @@ import scala.sys.process.stringSeqToProcess
  * Utility to exec processes
  */
 object SimpleExec {
-    /**
-     * Runs a external process.
-     *
-     * @param cmd an array of String -- their concatenation is the command to exec
-     * @return a triple of (stdout, stderr, exitcode) from running the command
-     */
-    def syncRunCmd(cmd: Seq[String])(implicit transid: TransactionId, logging: Logging): (String, String, Int) = {
-        logging.info(this, s"Running command: ${cmd.mkString(" ")}")
-        val pb = stringSeqToProcess(cmd)
 
-        val outs = new StringBuilder()
-        val errs = new StringBuilder()
+  /**
+   * Runs a external process.
+   *
+   * @param cmd an array of String -- their concatenation is the command to exec
+   * @return a triple of (stdout, stderr, exitcode) from running the command
+   */
+  def syncRunCmd(cmd: Seq[String])(implicit transid: TransactionId, logging: Logging): (String, String, Int) = {
+    logging.info(this, s"Running command: ${cmd.mkString(" ")}")
+    val pb = stringSeqToProcess(cmd)
 
-        val exitCode = pb ! ProcessLogger(
-            outStr => {
-                outs.append(outStr)
-                outs.append("\n")
-            },
-            errStr => {
-                errs.append(errStr)
-                errs.append("\n")
-            })
+    val outs = new StringBuilder()
+    val errs = new StringBuilder()
 
-        logging.info(this, s"Done running command: ${cmd.mkString(" ")}")
+    val exitCode = pb ! ProcessLogger(outStr => {
+      outs.append(outStr)
+      outs.append("\n")
+    }, errStr => {
+      errs.append(errStr)
+      errs.append("\n")
+    })
 
-        def noLastNewLine(sb: StringBuilder) = {
-            if (sb.isEmpty) "" else sb.substring(0, sb.size - 1)
-        }
+    logging.info(this, s"Done running command: ${cmd.mkString(" ")}")
 
-        (noLastNewLine(outs), noLastNewLine(errs), exitCode)
+    def noLastNewLine(sb: StringBuilder) = {
+      if (sb.isEmpty) "" else sb.substring(0, sb.size - 1)
     }
+
+    (noLastNewLine(outs), noLastNewLine(errs), exitCode)
+  }
 }

--- a/common/scala/src/main/scala/whisk/common/TimingUtil.scala
+++ b/common/scala/src/main/scala/whisk/common/TimingUtil.scala
@@ -26,10 +26,10 @@ import scala.concurrent.duration._
  */
 object TimingUtil {
 
-    def time[T](blk: => T): (Duration, T) = {
-        val start = System.currentTimeMillis
-        val res = blk
-        ((System.currentTimeMillis - start).millis, res)
-    }
+  def time[T](blk: => T): (Duration, T) = {
+    val start = System.currentTimeMillis
+    val res = blk
+    ((System.currentTimeMillis - start).millis, res)
+  }
 
 }

--- a/common/scala/src/main/scala/whisk/common/TransactionId.scala
+++ b/common/scala/src/main/scala/whisk/common/TransactionId.scala
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.math.BigDecimal.int2bigDecimal
 import scala.util.Try
 
-import akka.event.Logging.{ InfoLevel, WarningLevel }
+import akka.event.Logging.{InfoLevel, WarningLevel}
 import akka.event.Logging.LogLevel
 import spray.json.JsArray
 import spray.json.JsNumber
@@ -39,90 +39,108 @@ import whisk.core.entity.InstanceId
  * metadata is stored indirectly in the referenced meta object.
  */
 case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
-    def id = meta.id
-    override def toString = {
-        if (meta.id > 0) s"#tid_${meta.id}"
-        else if (meta.id < 0) s"#sid_${-meta.id}"
-        else "??"
-    }
+  def id = meta.id
+  override def toString = {
+    if (meta.id > 0) s"#tid_${meta.id}"
+    else if (meta.id < 0) s"#sid_${-meta.id}"
+    else "??"
+  }
 
-    /**
-     * Method to count events.
-     *
-     * @param from Reference, where the method was called from.
-     * @param marker A LogMarkerToken. They are defined in <code>LoggingMarkers</code>.
-     * @param message An additional message that is written into the log, together with the other information.
-     * @param logLevel The Loglevel, the message should have. Default is <code>InfoLevel</code>.
-     */
-    def mark(from: AnyRef, marker: LogMarkerToken, message: String = "", logLevel: LogLevel = InfoLevel)(implicit logging: Logging) = {
-        logging.emit(logLevel, this, from, createMessageWithMarker(message, LogMarker(marker, deltaToStart)))
-    }
+  /**
+   * Method to count events.
+   *
+   * @param from Reference, where the method was called from.
+   * @param marker A LogMarkerToken. They are defined in <code>LoggingMarkers</code>.
+   * @param message An additional message that is written into the log, together with the other information.
+   * @param logLevel The Loglevel, the message should have. Default is <code>InfoLevel</code>.
+   */
+  def mark(from: AnyRef, marker: LogMarkerToken, message: String = "", logLevel: LogLevel = InfoLevel)(
+    implicit logging: Logging) = {
+    logging.emit(logLevel, this, from, createMessageWithMarker(message, LogMarker(marker, deltaToStart)))
+  }
 
-    /**
-     * Method to start taking time of an action in the code. It returns a <code>StartMarker</code> which has to be
-     * passed into the <code>finished</code>-method.
-     *
-     * @param from Reference, where the method was called from.
-     * @param marker A LogMarkerToken. They are defined in <code>LoggingMarkers</code>.
-     * @param message An additional message that is written into the log, together with the other information.
-     * @param logLevel The Loglevel, the message should have. Default is <code>InfoLevel</code>.
-     *
-     * @return startMarker that has to be passed to the finished or failed method to calculate the time difference.
-     */
-    def started(from: AnyRef, marker: LogMarkerToken, message: String = "", logLevel: LogLevel = InfoLevel)(implicit logging: Logging): StartMarker = {
-        logging.emit(logLevel, this, from, createMessageWithMarker(message, LogMarker(marker, deltaToStart)))
-        StartMarker(Instant.now, marker)
-    }
+  /**
+   * Method to start taking time of an action in the code. It returns a <code>StartMarker</code> which has to be
+   * passed into the <code>finished</code>-method.
+   *
+   * @param from Reference, where the method was called from.
+   * @param marker A LogMarkerToken. They are defined in <code>LoggingMarkers</code>.
+   * @param message An additional message that is written into the log, together with the other information.
+   * @param logLevel The Loglevel, the message should have. Default is <code>InfoLevel</code>.
+   *
+   * @return startMarker that has to be passed to the finished or failed method to calculate the time difference.
+   */
+  def started(from: AnyRef, marker: LogMarkerToken, message: String = "", logLevel: LogLevel = InfoLevel)(
+    implicit logging: Logging): StartMarker = {
+    logging.emit(logLevel, this, from, createMessageWithMarker(message, LogMarker(marker, deltaToStart)))
+    StartMarker(Instant.now, marker)
+  }
 
-    /**
-     * Method to stop taking time of an action in the code. The time the method used will be written into a log message.
-     *
-     * @param from Reference, where the method was called from.
-     * @param startMarker <code>StartMarker</code> returned by a <code>starting</code> method.
-     * @param message An additional message that is written into the log, together with the other information.
-     * @param logLevel The Loglevel, the message should have. Default is <code>InfoLevel</code>.
-     * @param endTime Manually set the timestamp of the end. By default it is NOW.
-     */
-    def finished(from: AnyRef, startMarker: StartMarker, message: String = "", logLevel: LogLevel = InfoLevel, endTime: Instant = Instant.now(Clock.systemUTC))(implicit logging: Logging) = {
-        val endMarker = LogMarkerToken(startMarker.startMarker.component, startMarker.startMarker.action, LoggingMarkers.finish)
-        logging.emit(logLevel, this, from, createMessageWithMarker(message, LogMarker(endMarker, deltaToStart, Some(deltaToMarker(startMarker, endTime)))))
-    }
+  /**
+   * Method to stop taking time of an action in the code. The time the method used will be written into a log message.
+   *
+   * @param from Reference, where the method was called from.
+   * @param startMarker <code>StartMarker</code> returned by a <code>starting</code> method.
+   * @param message An additional message that is written into the log, together with the other information.
+   * @param logLevel The Loglevel, the message should have. Default is <code>InfoLevel</code>.
+   * @param endTime Manually set the timestamp of the end. By default it is NOW.
+   */
+  def finished(from: AnyRef,
+               startMarker: StartMarker,
+               message: String = "",
+               logLevel: LogLevel = InfoLevel,
+               endTime: Instant = Instant.now(Clock.systemUTC))(implicit logging: Logging) = {
+    val endMarker =
+      LogMarkerToken(startMarker.startMarker.component, startMarker.startMarker.action, LoggingMarkers.finish)
+    logging.emit(
+      logLevel,
+      this,
+      from,
+      createMessageWithMarker(message, LogMarker(endMarker, deltaToStart, Some(deltaToMarker(startMarker, endTime)))))
+  }
 
-    /**
-     * Method to stop taking time of an action in the code that failed. The time the method used will be written into a log message.
-     *
-     * @param from Reference, where the method was called from.
-     * @param startMarker <code>StartMarker</code> returned by a <code>starting</code> method.
-     * @param message An additional message that is written into the log, together with the other information.
-     * @param logLevel The <code>LogLevel</code> the message should have. Default is <code>WarningLevel</code>.
-     */
-    def failed(from: AnyRef, startMarker: StartMarker, message: String = "", logLevel: LogLevel = WarningLevel)(implicit logging: Logging) = {
-        val endMarker = LogMarkerToken(startMarker.startMarker.component, startMarker.startMarker.action, LoggingMarkers.error)
-        logging.emit(logLevel, this, from, createMessageWithMarker(message, LogMarker(endMarker, deltaToStart, Some(deltaToMarker(startMarker)))))
-    }
+  /**
+   * Method to stop taking time of an action in the code that failed. The time the method used will be written into a log message.
+   *
+   * @param from Reference, where the method was called from.
+   * @param startMarker <code>StartMarker</code> returned by a <code>starting</code> method.
+   * @param message An additional message that is written into the log, together with the other information.
+   * @param logLevel The <code>LogLevel</code> the message should have. Default is <code>WarningLevel</code>.
+   */
+  def failed(from: AnyRef, startMarker: StartMarker, message: String = "", logLevel: LogLevel = WarningLevel)(
+    implicit logging: Logging) = {
+    val endMarker =
+      LogMarkerToken(startMarker.startMarker.component, startMarker.startMarker.action, LoggingMarkers.error)
+    logging.emit(
+      logLevel,
+      this,
+      from,
+      createMessageWithMarker(message, LogMarker(endMarker, deltaToStart, Some(deltaToMarker(startMarker)))))
+  }
 
-    /**
-     * Calculates the time between now and the beginning of the transaction.
-     */
-    def deltaToStart = Duration.between(meta.start, Instant.now(Clock.systemUTC)).toMillis
+  /**
+   * Calculates the time between now and the beginning of the transaction.
+   */
+  def deltaToStart = Duration.between(meta.start, Instant.now(Clock.systemUTC)).toMillis
 
-    /**
-     * Calculates the time between now and the startMarker that was returned by <code>starting</code>.
-     *
-     * @param startMarker <code>StartMarker</code> returned by a <code>starting</code> method.
-     * @param endTime Manually set the endtime. By default it is NOW.
-     */
-    def deltaToMarker(startMarker: StartMarker, endTime: Instant = Instant.now(Clock.systemUTC)) = Duration.between(startMarker.start, endTime).toMillis
+  /**
+   * Calculates the time between now and the startMarker that was returned by <code>starting</code>.
+   *
+   * @param startMarker <code>StartMarker</code> returned by a <code>starting</code> method.
+   * @param endTime Manually set the endtime. By default it is NOW.
+   */
+  def deltaToMarker(startMarker: StartMarker, endTime: Instant = Instant.now(Clock.systemUTC)) =
+    Duration.between(startMarker.start, endTime).toMillis
 
-    /**
-     * Formats log message to include marker.
-     *
-     * @param message: The log message without the marker
-     * @param marker: The marker to add to the message
-     */
-    private def createMessageWithMarker(message: String, marker: LogMarker): String = {
-        (Option(message).filter(_.trim.nonEmpty) ++ Some(marker)).mkString(" ")
-    }
+  /**
+   * Formats log message to include marker.
+   *
+   * @param message: The log message without the marker
+   * @param marker: The marker to add to the message
+   */
+  private def createMessageWithMarker(message: String, marker: LogMarker): String = {
+    (Option(message).filter(_.trim.nonEmpty) ++ Some(marker)).mkString(" ")
+  }
 }
 
 /**
@@ -143,45 +161,46 @@ case class StartMarker(val start: Instant, startMarker: LogMarkerToken)
 protected case class TransactionMetadata(val id: Long, val start: Instant)
 
 object TransactionId {
-    val unknown = TransactionId(0)
-    val testing = TransactionId(-1)         // Common id for for unit testing
-    val invoker = TransactionId(-100)       // Invoker startup/shutdown or GC activity
-    val invokerWarmup = TransactionId(-101) // Invoker warmup thread that makes stem-cell containers
-    val invokerNanny = TransactionId(-102)  // Invoker nanny thread
-    val dispatcher = TransactionId(-110)    // Kafka message dispatcher
-    val loadbalancer = TransactionId(-120)  // Loadbalancer thread
-    val invokerHealth = TransactionId(-121) // Invoker supervision
-    val controller = TransactionId(-130)    // Controller startup
+  val unknown = TransactionId(0)
+  val testing = TransactionId(-1) // Common id for for unit testing
+  val invoker = TransactionId(-100) // Invoker startup/shutdown or GC activity
+  val invokerWarmup = TransactionId(-101) // Invoker warmup thread that makes stem-cell containers
+  val invokerNanny = TransactionId(-102) // Invoker nanny thread
+  val dispatcher = TransactionId(-110) // Kafka message dispatcher
+  val loadbalancer = TransactionId(-120) // Loadbalancer thread
+  val invokerHealth = TransactionId(-121) // Invoker supervision
+  val controller = TransactionId(-130) // Controller startup
 
-    def apply(tid: BigDecimal): TransactionId = {
-        Try {
-            val now = Instant.now(Clock.systemUTC())
-            TransactionId(TransactionMetadata(tid.toLong, now))
-        } getOrElse unknown
-    }
+  def apply(tid: BigDecimal): TransactionId = {
+    Try {
+      val now = Instant.now(Clock.systemUTC())
+      TransactionId(TransactionMetadata(tid.toLong, now))
+    } getOrElse unknown
+  }
 
-    implicit val serdes = new RootJsonFormat[TransactionId] {
-        def write(t: TransactionId) = JsArray(JsNumber(t.meta.id), JsNumber(t.meta.start.toEpochMilli))
+  implicit val serdes = new RootJsonFormat[TransactionId] {
+    def write(t: TransactionId) = JsArray(JsNumber(t.meta.id), JsNumber(t.meta.start.toEpochMilli))
 
-        def read(value: JsValue) = Try {
-            value match {
-                case JsArray(Vector(JsNumber(id), JsNumber(start))) =>
-                    TransactionId(TransactionMetadata(id.longValue, Instant.ofEpochMilli(start.longValue)))
-            }
-        } getOrElse unknown
-    }
+    def read(value: JsValue) =
+      Try {
+        value match {
+          case JsArray(Vector(JsNumber(id), JsNumber(start))) =>
+            TransactionId(TransactionMetadata(id.longValue, Instant.ofEpochMilli(start.longValue)))
+        }
+      } getOrElse unknown
+  }
 }
 
 /**
  * A thread-safe transaction counter.
  */
 trait TransactionCounter {
-    val numberOfInstances: Int
-    val instance: InstanceId
+  val numberOfInstances: Int
+  val instance: InstanceId
 
-    private lazy val cnt = new AtomicInteger(numberOfInstances + instance.toInt)
+  private lazy val cnt = new AtomicInteger(numberOfInstances + instance.toInt)
 
-    def transid(): TransactionId = {
-        TransactionId(cnt.addAndGet(numberOfInstances))
-    }
+  def transid(): TransactionId = {
+    TransactionId(cnt.addAndGet(numberOfInstances))
+  }
 }

--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaConsumerConnector.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaConsumerConnector.scala
@@ -32,66 +32,66 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import whisk.common.Logging
 import whisk.core.connector.MessageConsumer
 
-class KafkaConsumerConnector(
-    kafkahost: String,
-    groupid: String,
-    topic: String,
-    override val maxPeek: Int = Int.MaxValue,
-    readeos: Boolean = true,
-    sessionTimeout: FiniteDuration = 30.seconds,
-    autoCommitInterval: FiniteDuration = 10.seconds,
-    maxPollInterval: FiniteDuration = 5.minutes)(
-        implicit logging: Logging)
+class KafkaConsumerConnector(kafkahost: String,
+                             groupid: String,
+                             topic: String,
+                             override val maxPeek: Int = Int.MaxValue,
+                             readeos: Boolean = true,
+                             sessionTimeout: FiniteDuration = 30.seconds,
+                             autoCommitInterval: FiniteDuration = 10.seconds,
+                             maxPollInterval: FiniteDuration = 5.minutes)(implicit logging: Logging)
     extends MessageConsumer {
 
-    /**
-     * Long poll for messages. Method returns once message are available but no later than given
-     * duration.
-     *
-     * @param duration the maximum duration for the long poll
-     */
-    override def peek(duration: Duration = 500.milliseconds) = {
-        val records = consumer.poll(duration.toMillis)
-        records map { r => (r.topic, r.partition, r.offset, r.value) }
+  /**
+   * Long poll for messages. Method returns once message are available but no later than given
+   * duration.
+   *
+   * @param duration the maximum duration for the long poll
+   */
+  override def peek(duration: Duration = 500.milliseconds) = {
+    val records = consumer.poll(duration.toMillis)
+    records map { r =>
+      (r.topic, r.partition, r.offset, r.value)
     }
+  }
 
-    /**
-     * Commits offsets from last poll.
-     */
-    def commit() = consumer.commitSync()
+  /**
+   * Commits offsets from last poll.
+   */
+  def commit() = consumer.commitSync()
 
-    override def close() = {
-        logging.info(this, s"closing '$topic' consumer")
-    }
+  override def close() = {
+    logging.info(this, s"closing '$topic' consumer")
+  }
 
-    private def getProps: Properties = {
-        val props = new Properties
-        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupid)
-        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkahost)
-        props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, sessionTimeout.toMillis.toString)
-        props.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, (sessionTimeout.toMillis / 3).toString)
-        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, true.toString)
-        props.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, autoCommitInterval.toMillis.toString)
-        props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPeek.toString)
-        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, if (!readeos) "latest" else "earliest")
-        props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, maxPollInterval.toMillis.toString)
+  private def getProps: Properties = {
+    val props = new Properties
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, groupid)
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkahost)
+    props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, sessionTimeout.toMillis.toString)
+    props.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, (sessionTimeout.toMillis / 3).toString)
+    props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, true.toString)
+    props.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, autoCommitInterval.toMillis.toString)
+    props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPeek.toString)
+    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, if (!readeos) "latest" else "earliest")
+    props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, maxPollInterval.toMillis.toString)
 
-        // This value controls the server-side wait time which affects polling latency.
-        // A low value improves latency performance but it is important to not set it too low
-        // as that will cause excessive busy-waiting.
-        props.put(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, "20")
+    // This value controls the server-side wait time which affects polling latency.
+    // A low value improves latency performance but it is important to not set it too low
+    // as that will cause excessive busy-waiting.
+    props.put(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, "20")
 
-        props
-    }
+    props
+  }
 
-    /** Creates a new kafka consumer and subscribes to topic list if given. */
-    private def getConsumer(props: Properties, topics: Option[List[String]] = None) = {
-        val keyDeserializer = new ByteArrayDeserializer
-        val valueDeserializer = new ByteArrayDeserializer
-        val consumer = new KafkaConsumer(props, keyDeserializer, valueDeserializer)
-        topics foreach { consumer.subscribe(_) }
-        consumer
-    }
+  /** Creates a new kafka consumer and subscribes to topic list if given. */
+  private def getConsumer(props: Properties, topics: Option[List[String]] = None) = {
+    val keyDeserializer = new ByteArrayDeserializer
+    val valueDeserializer = new ByteArrayDeserializer
+    val consumer = new KafkaConsumer(props, keyDeserializer, valueDeserializer)
+    topics foreach { consumer.subscribe(_) }
+    consumer
+  }
 
-    private val consumer = getConsumer(getProps, Some(List(topic)))
+  private val consumer = getConsumer(getProps, Some(List(topic)))
 }

--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaMessagingProvider.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaMessagingProvider.scala
@@ -29,9 +29,10 @@ import whisk.core.connector.MessagingProvider
  * A Kafka based implementation of MessagingProvider
  */
 object KafkaMessagingProvider extends MessagingProvider {
-    def getConsumer(config: WhiskConfig, groupId: String, topic: String, maxPeek: Int, maxPollInterval: FiniteDuration)(implicit logging: Logging): MessageConsumer =
-        new KafkaConsumerConnector(config.kafkaHost, groupId, topic, maxPeek, maxPollInterval = maxPollInterval)
+  def getConsumer(config: WhiskConfig, groupId: String, topic: String, maxPeek: Int, maxPollInterval: FiniteDuration)(
+    implicit logging: Logging): MessageConsumer =
+    new KafkaConsumerConnector(config.kafkaHost, groupId, topic, maxPeek, maxPollInterval = maxPollInterval)
 
-    def getProducer(config: WhiskConfig, ec: ExecutionContext)(implicit logging: Logging): MessageProducer =
-        new KafkaProducerConnector(config.kafkaHost, ec)
+  def getProducer(config: WhiskConfig, ec: ExecutionContext)(implicit logging: Logging): MessageProducer =
+    new KafkaProducerConnector(config.kafkaHost, ec)
 }

--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaProducerConnector.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaProducerConnector.scala
@@ -38,58 +38,56 @@ import whisk.common.Logging
 import whisk.core.connector.Message
 import whisk.core.connector.MessageProducer
 
-class KafkaProducerConnector(
-    kafkahost: String,
-    implicit val executionContext: ExecutionContext,
-    id: String = UUID.randomUUID().toString)(
-        implicit logging: Logging)
+class KafkaProducerConnector(kafkahost: String,
+                             implicit val executionContext: ExecutionContext,
+                             id: String = UUID.randomUUID().toString)(implicit logging: Logging)
     extends MessageProducer {
 
-    override def sentCount() = sentCounter.cur
+  override def sentCount() = sentCounter.cur
 
-    /** Sends msg to topic. This is an asynchronous operation. */
-    override def send(topic: String, msg: Message): Future[RecordMetadata] = {
-        implicit val transid = msg.transid
-        val record = new ProducerRecord[String, String](topic, "messages", msg.serialize)
+  /** Sends msg to topic. This is an asynchronous operation. */
+  override def send(topic: String, msg: Message): Future[RecordMetadata] = {
+    implicit val transid = msg.transid
+    val record = new ProducerRecord[String, String](topic, "messages", msg.serialize)
 
-        logging.debug(this, s"sending to topic '$topic' msg '$msg'")
-        val produced = Promise[RecordMetadata]()
-        producer.send(record, new Callback {
-            override def onCompletion(metadata: RecordMetadata, exception: Exception): Unit = {
-                if (exception == null) produced.success(metadata)
-                else produced.failure(exception)
-            }
-        })
+    logging.debug(this, s"sending to topic '$topic' msg '$msg'")
+    val produced = Promise[RecordMetadata]()
+    producer.send(record, new Callback {
+      override def onCompletion(metadata: RecordMetadata, exception: Exception): Unit = {
+        if (exception == null) produced.success(metadata)
+        else produced.failure(exception)
+      }
+    })
 
-        produced.future.andThen {
-            case Success(status) =>
-                logging.debug(this, s"sent message: ${status.topic()}[${status.partition()}][${status.offset()}]")
-                sentCounter.next()
-            case Failure(t) =>
-                logging.error(this, s"sending message on topic '$topic' failed: ${t.getMessage}")
-        }
+    produced.future.andThen {
+      case Success(status) =>
+        logging.debug(this, s"sent message: ${status.topic()}[${status.partition()}][${status.offset()}]")
+        sentCounter.next()
+      case Failure(t) =>
+        logging.error(this, s"sending message on topic '$topic' failed: ${t.getMessage}")
     }
+  }
 
-    /** Closes producer. */
-    override def close() = {
-        logging.info(this, "closing producer")
-        producer.close()
-    }
+  /** Closes producer. */
+  override def close() = {
+    logging.info(this, "closing producer")
+    producer.close()
+  }
 
-    private val sentCounter = new Counter()
+  private val sentCounter = new Counter()
 
-    private def getProps: Properties = {
-        val props = new Properties
-        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkahost)
-        props.put(ProducerConfig.ACKS_CONFIG, 1.toString)
-        props
-    }
+  private def getProps: Properties = {
+    val props = new Properties
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkahost)
+    props.put(ProducerConfig.ACKS_CONFIG, 1.toString)
+    props
+  }
 
-    private def getProducer(props: Properties): KafkaProducer[String, String] = {
-        val keySerializer = new StringSerializer
-        val valueSerializer = new StringSerializer
-        new KafkaProducer(props, keySerializer, valueSerializer)
-    }
+  private def getProducer(props: Properties): KafkaProducer[String, String] = {
+    val keySerializer = new StringSerializer
+    val valueSerializer = new StringSerializer
+    new KafkaProducer(props, keySerializer, valueSerializer)
+  }
 
-    private val producer = getProducer(getProps)
+  private val producer = getProducer(getProps)
 }

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -34,189 +34,191 @@ import whisk.common.Logging
  * @param optionalProperties a set of optional properties (which may not be defined).
  * @param whiskPropertiesFile a File object, the whisk.properties file, which if given contains the property values.
  */
-
-class WhiskConfig(
-    requiredProperties: Map[String, String],
-    optionalProperties: Set[String] = Set(),
-    propertiesFile: File = null,
-    env: Map[String, String] = sys.env)(implicit val logging: Logging)
+class WhiskConfig(requiredProperties: Map[String, String],
+                  optionalProperties: Set[String] = Set(),
+                  propertiesFile: File = null,
+                  env: Map[String, String] = sys.env)(implicit val logging: Logging)
     extends Config(requiredProperties, optionalProperties)(env) {
 
-    /**
-     * Loads the properties as specified above.
-     *
-     * @return a pair which is the Map defining the properties, and a boolean indicating whether validation succeeded.
-     */
-    override protected def getProperties() = {
-        val properties = super.getProperties()
-        WhiskConfig.readPropertiesFromFile(properties, Option(propertiesFile) getOrElse (WhiskConfig.whiskPropertiesFile))
-        properties
-    }
+  /**
+   * Loads the properties as specified above.
+   *
+   * @return a pair which is the Map defining the properties, and a boolean indicating whether validation succeeded.
+   */
+  override protected def getProperties() = {
+    val properties = super.getProperties()
+    WhiskConfig.readPropertiesFromFile(properties, Option(propertiesFile) getOrElse (WhiskConfig.whiskPropertiesFile))
+    properties
+  }
 
-    val servicePort = this(WhiskConfig.servicePort)
-    val dockerRegistry = this(WhiskConfig.dockerRegistry)
-    val dockerEndpoint = this(WhiskConfig.dockerEndpoint)
-    val dockerPort = this(WhiskConfig.dockerPort)
+  val servicePort = this(WhiskConfig.servicePort)
+  val dockerRegistry = this(WhiskConfig.dockerRegistry)
+  val dockerEndpoint = this(WhiskConfig.dockerEndpoint)
+  val dockerPort = this(WhiskConfig.dockerPort)
 
-    val dockerImagePrefix = this(WhiskConfig.dockerImagePrefix)
-    val dockerImageTag = this(WhiskConfig.dockerImageTag)
+  val dockerImagePrefix = this(WhiskConfig.dockerImagePrefix)
+  val dockerImageTag = this(WhiskConfig.dockerImageTag)
 
-    val invokerContainerNetwork = this(WhiskConfig.invokerContainerNetwork)
-    val invokerContainerPolicy = if (this(WhiskConfig.invokerContainerPolicy) == "") None else Some(this(WhiskConfig.invokerContainerPolicy))
-    val invokerContainerDns = if (this(WhiskConfig.invokerContainerDns) == "") Seq() else this(WhiskConfig.invokerContainerDns).split(" ").toSeq
-    val invokerNumCore = this(WhiskConfig.invokerNumCore)
-    val invokerCoreShare = this(WhiskConfig.invokerCoreShare)
+  val invokerContainerNetwork = this(WhiskConfig.invokerContainerNetwork)
+  val invokerContainerPolicy =
+    if (this(WhiskConfig.invokerContainerPolicy) == "") None else Some(this(WhiskConfig.invokerContainerPolicy))
+  val invokerContainerDns =
+    if (this(WhiskConfig.invokerContainerDns) == "") Seq() else this(WhiskConfig.invokerContainerDns).split(" ").toSeq
+  val invokerNumCore = this(WhiskConfig.invokerNumCore)
+  val invokerCoreShare = this(WhiskConfig.invokerCoreShare)
 
-    val wskApiHost = this(WhiskConfig.wskApiProtocol) + "://" + this(WhiskConfig.wskApiHostname) + ":" + this(WhiskConfig.wskApiPort)
-    val controllerBlackboxFraction = this.getAsDouble(WhiskConfig.controllerBlackboxFraction, 0.10)
-    val loadbalancerInvokerBusyThreshold = this.getAsInt(WhiskConfig.loadbalancerInvokerBusyThreshold, 16)
-    val controllerInstances = this(WhiskConfig.controllerInstances)
+  val wskApiHost = this(WhiskConfig.wskApiProtocol) + "://" + this(WhiskConfig.wskApiHostname) + ":" + this(
+    WhiskConfig.wskApiPort)
+  val controllerBlackboxFraction = this.getAsDouble(WhiskConfig.controllerBlackboxFraction, 0.10)
+  val loadbalancerInvokerBusyThreshold = this.getAsInt(WhiskConfig.loadbalancerInvokerBusyThreshold, 16)
+  val controllerInstances = this(WhiskConfig.controllerInstances)
 
-    val edgeHost = this(WhiskConfig.edgeHostName) + ":" + this(WhiskConfig.edgeHostApiPort)
-    val kafkaHost = this(WhiskConfig.kafkaHostName) + ":" + this(WhiskConfig.kafkaHostPort)
+  val edgeHost = this(WhiskConfig.edgeHostName) + ":" + this(WhiskConfig.edgeHostApiPort)
+  val kafkaHost = this(WhiskConfig.kafkaHostName) + ":" + this(WhiskConfig.kafkaHostPort)
 
-    val edgeHostName = this(WhiskConfig.edgeHostName)
+  val edgeHostName = this(WhiskConfig.edgeHostName)
 
-    val zookeeperHost = this(WhiskConfig.zookeeperHostName) + ":" + this(WhiskConfig.zookeeperHostPort)
-    val invokerHosts = this(WhiskConfig.invokerHostsList)
+  val zookeeperHost = this(WhiskConfig.zookeeperHostName) + ":" + this(WhiskConfig.zookeeperHostPort)
+  val invokerHosts = this(WhiskConfig.invokerHostsList)
 
-    val dbProvider = this(WhiskConfig.dbProvider)
-    val dbUsername = this(WhiskConfig.dbUsername)
-    val dbPassword = this(WhiskConfig.dbPassword)
-    val dbProtocol = this(WhiskConfig.dbProtocol)
-    val dbHost = this(WhiskConfig.dbHost)
-    val dbPort = this(WhiskConfig.dbPort)
-    val dbWhisk = this(WhiskConfig.dbWhisk)
-    val dbAuths = this(WhiskConfig.dbAuths)
-    val dbActivations = this(WhiskConfig.dbActivations)
-    val dbPrefix = this(WhiskConfig.dbPrefix)
+  val dbProvider = this(WhiskConfig.dbProvider)
+  val dbUsername = this(WhiskConfig.dbUsername)
+  val dbPassword = this(WhiskConfig.dbPassword)
+  val dbProtocol = this(WhiskConfig.dbProtocol)
+  val dbHost = this(WhiskConfig.dbHost)
+  val dbPort = this(WhiskConfig.dbPort)
+  val dbWhisk = this(WhiskConfig.dbWhisk)
+  val dbAuths = this(WhiskConfig.dbAuths)
+  val dbActivations = this(WhiskConfig.dbActivations)
+  val dbPrefix = this(WhiskConfig.dbPrefix)
 
-    val mainDockerEndpoint = this(WhiskConfig.mainDockerEndpoint)
+  val mainDockerEndpoint = this(WhiskConfig.mainDockerEndpoint)
 
-    val runtimesManifest = this(WhiskConfig.runtimesManifest)
+  val runtimesManifest = this(WhiskConfig.runtimesManifest)
 
-    val actionInvokePerMinuteLimit = this(WhiskConfig.actionInvokePerMinuteLimit)
-    val actionInvokeConcurrentLimit = this(WhiskConfig.actionInvokeConcurrentLimit)
-    val triggerFirePerMinuteLimit = this(WhiskConfig.triggerFirePerMinuteLimit)
-    val actionInvokeSystemOverloadLimit = this(WhiskConfig.actionInvokeSystemOverloadLimit)
-    val actionSequenceLimit = this(WhiskConfig.actionSequenceMaxLimit)
+  val actionInvokePerMinuteLimit = this(WhiskConfig.actionInvokePerMinuteLimit)
+  val actionInvokeConcurrentLimit = this(WhiskConfig.actionInvokeConcurrentLimit)
+  val triggerFirePerMinuteLimit = this(WhiskConfig.triggerFirePerMinuteLimit)
+  val actionInvokeSystemOverloadLimit = this(WhiskConfig.actionInvokeSystemOverloadLimit)
+  val actionSequenceLimit = this(WhiskConfig.actionSequenceMaxLimit)
 }
 
 object WhiskConfig {
 
-    private def whiskPropertiesFile: File = {
-        def propfile(dir: String, recurse: Boolean = false): File =
-            if (dir != null) {
-                val base = new File(dir)
-                val file = new File(base, "whisk.properties")
-                if (file.exists())
-                    file
-                else if (recurse)
-                    propfile(base.getParent, true)
-                else null
-            } else null
-
-        val dir = sys.props.get("user.dir")
-        if (dir.isDefined) {
-            propfile(dir.get, true)
-        } else {
-            null
-        }
-    }
-
-    /**
-     * Reads a Map of key-value pairs from the environment (sys.env) -- store them in the
-     * mutable properties object.
-     */
-    def readPropertiesFromFile(properties: scala.collection.mutable.Map[String, String], file: File)(implicit logging: Logging) = {
-        if (file != null && file.exists) {
-            logging.info(this, s"reading properties from file $file")
-            for (line <- Source.fromFile(file).getLines if line.trim != "") {
-                val parts = line.split('=')
-                if (parts.length >= 1) {
-                    val p = parts(0).trim
-                    val v = if (parts.length == 2) parts(1).trim else ""
-                    if (properties.contains(p)) {
-                        properties += p -> v
-                        logging.debug(this, s"properties file set value for $p")
-                    }
-                } else {
-                    logging.warn(this, s"ignoring properties $line")
-                }
-            }
-        }
-    }
-
-    def asEnvVar(key: String): String =
-        if (key != null)
-            key.replace('.', '_').toUpperCase
+  private def whiskPropertiesFile: File = {
+    def propfile(dir: String, recurse: Boolean = false): File =
+      if (dir != null) {
+        val base = new File(dir)
+        val file = new File(base, "whisk.properties")
+        if (file.exists())
+          file
+        else if (recurse)
+          propfile(base.getParent, true)
         else null
+      } else null
 
-    val servicePort = "port"
-    val dockerRegistry = "docker.registry"
-    val dockerPort = "docker.port"
+    val dir = sys.props.get("user.dir")
+    if (dir.isDefined) {
+      propfile(dir.get, true)
+    } else {
+      null
+    }
+  }
 
-    val dockerEndpoint = "main.docker.endpoint"
+  /**
+   * Reads a Map of key-value pairs from the environment (sys.env) -- store them in the
+   * mutable properties object.
+   */
+  def readPropertiesFromFile(properties: scala.collection.mutable.Map[String, String], file: File)(
+    implicit logging: Logging) = {
+    if (file != null && file.exists) {
+      logging.info(this, s"reading properties from file $file")
+      for (line <- Source.fromFile(file).getLines if line.trim != "") {
+        val parts = line.split('=')
+        if (parts.length >= 1) {
+          val p = parts(0).trim
+          val v = if (parts.length == 2) parts(1).trim else ""
+          if (properties.contains(p)) {
+            properties += p -> v
+            logging.debug(this, s"properties file set value for $p")
+          }
+        } else {
+          logging.warn(this, s"ignoring properties $line")
+        }
+      }
+    }
+  }
 
-    val dbProvider = "db.provider"
-    val dbProtocol = "db.protocol"
-    val dbHost = "db.host"
-    val dbPort = "db.port"
-    val dbUsername = "db.username"
-    val dbPassword = "db.password"
-    val dbWhisk = "db.whisk.actions"
-    val dbAuths = "db.whisk.auths"
-    val dbPrefix = "db.prefix"
-    val dbActivations = "db.whisk.activations"
+  def asEnvVar(key: String): String =
+    if (key != null)
+      key.replace('.', '_').toUpperCase
+    else null
 
-    // these are not private because they are needed
-    // in the invoker (they are part of the environment
-    // passed to the user container)
-    val edgeHostName = "edge.host"
-    val whiskVersionDate = "whisk.version.date"
-    val whiskVersionBuildno = "whisk.version.buildno"
+  val servicePort = "port"
+  val dockerRegistry = "docker.registry"
+  val dockerPort = "docker.port"
 
-    val whiskVersion = Map(whiskVersionDate -> null, whiskVersionBuildno -> null)
+  val dockerEndpoint = "main.docker.endpoint"
 
-    val dockerImagePrefix = "docker.image.prefix"
-    val dockerImageTag = "docker.image.tag"
+  val dbProvider = "db.provider"
+  val dbProtocol = "db.protocol"
+  val dbHost = "db.host"
+  val dbPort = "db.port"
+  val dbUsername = "db.username"
+  val dbPassword = "db.password"
+  val dbWhisk = "db.whisk.actions"
+  val dbAuths = "db.whisk.auths"
+  val dbPrefix = "db.prefix"
+  val dbActivations = "db.whisk.activations"
 
-    val invokerContainerNetwork = "invoker.container.network"
-    val invokerContainerPolicy = "invoker.container.policy"
-    val invokerContainerDns = "invoker.container.dns"
-    val invokerNumCore = "invoker.numcore"
-    val invokerCoreShare = "invoker.coreshare"
+  // these are not private because they are needed
+  // in the invoker (they are part of the environment
+  // passed to the user container)
+  val edgeHostName = "edge.host"
+  val whiskVersionDate = "whisk.version.date"
+  val whiskVersionBuildno = "whisk.version.buildno"
 
-    val wskApiProtocol = "whisk.api.host.proto"
-    val wskApiPort = "whisk.api.host.port"
-    val wskApiHostname = "whisk.api.host.name"
-    val wskApiHost = Map(wskApiProtocol -> "https", wskApiPort -> 443.toString, wskApiHostname -> null)
+  val whiskVersion = Map(whiskVersionDate -> null, whiskVersionBuildno -> null)
 
-    val mainDockerEndpoint = "main.docker.endpoint"
+  val dockerImagePrefix = "docker.image.prefix"
+  val dockerImageTag = "docker.image.tag"
 
-    private val controllerBlackboxFraction = "controller.blackboxFraction"
-    val controllerInstances = "controller.instances"
+  val invokerContainerNetwork = "invoker.container.network"
+  val invokerContainerPolicy = "invoker.container.policy"
+  val invokerContainerDns = "invoker.container.dns"
+  val invokerNumCore = "invoker.numcore"
+  val invokerCoreShare = "invoker.coreshare"
 
-    val loadbalancerInvokerBusyThreshold = "loadbalancer.invokerBusyThreshold"
+  val wskApiProtocol = "whisk.api.host.proto"
+  val wskApiPort = "whisk.api.host.port"
+  val wskApiHostname = "whisk.api.host.name"
+  val wskApiHost = Map(wskApiProtocol -> "https", wskApiPort -> 443.toString, wskApiHostname -> null)
 
-    val kafkaHostName = "kafka.host"
-    private val zookeeperHostName = "zookeeper.host"
+  val mainDockerEndpoint = "main.docker.endpoint"
 
-    private val edgeHostApiPort = "edge.host.apiport"
-    val kafkaHostPort = "kafka.host.port"
-    private val zookeeperHostPort = "zookeeper.host.port"
+  private val controllerBlackboxFraction = "controller.blackboxFraction"
+  val controllerInstances = "controller.instances"
 
-    val invokerHostsList = "invoker.hosts"
+  val loadbalancerInvokerBusyThreshold = "loadbalancer.invokerBusyThreshold"
 
-    val edgeHost = Map(edgeHostName -> null, edgeHostApiPort -> null)
-    val invokerHosts = Map(invokerHostsList -> null)
-    val kafkaHost = Map(kafkaHostName -> null, kafkaHostPort -> null)
+  val kafkaHostName = "kafka.host"
+  private val zookeeperHostName = "zookeeper.host"
 
-    val runtimesManifest = "runtimes.manifest"
+  private val edgeHostApiPort = "edge.host.apiport"
+  val kafkaHostPort = "kafka.host.port"
+  private val zookeeperHostPort = "zookeeper.host.port"
 
-    val actionSequenceMaxLimit = "limits.actions.sequence.maxLength"
-    val actionInvokePerMinuteLimit = "limits.actions.invokes.perMinute"
-    val actionInvokeConcurrentLimit = "limits.actions.invokes.concurrent"
-    val actionInvokeSystemOverloadLimit = "limits.actions.invokes.concurrentInSystem"
-    val triggerFirePerMinuteLimit = "limits.triggers.fires.perMinute"
+  val invokerHostsList = "invoker.hosts"
+
+  val edgeHost = Map(edgeHostName -> null, edgeHostApiPort -> null)
+  val invokerHosts = Map(invokerHostsList -> null)
+  val kafkaHost = Map(kafkaHostName -> null, kafkaHostPort -> null)
+
+  val runtimesManifest = "runtimes.manifest"
+
+  val actionSequenceMaxLimit = "limits.actions.sequence.maxLength"
+  val actionInvokePerMinuteLimit = "limits.actions.invokes.perMinute"
+  val actionInvokeConcurrentLimit = "limits.actions.invokes.concurrent"
+  val actionInvokeSystemOverloadLimit = "limits.actions.invokes.concurrentInSystem"
+  val triggerFirePerMinuteLimit = "limits.triggers.fires.perMinute"
 }

--- a/common/scala/src/main/scala/whisk/core/connector/MessageProducer.scala
+++ b/common/scala/src/main/scala/whisk/core/connector/MessageProducer.scala
@@ -22,12 +22,13 @@ import scala.concurrent.Future
 import org.apache.kafka.clients.producer.RecordMetadata
 
 trait MessageProducer {
-    /** Count of messages sent. */
-    def sentCount(): Long
 
-    /** Sends msg to topic. This is an asynchronous operation. */
-    def send(topic: String, msg: Message): Future[RecordMetadata]
+  /** Count of messages sent. */
+  def sentCount(): Long
 
-    /** Closes producer. */
-    def close(): Unit
+  /** Sends msg to topic. This is an asynchronous operation. */
+  def send(topic: String, msg: Message): Future[RecordMetadata]
+
+  /** Closes producer. */
+  def close(): Unit
 }

--- a/common/scala/src/main/scala/whisk/core/connector/MessagingProvider.scala
+++ b/common/scala/src/main/scala/whisk/core/connector/MessagingProvider.scala
@@ -28,6 +28,10 @@ import whisk.spi.Spi
  * An Spi for providing Messaging implementations.
  */
 trait MessagingProvider extends Spi {
-    def getConsumer(config: WhiskConfig, groupId: String, topic: String, maxPeek: Int = Int.MaxValue, maxPollInterval: FiniteDuration = 5.minutes)(implicit logging: Logging): MessageConsumer
-    def getProducer(config: WhiskConfig, ec: ExecutionContext)(implicit logging: Logging): MessageProducer
+  def getConsumer(config: WhiskConfig,
+                  groupId: String,
+                  topic: String,
+                  maxPeek: Int = Int.MaxValue,
+                  maxPollInterval: FiniteDuration = 5.minutes)(implicit logging: Logging): MessageConsumer
+  def getProducer(config: WhiskConfig, ec: ExecutionContext)(implicit logging: Logging): MessageProducer
 }

--- a/common/scala/src/main/scala/whisk/core/database/ArtifactStoreProvider.scala
+++ b/common/scala/src/main/scala/whisk/core/database/ArtifactStoreProvider.scala
@@ -26,10 +26,9 @@ import whisk.spi.Spi
 /**
  * An Spi for providing ArtifactStore implementations
  */
-
 trait ArtifactStoreProvider extends Spi {
-    def makeStore[D <: DocumentSerializer](config: WhiskConfig, name: WhiskConfig => String)(
-        implicit jsonFormat: RootJsonFormat[D],
-        actorSystem: ActorSystem,
-        logging: Logging): ArtifactStore[D]
+  def makeStore[D <: DocumentSerializer](config: WhiskConfig, name: WhiskConfig => String)(
+    implicit jsonFormat: RootJsonFormat[D],
+    actorSystem: ActorSystem,
+    logging: Logging): ArtifactStore[D]
 }

--- a/common/scala/src/main/scala/whisk/core/database/CloudantRestClient.scala
+++ b/common/scala/src/main/scala/whisk/core/database/CloudantRestClient.scala
@@ -30,11 +30,13 @@ import whisk.common.Logging
  * This class only handles the basic communication to the proper endpoints
  *  ("JSON in, JSON out"). It is up to its clients to interpret the results.
  */
-class CloudantRestClient(host: String, port: Int, username: String, password: String, db: String)(implicit system: ActorSystem, logging: Logging)
+class CloudantRestClient(host: String, port: Int, username: String, password: String, db: String)(
+  implicit system: ActorSystem,
+  logging: Logging)
     extends CouchDbRestClient("https", host, port, username, password, db) {
 
-    // https://cloudant.com/blog/cloudant-query-grows-up-to-handle-ad-hoc-queries/#.VvllCD-0z2C
-    def simpleQuery(doc: JsObject): Future[Either[StatusCode, JsObject]] = {
-        requestJson[JsObject](mkJsonRequest(HttpMethods.POST, uri(db, "_find"), doc))
-    }
+  // https://cloudant.com/blog/cloudant-query-grows-up-to-handle-ad-hoc-queries/#.VvllCD-0z2C
+  def simpleQuery(doc: JsObject): Future[Either[StatusCode, JsObject]] = {
+    requestJson[JsObject](mkJsonRequest(HttpMethods.POST, uri(db, "_find"), doc))
+  }
 }

--- a/common/scala/src/main/scala/whisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/whisk/core/database/CouchDbRestClient.scala
@@ -22,7 +22,7 @@ import java.nio.charset.StandardCharsets
 
 import scala.concurrent.Future
 import scala.concurrent.Promise
-import scala.util.{ Success, Failure }
+import scala.util.{Failure, Success}
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
@@ -48,214 +48,236 @@ import whisk.common.Logging
  *  up the pool corresponding to the host. It is also easier to add an extra
  *  queueing mechanism.
  */
-class CouchDbRestClient(protocol: String, host: String, port: Int, username: String, password: String, db: String)(implicit system: ActorSystem, logging: Logging) {
-    require(protocol == "http" || protocol == "https", "Protocol must be one of { http, https }.")
+class CouchDbRestClient(protocol: String, host: String, port: Int, username: String, password: String, db: String)(
+  implicit system: ActorSystem,
+  logging: Logging) {
+  require(protocol == "http" || protocol == "https", "Protocol must be one of { http, https }.")
 
-    private implicit val context = system.dispatcher
-    private implicit val materializer = ActorMaterializer()
+  private implicit val context = system.dispatcher
+  private implicit val materializer = ActorMaterializer()
 
-    // Creates or retrieves a connection pool for the host.
-    private val pool = if (protocol == "http") {
-        Http().cachedHostConnectionPool[Promise[HttpResponse]](host = host, port = port)
-    } else {
-        Http().cachedHostConnectionPoolHttps[Promise[HttpResponse]](host = host, port = port)
+  // Creates or retrieves a connection pool for the host.
+  private val pool = if (protocol == "http") {
+    Http().cachedHostConnectionPool[Promise[HttpResponse]](host = host, port = port)
+  } else {
+    Http().cachedHostConnectionPoolHttps[Promise[HttpResponse]](host = host, port = port)
+  }
+
+  private val poolPromise = Promise[HostConnectionPool]
+
+  // Additional queue in case all connections are busy. Should hardly ever be
+  // filled in practice but can be useful, e.g., in tests starting many
+  // asynchronous requests in a very short period of time.
+  private val QUEUE_SIZE = 16 * 1024;
+  private val requestQueue = Source
+    .queue(QUEUE_SIZE, OverflowStrategy.dropNew)
+    .via(pool.mapMaterializedValue { x =>
+      poolPromise.success(x); x
+    })
+    .toMat(Sink.foreach({
+      case ((Success(response), p)) => p.success(response)
+      case ((Failure(error), p))    => p.failure(error)
+    }))(Keep.left)
+    .run
+
+  // Properly encodes the potential slashes in each segment.
+  protected def uri(segments: Any*): Uri = {
+    val encodedSegments = segments.map(s => URLEncoder.encode(s.toString, StandardCharsets.UTF_8.name))
+    Uri(s"/${encodedSegments.mkString("/")}")
+  }
+
+  // Headers common to all requests.
+  private val baseHeaders =
+    List(Authorization(BasicHttpCredentials(username, password)), Accept(MediaTypes.`application/json`))
+
+  // Prepares a request with the proper headers.
+  private def mkRequest0(method: HttpMethod,
+                         uri: Uri,
+                         body: Future[MessageEntity],
+                         forRev: Option[String] = None): Future[HttpRequest] = {
+    val revHeader = forRev.map(r => `If-Match`(EntityTagRange(EntityTag(r)))).toList
+    val headers = revHeader ::: baseHeaders
+    body.map { b =>
+      HttpRequest(method = method, uri = uri, headers = headers, entity = b)
     }
+  }
 
-    private val poolPromise = Promise[HostConnectionPool]
+  protected def mkRequest(method: HttpMethod, uri: Uri, forRev: Option[String] = None): Future[HttpRequest] = {
+    mkRequest0(method, uri, Future.successful(HttpEntity.Empty), forRev = forRev)
+  }
 
-    // Additional queue in case all connections are busy. Should hardly ever be
-    // filled in practice but can be useful, e.g., in tests starting many
-    // asynchronous requests in a very short period of time.
-    private val QUEUE_SIZE = 16 * 1024;
-    private val requestQueue = Source.queue(QUEUE_SIZE, OverflowStrategy.dropNew)
-        .via(pool.mapMaterializedValue { x => poolPromise.success(x); x })
-        .toMat(Sink.foreach({
-            case ((Success(response), p)) => p.success(response)
-            case ((Failure(error), p))    => p.failure(error)
-        }))(Keep.left)
-        .run
+  protected def mkJsonRequest(method: HttpMethod,
+                              uri: Uri,
+                              body: JsValue,
+                              forRev: Option[String] = None): Future[HttpRequest] = {
+    val b = Marshal(body).to[MessageEntity]
+    mkRequest0(method, uri, b, forRev = forRev)
+  }
 
-    // Properly encodes the potential slashes in each segment.
-    protected def uri(segments: Any*): Uri = {
-        val encodedSegments = segments.map(s => URLEncoder.encode(s.toString, StandardCharsets.UTF_8.name))
-        Uri(s"/${encodedSegments.mkString("/")}")
-    }
+  // Enqueue a request, and return a future capturing the corresponding response.
+  // WARNING: make sure that if the future response is not failed, its entity
+  // be drained entirely or the connection will be kept open until timeouts kick in.
+  private def request0(futureRequest: Future[HttpRequest]): Future[HttpResponse] = {
+    futureRequest flatMap { request =>
+      val promise = Promise[HttpResponse]
 
-    // Headers common to all requests.
-    private val baseHeaders = List(
-        Authorization(BasicHttpCredentials(username, password)),
-        Accept(MediaTypes.`application/json`))
+      // When the future completes, we know whether the request made it
+      // through the queue.
+      requestQueue.offer(request -> promise).flatMap { buffered =>
+        buffered match {
+          case QueueOfferResult.Enqueued =>
+            promise.future
 
-    // Prepares a request with the proper headers.
-    private def mkRequest0(
-        method: HttpMethod,
-        uri: Uri,
-        body: Future[MessageEntity],
-        forRev: Option[String] = None): Future[HttpRequest] = {
-        val revHeader = forRev.map(r => `If-Match`(EntityTagRange(EntityTag(r)))).toList
-        val headers = revHeader ::: baseHeaders
-        body.map { b => HttpRequest(method = method, uri = uri, headers = headers, entity = b) }
-    }
+          case QueueOfferResult.Dropped =>
+            Future.failed(new Exception("DB request queue is full."))
 
-    protected def mkRequest(method: HttpMethod, uri: Uri, forRev: Option[String] = None): Future[HttpRequest] = {
-        mkRequest0(method, uri, Future.successful(HttpEntity.Empty), forRev = forRev)
-    }
+          case QueueOfferResult.QueueClosed =>
+            Future.failed(new Exception("DB request queue was closed."))
 
-    protected def mkJsonRequest(method: HttpMethod, uri: Uri, body: JsValue, forRev: Option[String] = None): Future[HttpRequest] = {
-        val b = Marshal(body).to[MessageEntity]
-        mkRequest0(method, uri, b, forRev = forRev)
-    }
-
-    // Enqueue a request, and return a future capturing the corresponding response.
-    // WARNING: make sure that if the future response is not failed, its entity
-    // be drained entirely or the connection will be kept open until timeouts kick in.
-    private def request0(futureRequest: Future[HttpRequest]): Future[HttpResponse] = {
-        futureRequest flatMap { request =>
-            val promise = Promise[HttpResponse]
-
-            // When the future completes, we know whether the request made it
-            // through the queue.
-            requestQueue.offer(request -> promise).flatMap { buffered =>
-                buffered match {
-                    case QueueOfferResult.Enqueued =>
-                        promise.future
-
-                    case QueueOfferResult.Dropped =>
-                        Future.failed(new Exception("DB request queue is full."))
-
-                    case QueueOfferResult.QueueClosed =>
-                        Future.failed(new Exception("DB request queue was closed."))
-
-                    case QueueOfferResult.Failure(f) =>
-                        Future.failed(f)
-                }
-            }
+          case QueueOfferResult.Failure(f) =>
+            Future.failed(f)
         }
+      }
     }
+  }
 
-    // Runs a request and returns either a JsObject, or a StatusCode if not 2xx.
-    protected def requestJson[T: RootJsonReader](futureRequest: Future[HttpRequest]): Future[Either[StatusCode, T]] = {
-        request0(futureRequest) flatMap { response =>
-            if (response.status.isSuccess()) {
-                Unmarshal(response.entity.withoutSizeLimit()).to[T].map { o => Right(o) }
-            } else {
-                // This is important, as it drains the entity stream.
-                // Otherwise the connection stays open and the pool dries up.
-                response.entity.withoutSizeLimit().dataBytes.runWith(Sink.ignore).map { _ => Left(response.status) }
-            }
+  // Runs a request and returns either a JsObject, or a StatusCode if not 2xx.
+  protected def requestJson[T: RootJsonReader](futureRequest: Future[HttpRequest]): Future[Either[StatusCode, T]] = {
+    request0(futureRequest) flatMap { response =>
+      if (response.status.isSuccess()) {
+        Unmarshal(response.entity.withoutSizeLimit()).to[T].map { o =>
+          Right(o)
         }
-    }
-
-    import spray.json.DefaultJsonProtocol._
-
-    // http://docs.couchdb.org/en/1.6.1/api/document/common.html#put--db-docid
-    def putDoc(id: String, doc: JsObject): Future[Either[StatusCode, JsObject]] =
-        requestJson[JsObject](mkJsonRequest(HttpMethods.PUT, uri(db, id), doc))
-
-    // http://docs.couchdb.org/en/1.6.1/api/document/common.html#put--db-docid
-    def putDoc(id: String, rev: String, doc: JsObject): Future[Either[StatusCode, JsObject]] =
-        requestJson[JsObject](mkJsonRequest(HttpMethods.PUT, uri(db, id), doc, forRev = Some(rev)))
-
-    // http://docs.couchdb.org/en/1.6.1/api/document/common.html#get--db-docid
-    def getDoc(id: String): Future[Either[StatusCode, JsObject]] =
-        requestJson[JsObject](mkRequest(HttpMethods.GET, uri(db, id)))
-
-    // http://docs.couchdb.org/en/1.6.1/api/document/common.html#get--db-docid
-    def getDoc(id: String, rev: String): Future[Either[StatusCode, JsObject]] =
-        requestJson[JsObject](mkRequest(HttpMethods.GET, uri(db, id), forRev = Some(rev)))
-
-    // http://docs.couchdb.org/en/1.6.1/api/document/common.html#delete--db-docid
-    def deleteDoc(id: String, rev: String): Future[Either[StatusCode, JsObject]] =
-        requestJson[JsObject](mkRequest(HttpMethods.DELETE, uri(db, id), forRev = Some(rev)))
-
-    // http://docs.couchdb.org/en/1.6.1/api/ddoc/views.html
-    def executeView(designDoc: String, viewName: String)(
-        startKey: List[Any] = Nil,
-        endKey: List[Any] = Nil,
-        skip: Option[Int] = None,
-        limit: Option[Int] = None,
-        stale: StaleParameter = StaleParameter.No,
-        includeDocs: Boolean = false,
-        descending: Boolean = false,
-        reduce: Boolean = false,
-        group: Boolean = false): Future[Either[StatusCode, JsObject]] = {
-
-        require(reduce || !group, "Parameter 'group=true' cannot be used together with the parameter 'reduce=false'.")
-
-        def any2json(any: Any): JsValue = any match {
-            case b: Boolean => JsBoolean(b)
-            case i: Int     => JsNumber(i)
-            case l: Long    => JsNumber(l)
-            case d: Double  => JsNumber(d)
-            case f: Float   => JsNumber(f)
-            case s: String  => JsString(s)
-            case _ =>
-                logging.warn(this, s"Serializing uncontrolled type '${any.getClass}' to string in JSON conversion ('${any.toString}').")
-                JsString(any.toString)
+      } else {
+        // This is important, as it drains the entity stream.
+        // Otherwise the connection stays open and the pool dries up.
+        response.entity.withoutSizeLimit().dataBytes.runWith(Sink.ignore).map { _ =>
+          Left(response.status)
         }
+      }
+    }
+  }
 
-        def list2OptJson(lst: List[Any]): Option[JsValue] = {
-            lst match {
-                case Nil => None
-                case _   => Some(JsArray(lst.map(any2json): _*))
-            }
-        }
+  import spray.json.DefaultJsonProtocol._
 
-        val args = Seq[(String, Option[String])](
-            "startkey" -> list2OptJson(startKey).map(_.toString),
-            "endkey" -> list2OptJson(endKey).map(_.toString),
-            "skip" -> skip.filter(_ > 0).map(_.toString),
-            "limit" -> limit.filter(_ > 0).map(_.toString),
-            "stale" -> stale.value,
-            "include_docs" -> Some(includeDocs).filter(identity).map(_.toString),
-            "descending" -> Some(descending).filter(identity).map(_.toString),
-            "reduce" -> Some(reduce).map(_.toString),
-            "group" -> Some(group).filter(identity).map(_.toString))
+  // http://docs.couchdb.org/en/1.6.1/api/document/common.html#put--db-docid
+  def putDoc(id: String, doc: JsObject): Future[Either[StatusCode, JsObject]] =
+    requestJson[JsObject](mkJsonRequest(HttpMethods.PUT, uri(db, id), doc))
 
-        // Throw out all undefined arguments.
-        val argMap: Map[String, String] = args.collect({
-            case (l, Some(r)) => (l, r)
-        }).toMap
+  // http://docs.couchdb.org/en/1.6.1/api/document/common.html#put--db-docid
+  def putDoc(id: String, rev: String, doc: JsObject): Future[Either[StatusCode, JsObject]] =
+    requestJson[JsObject](mkJsonRequest(HttpMethods.PUT, uri(db, id), doc, forRev = Some(rev)))
 
-        val viewUri = uri(db, "_design", designDoc, "_view", viewName).withQuery(Uri.Query(argMap))
+  // http://docs.couchdb.org/en/1.6.1/api/document/common.html#get--db-docid
+  def getDoc(id: String): Future[Either[StatusCode, JsObject]] =
+    requestJson[JsObject](mkRequest(HttpMethods.GET, uri(db, id)))
 
-        requestJson[JsObject](mkRequest(HttpMethods.GET, viewUri))
+  // http://docs.couchdb.org/en/1.6.1/api/document/common.html#get--db-docid
+  def getDoc(id: String, rev: String): Future[Either[StatusCode, JsObject]] =
+    requestJson[JsObject](mkRequest(HttpMethods.GET, uri(db, id), forRev = Some(rev)))
+
+  // http://docs.couchdb.org/en/1.6.1/api/document/common.html#delete--db-docid
+  def deleteDoc(id: String, rev: String): Future[Either[StatusCode, JsObject]] =
+    requestJson[JsObject](mkRequest(HttpMethods.DELETE, uri(db, id), forRev = Some(rev)))
+
+  // http://docs.couchdb.org/en/1.6.1/api/ddoc/views.html
+  def executeView(designDoc: String, viewName: String)(startKey: List[Any] = Nil,
+                                                       endKey: List[Any] = Nil,
+                                                       skip: Option[Int] = None,
+                                                       limit: Option[Int] = None,
+                                                       stale: StaleParameter = StaleParameter.No,
+                                                       includeDocs: Boolean = false,
+                                                       descending: Boolean = false,
+                                                       reduce: Boolean = false,
+                                                       group: Boolean = false): Future[Either[StatusCode, JsObject]] = {
+
+    require(reduce || !group, "Parameter 'group=true' cannot be used together with the parameter 'reduce=false'.")
+
+    def any2json(any: Any): JsValue = any match {
+      case b: Boolean => JsBoolean(b)
+      case i: Int     => JsNumber(i)
+      case l: Long    => JsNumber(l)
+      case d: Double  => JsNumber(d)
+      case f: Float   => JsNumber(f)
+      case s: String  => JsString(s)
+      case _ =>
+        logging.warn(
+          this,
+          s"Serializing uncontrolled type '${any.getClass}' to string in JSON conversion ('${any.toString}').")
+        JsString(any.toString)
     }
 
-    // Streams an attachment to the database
-    // http://docs.couchdb.org/en/1.6.1/api/document/attachments.html#put--db-docid-attname
-    def putAttachment(id: String, rev: String, attName: String, contentType: ContentType, source: Source[ByteString, _]): Future[Either[StatusCode, JsObject]] = {
-        val entity = HttpEntity.Chunked(contentType, source.map(bs => HttpEntity.ChunkStreamPart(bs)))
-        val request = mkRequest0(HttpMethods.PUT, uri(db, id, attName), Future.successful(entity), forRev = Some(rev))
-        requestJson[JsObject](request)
+    def list2OptJson(lst: List[Any]): Option[JsValue] = {
+      lst match {
+        case Nil => None
+        case _   => Some(JsArray(lst.map(any2json): _*))
+      }
     }
 
-    // Retrieves and streams an attachment into a Sink, producing a result of type T.
-    // http://docs.couchdb.org/en/1.6.1/api/document/attachments.html#get--db-docid-attname
-    def getAttachment[T](id: String, rev: String, attName: String, sink: Sink[ByteString, Future[T]]): Future[Either[StatusCode, (ContentType, T)]] = {
-        val request = mkRequest(HttpMethods.GET, uri(db, id, attName), forRev = Some(rev))
+    val args = Seq[(String, Option[String])](
+      "startkey" -> list2OptJson(startKey).map(_.toString),
+      "endkey" -> list2OptJson(endKey).map(_.toString),
+      "skip" -> skip.filter(_ > 0).map(_.toString),
+      "limit" -> limit.filter(_ > 0).map(_.toString),
+      "stale" -> stale.value,
+      "include_docs" -> Some(includeDocs).filter(identity).map(_.toString),
+      "descending" -> Some(descending).filter(identity).map(_.toString),
+      "reduce" -> Some(reduce).map(_.toString),
+      "group" -> Some(group).filter(identity).map(_.toString))
 
-        request0(request) flatMap { response =>
-            if (response.status.isSuccess()) {
-                response.entity.withoutSizeLimit().dataBytes.runWith(sink).map(r => Right(response.entity.contentType, r))
-            } else {
-                response.entity.withoutSizeLimit().dataBytes.runWith(Sink.ignore).map(_ => Left(response.status))
-            }
-        }
-    }
+    // Throw out all undefined arguments.
+    val argMap: Map[String, String] = args
+      .collect({
+        case (l, Some(r)) => (l, r)
+      })
+      .toMap
 
-    def shutdown(): Future[Unit] = {
-        materializer.shutdown()
-        // The code below shuts down the pool, but is apparently not tolerant
-        // to multiple clients shutting down the same pool (the second one just
-        // hangs). Given that shutdown is only relevant for tests (unused pools
-        // close themselves anyway after some time) and that they can call
-        // Http().shutdownAllConnectionPools(), this is not a major issue.
-        /* Reintroduce below if they ever make HostConnectionPool.shutdown()
-         * safe to call >1x.
-         * val poolOpt = poolPromise.future.value.map(_.toOption).flatten
-         * poolOpt.map(_.shutdown().map(_ => ())).getOrElse(Future.successful(()))
-         */
-        Future.successful(())
+    val viewUri = uri(db, "_design", designDoc, "_view", viewName).withQuery(Uri.Query(argMap))
+
+    requestJson[JsObject](mkRequest(HttpMethods.GET, viewUri))
+  }
+
+  // Streams an attachment to the database
+  // http://docs.couchdb.org/en/1.6.1/api/document/attachments.html#put--db-docid-attname
+  def putAttachment(id: String,
+                    rev: String,
+                    attName: String,
+                    contentType: ContentType,
+                    source: Source[ByteString, _]): Future[Either[StatusCode, JsObject]] = {
+    val entity = HttpEntity.Chunked(contentType, source.map(bs => HttpEntity.ChunkStreamPart(bs)))
+    val request = mkRequest0(HttpMethods.PUT, uri(db, id, attName), Future.successful(entity), forRev = Some(rev))
+    requestJson[JsObject](request)
+  }
+
+  // Retrieves and streams an attachment into a Sink, producing a result of type T.
+  // http://docs.couchdb.org/en/1.6.1/api/document/attachments.html#get--db-docid-attname
+  def getAttachment[T](id: String,
+                       rev: String,
+                       attName: String,
+                       sink: Sink[ByteString, Future[T]]): Future[Either[StatusCode, (ContentType, T)]] = {
+    val request = mkRequest(HttpMethods.GET, uri(db, id, attName), forRev = Some(rev))
+
+    request0(request) flatMap { response =>
+      if (response.status.isSuccess()) {
+        response.entity.withoutSizeLimit().dataBytes.runWith(sink).map(r => Right(response.entity.contentType, r))
+      } else {
+        response.entity.withoutSizeLimit().dataBytes.runWith(Sink.ignore).map(_ => Left(response.status))
+      }
     }
+  }
+
+  def shutdown(): Future[Unit] = {
+    materializer.shutdown()
+    // The code below shuts down the pool, but is apparently not tolerant
+    // to multiple clients shutting down the same pool (the second one just
+    // hangs). Given that shutdown is only relevant for tests (unused pools
+    // close themselves anyway after some time) and that they can call
+    // Http().shutdownAllConnectionPools(), this is not a major issue.
+    /* Reintroduce below if they ever make HostConnectionPool.shutdown()
+     * safe to call >1x.
+     * val poolOpt = poolPromise.future.value.map(_.toOption).flatten
+     * poolOpt.map(_.shutdown().map(_ => ())).getOrElse(Future.successful(()))
+     */
+    Future.successful(())
+  }
 }

--- a/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
@@ -47,249 +47,323 @@ import whisk.http.Messages
  * @param serializerEvidence confirms the document abstraction is serializable to a Document with an id
  */
 class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](
-    dbProtocol: String,
-    dbHost: String,
-    dbPort: Int,
-    dbUsername: String,
-    dbPassword: String,
-    dbName: String)(implicit system: ActorSystem, val logging: Logging, jsonFormat: RootJsonFormat[DocumentAbstraction])
+  dbProtocol: String,
+  dbHost: String,
+  dbPort: Int,
+  dbUsername: String,
+  dbPassword: String,
+  dbName: String)(implicit system: ActorSystem, val logging: Logging, jsonFormat: RootJsonFormat[DocumentAbstraction])
     extends ArtifactStore[DocumentAbstraction]
     with DefaultJsonProtocol {
 
-    protected[core] implicit val executionContext = system.dispatcher
+  protected[core] implicit val executionContext = system.dispatcher
 
-    private val client: CouchDbRestClient = new CouchDbRestClient(dbProtocol, dbHost, dbPort.toInt, dbUsername, dbPassword, dbName)
+  private val client: CouchDbRestClient =
+    new CouchDbRestClient(dbProtocol, dbHost, dbPort.toInt, dbUsername, dbPassword, dbName)
 
-    override protected[database] def put(d: DocumentAbstraction)(implicit transid: TransactionId): Future[DocInfo] = {
-        val asJson = d.toDocumentRecord
+  override protected[database] def put(d: DocumentAbstraction)(implicit transid: TransactionId): Future[DocInfo] = {
+    val asJson = d.toDocumentRecord
 
-        val id: String = asJson.fields("_id").convertTo[String].trim
-        val rev: Option[String] = asJson.fields.get("_rev").map(_.convertTo[String])
-        require(!id.isEmpty, "document id must be defined")
+    val id: String = asJson.fields("_id").convertTo[String].trim
+    val rev: Option[String] = asJson.fields.get("_rev").map(_.convertTo[String])
+    require(!id.isEmpty, "document id must be defined")
 
-        val docinfoStr = s"id: $id, rev: ${rev.getOrElse("null")}"
+    val docinfoStr = s"id: $id, rev: ${rev.getOrElse("null")}"
 
-        val start = transid.started(this, LoggingMarkers.DATABASE_SAVE, s"[PUT] '$dbName' saving document: '${docinfoStr}'")
+    val start = transid.started(this, LoggingMarkers.DATABASE_SAVE, s"[PUT] '$dbName' saving document: '${docinfoStr}'")
 
-        val request: CouchDbRestClient => Future[Either[StatusCode, JsObject]] = rev match {
-            case Some(r) => client => client.putDoc(id, r, asJson)
-            case None => client => client.putDoc(id, asJson)
-        }
+    val request: CouchDbRestClient => Future[Either[StatusCode, JsObject]] = rev match {
+      case Some(r) =>
+        client =>
+          client.putDoc(id, r, asJson)
+      case None =>
+        client =>
+          client.putDoc(id, asJson)
+    }
 
-        val f = request(client).map { e =>
-            e match {
-                case Right(response) =>
-                    transid.finished(this, start, s"[PUT] '$dbName' completed document: '${docinfoStr}', response: '$response'")
-                    val id = response.fields("id").convertTo[String]
-                    val rev = response.fields("rev").convertTo[String]
-                    DocInfo ! (id, rev)
+    val f = request(client).map { e =>
+      e match {
+        case Right(response) =>
+          transid.finished(this, start, s"[PUT] '$dbName' completed document: '${docinfoStr}', response: '$response'")
+          val id = response.fields("id").convertTo[String]
+          val rev = response.fields("rev").convertTo[String]
+          DocInfo ! (id, rev)
 
-                case Left(StatusCodes.Conflict) =>
-                    transid.finished(this, start, s"[PUT] '$dbName', document: '${docinfoStr}'; conflict.")
-                    // For compatibility.
-                    throw DocumentConflictException("conflict on 'put'")
+        case Left(StatusCodes.Conflict) =>
+          transid.finished(this, start, s"[PUT] '$dbName', document: '${docinfoStr}'; conflict.")
+          // For compatibility.
+          throw DocumentConflictException("conflict on 'put'")
 
-                case Left(code) =>
-                    transid.failed(this, start, s"[PUT] '$dbName' failed to put document: '${docinfoStr}'; http status: '${code}'", ErrorLevel)
-                    throw new Exception("Unexpected http response code: " + code)
+        case Left(code) =>
+          transid.failed(
+            this,
+            start,
+            s"[PUT] '$dbName' failed to put document: '${docinfoStr}'; http status: '${code}'",
+            ErrorLevel)
+          throw new Exception("Unexpected http response code: " + code)
+      }
+    }
+
+    reportFailure(
+      f,
+      failure =>
+        transid.failed(this, start, s"[PUT] '$dbName' internal error, failure: '${failure.getMessage}'", ErrorLevel))
+  }
+
+  override protected[database] def del(doc: DocInfo)(implicit transid: TransactionId): Future[Boolean] = {
+    require(doc != null && doc.rev.asString != null, "doc revision required for delete")
+
+    val start = transid.started(this, LoggingMarkers.DATABASE_DELETE, s"[DEL] '$dbName' deleting document: '$doc'")
+
+    val f = client.deleteDoc(doc.id.id, doc.rev.rev).map { e =>
+      e match {
+        case Right(response) =>
+          transid.finished(this, start, s"[DEL] '$dbName' completed document: '$doc', response: $response")
+          response.fields("ok").convertTo[Boolean]
+
+        case Left(StatusCodes.NotFound) =>
+          transid.finished(this, start, s"[DEL] '$dbName', document: '${doc}'; not found.")
+          // for compatibility
+          throw NoDocumentException("not found on 'delete'")
+
+        case Left(StatusCodes.Conflict) =>
+          transid.finished(this, start, s"[DEL] '$dbName', document: '${doc}'; conflict.")
+          throw DocumentConflictException("conflict on 'delete'")
+
+        case Left(code) =>
+          transid.failed(
+            this,
+            start,
+            s"[DEL] '$dbName' failed to delete document: '${doc}'; http status: '${code}'",
+            ErrorLevel)
+          throw new Exception("Unexpected http response code: " + code)
+      }
+    }
+
+    reportFailure(
+      f,
+      failure =>
+        transid.failed(
+          this,
+          start,
+          s"[DEL] '$dbName' internal error, doc: '$doc', failure: '${failure.getMessage}'",
+          ErrorLevel))
+  }
+
+  override protected[database] def get[A <: DocumentAbstraction](doc: DocInfo)(implicit transid: TransactionId,
+                                                                               ma: Manifest[A]): Future[A] = {
+
+    val start = transid.started(this, LoggingMarkers.DATABASE_GET, s"[GET] '$dbName' finding document: '$doc'")
+
+    require(doc != null, "doc undefined")
+    val request: CouchDbRestClient => Future[Either[StatusCode, JsObject]] = if (doc.rev.rev != null) { client =>
+      client.getDoc(doc.id.id, doc.rev.rev)
+    } else { client =>
+      client.getDoc(doc.id.id)
+    }
+
+    val f = request(client).map { e =>
+      e match {
+        case Right(response) =>
+          transid.finished(this, start, s"[GET] '$dbName' completed: found document '$doc'")
+          val asFormat = jsonFormat.read(response)
+          if (asFormat.getClass != ma.runtimeClass) {
+            throw DocumentTypeMismatchException(
+              s"document type ${asFormat.getClass} did not match expected type ${ma.runtimeClass}.")
+          }
+
+          val deserialized = asFormat.asInstanceOf[A]
+
+          val responseRev = response.fields("_rev").convertTo[String]
+          assert(doc.rev.rev == null || doc.rev.rev == responseRev, "Returned revision should match original argument")
+          // FIXME remove mutability from appropriate classes now that it is no longer required by GSON.
+          deserialized.asInstanceOf[WhiskDocument].revision(DocRevision(responseRev))
+
+          deserialized
+
+        case Left(StatusCodes.NotFound) =>
+          transid.finished(this, start, s"[GET] '$dbName', document: '${doc}'; not found.")
+          // for compatibility
+          throw NoDocumentException("not found on 'get'")
+
+        case Left(code) =>
+          transid.finished(this, start, s"[GET] '$dbName' failed to get document: '${doc}'; http status: '${code}'")
+          throw new Exception("Unexpected http response code: " + code)
+      }
+    } recoverWith {
+      case e: DeserializationException => throw DocumentUnreadable(Messages.corruptedEntity)
+    }
+
+    reportFailure(
+      f,
+      failure =>
+        transid.failed(
+          this,
+          start,
+          s"[GET] '$dbName' internal error, doc: '$doc', failure: '${failure.getMessage}'",
+          ErrorLevel))
+  }
+
+  override protected[core] def query(table: String,
+                                     startKey: List[Any],
+                                     endKey: List[Any],
+                                     skip: Int,
+                                     limit: Int,
+                                     includeDocs: Boolean,
+                                     descending: Boolean,
+                                     reduce: Boolean,
+                                     stale: StaleParameter)(implicit transid: TransactionId): Future[List[JsObject]] = {
+
+    require(!(reduce && includeDocs), "reduce and includeDocs cannot both be true")
+
+    // Apparently you have to do that in addition to setting "descending"
+    val (realStartKey, realEndKey) = if (descending) {
+      (endKey, startKey)
+    } else {
+      (startKey, endKey)
+    }
+
+    val parts = table.split("/")
+
+    val start = transid.started(this, LoggingMarkers.DATABASE_QUERY, s"[QUERY] '$dbName' searching '$table")
+
+    val f = for (eitherResponse <- client.executeView(parts(0), parts(1))(
+                   startKey = realStartKey,
+                   endKey = realEndKey,
+                   skip = Some(skip),
+                   limit = Some(limit),
+                   stale = stale,
+                   includeDocs = includeDocs,
+                   descending = descending,
+                   reduce = reduce))
+      yield
+        eitherResponse match {
+          case Right(response) =>
+            val rows = response.fields("rows").convertTo[List[JsObject]]
+
+            val out = if (reduce && !rows.isEmpty) {
+              assert(rows.length == 1, s"result of reduced view contains more than one value: '$rows'")
+              rows.head.fields("value").convertTo[List[JsObject]]
+            } else if (reduce) {
+              List(JsObject())
+            } else {
+              rows
             }
+
+            transid.finished(this, start, s"[QUERY] '$dbName' completed: matched ${out.size}")
+            out
+
+          case Left(code) =>
+            transid.failed(this, start, s"Unexpected http response code: $code", ErrorLevel)
+            throw new Exception("Unexpected http response code: " + code)
         }
 
-        reportFailure(f, failure => transid.failed(this, start, s"[PUT] '$dbName' internal error, failure: '${failure.getMessage}'", ErrorLevel))
+    reportFailure(
+      f,
+      failure =>
+        transid.failed(this, start, s"[QUERY] '$dbName' internal error, failure: '${failure.getMessage}'", ErrorLevel))
+  }
+
+  override protected[core] def attach(
+    doc: DocInfo,
+    name: String,
+    contentType: ContentType,
+    docStream: Source[ByteString, _])(implicit transid: TransactionId): Future[DocInfo] = {
+
+    val start = transid.started(
+      this,
+      LoggingMarkers.DATABASE_ATT_SAVE,
+      s"[ATT_PUT] '$dbName' uploading attachment '$name' of document '$doc'")
+
+    require(doc != null, "doc undefined")
+    require(doc.rev.rev != null, "doc revision must be specified")
+
+    val f = client.putAttachment(doc.id.id, doc.rev.rev, name, contentType, docStream).map { e =>
+      e match {
+        case Right(response) =>
+          transid
+            .finished(this, start, s"[ATT_PUT] '$dbName' completed uploading attachment '$name' of document '$doc'")
+          val id = response.fields("id").convertTo[String]
+          val rev = response.fields("rev").convertTo[String]
+          DocInfo ! (id, rev)
+
+        case Left(StatusCodes.NotFound) =>
+          transid
+            .finished(this, start, s"[ATT_PUT] '$dbName' uploading attachment '$name' of document '$doc'; not found")
+          throw NoDocumentException("Not found on 'readAttachment'.")
+
+        case Left(code) =>
+          transid.failed(
+            this,
+            start,
+            s"[ATT_PUT] '$dbName' failed to upload attachment '$name' of document '$doc'; http status '$code'")
+          throw new Exception("Unexpected http response code: " + code)
+      }
     }
 
-    override protected[database] def del(doc: DocInfo)(implicit transid: TransactionId): Future[Boolean] = {
-        require(doc != null && doc.rev.asString != null, "doc revision required for delete")
+    reportFailure(
+      f,
+      failure =>
+        transid.failed(
+          this,
+          start,
+          s"[ATT_PUT] '$dbName' internal error, name: '$name', doc: '$doc', failure: '${failure.getMessage}'",
+          ErrorLevel))
+  }
 
-        val start = transid.started(this, LoggingMarkers.DATABASE_DELETE, s"[DEL] '$dbName' deleting document: '$doc'")
+  override protected[core] def readAttachment[T](doc: DocInfo, name: String, sink: Sink[ByteString, Future[T]])(
+    implicit transid: TransactionId): Future[(ContentType, T)] = {
 
-        val f = client.deleteDoc(doc.id.id, doc.rev.rev).map { e =>
-            e match {
-                case Right(response) =>
-                    transid.finished(this, start, s"[DEL] '$dbName' completed document: '$doc', response: $response")
-                    response.fields("ok").convertTo[Boolean]
+    val start = transid.started(
+      this,
+      LoggingMarkers.DATABASE_ATT_GET,
+      s"[ATT_GET] '$dbName' finding attachment '$name' of document '$doc'")
 
-                case Left(StatusCodes.NotFound) =>
-                    transid.finished(this, start, s"[DEL] '$dbName', document: '${doc}'; not found.")
-                    // for compatibility
-                    throw NoDocumentException("not found on 'delete'")
+    require(doc != null, "doc undefined")
+    require(doc.rev.rev != null, "doc revision must be specified")
 
-                case Left(StatusCodes.Conflict) =>
-                    transid.finished(this, start, s"[DEL] '$dbName', document: '${doc}'; conflict.")
-                    throw DocumentConflictException("conflict on 'delete'")
+    val f = client.getAttachment[T](doc.id.id, doc.rev.rev, name, sink)
+    val g = f.map { e =>
+      e match {
+        case Right((contentType, result)) =>
+          transid.finished(this, start, s"[ATT_GET] '$dbName' completed: found attachment '$name' of document '$doc'")
+          (contentType, result)
 
-                case Left(code) =>
-                    transid.failed(this, start, s"[DEL] '$dbName' failed to delete document: '${doc}'; http status: '${code}'", ErrorLevel)
-                    throw new Exception("Unexpected http response code: " + code)
-            }
-        }
+        case Left(StatusCodes.NotFound) =>
+          transid.finished(
+            this,
+            start,
+            s"[ATT_GET] '$dbName', retrieving attachment '$name' of document '$doc'; not found.")
+          throw NoDocumentException("Not found on 'readAttachment'.")
 
-        reportFailure(f, failure => transid.failed(this, start, s"[DEL] '$dbName' internal error, doc: '$doc', failure: '${failure.getMessage}'", ErrorLevel))
+        case Left(code) =>
+          transid.failed(
+            this,
+            start,
+            s"[ATT_GET] '$dbName' failed to get attachment '$name' of document '$doc'; http status: '${code}'")
+          throw new Exception("Unexpected http response code: " + code)
+      }
     }
 
-    override protected[database] def get[A <: DocumentAbstraction](doc: DocInfo)(
-        implicit transid: TransactionId,
-        ma: Manifest[A]): Future[A] = {
+    reportFailure(
+      g,
+      failure =>
+        transid.failed(
+          this,
+          start,
+          s"[ATT_GET] '$dbName' internal error, name: '$name', doc: '$doc', failure: '${failure.getMessage}'",
+          ErrorLevel))
+  }
 
-        val start = transid.started(this, LoggingMarkers.DATABASE_GET, s"[GET] '$dbName' finding document: '$doc'")
+  override def shutdown(): Unit = {
+    Await.ready(client.shutdown(), 1.minute)
+  }
 
-        require(doc != null, "doc undefined")
-        val request: CouchDbRestClient => Future[Either[StatusCode, JsObject]] = if (doc.rev.rev != null) {
-            client => client.getDoc(doc.id.id, doc.rev.rev)
-        } else {
-            client => client.getDoc(doc.id.id)
-        }
-
-        val f = request(client).map { e =>
-            e match {
-                case Right(response) =>
-                    transid.finished(this, start, s"[GET] '$dbName' completed: found document '$doc'")
-                    val asFormat = jsonFormat.read(response)
-                    if (asFormat.getClass != ma.runtimeClass) {
-                        throw DocumentTypeMismatchException(s"document type ${asFormat.getClass} did not match expected type ${ma.runtimeClass}.")
-                    }
-
-                    val deserialized = asFormat.asInstanceOf[A]
-
-                    val responseRev = response.fields("_rev").convertTo[String]
-                    assert(doc.rev.rev == null || doc.rev.rev == responseRev, "Returned revision should match original argument")
-                    // FIXME remove mutability from appropriate classes now that it is no longer required by GSON.
-                    deserialized.asInstanceOf[WhiskDocument].revision(DocRevision(responseRev))
-
-                    deserialized
-
-                case Left(StatusCodes.NotFound) =>
-                    transid.finished(this, start, s"[GET] '$dbName', document: '${doc}'; not found.")
-                    // for compatibility
-                    throw NoDocumentException("not found on 'get'")
-
-                case Left(code) =>
-                    transid.finished(this, start, s"[GET] '$dbName' failed to get document: '${doc}'; http status: '${code}'")
-                    throw new Exception("Unexpected http response code: " + code)
-            }
-        } recoverWith {
-            case e: DeserializationException => throw DocumentUnreadable(Messages.corruptedEntity)
-        }
-
-        reportFailure(f, failure => transid.failed(this, start, s"[GET] '$dbName' internal error, doc: '$doc', failure: '${failure.getMessage}'", ErrorLevel))
-    }
-
-    override protected[core] def query(table: String, startKey: List[Any], endKey: List[Any], skip: Int, limit: Int, includeDocs: Boolean, descending: Boolean, reduce: Boolean, stale: StaleParameter)(
-        implicit transid: TransactionId): Future[List[JsObject]] = {
-
-        require(!(reduce && includeDocs), "reduce and includeDocs cannot both be true")
-
-        // Apparently you have to do that in addition to setting "descending"
-        val (realStartKey, realEndKey) = if (descending) {
-            (endKey, startKey)
-        } else {
-            (startKey, endKey)
-        }
-
-        val parts = table.split("/")
-
-        val start = transid.started(this, LoggingMarkers.DATABASE_QUERY, s"[QUERY] '$dbName' searching '$table")
-
-        val f = for (
-            eitherResponse <- client.executeView(parts(0), parts(1))(
-                startKey = realStartKey,
-                endKey = realEndKey,
-                skip = Some(skip),
-                limit = Some(limit),
-                stale = stale,
-                includeDocs = includeDocs,
-                descending = descending,
-                reduce = reduce)
-        ) yield eitherResponse match {
-            case Right(response) =>
-                val rows = response.fields("rows").convertTo[List[JsObject]]
-
-                val out = if (reduce && !rows.isEmpty) {
-                    assert(rows.length == 1, s"result of reduced view contains more than one value: '$rows'")
-                    rows.head.fields("value").convertTo[List[JsObject]]
-                } else if (reduce) {
-                    List(JsObject())
-                } else {
-                    rows
-                }
-
-                transid.finished(this, start, s"[QUERY] '$dbName' completed: matched ${out.size}")
-                out
-
-            case Left(code) =>
-                transid.failed(this, start, s"Unexpected http response code: $code", ErrorLevel)
-                throw new Exception("Unexpected http response code: " + code)
-        }
-
-        reportFailure(f, failure => transid.failed(this, start, s"[QUERY] '$dbName' internal error, failure: '${failure.getMessage}'", ErrorLevel))
-    }
-
-    override protected[core] def attach(doc: DocInfo, name: String, contentType: ContentType, docStream: Source[ByteString, _])(
-        implicit transid: TransactionId): Future[DocInfo] = {
-
-        val start = transid.started(this, LoggingMarkers.DATABASE_ATT_SAVE, s"[ATT_PUT] '$dbName' uploading attachment '$name' of document '$doc'")
-
-        require(doc != null, "doc undefined")
-        require(doc.rev.rev != null, "doc revision must be specified")
-
-        val f = client.putAttachment(doc.id.id, doc.rev.rev, name, contentType, docStream).map { e =>
-            e match {
-                case Right(response) =>
-                    transid.finished(this, start, s"[ATT_PUT] '$dbName' completed uploading attachment '$name' of document '$doc'")
-                    val id = response.fields("id").convertTo[String]
-                    val rev = response.fields("rev").convertTo[String]
-                    DocInfo ! (id, rev)
-
-                case Left(StatusCodes.NotFound) =>
-                    transid.finished(this, start, s"[ATT_PUT] '$dbName' uploading attachment '$name' of document '$doc'; not found")
-                    throw NoDocumentException("Not found on 'readAttachment'.")
-
-                case Left(code) =>
-                    transid.failed(this, start, s"[ATT_PUT] '$dbName' failed to upload attachment '$name' of document '$doc'; http status '$code'")
-                    throw new Exception("Unexpected http response code: " + code)
-            }
-        }
-
-        reportFailure(f, failure => transid.failed(this, start, s"[ATT_PUT] '$dbName' internal error, name: '$name', doc: '$doc', failure: '${failure.getMessage}'", ErrorLevel))
-    }
-
-    override protected[core] def readAttachment[T](doc: DocInfo, name: String, sink: Sink[ByteString, Future[T]])(
-        implicit transid: TransactionId): Future[(ContentType, T)] = {
-
-        val start = transid.started(this, LoggingMarkers.DATABASE_ATT_GET, s"[ATT_GET] '$dbName' finding attachment '$name' of document '$doc'")
-
-        require(doc != null, "doc undefined")
-        require(doc.rev.rev != null, "doc revision must be specified")
-
-        val f = client.getAttachment[T](doc.id.id, doc.rev.rev, name, sink)
-        val g = f.map { e =>
-            e match {
-                case Right((contentType, result)) =>
-                    transid.finished(this, start, s"[ATT_GET] '$dbName' completed: found attachment '$name' of document '$doc'")
-                    (contentType, result)
-
-                case Left(StatusCodes.NotFound) =>
-                    transid.finished(this, start, s"[ATT_GET] '$dbName', retrieving attachment '$name' of document '$doc'; not found.")
-                    throw NoDocumentException("Not found on 'readAttachment'.")
-
-                case Left(code) =>
-                    transid.failed(this, start, s"[ATT_GET] '$dbName' failed to get attachment '$name' of document '$doc'; http status: '${code}'")
-                    throw new Exception("Unexpected http response code: " + code)
-            }
-        }
-
-        reportFailure(g, failure => transid.failed(this, start, s"[ATT_GET] '$dbName' internal error, name: '$name', doc: '$doc', failure: '${failure.getMessage}'", ErrorLevel))
-    }
-
-    override def shutdown(): Unit = {
-        Await.ready(client.shutdown(), 1.minute)
-    }
-
-    private def reportFailure[T, U](f: Future[T], onFailure: Throwable => U): Future[T] = {
-        f.onFailure({
-            case _: ArtifactStoreException => // These failures are intentional and shouldn't trigger the catcher.
-            case x                         => onFailure(x)
-        })
-        f
-    }
+  private def reportFailure[T, U](f: Future[T], onFailure: Throwable => U): Future[T] = {
+    f.onFailure({
+      case _: ArtifactStoreException => // These failures are intentional and shouldn't trigger the catcher.
+      case x                         => onFailure(x)
+    })
+    f
+  }
 }

--- a/common/scala/src/main/scala/whisk/core/database/CouchDbStoreProvider.scala
+++ b/common/scala/src/main/scala/whisk/core/database/CouchDbStoreProvider.scala
@@ -24,14 +24,25 @@ import whisk.core.WhiskConfig
 
 object CouchDbStoreProvider extends ArtifactStoreProvider {
 
-    def makeStore[D <: DocumentSerializer](config: WhiskConfig, name: WhiskConfig => String)(
-        implicit jsonFormat: RootJsonFormat[D],
-        actorSystem: ActorSystem,
-        logging: Logging): ArtifactStore[D] = {
-        require(config != null && config.isValid, "config is undefined or not valid")
-        require(config.dbProvider == "Cloudant" || config.dbProvider == "CouchDB", "Unsupported db.provider: " + config.dbProvider)
-        assume(Set(config.dbProtocol, config.dbHost, config.dbPort, config.dbUsername, config.dbPassword, name(config)).forall(_.nonEmpty), "At least one expected property is missing")
+  def makeStore[D <: DocumentSerializer](config: WhiskConfig, name: WhiskConfig => String)(
+    implicit jsonFormat: RootJsonFormat[D],
+    actorSystem: ActorSystem,
+    logging: Logging): ArtifactStore[D] = {
+    require(config != null && config.isValid, "config is undefined or not valid")
+    require(
+      config.dbProvider == "Cloudant" || config.dbProvider == "CouchDB",
+      "Unsupported db.provider: " + config.dbProvider)
+    assume(
+      Set(config.dbProtocol, config.dbHost, config.dbPort, config.dbUsername, config.dbPassword, name(config))
+        .forall(_.nonEmpty),
+      "At least one expected property is missing")
 
-        new CouchDbRestStore[D](config.dbProtocol, config.dbHost, config.dbPort.toInt, config.dbUsername, config.dbPassword, name(config))
-    }
+    new CouchDbRestStore[D](
+      config.dbProtocol,
+      config.dbHost,
+      config.dbPort.toInt,
+      config.dbUsername,
+      config.dbPassword,
+      name(config))
+  }
 }

--- a/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
+++ b/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
@@ -77,362 +77,380 @@ import whisk.core.entity.CacheKey
  *
  */
 private object MultipleReadersSingleWriterCache {
-    /** Each entry has a state, as explained in the class comment above. */
-    object State extends Enumeration {
-        type State = Value
-        val ReadInProgress, WriteInProgress, InvalidateInProgress, InvalidateWhenDone, Cached = Value
-    }
 
-    import State._
+  /** Each entry has a state, as explained in the class comment above. */
+  object State extends Enumeration {
+    type State = Value
+    val ReadInProgress, WriteInProgress, InvalidateInProgress, InvalidateWhenDone, Cached = Value
+  }
 
-    /** Failure modes, which will only occur if there is a bug in this implementation */
-    case class ConcurrentOperationUnderRead(actualState: State) extends Exception(s"Cache read started, but completion raced with a concurrent operation: $actualState.")
-    case class ConcurrentOperationUnderUpdate(actualState: State) extends Exception(s"Cache update started, but completion raced with a concurrent operation: $actualState.")
-    case class StaleRead(actualState: State) extends Exception(s"Attempted read of invalid entry due to $actualState.")
+  import State._
+
+  /** Failure modes, which will only occur if there is a bug in this implementation */
+  case class ConcurrentOperationUnderRead(actualState: State)
+      extends Exception(s"Cache read started, but completion raced with a concurrent operation: $actualState.")
+  case class ConcurrentOperationUnderUpdate(actualState: State)
+      extends Exception(s"Cache update started, but completion raced with a concurrent operation: $actualState.")
+  case class StaleRead(actualState: State) extends Exception(s"Attempted read of invalid entry due to $actualState.")
 }
 
 trait CacheChangeNotification extends (CacheKey => Future[Unit])
 
 trait MultipleReadersSingleWriterCache[W, Winfo] {
-    import MultipleReadersSingleWriterCache._
-    import MultipleReadersSingleWriterCache.State._
+  import MultipleReadersSingleWriterCache._
+  import MultipleReadersSingleWriterCache.State._
 
-    /** Subclasses: Toggle this to enable/disable caching for your entity type. */
-    protected val cacheEnabled = true
+  /** Subclasses: Toggle this to enable/disable caching for your entity type. */
+  protected val cacheEnabled = true
 
-    private object Entry {
-        def apply(transid: TransactionId, state: State, value: Option[Future[W]]): Entry = {
-            new Entry(transid, new AtomicReference(state), value)
-        }
+  private object Entry {
+    def apply(transid: TransactionId, state: State, value: Option[Future[W]]): Entry = {
+      new Entry(transid, new AtomicReference(state), value)
+    }
+  }
+
+  /**
+   * The entries in the cache will be a triple of (transid, State, Future[W]?).
+   *
+   * We need the transid in order to detect whether we have won the race to add an entry to the cache.
+   */
+  private class Entry(@volatile private var transid: TransactionId,
+                      val state: AtomicReference[State],
+                      @volatile private var value: Option[Future[W]]) {
+
+    def invalidate(): Unit = {
+      state.set(InvalidateInProgress)
     }
 
-    /**
-     * The entries in the cache will be a triple of (transid, State, Future[W]?).
-     *
-     * We need the transid in order to detect whether we have won the race to add an entry to the cache.
-     */
-    private class Entry(
-        @volatile private var transid: TransactionId,
-        val state: AtomicReference[State],
-        @volatile private var value: Option[Future[W]]) {
+    def unpack(): Future[W] = {
+      value getOrElse Future.failed(StaleRead(state.get))
+    }
 
-        def invalidate(): Unit = {
-            state.set(InvalidateInProgress)
-        }
+    def writeDone()(implicit logger: Logging): Boolean = {
+      logger.debug(this, "write finished")(transid)
+      trySet(WriteInProgress, Cached)
+    }
 
-        def unpack(): Future[W] = {
-            value getOrElse Future.failed(StaleRead(state.get))
-        }
+    def readDone()(implicit logger: Logging): Boolean = {
+      logger.debug(this, "read finished")(transid)
+      trySet(ReadInProgress, Cached)
+    }
 
-        def writeDone()(implicit logger: Logging): Boolean = {
-            logger.debug(this, "write finished")(transid)
-            trySet(WriteInProgress, Cached)
-        }
+    def trySet(expectedState: State, desiredState: State): Boolean = {
+      state.compareAndSet(expectedState, desiredState)
+    }
 
-        def readDone()(implicit logger: Logging): Boolean = {
-            logger.debug(this, "read finished")(transid)
-            trySet(ReadInProgress, Cached)
-        }
+    def grabWriteLock(newTransid: TransactionId, expectedState: State, newValue: Future[W]): Boolean = synchronized {
+      val swapped = trySet(expectedState, WriteInProgress)
+      if (swapped) {
+        value = Option(newValue)
+        transid = newTransid
+      }
+      swapped
+    }
 
-        def trySet(expectedState: State, desiredState: State): Boolean = {
-            state.compareAndSet(expectedState, desiredState)
-        }
+    def grabInvalidationLock() = state.set(InvalidateInProgress)
 
-        def grabWriteLock(newTransid: TransactionId, expectedState: State, newValue: Future[W]): Boolean = synchronized {
-            val swapped = trySet(expectedState, WriteInProgress)
-            if (swapped) {
-                value = Option(newValue)
-                transid = newTransid
+    override def toString = s"tid ${transid.meta.id}, state ${state.get}"
+  }
+
+  /**
+   * This method posts a delete to the backing store, and either directly invalidates the cache entry
+   * or informs any outstanding transaction that it must invalidate the cache on completion.
+   */
+  protected def cacheInvalidate[R](key: CacheKey, invalidator: => Future[R])(
+    implicit ec: ExecutionContext,
+    transid: TransactionId,
+    logger: Logging,
+    notifier: Option[CacheChangeNotification]): Future[R] = {
+    if (cacheEnabled) {
+      logger.info(this, s"invalidating $key on delete")
+
+      notifier.foreach(_(key))
+
+      // try inserting our desired entry...
+      val desiredEntry = Entry(transid, InvalidateInProgress, None)
+      cache(key)(desiredEntry) flatMap { actualEntry =>
+        // ... and see what we get back
+        val currentState = actualEntry.state.get
+
+        currentState match {
+          case Cached =>
+            // nobody owns the entry, forcefully grab ownership
+            // note: if a new cache lookup is received while
+            // the invalidator has not yet completed (and hence the actual entry
+            // removed from the cache), such lookup operations will still be able
+            // to return the value that is cached, and this is acceptable (under
+            // the eventual consistency model) as long as such lookups do not
+            // mutate the state of the cache to violate the invalidation that is
+            // about to occur (this is eventually consistent and NOT sequentially
+            // consistent since the cache lookup and the setting of the
+            // InvalidateInProgress bit are not atomic
+            invalidateEntryAfter(invalidator, key, actualEntry)
+
+          case ReadInProgress | WriteInProgress =>
+            if (actualEntry.trySet(currentState, InvalidateWhenDone)) {
+              // then the pre-existing owner will take care of the invalidation
+              invalidator
+            } else {
+              // the pre-existing reader or writer finished and so must
+              // explicitly invalidate here
+              invalidateEntryAfter(invalidator, key, actualEntry)
             }
-            swapped
-        }
 
-        def grabInvalidationLock() = state.set(InvalidateInProgress)
-
-        override def toString = s"tid ${transid.meta.id}, state ${state.get}"
-    }
-
-    /**
-     * This method posts a delete to the backing store, and either directly invalidates the cache entry
-     * or informs any outstanding transaction that it must invalidate the cache on completion.
-     */
-    protected def cacheInvalidate[R](key: CacheKey, invalidator: => Future[R])(
-        implicit ec: ExecutionContext, transid: TransactionId, logger: Logging, notifier: Option[CacheChangeNotification]): Future[R] = {
-        if (cacheEnabled) {
-            logger.info(this, s"invalidating $key on delete")
-
-            notifier.foreach(_(key))
-
-            // try inserting our desired entry...
-            val desiredEntry = Entry(transid, InvalidateInProgress, None)
-            cache(key)(desiredEntry) flatMap { actualEntry =>
-                // ... and see what we get back
-                val currentState = actualEntry.state.get
-
-                currentState match {
-                    case Cached =>
-                        // nobody owns the entry, forcefully grab ownership
-                        // note: if a new cache lookup is received while
-                        // the invalidator has not yet completed (and hence the actual entry
-                        // removed from the cache), such lookup operations will still be able
-                        // to return the value that is cached, and this is acceptable (under
-                        // the eventual consistency model) as long as such lookups do not
-                        // mutate the state of the cache to violate the invalidation that is
-                        // about to occur (this is eventually consistent and NOT sequentially
-                        // consistent since the cache lookup and the setting of the
-                        // InvalidateInProgress bit are not atomic
-                        invalidateEntryAfter(invalidator, key, actualEntry)
-
-                    case ReadInProgress | WriteInProgress =>
-                        if (actualEntry.trySet(currentState, InvalidateWhenDone)) {
-                            // then the pre-existing owner will take care of the invalidation
-                            invalidator
-                        } else {
-                            // the pre-existing reader or writer finished and so must
-                            // explicitly invalidate here
-                            invalidateEntryAfter(invalidator, key, actualEntry)
-                        }
-
-                    case InvalidateInProgress =>
-                        if (actualEntry == desiredEntry) {
-                            // we own the entry, so we are responsible for cleaning it up
-                            invalidateEntryAfter(invalidator, key, actualEntry)
-                        } else {
-                            // someone else requested an invalidation already
-                            invalidator
-                        }
-
-                    case InvalidateWhenDone =>
-                        // a pre-existing owner will take care of the invalidation
-                        invalidator
-                }
+          case InvalidateInProgress =>
+            if (actualEntry == desiredEntry) {
+              // we own the entry, so we are responsible for cleaning it up
+              invalidateEntryAfter(invalidator, key, actualEntry)
+            } else {
+              // someone else requested an invalidation already
+              invalidator
             }
-        } else invalidator // not caching
-    }
 
-    /**
-     * This method may initiate a read from the backing store, and potentially stores the result in the cache.
-     */
-    protected def cacheLookup[Wsuper >: W](key: CacheKey, generator: => Future[W], fromCache: Boolean = cacheEnabled)(
-        implicit ec: ExecutionContext, transid: TransactionId, logger: Logging): Future[W] = {
-        if (fromCache) {
-            val promise = Promise[W] // this promise completes with the generator value
+          case InvalidateWhenDone =>
+            // a pre-existing owner will take care of the invalidation
+            invalidator
+        }
+      }
+    } else invalidator // not caching
+  }
 
-            // try inserting our desired entry...
-            val desiredEntry = Entry(transid, ReadInProgress, Some(promise.future))
-            cache(key)(desiredEntry) flatMap { actualEntry =>
-                // ... and see what we get back
+  /**
+   * This method may initiate a read from the backing store, and potentially stores the result in the cache.
+   */
+  protected def cacheLookup[Wsuper >: W](key: CacheKey, generator: => Future[W], fromCache: Boolean = cacheEnabled)(
+    implicit ec: ExecutionContext,
+    transid: TransactionId,
+    logger: Logging): Future[W] = {
+    if (fromCache) {
+      val promise = Promise[W] // this promise completes with the generator value
 
-                actualEntry.state.get match {
-                    case Cached =>
-                        logger.debug(this, "cached read")
-                        makeNoteOfCacheHit(key)
-                        actualEntry.unpack
+      // try inserting our desired entry...
+      val desiredEntry = Entry(transid, ReadInProgress, Some(promise.future))
+      cache(key)(desiredEntry) flatMap { actualEntry =>
+        // ... and see what we get back
 
-                    case ReadInProgress =>
-                        if (actualEntry == desiredEntry) {
-                            logger.debug(this, "read initiated");
-                            makeNoteOfCacheMiss(key)
-                            // updating the cache with the new value is done in the listener
-                            // and will complete unless an invalidation request or an intervening
-                            // write occur in the meantime
-                            listenForReadDone(key, actualEntry, generator, promise)
-                            actualEntry.unpack
-                        } else {
-                            logger.debug(this, "coalesced read")
-                            makeNoteOfCacheHit(key)
-                            actualEntry.unpack
-                        }
+        actualEntry.state.get match {
+          case Cached =>
+            logger.debug(this, "cached read")
+            makeNoteOfCacheHit(key)
+            actualEntry.unpack
 
-                    case WriteInProgress | InvalidateInProgress =>
-                        logger.debug(this, "reading around an update in progress")
-                        makeNoteOfCacheMiss(key)
-                        generator
-                }
+          case ReadInProgress =>
+            if (actualEntry == desiredEntry) {
+              logger.debug(this, "read initiated");
+              makeNoteOfCacheMiss(key)
+              // updating the cache with the new value is done in the listener
+              // and will complete unless an invalidation request or an intervening
+              // write occur in the meantime
+              listenForReadDone(key, actualEntry, generator, promise)
+              actualEntry.unpack
+            } else {
+              logger.debug(this, "coalesced read")
+              makeNoteOfCacheHit(key)
+              actualEntry.unpack
             }
-        } else generator // not caching
-    }
 
-    /**
-     * This method posts an update to the backing store, and potentially stores the result in the cache.
-     */
-    protected def cacheUpdate(doc: W, key: CacheKey, generator: => Future[Winfo])(
-        implicit ec: ExecutionContext, transid: TransactionId, logger: Logging, notifier: Option[CacheChangeNotification]): Future[Winfo] = {
-        if (cacheEnabled) {
-
-            notifier.foreach(_(key))
-
-            // try inserting our desired entry...
-            val desiredEntry = Entry(transid, WriteInProgress, Some(Future.successful(doc)))
-            cache(key)(desiredEntry) flatMap { actualEntry =>
-                // ... and see what we get back
-
-                if (actualEntry == desiredEntry) {
-                    // then this transaction won the race to insert a new entry in the cache
-                    // and it is responsible for updating the cache entry...
-                    logger.info(this, s"write initiated on new cache entry")
-                    listenForWriteDone(key, actualEntry, generator)
-                } else {
-                    // ... otherwise, some existing entry is in the way, so try to grab a write lock
-                    val currentState = actualEntry.state.get
-                    val allowedToAssumeCompletion = currentState == Cached || currentState == ReadInProgress
-
-                    if (allowedToAssumeCompletion && actualEntry.grabWriteLock(transid, currentState, desiredEntry.unpack)) {
-                        // this transaction is now responsible for updating the cache entry
-                        logger.info(this, s"write initiated on existing cache entry, invalidating $key, $actualEntry")
-                        listenForWriteDone(key, actualEntry, generator)
-                    } else {
-                        // there is a conflicting operation in progress on this key
-                        logger.info(this, s"write-around (i.e., not cached) under $currentState")
-                        invalidateEntryAfter(generator, key, actualEntry)
-                    }
-                }
-            }
-        } else generator // not caching
-    }
-
-    def cacheSize: Int = cache.size
-
-    /**
-     * This method removes an entry from the cache immediately. You can use this method
-     * if you do not need to perform any updates on the backing store but only to the cache.
-     */
-    protected[database] def removeId(key: CacheKey)(implicit ec: ExecutionContext): Unit = cache.remove(key)
-
-    /**
-     * Log a cache hit
-     *
-     */
-    private def makeNoteOfCacheHit(key: CacheKey)(implicit transid: TransactionId, logger: Logging) = {
-        transid.mark(this, LoggingMarkers.DATABASE_CACHE_HIT, s"[GET] serving from cache: $key")(logger)
-    }
-
-    /**
-     * Log a cache miss
-     *
-     */
-    private def makeNoteOfCacheMiss(key: CacheKey)(implicit transid: TransactionId, logger: Logging) = {
-        transid.mark(this, LoggingMarkers.DATABASE_CACHE_MISS, s"[GET] serving from datastore: $key")(logger)
-    }
-
-    /**
-     * We have initiated a read (in cacheLookup), now handle its completion:
-     * 1. either cache the result if there is no intervening delete or update, or
-     * 2. invalidate the cache because there was an intervening delete or update.
-     */
-    private def listenForReadDone(key: CacheKey, entry: Entry, generator: => Future[W], promise: Promise[W])(
-        implicit ec: ExecutionContext, transid: TransactionId, logger: Logging): Unit = {
-
-        generator onComplete {
-            case Success(value) =>
-                // if the datastore read was successful, then try to transition to the Cached state
-                logger.debug(this, "read backend part done, now marking cache entry as done")
-
-                // always complete the promise for the generator since the read listener is
-                // only created when reading directly from the database (hence, must complete
-                // promise with the generated value)
-                promise success value
-
-                // now update the cache line
-                if (entry.readDone()) {
-                    // cache entry is still in ReadInProgress and successful transitioned to Cached
-                    // hence the new value is cached; nothing left to do
-                } else {
-                    val cachedLineState = entry.state.get
-
-                    cachedLineState match {
-                        case WriteInProgress | Cached =>
-                            // do nothing: if there was a write in progress, the write has not yet
-                            // finished, but that operation has assumed ownership of the cache line
-                            // and will update it; otherwise the write has completed and the value
-                            // is now cached
-                            ()
-                        case _ =>
-                            // some transaction requested an invalidation so remove the key from the cache,
-                            // or there is an error in which case invalidate anyway, defensively, but log a message
-                            invalidateEntry(key, entry)
-                            if (cachedLineState != InvalidateWhenDone) {
-                                // this should not happen, but could if the callback on the generator
-                                // is delayed - invalidate the cache entry as a result
-                                val error = ConcurrentOperationUnderRead(cachedLineState)
-                                logger.warn(this, error.toString)
-                            }
-                    }
-                }
-
-            case Failure(t) =>
-                // oops, the datastore read failed. invalidate the cache entry
-                // note: that this might be a perfectly legitimate failure,
-                // e.g. a lookup for a non-existant key; we need to pass the particular t through
-                invalidateEntry(key, entry)
-                promise.failure(t)
+          case WriteInProgress | InvalidateInProgress =>
+            logger.debug(this, "reading around an update in progress")
+            makeNoteOfCacheMiss(key)
+            generator
         }
-    }
+      }
+    } else generator // not caching
+  }
 
-    /**
-     * We have initiated a write, now handle its completion:
-     * 1. either cache the result if there is no intervening delete or update, or
-     * 2. invalidate the cache cache because there was an intervening delete or update
-     */
-    private def listenForWriteDone(key: CacheKey, entry: Entry, generator: => Future[Winfo])(
-        implicit ec: ExecutionContext, transid: TransactionId, logger: Logging): Future[Winfo] = {
+  /**
+   * This method posts an update to the backing store, and potentially stores the result in the cache.
+   */
+  protected def cacheUpdate(doc: W, key: CacheKey, generator: => Future[Winfo])(
+    implicit ec: ExecutionContext,
+    transid: TransactionId,
+    logger: Logging,
+    notifier: Option[CacheChangeNotification]): Future[Winfo] = {
+    if (cacheEnabled) {
 
-        generator andThen {
-            case Success(_) =>
-                // if the datastore write was successful, then transition to the Cached state
-                logger.debug(this, "write backend part done, now marking cache entry as done")
+      notifier.foreach(_(key))
 
-                if (entry.writeDone()) {
-                    // entry transitioned from WriteInProgress to Cached state
-                    logger.info(this, s"write all done, caching $key ${entry.state.get}")
-                } else {
-                    // state transition from WriteInProgress to Cached fails so invalidate
-                    // the entry in the cache
-                    val prevState = entry.state.get
-                    if (prevState != InvalidateWhenDone) {
-                        // this should not happen but could for example during a document
-                        // update where the "read" that would fetch a previous instance of
-                        // the document fails because the document does not exist, but the
-                        // future callback to invalidate the cache entry is delayed; so it
-                        // is possible the state here is InvalidateInProgress as a result.
-                        // the end result is to invalidate the entry, which may be unnecessary;
-                        // so this is a performance hit, not a correctness concern.
-                        val error = ConcurrentOperationUnderUpdate(prevState)
-                        logger.warn(this, error.toString)
-                    } else {
-                        logger.info(this, s"write done, but invalidating cache entry as requested")
-                    }
-                    invalidateEntry(key, entry)
-                }
+      // try inserting our desired entry...
+      val desiredEntry = Entry(transid, WriteInProgress, Some(Future.successful(doc)))
+      cache(key)(desiredEntry) flatMap { actualEntry =>
+        // ... and see what we get back
 
-            case Failure(_) => invalidateEntry(key, entry) // datastore write failed, invalidate cache entry
+        if (actualEntry == desiredEntry) {
+          // then this transaction won the race to insert a new entry in the cache
+          // and it is responsible for updating the cache entry...
+          logger.info(this, s"write initiated on new cache entry")
+          listenForWriteDone(key, actualEntry, generator)
+        } else {
+          // ... otherwise, some existing entry is in the way, so try to grab a write lock
+          val currentState = actualEntry.state.get
+          val allowedToAssumeCompletion = currentState == Cached || currentState == ReadInProgress
+
+          if (allowedToAssumeCompletion && actualEntry.grabWriteLock(transid, currentState, desiredEntry.unpack)) {
+            // this transaction is now responsible for updating the cache entry
+            logger.info(this, s"write initiated on existing cache entry, invalidating $key, $actualEntry")
+            listenForWriteDone(key, actualEntry, generator)
+          } else {
+            // there is a conflicting operation in progress on this key
+            logger.info(this, s"write-around (i.e., not cached) under $currentState")
+            invalidateEntryAfter(generator, key, actualEntry)
+          }
         }
-    }
+      }
+    } else generator // not caching
+  }
 
-    /** Immediately invalidates the given entry. */
-    private def invalidateEntry(key: CacheKey, entry: Entry)(
-        implicit transid: TransactionId, logger: Logging): Unit = {
-        logger.info(this, s"invalidating $key")
-        entry.invalidate()
-        cache remove key
-    }
+  def cacheSize: Int = cache.size
 
-    /** Invalidates the given entry after a given invalidator completes. */
-    private def invalidateEntryAfter[R](invalidator: => Future[R], key: CacheKey, entry: Entry)(
-        implicit ec: ExecutionContext, transid: TransactionId, logger: Logging): Future[R] = {
+  /**
+   * This method removes an entry from the cache immediately. You can use this method
+   * if you do not need to perform any updates on the backing store but only to the cache.
+   */
+  protected[database] def removeId(key: CacheKey)(implicit ec: ExecutionContext): Unit = cache.remove(key)
 
-        entry.grabInvalidationLock()
-        invalidator andThen {
-            case _ => invalidateEntry(key, entry)
+  /**
+   * Log a cache hit
+   *
+   */
+  private def makeNoteOfCacheHit(key: CacheKey)(implicit transid: TransactionId, logger: Logging) = {
+    transid.mark(this, LoggingMarkers.DATABASE_CACHE_HIT, s"[GET] serving from cache: $key")(logger)
+  }
+
+  /**
+   * Log a cache miss
+   *
+   */
+  private def makeNoteOfCacheMiss(key: CacheKey)(implicit transid: TransactionId, logger: Logging) = {
+    transid.mark(this, LoggingMarkers.DATABASE_CACHE_MISS, s"[GET] serving from datastore: $key")(logger)
+  }
+
+  /**
+   * We have initiated a read (in cacheLookup), now handle its completion:
+   * 1. either cache the result if there is no intervening delete or update, or
+   * 2. invalidate the cache because there was an intervening delete or update.
+   */
+  private def listenForReadDone(key: CacheKey, entry: Entry, generator: => Future[W], promise: Promise[W])(
+    implicit ec: ExecutionContext,
+    transid: TransactionId,
+    logger: Logging): Unit = {
+
+    generator onComplete {
+      case Success(value) =>
+        // if the datastore read was successful, then try to transition to the Cached state
+        logger.debug(this, "read backend part done, now marking cache entry as done")
+
+        // always complete the promise for the generator since the read listener is
+        // only created when reading directly from the database (hence, must complete
+        // promise with the generated value)
+        promise success value
+
+        // now update the cache line
+        if (entry.readDone()) {
+          // cache entry is still in ReadInProgress and successful transitioned to Cached
+          // hence the new value is cached; nothing left to do
+        } else {
+          val cachedLineState = entry.state.get
+
+          cachedLineState match {
+            case WriteInProgress | Cached =>
+              // do nothing: if there was a write in progress, the write has not yet
+              // finished, but that operation has assumed ownership of the cache line
+              // and will update it; otherwise the write has completed and the value
+              // is now cached
+              ()
+            case _ =>
+              // some transaction requested an invalidation so remove the key from the cache,
+              // or there is an error in which case invalidate anyway, defensively, but log a message
+              invalidateEntry(key, entry)
+              if (cachedLineState != InvalidateWhenDone) {
+                // this should not happen, but could if the callback on the generator
+                // is delayed - invalidate the cache entry as a result
+                val error = ConcurrentOperationUnderRead(cachedLineState)
+                logger.warn(this, error.toString)
+              }
+          }
         }
-    }
 
-    /** This is the backing store. */
-    private val cache: ConcurrentMapBackedCache[Entry] = new ConcurrentMapBackedCache(
-        Caffeine.newBuilder().asInstanceOf[Caffeine[Any, Future[Entry]]]
-            .expireAfterWrite(5, TimeUnit.MINUTES)
-            .softValues()
-            .build().asMap())
+      case Failure(t) =>
+        // oops, the datastore read failed. invalidate the cache entry
+        // note: that this might be a perfectly legitimate failure,
+        // e.g. a lookup for a non-existant key; we need to pass the particular t through
+        invalidateEntry(key, entry)
+        promise.failure(t)
+    }
+  }
+
+  /**
+   * We have initiated a write, now handle its completion:
+   * 1. either cache the result if there is no intervening delete or update, or
+   * 2. invalidate the cache cache because there was an intervening delete or update
+   */
+  private def listenForWriteDone(key: CacheKey, entry: Entry, generator: => Future[Winfo])(
+    implicit ec: ExecutionContext,
+    transid: TransactionId,
+    logger: Logging): Future[Winfo] = {
+
+    generator andThen {
+      case Success(_) =>
+        // if the datastore write was successful, then transition to the Cached state
+        logger.debug(this, "write backend part done, now marking cache entry as done")
+
+        if (entry.writeDone()) {
+          // entry transitioned from WriteInProgress to Cached state
+          logger.info(this, s"write all done, caching $key ${entry.state.get}")
+        } else {
+          // state transition from WriteInProgress to Cached fails so invalidate
+          // the entry in the cache
+          val prevState = entry.state.get
+          if (prevState != InvalidateWhenDone) {
+            // this should not happen but could for example during a document
+            // update where the "read" that would fetch a previous instance of
+            // the document fails because the document does not exist, but the
+            // future callback to invalidate the cache entry is delayed; so it
+            // is possible the state here is InvalidateInProgress as a result.
+            // the end result is to invalidate the entry, which may be unnecessary;
+            // so this is a performance hit, not a correctness concern.
+            val error = ConcurrentOperationUnderUpdate(prevState)
+            logger.warn(this, error.toString)
+          } else {
+            logger.info(this, s"write done, but invalidating cache entry as requested")
+          }
+          invalidateEntry(key, entry)
+        }
+
+      case Failure(_) => invalidateEntry(key, entry) // datastore write failed, invalidate cache entry
+    }
+  }
+
+  /** Immediately invalidates the given entry. */
+  private def invalidateEntry(key: CacheKey, entry: Entry)(implicit transid: TransactionId, logger: Logging): Unit = {
+    logger.info(this, s"invalidating $key")
+    entry.invalidate()
+    cache remove key
+  }
+
+  /** Invalidates the given entry after a given invalidator completes. */
+  private def invalidateEntryAfter[R](invalidator: => Future[R], key: CacheKey, entry: Entry)(
+    implicit ec: ExecutionContext,
+    transid: TransactionId,
+    logger: Logging): Future[R] = {
+
+    entry.grabInvalidationLock()
+    invalidator andThen {
+      case _ => invalidateEntry(key, entry)
+    }
+  }
+
+  /** This is the backing store. */
+  private val cache: ConcurrentMapBackedCache[Entry] = new ConcurrentMapBackedCache(
+    Caffeine
+      .newBuilder()
+      .asInstanceOf[Caffeine[Any, Future[Entry]]]
+      .expireAfterWrite(5, TimeUnit.MINUTES)
+      .softValues()
+      .build()
+      .asMap())
 }
 
 /**
@@ -444,37 +462,41 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
  * Implementation otherwise is identical.
  */
 private class ConcurrentMapBackedCache[V](store: ConcurrentMap[Any, Future[V]]) {
-    val cache = this
+  val cache = this
 
-    def apply(key: Any) = new Keyed(key)
+  def apply(key: Any) = new Keyed(key)
 
-    class Keyed(key: Any) {
-        def apply(magnet: => ValueMagnet[V])(implicit ec: ExecutionContext): Future[V] =
-            cache.apply(key, () => try magnet.future catch { case NonFatal(e) => Future.failed(e) })
-    }
+  class Keyed(key: Any) {
+    def apply(magnet: => ValueMagnet[V])(implicit ec: ExecutionContext): Future[V] =
+      cache.apply(
+        key,
+        () =>
+          try magnet.future
+          catch { case NonFatal(e) => Future.failed(e) })
+  }
 
-    def apply(key: Any, genValue: () => Future[V])(implicit ec: ExecutionContext): Future[V] = {
-        val promise = Promise[V]()
-        store.putIfAbsent(key, promise.future) match {
-            case null =>
-                val future = genValue()
-                future.onComplete { value =>
-                    promise.complete(value)
-                    // in case of exceptions we remove the cache entry (i.e. try again later)
-                    if (value.isFailure) store.remove(key, promise.future)
-                }
-                future
-            case existingFuture => existingFuture
+  def apply(key: Any, genValue: () => Future[V])(implicit ec: ExecutionContext): Future[V] = {
+    val promise = Promise[V]()
+    store.putIfAbsent(key, promise.future) match {
+      case null =>
+        val future = genValue()
+        future.onComplete { value =>
+          promise.complete(value)
+          // in case of exceptions we remove the cache entry (i.e. try again later)
+          if (value.isFailure) store.remove(key, promise.future)
         }
+        future
+      case existingFuture => existingFuture
     }
+  }
 
-    def remove(key: Any) = Option(store.remove(key))
+  def remove(key: Any) = Option(store.remove(key))
 
-    def size = store.size
+  def size = store.size
 }
 
 class ValueMagnet[V](val future: Future[V])
 object ValueMagnet {
-    implicit def fromAny[V](block: V): ValueMagnet[V] = fromFuture(Future.successful(block))
-    implicit def fromFuture[V](future: Future[V]): ValueMagnet[V] = new ValueMagnet(future)
+  implicit def fromAny[V](block: V): ValueMagnet[V] = fromFuture(Future.successful(block))
+  implicit def fromFuture[V](future: Future[V]): ValueMagnet[V] = new ValueMagnet(future)
 }

--- a/common/scala/src/main/scala/whisk/core/entitlement/Privilege.scala
+++ b/common/scala/src/main/scala/whisk/core/entitlement/Privilege.scala
@@ -26,21 +26,22 @@ import spray.json.RootJsonFormat
 
 /** An enumeration of privileges available to subjects. */
 protected[core] object Privilege extends Enumeration {
-    type Privilege = Value
+  type Privilege = Value
 
-    val READ, PUT, DELETE, ACTIVATE, REJECT = Value
+  val READ, PUT, DELETE, ACTIVATE, REJECT = Value
 
-    val CRUD = Set(READ, PUT, DELETE)
-    val ALL = CRUD + ACTIVATE
+  val CRUD = Set(READ, PUT, DELETE)
+  val ALL = CRUD + ACTIVATE
 
-    implicit val serdes = new RootJsonFormat[Privilege] {
-        def write(p: Privilege) = JsString(p.toString)
+  implicit val serdes = new RootJsonFormat[Privilege] {
+    def write(p: Privilege) = JsString(p.toString)
 
-        def read(json: JsValue) = Try {
-            val JsString(str) = json
-            Privilege.withName(str.trim.toUpperCase)
-        } getOrElse {
-            throw new DeserializationException("Privilege must be a valid string")
-        }
-    }
+    def read(json: JsValue) =
+      Try {
+        val JsString(str) = json
+        Privilege.withName(str.trim.toUpperCase)
+      } getOrElse {
+        throw new DeserializationException("Privilege must be a valid string")
+      }
+  }
 }

--- a/common/scala/src/main/scala/whisk/core/entity/ActivationEntityLimit.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ActivationEntityLimit.scala
@@ -25,5 +25,5 @@ import whisk.core.entity.size.SizeInt
  * parameters for triggers.
  */
 protected[core] object ActivationEntityLimit {
-    protected[core] val MAX_ACTIVATION_ENTITY_LIMIT = 1.MB
+  protected[core] val MAX_ACTIVATION_ENTITY_LIMIT = 1.MB
 }

--- a/common/scala/src/main/scala/whisk/core/entity/ActivationLogs.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ActivationLogs.scala
@@ -30,22 +30,23 @@ import spray.json.deserializationError
 import spray.json.pimpAny
 
 protected[core] case class ActivationLogs(val logs: Vector[String] = Vector()) extends AnyVal {
-    def toJsonObject = JsObject("logs" -> toJson)
-    def toJson = JsArray(logs map { _.toJson })
+  def toJsonObject = JsObject("logs" -> toJson)
+  def toJson = JsArray(logs map { _.toJson })
 
-    override def toString = logs mkString ("[", ", ", "]")
+  override def toString = logs mkString ("[", ", ", "]")
 }
 
 protected[core] object ActivationLogs {
-    protected[core] implicit val serdes = new RootJsonFormat[ActivationLogs] {
-        def write(l: ActivationLogs) = l.toJson
+  protected[core] implicit val serdes = new RootJsonFormat[ActivationLogs] {
+    def write(l: ActivationLogs) = l.toJson
 
-        def read(value: JsValue) = Try {
-            val JsArray(logs) = value
-            ActivationLogs(logs map {
-                case JsString(s) => s
-                case _           => deserializationError("activation logs malformed")
-            })
-        } getOrElse deserializationError("activation logs malformed")
-    }
+    def read(value: JsValue) =
+      Try {
+        val JsArray(logs) = value
+        ActivationLogs(logs map {
+          case JsString(s) => s
+          case _           => deserializationError("activation logs malformed")
+        })
+      } getOrElse deserializationError("activation logs malformed")
+  }
 }

--- a/common/scala/src/main/scala/whisk/core/entity/ActivationResult.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ActivationResult.scala
@@ -27,181 +27,190 @@ import spray.json.DefaultJsonProtocol
 import whisk.common.Logging
 import whisk.http.Messages._
 
-protected[core] case class ActivationResponse private (
-    val statusCode: Int, val result: Option[JsValue]) {
+protected[core] case class ActivationResponse private (val statusCode: Int, val result: Option[JsValue]) {
 
-    def toJsonObject = ActivationResponse.serdes.write(this).asJsObject
+  def toJsonObject = ActivationResponse.serdes.write(this).asJsObject
 
-    // Used when presenting to end-users, to hide the statusCode (which is an implementation detail),
-    // and to provide a convenience boolean "success" field.
-    def toExtendedJson: JsObject = {
-        val baseFields = this.toJsonObject.fields
-        JsObject((baseFields - "statusCode") ++ Seq(
-            "success" -> JsBoolean(this.isSuccess),
-            "status" -> JsString(ActivationResponse.messageForCode(statusCode))))
+  // Used when presenting to end-users, to hide the statusCode (which is an implementation detail),
+  // and to provide a convenience boolean "success" field.
+  def toExtendedJson: JsObject = {
+    val baseFields = this.toJsonObject.fields
+    JsObject(
+      (baseFields - "statusCode") ++ Seq(
+        "success" -> JsBoolean(this.isSuccess),
+        "status" -> JsString(ActivationResponse.messageForCode(statusCode))))
 
-    }
+  }
 
-    def isSuccess = statusCode == ActivationResponse.Success
-    def isApplicationError = statusCode == ActivationResponse.ApplicationError
-    def isContainerError = statusCode == ActivationResponse.ContainerError
-    def isWhiskError = statusCode == ActivationResponse.WhiskError
-    def withoutResult = ActivationResponse(statusCode, None)
+  def isSuccess = statusCode == ActivationResponse.Success
+  def isApplicationError = statusCode == ActivationResponse.ApplicationError
+  def isContainerError = statusCode == ActivationResponse.ContainerError
+  def isWhiskError = statusCode == ActivationResponse.WhiskError
+  def withoutResult = ActivationResponse(statusCode, None)
 
-    override def toString = toJsonObject.compactPrint
+  override def toString = toJsonObject.compactPrint
 }
 
 protected[core] object ActivationResponse extends DefaultJsonProtocol {
-    /* The field name that is universally recognized as the marker of an error, from the application or otherwise. */
-    val ERROR_FIELD: String = "error"
+  /* The field name that is universally recognized as the marker of an error, from the application or otherwise. */
+  val ERROR_FIELD: String = "error"
 
-    val Success          = 0 // action ran successfully and produced a result
-    val ApplicationError = 1 // action ran but there was an error and it was handled
-    val ContainerError   = 2 // action ran but failed to handle an error, or action did not run and failed to initialize
-    val WhiskError       = 3 // internal system error
+  val Success = 0 // action ran successfully and produced a result
+  val ApplicationError = 1 // action ran but there was an error and it was handled
+  val ContainerError = 2 // action ran but failed to handle an error, or action did not run and failed to initialize
+  val WhiskError = 3 // internal system error
 
-    protected[core] def messageForCode(code: Int) = {
-        require(code >= 0 && code <= 3)
-        code match {
-            case 0 => "success"
-            case 1 => "application error"
-            case 2 => "action developer error"
-            case 3 => "whisk internal error"
-        }
+  protected[core] def messageForCode(code: Int) = {
+    require(code >= 0 && code <= 3)
+    code match {
+      case 0 => "success"
+      case 1 => "application error"
+      case 2 => "action developer error"
+      case 3 => "whisk internal error"
     }
+  }
 
-    private def error(code: Int, errorValue: JsValue) = {
-        require(code == ApplicationError || code == ContainerError || code == WhiskError)
-        ActivationResponse(code, Some(JsObject(ERROR_FIELD -> errorValue)))
+  private def error(code: Int, errorValue: JsValue) = {
+    require(code == ApplicationError || code == ContainerError || code == WhiskError)
+    ActivationResponse(code, Some(JsObject(ERROR_FIELD -> errorValue)))
+  }
+
+  protected[core] def success(result: Option[JsValue] = None) = ActivationResponse(Success, result)
+
+  protected[core] def applicationError(errorValue: JsValue) = error(ApplicationError, errorValue)
+  protected[core] def applicationError(errorMsg: String) = error(ApplicationError, JsString(errorMsg))
+  protected[core] def containerError(errorValue: JsValue) = error(ContainerError, errorValue)
+  protected[core] def containerError(errorMsg: String) = error(ContainerError, JsString(errorMsg))
+  protected[core] def whiskError(errorValue: JsValue) = error(WhiskError, errorValue)
+  protected[core] def whiskError(errorMsg: String) = error(WhiskError, JsString(errorMsg))
+
+  /**
+   * Returns an ActivationResponse that is used as a placeholder for payload
+   * Used as a feed for starting a sequence.
+   * NOTE: the code is application error (since this response could be used as a response for the sequence
+   * if the payload contains an error)
+   */
+  protected[core] def payloadPlaceholder(payload: Option[JsObject]) = ActivationResponse(ApplicationError, payload)
+
+  /**
+   * Class of errors for invoker-container communication.
+   */
+  protected[core] sealed abstract class ContainerConnectionError
+  protected[core] case class NoHost() extends ContainerConnectionError
+  protected[core] case class ConnectionError(t: Throwable) extends ContainerConnectionError
+  protected[core] case class NoResponseReceived() extends ContainerConnectionError
+  protected[core] case class Timeout() extends ContainerConnectionError
+
+  /**
+   * @param statusCode the container HTTP response code (e.g., 200 OK)
+   * @param entity the entity response as string
+   * @param truncated either None to indicate complete entity or Some(actual length, max allowed)
+   */
+  protected[core] case class ContainerResponse(statusCode: Int,
+                                               entity: String,
+                                               truncated: Option[(ByteSize, ByteSize)]) {
+
+    /** true iff status code is OK (HTTP 200 status code), anything else is considered an error. **/
+    val okStatus = statusCode == OK.intValue
+    val ok = okStatus && truncated.isEmpty
+    override def toString = {
+      val base = if (okStatus) "ok" else "not ok"
+      val rest = truncated.map(e => s", truncated ${e.toString}").getOrElse("")
+      base + rest
     }
+  }
 
-    protected[core] def success(result: Option[JsValue] = None) = ActivationResponse(Success, result)
-
-    protected[core] def applicationError(errorValue: JsValue) = error(ApplicationError, errorValue)
-    protected[core] def applicationError(errorMsg: String)    = error(ApplicationError, JsString(errorMsg))
-    protected[core] def containerError(errorValue: JsValue)   = error(ContainerError, errorValue)
-    protected[core] def containerError(errorMsg: String)      = error(ContainerError, JsString(errorMsg))
-    protected[core] def whiskError(errorValue: JsValue)       = error(WhiskError, errorValue)
-    protected[core] def whiskError(errorMsg: String)          = error(WhiskError, JsString(errorMsg))
-
-    /**
-     * Returns an ActivationResponse that is used as a placeholder for payload
-     * Used as a feed for starting a sequence.
-     * NOTE: the code is application error (since this response could be used as a response for the sequence
-     * if the payload contains an error)
-     */
-    protected[core] def payloadPlaceholder(payload: Option[JsObject]) = ActivationResponse(ApplicationError, payload)
-
-    /**
-     * Class of errors for invoker-container communication.
-     */
-    protected[core] sealed abstract class ContainerConnectionError
-    protected[core] case class NoHost() extends ContainerConnectionError
-    protected[core] case class ConnectionError(t: Throwable) extends ContainerConnectionError
-    protected[core] case class NoResponseReceived() extends ContainerConnectionError
-    protected[core] case class Timeout() extends ContainerConnectionError
-
-    /**
-     * @param statusCode the container HTTP response code (e.g., 200 OK)
-     * @param entity the entity response as string
-     * @param truncated either None to indicate complete entity or Some(actual length, max allowed)
-     */
-    protected[core] case class ContainerResponse(statusCode: Int, entity: String, truncated: Option[(ByteSize, ByteSize)]) {
-        /** true iff status code is OK (HTTP 200 status code), anything else is considered an error. **/
-        val okStatus = statusCode == OK.intValue
-        val ok = okStatus && truncated.isEmpty
-        override def toString = {
-            val base = if (okStatus) "ok" else "not ok"
-            val rest = truncated.map(e => s", truncated ${e.toString}").getOrElse("")
-            base + rest
-        }
+  protected[core] object ContainerResponse {
+    def apply(okStatus: Boolean, entity: String, truncated: Option[(ByteSize, ByteSize)] = None): ContainerResponse = {
+      ContainerResponse(if (okStatus) OK.intValue else 500, entity, truncated)
     }
+  }
 
-    protected[core] object ContainerResponse {
-        def apply(okStatus: Boolean, entity: String, truncated: Option[(ByteSize, ByteSize)] = None): ContainerResponse = {
-            ContainerResponse(if (okStatus) OK.intValue else 500, entity, truncated)
-        }
-    }
-
-    /**
-     * Interprets response from container after initialization. This method is only called when the initialization failed.
-     *
-     * @param response an either a container error or container response (HTTP Status Code, HTTP response bytes as String)
-     * @return appropriate ActivationResponse representing initialization error
-     */
-    protected[core] def processInitResponseContent(response: Either[ContainerConnectionError, ContainerResponse], logger: Logging): ActivationResponse = {
-        require(response.isLeft || !response.right.exists(_.ok), s"should not interpret init response when status code is OK")
-        response match {
-            case Right(ContainerResponse(code, str, truncated)) => truncated match {
-                case None =>
-                    Try { str.parseJson.asJsObject } match {
-                        case scala.util.Success(result @ JsObject(fields)) =>
-                            // If the response is a JSON object container an error field, accept it as the response error.
-                            val errorOpt = fields.get(ERROR_FIELD)
-                            val errorContent = errorOpt getOrElse invalidInitResponse(str).toJson
-                            containerError(errorContent)
-                        case _ =>
-                            containerError(invalidInitResponse(str))
-                    }
-
-                case Some((length, maxlength)) =>
-                    containerError(truncatedResponse(str, length, maxlength))
+  /**
+   * Interprets response from container after initialization. This method is only called when the initialization failed.
+   *
+   * @param response an either a container error or container response (HTTP Status Code, HTTP response bytes as String)
+   * @return appropriate ActivationResponse representing initialization error
+   */
+  protected[core] def processInitResponseContent(response: Either[ContainerConnectionError, ContainerResponse],
+                                                 logger: Logging): ActivationResponse = {
+    require(
+      response.isLeft || !response.right.exists(_.ok),
+      s"should not interpret init response when status code is OK")
+    response match {
+      case Right(ContainerResponse(code, str, truncated)) =>
+        truncated match {
+          case None =>
+            Try { str.parseJson.asJsObject } match {
+              case scala.util.Success(result @ JsObject(fields)) =>
+                // If the response is a JSON object container an error field, accept it as the response error.
+                val errorOpt = fields.get(ERROR_FIELD)
+                val errorContent = errorOpt getOrElse invalidInitResponse(str).toJson
+                containerError(errorContent)
+              case _ =>
+                containerError(invalidInitResponse(str))
             }
 
-            case Left(e) =>
-                // This indicates a terminal failure in the container (it exited prematurely).
-                containerError(abnormalInitialization)
+          case Some((length, maxlength)) =>
+            containerError(truncatedResponse(str, length, maxlength))
         }
+
+      case Left(e) =>
+        // This indicates a terminal failure in the container (it exited prematurely).
+        containerError(abnormalInitialization)
     }
+  }
 
-    /**
-     * Interprets response from container after running the action. This method is only called when the initialization succeeded.
-     *
-     * @param response an Option (HTTP Status Code, HTTP response bytes as String)
-     * @return appropriate ActivationResponse representing run result
-     */
-    protected[core] def processRunResponseContent(response: Either[ContainerConnectionError, ContainerResponse], logger: Logging): ActivationResponse = {
-        response match {
-            case Right(res @ ContainerResponse(_, str, truncated)) => truncated match {
-                case None =>
-                    Try { str.parseJson.asJsObject } match {
-                        case scala.util.Success(result @ JsObject(fields)) =>
-                            // If the response is a JSON object container an error field, accept it as the response error.
-                            val errorOpt = fields.get(ERROR_FIELD)
+  /**
+   * Interprets response from container after running the action. This method is only called when the initialization succeeded.
+   *
+   * @param response an Option (HTTP Status Code, HTTP response bytes as String)
+   * @return appropriate ActivationResponse representing run result
+   */
+  protected[core] def processRunResponseContent(response: Either[ContainerConnectionError, ContainerResponse],
+                                                logger: Logging): ActivationResponse = {
+    response match {
+      case Right(res @ ContainerResponse(_, str, truncated)) =>
+        truncated match {
+          case None =>
+            Try { str.parseJson.asJsObject } match {
+              case scala.util.Success(result @ JsObject(fields)) =>
+                // If the response is a JSON object container an error field, accept it as the response error.
+                val errorOpt = fields.get(ERROR_FIELD)
 
-                            if (res.okStatus) {
-                                errorOpt map { error =>
-                                    applicationError(error)
-                                } getOrElse {
-                                    // The happy path.
-                                    success(Some(result))
-                                }
-                            } else {
-                                // Any non-200 code is treated as a container failure. We still need to check whether
-                                // there was a useful error message in there.
-                                val errorContent = errorOpt getOrElse invalidRunResponse(str).toJson
-                                containerError(errorContent)
-                            }
+                if (res.okStatus) {
+                  errorOpt map { error =>
+                    applicationError(error)
+                  } getOrElse {
+                    // The happy path.
+                    success(Some(result))
+                  }
+                } else {
+                  // Any non-200 code is treated as a container failure. We still need to check whether
+                  // there was a useful error message in there.
+                  val errorContent = errorOpt getOrElse invalidRunResponse(str).toJson
+                  containerError(errorContent)
+                }
 
-                        case scala.util.Success(notAnObj) =>
-                            // This should affect only blackbox containers, since our own containers should already test for that.
-                            containerError(invalidRunResponse(str))
+              case scala.util.Success(notAnObj) =>
+                // This should affect only blackbox containers, since our own containers should already test for that.
+                containerError(invalidRunResponse(str))
 
-                        case scala.util.Failure(t) =>
-                            // This should affect only blackbox containers, since our own containers should already test for that.
-                            logger.warn(this, s"response did not json parse: '$str' led to $t")
-                            containerError(invalidRunResponse(str))
-                    }
-
-                case Some((length, maxlength)) =>
-                    containerError(truncatedResponse(str, length, maxlength))
+              case scala.util.Failure(t) =>
+                // This should affect only blackbox containers, since our own containers should already test for that.
+                logger.warn(this, s"response did not json parse: '$str' led to $t")
+                containerError(invalidRunResponse(str))
             }
 
-            case Left(e) =>
-                // This indicates a terminal failure in the container (it exited prematurely).
-                containerError(abnormalRun)
+          case Some((length, maxlength)) =>
+            containerError(truncatedResponse(str, length, maxlength))
         }
-    }
 
-    protected[core] implicit val serdes = jsonFormat2(ActivationResponse.apply)
+      case Left(e) =>
+        // This indicates a terminal failure in the container (it exited prematurely).
+        containerError(abnormalRun)
+    }
+  }
+
+  protected[core] implicit val serdes = jsonFormat2(ActivationResponse.apply)
 }

--- a/common/scala/src/main/scala/whisk/core/entity/ArgNormalizer.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ArgNormalizer.scala
@@ -24,28 +24,28 @@ import scala.util.Try
 
 protected[entity] trait ArgNormalizer[T] {
 
-    protected[core] val serdes: RootJsonFormat[T]
+  protected[core] val serdes: RootJsonFormat[T]
 
-    protected[entity] def factory(s: String): T = {
-        serdes.read(Try { s.parseJson } getOrElse JsString(s))
-    }
+  protected[entity] def factory(s: String): T = {
+    serdes.read(Try { s.parseJson } getOrElse JsString(s))
+  }
 
-    /**
-     * Creates a new T from string. The method checks that a string
-     * argument is not null, not empty, and normalizes it by trimming
-     * white space before creating new T.
-     *
-     * @param s is the string argument to supply to factory of T
-     * @return T instance
-     * @throws IllegalArgumentException if string is null or empty
-     */
-    @throws[IllegalArgumentException]
-    protected[core] def apply(s: String): T = {
-        require(s != null && s.trim.nonEmpty, "argument undefined")
-        factory(s.trim)
-    }
+  /**
+   * Creates a new T from string. The method checks that a string
+   * argument is not null, not empty, and normalizes it by trimming
+   * white space before creating new T.
+   *
+   * @param s is the string argument to supply to factory of T
+   * @return T instance
+   * @throws IllegalArgumentException if string is null or empty
+   */
+  @throws[IllegalArgumentException]
+  protected[core] def apply(s: String): T = {
+    require(s != null && s.trim.nonEmpty, "argument undefined")
+    factory(s.trim)
+  }
 }
 
 protected[entity] object ArgNormalizer {
-    protected[entity] def trim(s: String) = Option(s) map { _.trim} getOrElse s
+  protected[entity] def trim(s: String) = Option(s) map { _.trim } getOrElse s
 }

--- a/common/scala/src/main/scala/whisk/core/entity/AuthKey.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/AuthKey.scala
@@ -34,66 +34,67 @@ import spray.json.deserializationError
  * @param (uuid, key) the uuid and key, assured to be non-null because both types are values
  */
 protected[core] class AuthKey private (private val k: (UUID, Secret)) extends AnyVal {
-    def uuid = k._1
-    def key = k._2
-    def revoke = new AuthKey(uuid, Secret())
-    def compact = s"$uuid:$key"
-    override def toString = uuid.toString
+  def uuid = k._1
+  def key = k._2
+  def revoke = new AuthKey(uuid, Secret())
+  def compact = s"$uuid:$key"
+  override def toString = uuid.toString
 }
 
 protected[core] object AuthKey {
 
-    /**
-     * Creates AuthKey.
-     *
-     * @param uuid the uuid, assured to be non-null because UUID is a value
-     * @param key the key, assured to be non-null because Secret is a value
-     */
-    protected[core] def apply(uuid: UUID, key: Secret): AuthKey = new AuthKey(uuid, key)
+  /**
+   * Creates AuthKey.
+   *
+   * @param uuid the uuid, assured to be non-null because UUID is a value
+   * @param key the key, assured to be non-null because Secret is a value
+   */
+  protected[core] def apply(uuid: UUID, key: Secret): AuthKey = new AuthKey(uuid, key)
 
-    /**
-     * Creates an auth key for a randomly generated UUID with a randomly generated secret.
-     *
-     * @return AuthKey
-     */
-    protected[core] def apply(): AuthKey = new AuthKey(UUID(), Secret())
+  /**
+   * Creates an auth key for a randomly generated UUID with a randomly generated secret.
+   *
+   * @return AuthKey
+   */
+  protected[core] def apply(): AuthKey = new AuthKey(UUID(), Secret())
 
-    /**
-     * Creates AuthKey from a string where the uuid and key are separated by a colon.
-     * If the string contains more than one colon, all values are ignored except for
-     * the first two hence "k:v*" produces ("k","v").
-     *
-     * @param str the string containing uuid and key separated by colon
-     * @return AuthKey if argument is properly formated
-     * @throws IllegalArgumentException if argument is not well formed
-     */
-    @throws[IllegalArgumentException]
-    protected[core] def apply(str: String): AuthKey = {
-        val (k, v) = split(str)
-        new AuthKey(UUID(k), Secret(v))
-    }
+  /**
+   * Creates AuthKey from a string where the uuid and key are separated by a colon.
+   * If the string contains more than one colon, all values are ignored except for
+   * the first two hence "k:v*" produces ("k","v").
+   *
+   * @param str the string containing uuid and key separated by colon
+   * @return AuthKey if argument is properly formated
+   * @throws IllegalArgumentException if argument is not well formed
+   */
+  @throws[IllegalArgumentException]
+  protected[core] def apply(str: String): AuthKey = {
+    val (k, v) = split(str)
+    new AuthKey(UUID(k), Secret(v))
+  }
 
-    /**
-     * Makes a tuple from a string where the values are separated by a colon.
-     * If the string contains more than one colon, all values are ignored except for
-     * the first two hence "k:v*" produces the tuple ("k","v") and "::*" produces ("","").
-     *
-     * @param string to create pair from
-     * @return (key, value) where both are null, value is null, or neither is null
-     */
-    private def split(str: String): (String, String) = {
-        val parts = if (str != null && str.nonEmpty) str.split(":") else Array[String]()
-        val k = if (parts.size >= 1) parts(0).trim else null
-        val v = if (parts.size == 2) parts(1).trim else null
-        (k, v)
-    }
+  /**
+   * Makes a tuple from a string where the values are separated by a colon.
+   * If the string contains more than one colon, all values are ignored except for
+   * the first two hence "k:v*" produces the tuple ("k","v") and "::*" produces ("","").
+   *
+   * @param string to create pair from
+   * @return (key, value) where both are null, value is null, or neither is null
+   */
+  private def split(str: String): (String, String) = {
+    val parts = if (str != null && str.nonEmpty) str.split(":") else Array[String]()
+    val k = if (parts.size >= 1) parts(0).trim else null
+    val v = if (parts.size == 2) parts(1).trim else null
+    (k, v)
+  }
 
-    protected[core] implicit val serdes = new RootJsonFormat[AuthKey] {
-        def write(k: AuthKey) = JsString(k.compact)
+  protected[core] implicit val serdes = new RootJsonFormat[AuthKey] {
+    def write(k: AuthKey) = JsString(k.compact)
 
-        def read(value: JsValue) = Try {
-            val JsString(s) = value
-            AuthKey(s)
-        } getOrElse deserializationError("authorization key malformed")
-    }
+    def read(value: JsValue) =
+      Try {
+        val JsString(s) = value
+        AuthKey(s)
+      } getOrElse deserializationError("authorization key malformed")
+  }
 }

--- a/common/scala/src/main/scala/whisk/core/entity/CacheKey.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/CacheKey.scala
@@ -29,27 +29,27 @@ class UnsupportedCacheKeyTypeException(msg: String) extends Exception(msg)
  * of the key will not be written to the logs.
  */
 case class CacheKey(mainId: String, secondaryId: Option[String]) {
-    override def toString() = {
-        s"CacheKey($mainId)"
-    }
+  override def toString() = {
+    s"CacheKey($mainId)"
+  }
 }
 
 object CacheKey extends DefaultJsonProtocol {
-    implicit val serdes = jsonFormat2(CacheKey.apply)
+  implicit val serdes = jsonFormat2(CacheKey.apply)
 
-    def apply(key: Any): CacheKey = {
-        key match {
-            case e: EntityName => CacheKey(e.asString, None)
-            case a: AuthKey    => CacheKey(a.uuid.asString, Some(a.key.asString))
-            case d: DocInfo => {
-                val revision = if (d.rev.empty) None else Some(d.rev.asString)
-                CacheKey(d.id.asString, revision)
-            }
-            case w: WhiskEntity => CacheKey(w.docid.asDocInfo)
-            case s: String      => CacheKey(s, None)
-            case others => {
-                throw new UnsupportedCacheKeyTypeException(s"Unable to apply the entity ${others.getClass} on CacheKey.")
-            }
-        }
+  def apply(key: Any): CacheKey = {
+    key match {
+      case e: EntityName => CacheKey(e.asString, None)
+      case a: AuthKey    => CacheKey(a.uuid.asString, Some(a.key.asString))
+      case d: DocInfo => {
+        val revision = if (d.rev.empty) None else Some(d.rev.asString)
+        CacheKey(d.id.asString, revision)
+      }
+      case w: WhiskEntity => CacheKey(w.docid.asDocInfo)
+      case s: String      => CacheKey(s, None)
+      case others => {
+        throw new UnsupportedCacheKeyTypeException(s"Unable to apply the entity ${others.getClass} on CacheKey.")
+      }
     }
+  }
 }

--- a/common/scala/src/main/scala/whisk/core/entity/DocInfo.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/DocInfo.scala
@@ -35,11 +35,11 @@ import spray.json.deserializationError
  * @param id the document id, required not null
  */
 protected[core] class DocId private (val id: String) extends AnyVal {
-    def asString = id // to make explicit that this is a string conversion
-    protected[core] def asDocInfo = DocInfo(this)
-    protected[core] def asDocInfo(rev: DocRevision) = DocInfo(this, rev)
-    protected[entity] def toJson = JsString(id)
-    override def toString = id
+  def asString = id // to make explicit that this is a string conversion
+  protected[core] def asDocInfo = DocInfo(this)
+  protected[core] def asDocInfo(rev: DocRevision) = DocInfo(this, rev)
+  protected[entity] def toJson = JsString(id)
+  override def toString = id
 }
 
 /**
@@ -53,9 +53,9 @@ protected[core] class DocId private (val id: String) extends AnyVal {
  * @param rev the document revision, optional
  */
 protected[core] class DocRevision private (val rev: String) extends AnyVal {
-    def asString = rev // to make explicit that this is a string conversion
-    def empty = rev == null
-    override def toString = rev
+  def asString = rev // to make explicit that this is a string conversion
+  def empty = rev == null
+  override def toString = rev
 }
 
 /**
@@ -68,79 +68,83 @@ protected[core] class DocRevision private (val rev: String) extends AnyVal {
  * @param rev the document revision, optional; this is an opaque value determined by the datastore
  */
 protected[core] case class DocInfo protected[entity] (id: DocId, rev: DocRevision = DocRevision.empty) {
-    override def toString = {
-        if (rev.empty) {
-            s"id: $id"
-        } else {
-            s"id: $id, rev: $rev"
-        }
+  override def toString = {
+    if (rev.empty) {
+      s"id: $id"
+    } else {
+      s"id: $id, rev: $rev"
     }
+  }
 
-    override def hashCode = {
-        if (rev.empty) {
-            id.hashCode
-        } else {
-            s"$id.$rev".hashCode
-        }
+  override def hashCode = {
+    if (rev.empty) {
+      id.hashCode
+    } else {
+      s"$id.$rev".hashCode
     }
+  }
 }
 
 protected[core] object DocId extends ArgNormalizer[DocId] {
-    /**
-     * Unapply method for convenience of case matching.
-     */
-    def unapply(s: String): Option[DocId] = Try(DocId(s)).toOption
 
-    implicit val serdes = new RootJsonFormat[DocId] {
-        def write(d: DocId) = d.toJson
+  /**
+   * Unapply method for convenience of case matching.
+   */
+  def unapply(s: String): Option[DocId] = Try(DocId(s)).toOption
 
-        def read(value: JsValue) = Try {
-            val JsString(s) = value
-            new DocId(s)
-        } getOrElse deserializationError("doc id malformed")
-    }
+  implicit val serdes = new RootJsonFormat[DocId] {
+    def write(d: DocId) = d.toJson
+
+    def read(value: JsValue) =
+      Try {
+        val JsString(s) = value
+        new DocId(s)
+      } getOrElse deserializationError("doc id malformed")
+  }
 }
 
 protected[core] object DocRevision {
-    /**
-     * Creates a DocRevision. Normalizes the revision if necessary.
-     *
-     * @param s is the document revision as a string, may be null
-     * @return DocRevision
-     */
-    protected[core] def apply(s: String): DocRevision = new DocRevision(trim(s))
 
-    protected[core] val empty: DocRevision = new DocRevision(null)
+  /**
+   * Creates a DocRevision. Normalizes the revision if necessary.
+   *
+   * @param s is the document revision as a string, may be null
+   * @return DocRevision
+   */
+  protected[core] def apply(s: String): DocRevision = new DocRevision(trim(s))
 
-    implicit val serdes = new RootJsonFormat[DocRevision] {
-        def write(d: DocRevision) = if (d.rev != null) JsString(d.rev) else JsNull
+  protected[core] val empty: DocRevision = new DocRevision(null)
 
-        def read(value: JsValue) = value match {
-            case JsString(s) => DocRevision(s)
-            case JsNull      => DocRevision.empty
-            case _           => deserializationError("doc revision malformed")
-        }
+  implicit val serdes = new RootJsonFormat[DocRevision] {
+    def write(d: DocRevision) = if (d.rev != null) JsString(d.rev) else JsNull
+
+    def read(value: JsValue) = value match {
+      case JsString(s) => DocRevision(s)
+      case JsNull      => DocRevision.empty
+      case _           => deserializationError("doc revision malformed")
     }
+  }
 }
 
 protected[core] object DocInfo {
-    /**
-     * Creates a DocInfo with id set to the argument and no revision.
-     *
-     * @param id is the document identifier, must be defined
-     * @throws IllegalArgumentException if id is null or empty
-     */
-    @throws[IllegalArgumentException]
-    protected[core] def apply(id: String): DocInfo = DocInfo(DocId(id))
 
-    /**
-     * Creates a DocInfo with id and revision per the provided arguments.
-     *
-     * @param id is the document identifier, must be defined
-     * @param rev the document revision, optional
-     * @return DocInfo for id and revision
-     * @throws IllegalArgumentException if id is null or empty
-     */
-    @throws[IllegalArgumentException]
-    protected[core] def !(id: String, rev: String): DocInfo = DocInfo(DocId(id), DocRevision(rev))
+  /**
+   * Creates a DocInfo with id set to the argument and no revision.
+   *
+   * @param id is the document identifier, must be defined
+   * @throws IllegalArgumentException if id is null or empty
+   */
+  @throws[IllegalArgumentException]
+  protected[core] def apply(id: String): DocInfo = DocInfo(DocId(id))
+
+  /**
+   * Creates a DocInfo with id and revision per the provided arguments.
+   *
+   * @param id is the document identifier, must be defined
+   * @param rev the document revision, optional
+   * @return DocInfo for id and revision
+   * @throws IllegalArgumentException if id is null or empty
+   */
+  @throws[IllegalArgumentException]
+  protected[core] def !(id: String, rev: String): DocInfo = DocInfo(DocId(id), DocRevision(rev))
 }

--- a/common/scala/src/main/scala/whisk/core/entity/EntityPath.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/EntityPath.scala
@@ -40,125 +40,130 @@ import whisk.http.Messages
  * @param path the sequence of parts that make up a namespace path
  */
 protected[core] class EntityPath private (private val path: Seq[String]) extends AnyVal {
-    def namespace: String = path.foldLeft("")((a, b) => if (a != "") a.trim + EntityPath.PATHSEP + b.trim else b.trim)
+  def namespace: String = path.foldLeft("")((a, b) => if (a != "") a.trim + EntityPath.PATHSEP + b.trim else b.trim)
 
-    /**
-     * Adds segment to path.
-     */
-    def addPath(e: EntityName) = EntityPath(path :+ e.name)
+  /**
+   * Adds segment to path.
+   */
+  def addPath(e: EntityName) = EntityPath(path :+ e.name)
 
-    /**
-     * Concatenates given path to existin path.
-     */
-    def addPath(p: EntityPath) = EntityPath(path ++ p.path)
+  /**
+   * Concatenates given path to existin path.
+   */
+  def addPath(p: EntityPath) = EntityPath(path ++ p.path)
 
-    /**
-     * Computes the relative path by dropping the leftmost segment. The return is an option
-     * since dropping a singleton results in an invalid path.
-     */
-    def relativePath: Option[EntityPath] = Try(EntityPath(path.drop(1))).toOption
+  /**
+   * Computes the relative path by dropping the leftmost segment. The return is an option
+   * since dropping a singleton results in an invalid path.
+   */
+  def relativePath: Option[EntityPath] = Try(EntityPath(path.drop(1))).toOption
 
-    /**
-     * @return the root of the path (the first segment).
-     */
-    def root: EntityName = EntityName(path.head)
+  /**
+   * @return the root of the path (the first segment).
+   */
+  def root: EntityName = EntityName(path.head)
 
-    /**
-     * @return the last segment of the path.
-     */
-    def last: EntityName = EntityName(path.last)
+  /**
+   * @return the last segment of the path.
+   */
+  def last: EntityName = EntityName(path.last)
 
-    /**
-     * @return true iff the path contains exactly one segment (i.e., the namespace)
-     */
-    def defaultPackage: Boolean = path.size == 1
+  /**
+   * @return true iff the path contains exactly one segment (i.e., the namespace)
+   */
+  def defaultPackage: Boolean = path.size == 1
 
-    /**
-     * Replaces root of this path with given namespace iff the root is
-     * the default namespace.
-     */
-    def resolveNamespace(newNamespace: EntityName): EntityPath = {
-        // check if namespace is default
-        if (root.toPath == EntityPath.DEFAULT) {
-            val newPath = path.updated(0, newNamespace.name)
-            EntityPath(newPath)
-        } else this
-    }
+  /**
+   * Replaces root of this path with given namespace iff the root is
+   * the default namespace.
+   */
+  def resolveNamespace(newNamespace: EntityName): EntityPath = {
+    // check if namespace is default
+    if (root.toPath == EntityPath.DEFAULT) {
+      val newPath = path.updated(0, newNamespace.name)
+      EntityPath(newPath)
+    } else this
+  }
 
-    /**
-     * Converts the path to a fully qualified name. The path must contains at least 2 parts.
-     *
-     * @throws IllegalArgumentException if the path does not conform to schema (at least namespace and entity name must be present0
-     */
-    @throws[IllegalArgumentException]
-    def toFullyQualifiedEntityName = {
-        require(path.size > 1, Messages.malformedFullyQualifiedEntityName)
-        val name = last
-        val newPath = EntityPath(path.dropRight(1))
-        FullyQualifiedEntityName(newPath, name)
-    }
+  /**
+   * Converts the path to a fully qualified name. The path must contains at least 2 parts.
+   *
+   * @throws IllegalArgumentException if the path does not conform to schema (at least namespace and entity name must be present0
+   */
+  @throws[IllegalArgumentException]
+  def toFullyQualifiedEntityName = {
+    require(path.size > 1, Messages.malformedFullyQualifiedEntityName)
+    val name = last
+    val newPath = EntityPath(path.dropRight(1))
+    FullyQualifiedEntityName(newPath, name)
+  }
 
-    def toDocId = DocId(namespace)
-    def toJson = JsString(namespace)
-    def asString = namespace // to make explicit that this is a string conversion
-    override def toString = namespace
+  def toDocId = DocId(namespace)
+  def toJson = JsString(namespace)
+  def asString = namespace // to make explicit that this is a string conversion
+  override def toString = namespace
 }
 
 protected[core] object EntityPath {
 
-    /** Path separator */
-    protected[core] val PATHSEP = "/"
+  /** Path separator */
+  protected[core] val PATHSEP = "/"
 
-    /**
-     * Default namespace name. This name is not a valid entity name and is a special string
-     * that allows omission of the namespace during API calls. It is only used in the URI
-     * namespace extraction.
-     */
-    protected[core] val DEFAULT = EntityPath("_")
+  /**
+   * Default namespace name. This name is not a valid entity name and is a special string
+   * that allows omission of the namespace during API calls. It is only used in the URI
+   * namespace extraction.
+   */
+  protected[core] val DEFAULT = EntityPath("_")
 
-    /**
-     * Constructs a Namespace from a string. String must be a valid path, consisting of
-     * a valid EntityName separated by the Namespace separator character.
-     *
-     * @param path a valid namespace path
-     * @return Namespace for the path
-     * @throws IllegalArgumentException if the path does not conform to schema
-     */
-    @throws[IllegalArgumentException]
-    protected[core] def apply(path: String): EntityPath = {
-        require(path != null, "path undefined")
-        val parts = path.split(PATHSEP).filter { _.nonEmpty }.toSeq
-        EntityPath(parts)
-    }
+  /**
+   * Constructs a Namespace from a string. String must be a valid path, consisting of
+   * a valid EntityName separated by the Namespace separator character.
+   *
+   * @param path a valid namespace path
+   * @return Namespace for the path
+   * @throws IllegalArgumentException if the path does not conform to schema
+   */
+  @throws[IllegalArgumentException]
+  protected[core] def apply(path: String): EntityPath = {
+    require(path != null, "path undefined")
+    val parts = path.split(PATHSEP).filter { _.nonEmpty }.toSeq
+    EntityPath(parts)
+  }
 
-    /**
-     * Namespace is a path string of allowed characters. The path consists of parts each of which
-     * must be a valid EntityName, separated by the Namespace separator character. The constructor
-     * accepts a sequence of path parts and can reconstruct the path from it.
-     *
-     * @param path the sequence of parts that make up a namespace path
-     * @throws IllegalArgumentException if any of the parts are not valid path part names
-     */
-    @throws[IllegalArgumentException]
-    private def apply(parts: Seq[String]): EntityPath = {
-        require(parts != null && parts.nonEmpty, "path undefined")
-        require(parts.forall { s => s != null && EntityName.entityNameMatcher(s).matches }, s"path contains invalid parts ${parts.toString}")
-        new EntityPath(parts)
-    }
+  /**
+   * Namespace is a path string of allowed characters. The path consists of parts each of which
+   * must be a valid EntityName, separated by the Namespace separator character. The constructor
+   * accepts a sequence of path parts and can reconstruct the path from it.
+   *
+   * @param path the sequence of parts that make up a namespace path
+   * @throws IllegalArgumentException if any of the parts are not valid path part names
+   */
+  @throws[IllegalArgumentException]
+  private def apply(parts: Seq[String]): EntityPath = {
+    require(parts != null && parts.nonEmpty, "path undefined")
+    require(parts.forall { s =>
+      s != null && EntityName.entityNameMatcher(s).matches
+    }, s"path contains invalid parts ${parts.toString}")
+    new EntityPath(parts)
+  }
 
-    /** Returns true iff the path is a valid namespace path. */
-    protected[core] def validate(path: String): Boolean = {
-        Try { EntityPath(path) } map { _ => true } getOrElse false
-    }
+  /** Returns true iff the path is a valid namespace path. */
+  protected[core] def validate(path: String): Boolean = {
+    Try { EntityPath(path) } map { _ =>
+      true
+    } getOrElse false
+  }
 
-    implicit val serdes = new RootJsonFormat[EntityPath] {
-        def write(n: EntityPath) = n.toJson
+  implicit val serdes = new RootJsonFormat[EntityPath] {
+    def write(n: EntityPath) = n.toJson
 
-        def read(value: JsValue) = Try {
-            val JsString(name) = value
-            EntityPath(name)
-        } getOrElse deserializationError("namespace malformed")
-    }
+    def read(value: JsValue) =
+      Try {
+        val JsString(name) = value
+        EntityPath(name)
+      } getOrElse deserializationError("namespace malformed")
+  }
 }
 
 /**
@@ -169,49 +174,50 @@ protected[core] object EntityPath {
  * before creating a new instance.
  */
 protected[core] class EntityName private (val name: String) extends AnyVal {
-    def asString = name // to make explicit that this is a string conversion
-    def toJson = JsString(name)
-    def toPath: EntityPath = EntityPath(name)
-    def addPath(e: EntityName): EntityPath = toPath.addPath(e)
-    def addPath(e: Option[EntityName]): EntityPath = e map { toPath.addPath(_) } getOrElse toPath
-    override def toString = name
+  def asString = name // to make explicit that this is a string conversion
+  def toJson = JsString(name)
+  def toPath: EntityPath = EntityPath(name)
+  def addPath(e: EntityName): EntityPath = toPath.addPath(e)
+  def addPath(e: Option[EntityName]): EntityPath = e map { toPath.addPath(_) } getOrElse toPath
+  override def toString = name
 }
 
 protected[core] object EntityName {
-    protected[core] val ENTITY_NAME_MAX_LENGTH = 256
+  protected[core] val ENTITY_NAME_MAX_LENGTH = 256
 
-    /**
-     * Allowed path part or entity name format (excludes path separator): first character
-     * is a letter|digit|underscore, followed by one or more allowed characters in [\w@ .-].
-     * The name may not have trailing white space.
-     */
-    protected[core] val REGEX = raw"\A([\w]|[\w][\w@ .-]{0,${ENTITY_NAME_MAX_LENGTH - 2}}[\w@.-])\z"
-    private val entityNamePattern = REGEX.r.pattern // compile once
-    protected[core] def entityNameMatcher(s: String): Matcher = entityNamePattern.matcher(s)
+  /**
+   * Allowed path part or entity name format (excludes path separator): first character
+   * is a letter|digit|underscore, followed by one or more allowed characters in [\w@ .-].
+   * The name may not have trailing white space.
+   */
+  protected[core] val REGEX = raw"\A([\w]|[\w][\w@ .-]{0,${ENTITY_NAME_MAX_LENGTH - 2}}[\w@.-])\z"
+  private val entityNamePattern = REGEX.r.pattern // compile once
+  protected[core] def entityNameMatcher(s: String): Matcher = entityNamePattern.matcher(s)
 
-    /**
-     * Unapply method for convenience of case matching.
-     */
-    protected[core] def unapply(name: String): Option[EntityName] = Try(EntityName(name)).toOption
+  /**
+   * Unapply method for convenience of case matching.
+   */
+  protected[core] def unapply(name: String): Option[EntityName] = Try(EntityName(name)).toOption
 
-    /**
-     * EntityName is a string of allowed characters.
-     *
-     * @param name the entity name
-     * @throws IllegalArgumentException if the name does not conform to schema
-     */
-    @throws[IllegalArgumentException]
-    protected[core] def apply(name: String): EntityName = {
-        require(name != null && entityNameMatcher(name).matches, s"name [$name] is not allowed")
-        new EntityName(name)
-    }
+  /**
+   * EntityName is a string of allowed characters.
+   *
+   * @param name the entity name
+   * @throws IllegalArgumentException if the name does not conform to schema
+   */
+  @throws[IllegalArgumentException]
+  protected[core] def apply(name: String): EntityName = {
+    require(name != null && entityNameMatcher(name).matches, s"name [$name] is not allowed")
+    new EntityName(name)
+  }
 
-    implicit val serdes = new RootJsonFormat[EntityName] {
-        def write(n: EntityName) = n.toJson
+  implicit val serdes = new RootJsonFormat[EntityName] {
+    def write(n: EntityName) = n.toJson
 
-        def read(value: JsValue) = Try {
-            val JsString(name) = value
-            EntityName(name)
-        } getOrElse deserializationError("entity name malformed")
-    }
+    def read(value: JsValue) =
+      Try {
+        val JsString(name) = value
+        EntityName(name)
+      } getOrElse deserializationError("entity name malformed")
+  }
 }

--- a/common/scala/src/main/scala/whisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Exec.scala
@@ -45,12 +45,13 @@ import whisk.core.entity.size.SizeString
  *   main  : name of the entry point function, when using a non-default value (for Java, the name of the main class)" }
  */
 sealed abstract class Exec extends ByteSizeable {
-    override def toString = Exec.serdes.write(this).compactPrint
-    /** A type descriptor. */
-    val kind: String
+  override def toString = Exec.serdes.write(this).compactPrint
 
-    /** When true exec may not be executed or updated. */
-    val deprecated: Boolean
+  /** A type descriptor. */
+  val kind: String
+
+  /** When true exec may not be executed or updated. */
+  val deprecated: Boolean
 }
 
 /**
@@ -58,215 +59,222 @@ sealed abstract class Exec extends ByteSizeable {
  * code explicitly (i.e., any action other than a sequence).
  */
 sealed abstract class CodeExec[+T <% SizeConversion] extends Exec {
-    /** An entrypoint (typically name of 'main' function). 'None' means a default value will be used. */
-    val entryPoint: Option[String]
 
-    /** The executable code. */
-    val code: T
+  /** An entrypoint (typically name of 'main' function). 'None' means a default value will be used. */
+  val entryPoint: Option[String]
 
-    /** Serialize code to a JSON value. */
-    def codeAsJson: JsValue
+  /** The executable code. */
+  val code: T
 
-    /** The runtime image (either built-in or a public image). */
-    val image: ImageName
+  /** Serialize code to a JSON value. */
+  def codeAsJson: JsValue
 
-    /** Indicates if the action execution generates log markers to stdout/stderr once action activation completes. */
-    val sentinelledLogs: Boolean
+  /** The runtime image (either built-in or a public image). */
+  val image: ImageName
 
-    /** Indicates if a container image is required from the registry to execute the action. */
-    val pull: Boolean
+  /** Indicates if the action execution generates log markers to stdout/stderr once action activation completes. */
+  val sentinelledLogs: Boolean
 
-    /**
-     * Indicates whether the code is stored in a text-readable or binary format.
-     * The binary bit may be read from the database but currently it is always computed
-     * when the "code" is moved to an attachment this may get changed to avoid recomputing
-     * the binary property.
-     */
-    val binary: Boolean
+  /** Indicates if a container image is required from the registry to execute the action. */
+  val pull: Boolean
 
-    override def size = code.sizeInBytes + entryPoint.map(_.sizeInBytes).getOrElse(0.B)
+  /**
+   * Indicates whether the code is stored in a text-readable or binary format.
+   * The binary bit may be read from the database but currently it is always computed
+   * when the "code" is moved to an attachment this may get changed to avoid recomputing
+   * the binary property.
+   */
+  val binary: Boolean
+
+  override def size = code.sizeInBytes + entryPoint.map(_.sizeInBytes).getOrElse(0.B)
 }
 
-protected[core] case class CodeExecAsString(
-    manifest: RuntimeManifest,
-    override val code: String,
-    override val entryPoint: Option[String])
+protected[core] case class CodeExecAsString(manifest: RuntimeManifest,
+                                            override val code: String,
+                                            override val entryPoint: Option[String])
     extends CodeExec[String] {
-    override val kind = manifest.kind
-    override val image = manifest.image
-    override val sentinelledLogs = manifest.sentinelledLogs.getOrElse(true)
-    override val deprecated = manifest.deprecated.getOrElse(false)
-    override val pull = false
-    override lazy val binary = Exec.isBinaryCode(code)
-    override def codeAsJson = JsString(code)
+  override val kind = manifest.kind
+  override val image = manifest.image
+  override val sentinelledLogs = manifest.sentinelledLogs.getOrElse(true)
+  override val deprecated = manifest.deprecated.getOrElse(false)
+  override val pull = false
+  override lazy val binary = Exec.isBinaryCode(code)
+  override def codeAsJson = JsString(code)
 }
 
-protected[core] case class CodeExecAsAttachment(
-    manifest: RuntimeManifest,
-    override val code: Attachment[String],
-    override val entryPoint: Option[String])
+protected[core] case class CodeExecAsAttachment(manifest: RuntimeManifest,
+                                                override val code: Attachment[String],
+                                                override val entryPoint: Option[String])
     extends CodeExec[Attachment[String]] {
-    override val kind = manifest.kind
-    override val image = manifest.image
-    override val sentinelledLogs = manifest.sentinelledLogs.getOrElse(true)
-    override val deprecated = manifest.deprecated.getOrElse(false)
-    override val pull = false
-    override lazy val binary = true
-    override def codeAsJson = code.toJson
+  override val kind = manifest.kind
+  override val image = manifest.image
+  override val sentinelledLogs = manifest.sentinelledLogs.getOrElse(true)
+  override val deprecated = manifest.deprecated.getOrElse(false)
+  override val pull = false
+  override lazy val binary = true
+  override def codeAsJson = code.toJson
 
-    def inline(bytes: Array[Byte]): CodeExecAsAttachment = {
-        val encoded = new String(bytes, StandardCharsets.UTF_8)
-        copy(code = Inline(encoded))
-    }
+  def inline(bytes: Array[Byte]): CodeExecAsAttachment = {
+    val encoded = new String(bytes, StandardCharsets.UTF_8)
+    copy(code = Inline(encoded))
+  }
 
-    def attach: CodeExecAsAttachment = {
-        manifest.attached.map { a =>
-            copy(code = Attached(a.attachmentName, a.attachmentType))
-        } getOrElse this
-    }
+  def attach: CodeExecAsAttachment = {
+    manifest.attached.map { a =>
+      copy(code = Attached(a.attachmentName, a.attachmentType))
+    } getOrElse this
+  }
 }
 
 /**
  * @param image the image name
  * @param code an optional script or zip archive (as base64 encoded) string
  */
-protected[core] case class BlackBoxExec(
-    override val image: ImageName,
-    override val code: Option[String],
-    override val entryPoint: Option[String],
-    val native: Boolean)
+protected[core] case class BlackBoxExec(override val image: ImageName,
+                                        override val code: Option[String],
+                                        override val entryPoint: Option[String],
+                                        val native: Boolean)
     extends CodeExec[Option[String]] {
-    override val kind = Exec.BLACKBOX
-    override val deprecated = false
-    override def codeAsJson = code.toJson
-    override lazy val binary = code map { Exec.isBinaryCode(_) } getOrElse false
-    override val sentinelledLogs = native
-    override val pull = !native
-    override def size = super.size + image.publicImageName.sizeInBytes
+  override val kind = Exec.BLACKBOX
+  override val deprecated = false
+  override def codeAsJson = code.toJson
+  override lazy val binary = code map { Exec.isBinaryCode(_) } getOrElse false
+  override val sentinelledLogs = native
+  override val pull = !native
+  override def size = super.size + image.publicImageName.sizeInBytes
 }
 
 protected[core] case class SequenceExec(components: Vector[FullyQualifiedEntityName]) extends Exec {
-    override val kind = Exec.SEQUENCE
-    override val deprecated = false
-    override def size = components.map(_.size).reduceOption(_ + _).getOrElse(0.B)
+  override val kind = Exec.SEQUENCE
+  override val deprecated = false
+  override def size = components.map(_.size).reduceOption(_ + _).getOrElse(0.B)
 }
 
-protected[core] object Exec
-    extends ArgNormalizer[Exec]
-    with DefaultJsonProtocol {
+protected[core] object Exec extends ArgNormalizer[Exec] with DefaultJsonProtocol {
 
-    val sizeLimit = 48 MB
+  val sizeLimit = 48 MB
 
-    // The possible values of the JSON 'kind' field for certain runtimes:
-    // - Sequence because it is an intrinsic
-    // - Black Box because it is a type marker
-    protected[core] val SEQUENCE = "sequence"
-    protected[core] val BLACKBOX = "blackbox"
+  // The possible values of the JSON 'kind' field for certain runtimes:
+  // - Sequence because it is an intrinsic
+  // - Black Box because it is a type marker
+  protected[core] val SEQUENCE = "sequence"
+  protected[core] val BLACKBOX = "blackbox"
 
-    private def execManifests = ExecManifest.runtimesManifest
+  private def execManifests = ExecManifest.runtimesManifest
 
-    override protected[core] implicit lazy val serdes = new RootJsonFormat[Exec] {
-        private def attFmt[T: JsonFormat] = Attachments.serdes[T]
-        private lazy val runtimes: Set[String] = execManifests.knownContainerRuntimes ++ Set(SEQUENCE, BLACKBOX)
+  override protected[core] implicit lazy val serdes = new RootJsonFormat[Exec] {
+    private def attFmt[T: JsonFormat] = Attachments.serdes[T]
+    private lazy val runtimes: Set[String] = execManifests.knownContainerRuntimes ++ Set(SEQUENCE, BLACKBOX)
 
-        override def write(e: Exec) = e match {
-            case c: CodeExecAsString =>
-                val base = Map("kind" -> JsString(c.kind), "code" -> JsString(c.code), "binary" -> JsBoolean(c.binary))
-                val main = c.entryPoint.map("main" -> JsString(_))
-                JsObject(base ++ main)
+    override def write(e: Exec) = e match {
+      case c: CodeExecAsString =>
+        val base = Map("kind" -> JsString(c.kind), "code" -> JsString(c.code), "binary" -> JsBoolean(c.binary))
+        val main = c.entryPoint.map("main" -> JsString(_))
+        JsObject(base ++ main)
 
-            case a: CodeExecAsAttachment =>
-                val base = Map("kind" -> JsString(a.kind), "code" -> attFmt[String].write(a.code), "binary" -> JsBoolean(a.binary))
-                val main = a.entryPoint.map("main" -> JsString(_))
-                JsObject(base ++ main)
+      case a: CodeExecAsAttachment =>
+        val base =
+          Map("kind" -> JsString(a.kind), "code" -> attFmt[String].write(a.code), "binary" -> JsBoolean(a.binary))
+        val main = a.entryPoint.map("main" -> JsString(_))
+        JsObject(base ++ main)
 
-            case s @ SequenceExec(comp) =>
-                JsObject("kind" -> JsString(s.kind), "components" -> comp.map(_.qualifiedNameWithLeadingSlash).toJson)
+      case s @ SequenceExec(comp) =>
+        JsObject("kind" -> JsString(s.kind), "components" -> comp.map(_.qualifiedNameWithLeadingSlash).toJson)
 
-            case b: BlackBoxExec =>
-                val base = Map("kind" -> JsString(b.kind), "image" -> JsString(b.image.publicImageName), "binary" -> JsBoolean(b.binary))
-                val code = b.code.filter(_.trim.nonEmpty).map("code" -> JsString(_))
-                val main = b.entryPoint.map("main" -> JsString(_))
-                JsObject(base ++ code ++ main)
-        }
+      case b: BlackBoxExec =>
+        val base =
+          Map("kind" -> JsString(b.kind), "image" -> JsString(b.image.publicImageName), "binary" -> JsBoolean(b.binary))
+        val code = b.code.filter(_.trim.nonEmpty).map("code" -> JsString(_))
+        val main = b.entryPoint.map("main" -> JsString(_))
+        JsObject(base ++ code ++ main)
+    }
 
-        override def read(v: JsValue) = {
-            require(v != null)
+    override def read(v: JsValue) = {
+      require(v != null)
 
-            val obj = v.asJsObject
+      val obj = v.asJsObject
 
-            val kind = obj.fields.get("kind") match {
-                case Some(JsString(k)) => k.trim.toLowerCase
-                case _                 => throw new DeserializationException("'kind' must be a string defined in 'exec'")
+      val kind = obj.fields.get("kind") match {
+        case Some(JsString(k)) => k.trim.toLowerCase
+        case _                 => throw new DeserializationException("'kind' must be a string defined in 'exec'")
+      }
+
+      lazy val optMainField: Option[String] = obj.fields.get("main") match {
+        case Some(JsString(m)) => Some(m)
+        case Some(_) =>
+          throw new DeserializationException(s"if defined, 'main' be a string in 'exec' for '$kind' actions")
+        case None => None
+      }
+
+      kind match {
+        case Exec.SEQUENCE =>
+          val comp: Vector[FullyQualifiedEntityName] = obj.fields.get("components") match {
+            case Some(JsArray(components)) => components map (FullyQualifiedEntityName.serdes.read(_))
+            case Some(_)                   => throw new DeserializationException(s"'components' must be an array")
+            case None                      => throw new DeserializationException(s"'components' must be defined for sequence kind")
+          }
+          SequenceExec(comp)
+
+        case Exec.BLACKBOX =>
+          val image: ImageName = obj.fields.get("image") match {
+            case Some(JsString(i)) => ImageName.fromString(i).get // throws deserialization exception on failure
+            case _ =>
+              throw new DeserializationException(
+                s"'image' must be a string defined in 'exec' for '${Exec.BLACKBOX}' actions")
+          }
+          val code: Option[String] = obj.fields.get("code") match {
+            case Some(JsString(i)) => if (i.trim.nonEmpty) Some(i) else None
+            case Some(_) =>
+              throw new DeserializationException(
+                s"if defined, 'code' must a string defined in 'exec' for '${Exec.BLACKBOX}' actions")
+            case None => None
+          }
+          val native = execManifests.blackboxImages.contains(image)
+          BlackBoxExec(image, code, optMainField, native)
+
+        case _ =>
+          // map "default" virtual runtime versions to the currently blessed actual runtime version
+          val manifest = execManifests.resolveDefaultRuntime(kind) match {
+            case Some(k) => k
+            case None    => throw new DeserializationException(s"kind '$kind' not in $runtimes")
+          }
+
+          manifest.attached
+            .map { a =>
+              val jar: Attachment[String] = {
+                // java actions once stored the attachment in "jar" instead of "code"
+                obj.fields.get("code").orElse(obj.fields.get("jar"))
+              } map {
+                attFmt[String].read(_)
+              } getOrElse {
+                throw new DeserializationException(
+                  s"'code' must be a valid base64 string in 'exec' for '$kind' actions")
+              }
+              val main = optMainField.orElse {
+                if (manifest.requireMain.exists(identity)) {
+                  throw new DeserializationException(s"'main' must be a string defined in 'exec' for '$kind' actions")
+                } else None
+              }
+              CodeExecAsAttachment(manifest, jar, main)
             }
-
-            lazy val optMainField: Option[String] = obj.fields.get("main") match {
-                case Some(JsString(m)) => Some(m)
-                case Some(_)           => throw new DeserializationException(s"if defined, 'main' be a string in 'exec' for '$kind' actions")
-                case None              => None
-            }
-
-            kind match {
-                case Exec.SEQUENCE =>
-                    val comp: Vector[FullyQualifiedEntityName] = obj.fields.get("components") match {
-                        case Some(JsArray(components)) => components map (FullyQualifiedEntityName.serdes.read(_))
-                        case Some(_)                   => throw new DeserializationException(s"'components' must be an array")
-                        case None                      => throw new DeserializationException(s"'components' must be defined for sequence kind")
-                    }
-                    SequenceExec(comp)
-
-                case Exec.BLACKBOX =>
-                    val image: ImageName = obj.fields.get("image") match {
-                        case Some(JsString(i)) => ImageName.fromString(i).get // throws deserialization exception on failure
-                        case _                 => throw new DeserializationException(s"'image' must be a string defined in 'exec' for '${Exec.BLACKBOX}' actions")
-                    }
-                    val code: Option[String] = obj.fields.get("code") match {
-                        case Some(JsString(i)) => if (i.trim.nonEmpty) Some(i) else None
-                        case Some(_)           => throw new DeserializationException(s"if defined, 'code' must a string defined in 'exec' for '${Exec.BLACKBOX}' actions")
-                        case None              => None
-                    }
-                    val native = execManifests.blackboxImages.contains(image)
-                    BlackBoxExec(image, code, optMainField, native)
-
+            .getOrElse {
+              val code: String = obj.fields.get("code") match {
+                case Some(JsString(c)) => c
                 case _ =>
-                    // map "default" virtual runtime versions to the currently blessed actual runtime version
-                    val manifest = execManifests.resolveDefaultRuntime(kind) match {
-                        case Some(k) => k
-                        case None    => throw new DeserializationException(s"kind '$kind' not in $runtimes")
-                    }
-
-                    manifest.attached.map { a =>
-                        val jar: Attachment[String] = {
-                            // java actions once stored the attachment in "jar" instead of "code"
-                            obj.fields.get("code").orElse(obj.fields.get("jar"))
-                        } map {
-                            attFmt[String].read(_)
-                        } getOrElse {
-                            throw new DeserializationException(s"'code' must be a valid base64 string in 'exec' for '$kind' actions")
-                        }
-                        val main = optMainField.orElse {
-                            if (manifest.requireMain.exists(identity)) {
-                                throw new DeserializationException(s"'main' must be a string defined in 'exec' for '$kind' actions")
-                            } else None
-                        }
-                        CodeExecAsAttachment(manifest, jar, main)
-                    }.getOrElse {
-                        val code: String = obj.fields.get("code") match {
-                            case Some(JsString(c)) => c
-                            case _                 => throw new DeserializationException(s"'code' must be a string defined in 'exec' for '$kind' actions")
-                        }
-                        CodeExecAsString(manifest, code, optMainField)
-                    }
+                  throw new DeserializationException(s"'code' must be a string defined in 'exec' for '$kind' actions")
+              }
+              CodeExecAsString(manifest, code, optMainField)
             }
-        }
+      }
     }
+  }
 
-    val isBase64Pattern = new Regex("^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$").pattern
+  val isBase64Pattern = new Regex("^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$").pattern
 
-    def isBinaryCode(code: String): Boolean = {
-        if (code != null) {
-            val t = code.trim
-            (t.length > 0) && (t.length % 4 == 0) && isBase64Pattern.matcher(t).matches()
-        } else false
-    }
+  def isBinaryCode(code: String): Boolean = {
+    if (code != null) {
+      val t = code.trim
+      (t.length > 0) && (t.length % 4 == 0) && isBase64Pattern.matcher(t).matches()
+    } else false
+  }
 }

--- a/common/scala/src/main/scala/whisk/core/entity/ExecManifest.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ExecManifest.scala
@@ -31,227 +31,234 @@ import whisk.core.entity.Attachments.Attached._
  */
 protected[core] object ExecManifest {
 
-    /**
-     * Required properties to initialize this singleton via WhiskConfig.
-     */
-    protected[core] def requiredProperties = Map(WhiskConfig.runtimesManifest -> null)
+  /**
+   * Required properties to initialize this singleton via WhiskConfig.
+   */
+  protected[core] def requiredProperties = Map(WhiskConfig.runtimesManifest -> null)
+
+  /**
+   * Reads runtimes manifest from WhiskConfig and initializes the
+   * singleton Runtime instance.
+   *
+   * @param config a valid configuration
+   * @param reinit re-initialize singleton iff true
+   * @return the manifest if initialized successfully, or if previously initialized
+   */
+  protected[core] def initialize(config: WhiskConfig, reinit: Boolean = false): Try[Runtimes] = {
+    if (manifest.isEmpty || reinit) {
+      val mf = Try(config.runtimesManifest.parseJson.asJsObject).flatMap(runtimes(_))
+      mf.foreach(m => manifest = Some(m))
+      mf
+    } else Success(manifest.get)
+  }
+
+  /**
+   * Gets existing runtime manifests.
+   *
+   * @return singleton Runtimes instance previous initialized from WhiskConfig
+   * @throws IllegalStateException if singleton was not previously initialized
+   */
+  @throws[IllegalStateException]
+  protected[core] def runtimesManifest: Runtimes = {
+    manifest.getOrElse {
+      throw new IllegalStateException("Runtimes manifest is not initialized.")
+    }
+  }
+
+  private var manifest: Option[Runtimes] = None
+
+  /**
+   * @param config a configuration object as JSON
+   * @return Runtimes instance
+   */
+  protected[entity] def runtimes(config: JsObject): Try[Runtimes] = Try {
+    val prefix = config.fields.get("defaultImagePrefix").map(_.convertTo[String])
+    val tag = config.fields.get("defaultImageTag").map(_.convertTo[String])
+    val runtimes = config
+      .fields("runtimes")
+      .convertTo[Map[String, Set[RuntimeManifest]]]
+      .map {
+        case (name, versions) =>
+          RuntimeFamily(name, versions.map { mf =>
+            val img = ImageName(mf.image.name, mf.image.prefix.orElse(prefix), mf.image.tag.orElse(tag))
+            mf.copy(image = img)
+          })
+      }
+      .toSet
+    val blackbox = config.fields
+      .get("blackboxes")
+      .map(_.convertTo[Set[ImageName]].map { image =>
+        ImageName(image.name, image.prefix.orElse(prefix), image.tag.orElse(tag))
+      })
+    Runtimes(runtimes, blackbox.getOrElse(Set.empty))
+  }
+
+  /**
+   * A runtime manifest describes the "exec" runtime support.
+   *
+   * @param kind the name of the kind e.g., nodejs:6
+   * @param deprecated true iff the runtime is deprecated (allows get/delete but not create/update/invoke)
+   * @param default true iff the runtime is the default kind for its family (nodejs:default -> nodejs:6)
+   * @param attached true iff the source is an attachments (not inlined source)
+   * @param requireMain true iff main entry point is not optional
+   * @param sentinelledLogs true iff the runtime generates stdout/stderr log sentinels after an activation
+   * @param image optional image name, otherwise inferred via fixed mapping (remove colons and append 'action')
+   */
+  protected[core] case class RuntimeManifest(kind: String,
+                                             image: ImageName,
+                                             deprecated: Option[Boolean] = None,
+                                             default: Option[Boolean] = None,
+                                             attached: Option[Attached] = None,
+                                             requireMain: Option[Boolean] = None,
+                                             sentinelledLogs: Option[Boolean] = None) {
+
+    protected[entity] def toJsonSummary = {
+      JsObject(
+        "kind" -> kind.toJson,
+        "image" -> image.publicImageName.toJson,
+        "deprecated" -> deprecated.getOrElse(false).toJson,
+        "default" -> default.getOrElse(false).toJson,
+        "attached" -> attached.isDefined.toJson,
+        "requireMain" -> requireMain.getOrElse(false).toJson)
+    }
+  }
+
+  /**
+   * An image name for an action refers to the container image canonically as
+   * "prefix/name[:tag]" e.g., "openwhisk/python3action:latest".
+   */
+  protected[core] case class ImageName(name: String, prefix: Option[String] = None, tag: Option[String] = None) {
 
     /**
-     * Reads runtimes manifest from WhiskConfig and initializes the
-     * singleton Runtime instance.
-     *
-     * @param config a valid configuration
-     * @param reinit re-initialize singleton iff true
-     * @return the manifest if initialized successfully, or if previously initialized
+     * The name of the public image for an action kind.
      */
-    protected[core] def initialize(config: WhiskConfig, reinit: Boolean = false): Try[Runtimes] = {
-        if (manifest.isEmpty || reinit) {
-            val mf = Try(config.runtimesManifest.parseJson.asJsObject).flatMap(runtimes(_))
-            mf.foreach(m => manifest = Some(m))
-            mf
-        } else Success(manifest.get)
+    def publicImageName: String = {
+      val p = prefix.filter(_.nonEmpty).map(_ + "/").getOrElse("")
+      val t = tag.filter(_.nonEmpty).map(":" + _).getOrElse("")
+      p + name + t
     }
 
     /**
-     * Gets existing runtime manifests.
-     *
-     * @return singleton Runtimes instance previous initialized from WhiskConfig
-     * @throws IllegalStateException if singleton was not previously initialized
+     * The internal name of the image for an action kind. It overrides
+     * the prefix with an internal name. Optionally overrides tag.
      */
-    @throws[IllegalStateException]
-    protected[core] def runtimesManifest: Runtimes = {
-        manifest.getOrElse {
-            throw new IllegalStateException("Runtimes manifest is not initialized.")
+    def localImageName(registry: String, prefix: String, tagOverride: Option[String] = None): String = {
+      val r = Option(registry)
+        .filter(_.nonEmpty)
+        .map { reg =>
+          if (reg.endsWith("/")) reg else reg + "/"
         }
-    }
-
-    private var manifest: Option[Runtimes] = None
-
-    /**
-     * @param config a configuration object as JSON
-     * @return Runtimes instance
-     */
-    protected[entity] def runtimes(config: JsObject): Try[Runtimes] = Try {
-        val prefix = config.fields.get("defaultImagePrefix").map(_.convertTo[String])
-        val tag = config.fields.get("defaultImageTag").map(_.convertTo[String])
-        val runtimes = config.fields("runtimes")
-            .convertTo[Map[String, Set[RuntimeManifest]]]
-            .map {
-                case (name, versions) =>
-                    RuntimeFamily(name, versions.map { mf =>
-                        val img = ImageName(mf.image.name, mf.image.prefix.orElse(prefix), mf.image.tag.orElse(tag))
-                        mf.copy(image = img)
-                    })
-            }
-            .toSet
-        val blackbox = config.fields.get("blackboxes")
-            .map(_.convertTo[Set[ImageName]].map {
-                image => ImageName(image.name, image.prefix.orElse(prefix), image.tag.orElse(tag))
-            })
-        Runtimes(runtimes, blackbox.getOrElse(Set.empty))
+        .getOrElse("")
+      val p = Option(prefix).filter(_.nonEmpty).map(_ + "/").getOrElse("")
+      r + p + name + ":" + tagOverride.orElse(tag).getOrElse(ImageName.defaultImageTag)
     }
 
     /**
-     * A runtime manifest describes the "exec" runtime support.
-     *
-     * @param kind the name of the kind e.g., nodejs:6
-     * @param deprecated true iff the runtime is deprecated (allows get/delete but not create/update/invoke)
-     * @param default true iff the runtime is the default kind for its family (nodejs:default -> nodejs:6)
-     * @param attached true iff the source is an attachments (not inlined source)
-     * @param requireMain true iff main entry point is not optional
-     * @param sentinelledLogs true iff the runtime generates stdout/stderr log sentinels after an activation
-     * @param image optional image name, otherwise inferred via fixed mapping (remove colons and append 'action')
+     * Overrides equals to allow match on undefined tag or when tag is latest
+     * in this or that.
      */
-    protected[core] case class RuntimeManifest(
-        kind: String,
-        image: ImageName,
-        deprecated: Option[Boolean] = None,
-        default: Option[Boolean] = None,
-        attached: Option[Attached] = None,
-        requireMain: Option[Boolean] = None,
-        sentinelledLogs: Option[Boolean] = None) {
+    override def equals(that: Any) = that match {
+      case ImageName(n, p, t) =>
+        name == n && p == prefix && (t == tag || {
+          val thisTag = tag.getOrElse(ImageName.defaultImageTag)
+          val thatTag = t.getOrElse(ImageName.defaultImageTag)
+          thisTag == thatTag
+        })
 
-        protected[entity] def toJsonSummary = {
-            JsObject(
-                "kind" -> kind.toJson,
-                "image" -> image.publicImageName.toJson,
-                "deprecated" -> deprecated.getOrElse(false).toJson,
-                "default" -> default.getOrElse(false).toJson,
-                "attached" -> attached.isDefined.toJson,
-                "requireMain" -> requireMain.getOrElse(false).toJson)
-        }
+      case _ => false
     }
+  }
+
+  protected[core] object ImageName {
+    protected val defaultImageTag = "latest"
+    private val componentRegex = """([a-z0-9._-]+)""".r
+    private val tagRegex = """([\w.-]{0,128})""".r
 
     /**
-     * An image name for an action refers to the container image canonically as
-     * "prefix/name[:tag]" e.g., "openwhisk/python3action:latest".
+     * Constructs an ImageName from a string. This method checks that the image name conforms
+     * to the Docker naming. As a result, failure to deserialize a string will throw an exception
+     * which fails the Try. Callers could use this to short-circuit operations (CRUD or activation).
+     * Internal container names use the proper constructor directly.
      */
-    protected[core] case class ImageName(
-        name: String,
-        prefix: Option[String] = None,
-        tag: Option[String] = None) {
+    def fromString(s: String): Try[ImageName] =
+      Try {
+        val parts = s.split("/")
 
-        /**
-         * The name of the public image for an action kind.
-         */
-        def publicImageName: String = {
-            val p = prefix.filter(_.nonEmpty).map(_ + "/").getOrElse("")
-            val t = tag.filter(_.nonEmpty).map(":" + _).getOrElse("")
-            p + name + t
+        val (name, tag) = parts.last.split(":") match {
+          case Array(componentRegex(s))              => (s, None)
+          case Array(componentRegex(s), tagRegex(t)) => (s, Some(t))
+          case _                                     => throw DeserializationException("image name is not valid")
         }
 
-        /**
-         * The internal name of the image for an action kind. It overrides
-         * the prefix with an internal name. Optionally overrides tag.
-         */
-        def localImageName(registry: String, prefix: String, tagOverride: Option[String] = None): String = {
-            val r = Option(registry).filter(_.nonEmpty).map { reg =>
-                if (reg.endsWith("/")) reg else reg + "/"
-            }.getOrElse("")
-            val p = Option(prefix).filter(_.nonEmpty).map(_ + "/").getOrElse("")
-            r + p + name + ":" + tagOverride.orElse(tag).getOrElse(ImageName.defaultImageTag)
+        val prefixParts = parts.dropRight(1)
+        if (!prefixParts.forall(componentRegex.pattern.matcher(_).matches)) {
+          throw DeserializationException("image prefix not is not valid")
         }
+        val prefix = if (prefixParts.nonEmpty) Some(prefixParts.mkString("/")) else None
 
-        /**
-         * Overrides equals to allow match on undefined tag or when tag is latest
-         * in this or that.
-         */
-        override def equals(that: Any) = that match {
-            case ImageName(n, p, t) =>
-                name == n && p == prefix && (t == tag || {
-                    val thisTag = tag.getOrElse(ImageName.defaultImageTag)
-                    val thatTag = t.getOrElse(ImageName.defaultImageTag)
-                    thisTag == thatTag
-                })
+        ImageName(name, prefix, tag)
+      } recoverWith {
+        case t: DeserializationException => Failure(t)
+        case t                           => Failure(DeserializationException("could not parse image name"))
+      }
+  }
 
-            case _ => false
+  /**
+   * A runtime family manifest is a collection of runtimes grouped by a family (e.g., swift with versions swift:2 and swift:3).
+   * @param family runtime family
+   * @version set of runtime manifests
+   */
+  protected[entity] case class RuntimeFamily(name: String, versions: Set[RuntimeManifest])
+
+  /**
+   * A collection of runtime families.
+   *
+   * @param set of supported runtime families
+   */
+  protected[core] case class Runtimes(runtimes: Set[RuntimeFamily], blackboxImages: Set[ImageName]) {
+
+    val knownContainerRuntimes: Set[String] = runtimes.flatMap(_.versions.map(_.kind))
+
+    def toJson: JsObject = {
+      runtimes
+        .map { family =>
+          family.name -> family.versions.map(_.toJsonSummary)
         }
+        .toMap
+        .toJson
+        .asJsObject
     }
 
-    protected[core] object ImageName {
-        protected val defaultImageTag = "latest"
-        private val componentRegex = """([a-z0-9._-]+)""".r
-        private val tagRegex = """([\w.-]{0,128})""".r
-
-        /**
-         * Constructs an ImageName from a string. This method checks that the image name conforms
-         * to the Docker naming. As a result, failure to deserialize a string will throw an exception
-         * which fails the Try. Callers could use this to short-circuit operations (CRUD or activation).
-         * Internal container names use the proper constructor directly.
-         */
-        def fromString(s: String): Try[ImageName] = Try {
-            val parts = s.split("/")
-
-            val (name, tag) = parts.last.split(":") match {
-                case Array(componentRegex(s))              => (s, None)
-                case Array(componentRegex(s), tagRegex(t)) => (s, Some(t))
-                case _                                     => throw DeserializationException("image name is not valid")
-            }
-
-            val prefixParts = parts.dropRight(1)
-            if (!prefixParts.forall(componentRegex.pattern.matcher(_).matches)) {
-                throw DeserializationException("image prefix not is not valid")
-            }
-            val prefix = if (prefixParts.nonEmpty) Some(prefixParts.mkString("/")) else None
-
-            ImageName(name, prefix, tag)
-        } recoverWith {
-            case t: DeserializationException => Failure(t)
-            case t                           => Failure(DeserializationException("could not parse image name"))
-        }
+    def resolveDefaultRuntime(kind: String): Option[RuntimeManifest] = {
+      kind match {
+        case defaultSplitter(family) => defaultRuntimes.get(family).flatMap(manifests.get(_))
+        case _                       => manifests.get(kind)
+      }
     }
 
-    /**
-     * A runtime family manifest is a collection of runtimes grouped by a family (e.g., swift with versions swift:2 and swift:3).
-     * @param family runtime family
-     * @version set of runtime manifests
-     */
-    protected[entity] case class RuntimeFamily(name: String, versions: Set[RuntimeManifest])
-
-    /**
-     * A collection of runtime families.
-     *
-     * @param set of supported runtime families
-     */
-    protected[core] case class Runtimes(runtimes: Set[RuntimeFamily], blackboxImages: Set[ImageName]) {
-
-        val knownContainerRuntimes: Set[String] = runtimes.flatMap(_.versions.map(_.kind))
-
-        def toJson: JsObject = {
-            runtimes.map { family =>
-                family.name -> family.versions.map(_.toJsonSummary)
-            }.toMap.toJson.asJsObject
+    val manifests: Map[String, RuntimeManifest] = {
+      runtimes.flatMap {
+        _.versions.map { m =>
+          m.kind -> m
         }
-
-        def resolveDefaultRuntime(kind: String): Option[RuntimeManifest] = {
-            kind match {
-                case defaultSplitter(family) => defaultRuntimes.get(family).flatMap(manifests.get(_))
-                case _                       => manifests.get(kind)
-            }
-        }
-
-        val manifests: Map[String, RuntimeManifest] = {
-            runtimes.flatMap {
-                _.versions.map {
-                    m => m.kind -> m
-                }
-            }.toMap
-        }
-
-        private val defaultRuntimes: Map[String, String] = {
-            runtimes.map { family =>
-                family.versions.filter(_.default.exists(identity)).toList match {
-                    case Nil if family.versions.size == 1 => family.name -> family.versions.head.kind
-                    case Nil                              => throw new IllegalArgumentException(s"${family.name} has multiple versions, but no default.")
-                    case d :: Nil                         => family.name -> d.kind
-                    case ds                               => throw new IllegalArgumentException(s"Found more than one default for ${family.name}: ${ds.mkString(",")}.")
-                }
-            }.toMap
-        }
-
-        private val defaultSplitter = "([a-z0-9]+):default".r
+      }.toMap
     }
 
-    protected[entity] implicit val imageNameSerdes = jsonFormat3(ImageName.apply)
-    protected[entity] implicit val runtimeManifestSerdes = jsonFormat7(RuntimeManifest)
+    private val defaultRuntimes: Map[String, String] = {
+      runtimes.map { family =>
+        family.versions.filter(_.default.exists(identity)).toList match {
+          case Nil if family.versions.size == 1 => family.name -> family.versions.head.kind
+          case Nil                              => throw new IllegalArgumentException(s"${family.name} has multiple versions, but no default.")
+          case d :: Nil                         => family.name -> d.kind
+          case ds =>
+            throw new IllegalArgumentException(s"Found more than one default for ${family.name}: ${ds.mkString(",")}.")
+        }
+      }.toMap
+    }
+
+    private val defaultSplitter = "([a-z0-9]+):default".r
+  }
+
+  protected[entity] implicit val imageNameSerdes = jsonFormat3(ImageName.apply)
+  protected[entity] implicit val runtimeManifestSerdes = jsonFormat7(RuntimeManifest)
 }

--- a/common/scala/src/main/scala/whisk/core/entity/Identity.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Identity.scala
@@ -30,98 +30,104 @@ import whisk.core.database.StaleParameter
 import whisk.core.entitlement.Privilege
 import whisk.core.entitlement.Privilege.Privilege
 
-case class UserLimits(invocationsPerMinute: Option[Int] = None, concurrentInvocations: Option[Int] = None, firesPerMinute: Option[Int] = None)
+case class UserLimits(invocationsPerMinute: Option[Int] = None,
+                      concurrentInvocations: Option[Int] = None,
+                      firesPerMinute: Option[Int] = None)
 
 object UserLimits extends DefaultJsonProtocol {
-    implicit val serdes = jsonFormat3(UserLimits.apply)
+  implicit val serdes = jsonFormat3(UserLimits.apply)
 }
 
-protected[core] case class Identity(subject: Subject, namespace: EntityName, authkey: AuthKey, rights: Set[Privilege], limits: UserLimits = UserLimits()) {
-    def uuid = authkey.uuid
+protected[core] case class Identity(subject: Subject,
+                                    namespace: EntityName,
+                                    authkey: AuthKey,
+                                    rights: Set[Privilege],
+                                    limits: UserLimits = UserLimits()) {
+  def uuid = authkey.uuid
 }
 
 object Identity extends MultipleReadersSingleWriterCache[Identity, DocInfo] with DefaultJsonProtocol {
 
-    private val viewName = "subjects/identities"
+  private val viewName = "subjects/identities"
 
-    override val cacheEnabled = true
-    implicit val serdes = jsonFormat5(Identity.apply)
+  override val cacheEnabled = true
+  implicit val serdes = jsonFormat5(Identity.apply)
 
-    /**
-     * Retrieves a key for namespace.
-     * There may be more than one key for the namespace, in which case,
-     * one is picked arbitrarily.
-     */
-    def get(datastore: AuthStore, namespace: EntityName)(
-        implicit transid: TransactionId): Future[Identity] = {
-        implicit val logger: Logging = datastore.logging
-        implicit val ec = datastore.executionContext
-        val ns = namespace.asString
-        val key = CacheKey(namespace)
+  /**
+   * Retrieves a key for namespace.
+   * There may be more than one key for the namespace, in which case,
+   * one is picked arbitrarily.
+   */
+  def get(datastore: AuthStore, namespace: EntityName)(implicit transid: TransactionId): Future[Identity] = {
+    implicit val logger: Logging = datastore.logging
+    implicit val ec = datastore.executionContext
+    val ns = namespace.asString
+    val key = CacheKey(namespace)
 
-        cacheLookup(key, {
-            list(datastore, List(ns), limit = 1) map { list =>
-                list.length match {
-                    case 1 =>
-                        rowToIdentity(list.head, ns)
-                    case 0 =>
-                        logger.info(this, s"$viewName[$namespace] does not exist")
-                        throw new NoDocumentException("namespace does not exist")
-                    case _ =>
-                        logger.error(this, s"$viewName[$namespace] is not unique")
-                        throw new IllegalStateException("namespace is not unique")
-                }
-            }
-        })
-    }
-
-    def get(datastore: AuthStore, authkey: AuthKey)(
-        implicit transid: TransactionId): Future[Identity] = {
-        implicit val logger: Logging = datastore.logging
-        implicit val ec = datastore.executionContext
-
-        cacheLookup(CacheKey(authkey), {
-            list(datastore, List(authkey.uuid.asString, authkey.key.asString)) map { list =>
-                list.length match {
-                    case 1 =>
-                        rowToIdentity(list.head, authkey.uuid.asString)
-                    case 0 =>
-                        logger.info(this, s"$viewName[${authkey.uuid}] does not exist")
-                        throw new NoDocumentException("uuid does not exist")
-                    case _ =>
-                        logger.error(this, s"$viewName[${authkey.uuid}] is not unique")
-                        throw new IllegalStateException("uuid is not unique")
-                }
-            }
-        })
-    }
-
-    def list(datastore: AuthStore, key: List[Any], limit: Int = 2)(
-        implicit transid: TransactionId): Future[List[JsObject]] = {
-        datastore.query(viewName,
-            startKey = key,
-            endKey = key,
-            skip = 0,
-            limit = limit,
-            includeDocs = true,
-            descending = true,
-            reduce = false,
-            stale = StaleParameter.No)
-    }
-
-    private def rowToIdentity(row: JsObject, key: String)(
-        implicit transid: TransactionId, logger: Logging) = {
-        row.getFields("id", "value", "doc") match {
-            case Seq(JsString(id), JsObject(value), doc) =>
-                val limits = Try(doc.convertTo[UserLimits]).getOrElse(UserLimits())
-                val subject = Subject(id)
-                val JsString(uuid) = value("uuid")
-                val JsString(secret) = value("key")
-                val JsString(namespace) = value("namespace")
-                Identity(subject, EntityName(namespace), AuthKey(UUID(uuid), Secret(secret)), Privilege.ALL, limits)
+    cacheLookup(
+      key, {
+        list(datastore, List(ns), limit = 1) map { list =>
+          list.length match {
+            case 1 =>
+              rowToIdentity(list.head, ns)
+            case 0 =>
+              logger.info(this, s"$viewName[$namespace] does not exist")
+              throw new NoDocumentException("namespace does not exist")
             case _ =>
-                logger.error(this, s"$viewName[$key] has malformed view '${row.compactPrint}'")
-                throw new IllegalStateException("identities view malformed")
+              logger.error(this, s"$viewName[$namespace] is not unique")
+              throw new IllegalStateException("namespace is not unique")
+          }
         }
+      })
+  }
+
+  def get(datastore: AuthStore, authkey: AuthKey)(implicit transid: TransactionId): Future[Identity] = {
+    implicit val logger: Logging = datastore.logging
+    implicit val ec = datastore.executionContext
+
+    cacheLookup(
+      CacheKey(authkey), {
+        list(datastore, List(authkey.uuid.asString, authkey.key.asString)) map { list =>
+          list.length match {
+            case 1 =>
+              rowToIdentity(list.head, authkey.uuid.asString)
+            case 0 =>
+              logger.info(this, s"$viewName[${authkey.uuid}] does not exist")
+              throw new NoDocumentException("uuid does not exist")
+            case _ =>
+              logger.error(this, s"$viewName[${authkey.uuid}] is not unique")
+              throw new IllegalStateException("uuid is not unique")
+          }
+        }
+      })
+  }
+
+  def list(datastore: AuthStore, key: List[Any], limit: Int = 2)(
+    implicit transid: TransactionId): Future[List[JsObject]] = {
+    datastore.query(
+      viewName,
+      startKey = key,
+      endKey = key,
+      skip = 0,
+      limit = limit,
+      includeDocs = true,
+      descending = true,
+      reduce = false,
+      stale = StaleParameter.No)
+  }
+
+  private def rowToIdentity(row: JsObject, key: String)(implicit transid: TransactionId, logger: Logging) = {
+    row.getFields("id", "value", "doc") match {
+      case Seq(JsString(id), JsObject(value), doc) =>
+        val limits = Try(doc.convertTo[UserLimits]).getOrElse(UserLimits())
+        val subject = Subject(id)
+        val JsString(uuid) = value("uuid")
+        val JsString(secret) = value("key")
+        val JsString(namespace) = value("namespace")
+        Identity(subject, EntityName(namespace), AuthKey(UUID(uuid), Secret(secret)), Privilege.ALL, limits)
+      case _ =>
+        logger.error(this, s"$viewName[$key] has malformed view '${row.compactPrint}'")
+        throw new IllegalStateException("identities view malformed")
     }
+  }
 }

--- a/common/scala/src/main/scala/whisk/core/entity/InstanceId.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/InstanceId.scala
@@ -20,9 +20,9 @@ package whisk.core.entity
 import spray.json.DefaultJsonProtocol
 
 case class InstanceId(val instance: Int) {
-    def toInt: Int = instance
+  def toInt: Int = instance
 }
 
 object InstanceId extends DefaultJsonProtocol {
-    implicit val serdes = jsonFormat1(InstanceId.apply)
+  implicit val serdes = jsonFormat1(InstanceId.apply)
 }

--- a/common/scala/src/main/scala/whisk/core/entity/Limits.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Limits.scala
@@ -29,8 +29,8 @@ import spray.json.DefaultJsonProtocol
  * that require global knowledge).
  */
 protected[entity] abstract class Limits {
-    protected[entity] def toJson: JsValue
-    override def toString = toJson.compactPrint
+  protected[entity] def toJson: JsValue
+  override def toString = toJson.compactPrint
 }
 
 /**
@@ -45,46 +45,43 @@ protected[entity] abstract class Limits {
  * @param memory the memory limit in megabytes, assured to be non-null because it is a value
  * @param logs the limit for logs written by the container and stored in the activation record, assured to be non-null because it is a value
  */
-protected[core] case class ActionLimits protected[core] (timeout: TimeLimit, memory: MemoryLimit, logs: LogLimit) extends Limits {
-    override protected[entity] def toJson = ActionLimits.serdes.write(this)
+protected[core] case class ActionLimits protected[core] (timeout: TimeLimit, memory: MemoryLimit, logs: LogLimit)
+    extends Limits {
+  override protected[entity] def toJson = ActionLimits.serdes.write(this)
 }
 
 /**
  * Limits on a specific trigger. None yet.
  */
 protected[core] case class TriggerLimits protected[core] () extends Limits {
-    override protected[entity] def toJson: JsValue = TriggerLimits.serdes.write(this)
+  override protected[entity] def toJson: JsValue = TriggerLimits.serdes.write(this)
 }
 
-protected[core] object ActionLimits
-    extends ArgNormalizer[ActionLimits]
-    with DefaultJsonProtocol {
+protected[core] object ActionLimits extends ArgNormalizer[ActionLimits] with DefaultJsonProtocol {
 
-    /** Creates a ActionLimits instance with default duration, memory and log limits. */
-    protected[core] def apply(): ActionLimits = ActionLimits(TimeLimit(), MemoryLimit(), LogLimit())
+  /** Creates a ActionLimits instance with default duration, memory and log limits. */
+  protected[core] def apply(): ActionLimits = ActionLimits(TimeLimit(), MemoryLimit(), LogLimit())
 
-    override protected[core] implicit val serdes = new RootJsonFormat[ActionLimits] {
-        val helper = jsonFormat3(ActionLimits.apply)
+  override protected[core] implicit val serdes = new RootJsonFormat[ActionLimits] {
+    val helper = jsonFormat3(ActionLimits.apply)
 
-        def read(value: JsValue) = {
-            val obj = Try {
-                value.asJsObject.convertTo[Map[String, JsValue]]
-            } getOrElse deserializationError("no valid json object passed")
+    def read(value: JsValue) = {
+      val obj = Try {
+        value.asJsObject.convertTo[Map[String, JsValue]]
+      } getOrElse deserializationError("no valid json object passed")
 
-            val time = TimeLimit.serdes.read(obj.get("timeout") getOrElse deserializationError("'timeout' is missing"))
-            val memory = MemoryLimit.serdes.read(obj.get("memory") getOrElse deserializationError("'memory' is missing"))
-            val logs = obj.get("logs") map { LogLimit.serdes.read(_) } getOrElse LogLimit()
+      val time = TimeLimit.serdes.read(obj.get("timeout") getOrElse deserializationError("'timeout' is missing"))
+      val memory = MemoryLimit.serdes.read(obj.get("memory") getOrElse deserializationError("'memory' is missing"))
+      val logs = obj.get("logs") map { LogLimit.serdes.read(_) } getOrElse LogLimit()
 
-            ActionLimits(time, memory, logs)
-        }
-
-        def write(a: ActionLimits) = helper.write(a)
+      ActionLimits(time, memory, logs)
     }
+
+    def write(a: ActionLimits) = helper.write(a)
+  }
 }
 
-protected[core] object TriggerLimits
-    extends ArgNormalizer[TriggerLimits]
-    with DefaultJsonProtocol {
+protected[core] object TriggerLimits extends ArgNormalizer[TriggerLimits] with DefaultJsonProtocol {
 
-    override protected[core] implicit val serdes = jsonFormat0(TriggerLimits.apply)
+  override protected[core] implicit val serdes = jsonFormat0(TriggerLimits.apply)
 }

--- a/common/scala/src/main/scala/whisk/core/entity/LogLimit.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/LogLimit.scala
@@ -41,42 +41,43 @@ import whisk.core.entity.size.SizeInt
  * @param megabytes the memory limit in megabytes for the action
  */
 protected[core] class LogLimit private (val megabytes: Int) extends AnyVal {
-    protected[core] def asMegaBytes: ByteSize = megabytes.megabytes
+  protected[core] def asMegaBytes: ByteSize = megabytes.megabytes
 }
 
 protected[core] object LogLimit extends ArgNormalizer[LogLimit] {
-    protected[core] val MIN_LOGSIZE = 0 MB
-    protected[core] val MAX_LOGSIZE = 10 MB
-    protected[core] val STD_LOGSIZE = 10 MB
+  protected[core] val MIN_LOGSIZE = 0 MB
+  protected[core] val MAX_LOGSIZE = 10 MB
+  protected[core] val STD_LOGSIZE = 10 MB
 
-    /** Gets LogLimit with default log limit */
-    protected[core] def apply(): LogLimit = LogLimit(STD_LOGSIZE)
+  /** Gets LogLimit with default log limit */
+  protected[core] def apply(): LogLimit = LogLimit(STD_LOGSIZE)
 
-    /**
-     * Creates LogLimit for limit. Only the default limit is allowed currently.
-     *
-     * @param megabytes the limit in megabytes, must be within permissible range
-     * @return LogLimit with limit set
-     * @throws IllegalArgumentException if limit does not conform to requirements
-     */
-    @throws[IllegalArgumentException]
-    protected[core] def apply(megabytes: ByteSize): LogLimit = {
-        require(megabytes >= MIN_LOGSIZE, s"log size $megabytes below allowed threshold of $MIN_LOGSIZE")
-        require(megabytes <= MAX_LOGSIZE, s"log size $megabytes exceeds allowed threshold of $MAX_LOGSIZE")
-        new LogLimit(megabytes.toMB.toInt);
-    }
+  /**
+   * Creates LogLimit for limit. Only the default limit is allowed currently.
+   *
+   * @param megabytes the limit in megabytes, must be within permissible range
+   * @return LogLimit with limit set
+   * @throws IllegalArgumentException if limit does not conform to requirements
+   */
+  @throws[IllegalArgumentException]
+  protected[core] def apply(megabytes: ByteSize): LogLimit = {
+    require(megabytes >= MIN_LOGSIZE, s"log size $megabytes below allowed threshold of $MIN_LOGSIZE")
+    require(megabytes <= MAX_LOGSIZE, s"log size $megabytes exceeds allowed threshold of $MAX_LOGSIZE")
+    new LogLimit(megabytes.toMB.toInt);
+  }
 
-    override protected[core] implicit val serdes = new RootJsonFormat[LogLimit] {
-        def write(m: LogLimit) = JsNumber(m.megabytes)
+  override protected[core] implicit val serdes = new RootJsonFormat[LogLimit] {
+    def write(m: LogLimit) = JsNumber(m.megabytes)
 
-        def read(value: JsValue) = Try {
-            val JsNumber(mb) = value
-            require(mb.isWhole(), "log limit must be whole number")
-            LogLimit(mb.intValue MB)
-        } match {
-            case Success(limit)                       => limit
-            case Failure(e: IllegalArgumentException) => deserializationError(e.getMessage, e)
-            case Failure(e: Throwable)                => deserializationError("log limit malformed", e)
-        }
-    }
+    def read(value: JsValue) =
+      Try {
+        val JsNumber(mb) = value
+        require(mb.isWhole(), "log limit must be whole number")
+        LogLimit(mb.intValue MB)
+      } match {
+        case Success(limit)                       => limit
+        case Failure(e: IllegalArgumentException) => deserializationError(e.getMessage, e)
+        case Failure(e: Throwable)                => deserializationError("log limit malformed", e)
+      }
+  }
 }

--- a/common/scala/src/main/scala/whisk/core/entity/MemoryLimit.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/MemoryLimit.scala
@@ -38,42 +38,42 @@ import whisk.core.entity.size.SizeInt
  *
  * @param megabytes the memory limit in megabytes for the action
  */
-protected[entity] class MemoryLimit private (val megabytes: Int) extends AnyVal {
-}
+protected[entity] class MemoryLimit private (val megabytes: Int) extends AnyVal {}
 
 protected[core] object MemoryLimit extends ArgNormalizer[MemoryLimit] {
-    protected[core] val MIN_MEMORY = 128 MB
-    protected[core] val MAX_MEMORY = 512 MB
-    protected[core] val STD_MEMORY = 256 MB
+  protected[core] val MIN_MEMORY = 128 MB
+  protected[core] val MAX_MEMORY = 512 MB
+  protected[core] val STD_MEMORY = 256 MB
 
-    /** Gets TimeLimit with default duration */
-    protected[core] def apply(): MemoryLimit = MemoryLimit(STD_MEMORY)
+  /** Gets TimeLimit with default duration */
+  protected[core] def apply(): MemoryLimit = MemoryLimit(STD_MEMORY)
 
-    /**
-     * Creates MemoryLimit for limit, iff limit is within permissible range.
-     *
-     * @param megabytes the limit in megabytes, must be within permissible range
-     * @return MemoryLimit with limit set
-     * @throws IllegalArgumentException if limit does not conform to requirements
-     */
-    @throws[IllegalArgumentException]
-    protected[core] def apply(megabytes: ByteSize): MemoryLimit = {
-        require(megabytes >= MIN_MEMORY, s"memory $megabytes below allowed threshold of $MIN_MEMORY")
-        require(megabytes <= MAX_MEMORY, s"memory $megabytes exceeds allowed threshold of $MAX_MEMORY")
-        new MemoryLimit(megabytes.toMB.toInt);
-    }
+  /**
+   * Creates MemoryLimit for limit, iff limit is within permissible range.
+   *
+   * @param megabytes the limit in megabytes, must be within permissible range
+   * @return MemoryLimit with limit set
+   * @throws IllegalArgumentException if limit does not conform to requirements
+   */
+  @throws[IllegalArgumentException]
+  protected[core] def apply(megabytes: ByteSize): MemoryLimit = {
+    require(megabytes >= MIN_MEMORY, s"memory $megabytes below allowed threshold of $MIN_MEMORY")
+    require(megabytes <= MAX_MEMORY, s"memory $megabytes exceeds allowed threshold of $MAX_MEMORY")
+    new MemoryLimit(megabytes.toMB.toInt);
+  }
 
-    override protected[core] implicit val serdes = new RootJsonFormat[MemoryLimit] {
-        def write(m: MemoryLimit) = JsNumber(m.megabytes)
+  override protected[core] implicit val serdes = new RootJsonFormat[MemoryLimit] {
+    def write(m: MemoryLimit) = JsNumber(m.megabytes)
 
-        def read(value: JsValue) = Try {
-            val JsNumber(mb) = value
-            require(mb.isWhole(), "memory limit must be whole number")
-            MemoryLimit(mb.intValue MB)
-        } match {
-            case Success(limit)                       => limit
-            case Failure(e: IllegalArgumentException) => deserializationError(e.getMessage, e)
-            case Failure(e: Throwable)                => deserializationError("memory limit malformed", e)
-        }
-    }
+    def read(value: JsValue) =
+      Try {
+        val JsNumber(mb) = value
+        require(mb.isWhole(), "memory limit must be whole number")
+        MemoryLimit(mb.intValue MB)
+      } match {
+        case Success(limit)                       => limit
+        case Failure(e: IllegalArgumentException) => deserializationError(e.getMessage, e)
+        case Failure(e: Throwable)                => deserializationError("memory limit malformed", e)
+      }
+  }
 }

--- a/common/scala/src/main/scala/whisk/core/entity/Parameter.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Parameter.scala
@@ -31,83 +31,93 @@ import whisk.core.entity.size.SizeString
  * @param key the parameter name, assured to be non-null because it is a value
  * @param value the parameter value, assured to be non-null because it is a value
  */
-protected[core] class Parameters protected[entity] (
-    private val params: Map[ParameterName, ParameterValue])
+protected[core] class Parameters protected[entity] (private val params: Map[ParameterName, ParameterValue])
     extends AnyVal {
 
-    /**
-     * Calculates the size in Bytes of the Parameters-instance.
-     *
-     * @return Size of instance as ByteSize
-     */
-    def size = params.map {
+  /**
+   * Calculates the size in Bytes of the Parameters-instance.
+   *
+   * @return Size of instance as ByteSize
+   */
+  def size =
+    params
+      .map {
         case (name, value) =>
-            name.size + value.size
-    }.foldLeft(0 B)(_ + _)
+          name.size + value.size
+      }
+      .foldLeft(0 B)(_ + _)
 
-    protected[entity] def +(p: (ParameterName, ParameterValue)) = {
-        Option(p) map { p => new Parameters(params + (p._1 -> p._2)) } getOrElse this
+  protected[entity] def +(p: (ParameterName, ParameterValue)) = {
+    Option(p) map { p =>
+      new Parameters(params + (p._1 -> p._2))
+    } getOrElse this
+  }
+
+  protected[entity] def +(p: ParameterName, v: ParameterValue) = {
+    new Parameters(params + (p -> v))
+  }
+
+  /** Add parameters from p to existing map, overwriting existing values in case of overlap in keys. */
+  protected[core] def ++(p: Parameters) = new Parameters(params ++ p.params)
+
+  /** Remove parameter by name. */
+  protected[core] def -(p: String) = {
+    // wrap with try since parameter name may throw an exception for illegal p
+    Try(new Parameters(params - new ParameterName(p))) getOrElse this
+  }
+
+  /** Gets list all defined parameters. */
+  protected[core] def definedParameters: Set[String] = {
+    params.keySet filter (params(_).isDefined) map (_.name)
+  }
+
+  protected[core] def toJsArray =
+    JsArray(params map { p =>
+      JsObject("key" -> p._1.name.toJson, "value" -> p._2.value.toJson)
+    } toSeq: _*)
+  protected[core] def toJsObject =
+    JsObject(params map { p =>
+      (p._1.name -> p._2.value.toJson)
+    })
+  override def toString = toJsArray.compactPrint
+
+  /**
+   * Converts parameters to JSON object and merge keys with payload if defined.
+   * In case of overlap, the keys in the payload supersede.
+   */
+  protected[core] def merge(payload: Option[JsObject]): Some[JsObject] = {
+    val args = payload getOrElse JsObject()
+    Some { (toJsObject.fields ++ args.fields).toJson.asJsObject }
+  }
+
+  /**
+   * Retrieves parameter by name if it exists.
+   */
+  protected[core] def get(p: String): Option[JsValue] = {
+    params.get(new ParameterName(p)).map(_.value)
+  }
+
+  /**
+   * Retrieves parameter by name if it exist. If value of parameter
+   * is a boolean, return its value else false.
+   */
+  protected[core] def asBool(p: String): Option[Boolean] = {
+    get(p) flatMap {
+      case JsBoolean(b) => Some(b)
+      case _            => None
     }
+  }
 
-    protected[entity] def +(p: ParameterName, v: ParameterValue) = {
-        new Parameters(params + (p -> v))
+  /**
+   * Retrieves parameter by name if it exist. If value of parameter
+   * is a string, return its value else none.
+   */
+  protected[core] def asString(p: String): Option[String] = {
+    get(p) flatMap {
+      case JsString(s) => Some(s)
+      case _           => None
     }
-
-    /** Add parameters from p to existing map, overwriting existing values in case of overlap in keys. */
-    protected[core] def ++(p: Parameters) = new Parameters(params ++ p.params)
-
-    /** Remove parameter by name. */
-    protected[core] def -(p: String) = {
-        // wrap with try since parameter name may throw an exception for illegal p
-        Try(new Parameters(params - new ParameterName(p))) getOrElse this
-    }
-
-    /** Gets list all defined parameters. */
-    protected[core] def definedParameters: Set[String] = {
-        params.keySet filter (params(_).isDefined) map (_.name)
-    }
-
-    protected[core] def toJsArray = JsArray(params map { p => JsObject("key" -> p._1.name.toJson, "value" -> p._2.value.toJson) } toSeq: _*)
-    protected[core] def toJsObject = JsObject(params map { p => (p._1.name -> p._2.value.toJson) })
-    override def toString = toJsArray.compactPrint
-
-    /**
-     * Converts parameters to JSON object and merge keys with payload if defined.
-     * In case of overlap, the keys in the payload supersede.
-     */
-    protected[core] def merge(payload: Option[JsObject]): Some[JsObject] = {
-        val args = payload getOrElse JsObject()
-        Some { (toJsObject.fields ++ args.fields).toJson.asJsObject }
-    }
-
-    /**
-     * Retrieves parameter by name if it exists.
-     */
-    protected[core] def get(p: String): Option[JsValue] = {
-        params.get(new ParameterName(p)).map(_.value)
-    }
-
-    /**
-     * Retrieves parameter by name if it exist. If value of parameter
-     * is a boolean, return its value else false.
-     */
-    protected[core] def asBool(p: String): Option[Boolean] = {
-        get(p) flatMap {
-            case JsBoolean(b) => Some(b)
-            case _            => None
-        }
-    }
-
-    /**
-     * Retrieves parameter by name if it exist. If value of parameter
-     * is a string, return its value else none.
-     */
-    protected[core] def asString(p: String): Option[String] = {
-        get(p) flatMap {
-            case JsString(s) => Some(s)
-            case _           => None
-        }
-    }
+  }
 }
 
 /**
@@ -121,10 +131,11 @@ protected[core] class Parameters protected[entity] (
  * @param name the name of the parameter (its key)
  */
 protected[entity] class ParameterName protected[entity] (val name: String) extends AnyVal {
-    /**
-     * The size of the ParameterName entity as ByteSize.
-     */
-    def size = name sizeInBytes
+
+  /**
+   * The size of the ParameterName entity as ByteSize.
+   */
+  def size = name sizeInBytes
 }
 
 /**
@@ -140,92 +151,92 @@ protected[entity] class ParameterName protected[entity] (val name: String) exten
  * @param value the value of the parameter, may be null
  */
 protected[entity] class ParameterValue protected[entity] (private val v: JsValue) extends AnyVal {
-    /** @return JsValue if defined else JsNull. */
-    protected[entity] def value = Option(v) getOrElse JsNull
 
-    /** @return true iff value is not JsNull. */
-    protected[entity] def isDefined = value != JsNull
+  /** @return JsValue if defined else JsNull. */
+  protected[entity] def value = Option(v) getOrElse JsNull
 
-    /**
-     * The size of the ParameterValue entity as ByteSize.
-     */
-    def size = value.toString.sizeInBytes
+  /** @return true iff value is not JsNull. */
+  protected[entity] def isDefined = value != JsNull
+
+  /**
+   * The size of the ParameterValue entity as ByteSize.
+   */
+  def size = value.toString.sizeInBytes
 }
 
 protected[core] object Parameters extends ArgNormalizer[Parameters] {
 
-    /** Name of parameter that indicates if action is a feed. */
-    protected[core] val Feed = "feed"
-    protected[core] val sizeLimit = 1 MB
+  /** Name of parameter that indicates if action is a feed. */
+  protected[core] val Feed = "feed"
+  protected[core] val sizeLimit = 1 MB
 
-    protected[core] def apply(): Parameters = new Parameters(Map())
+  protected[core] def apply(): Parameters = new Parameters(Map())
+
+  /**
+   * Creates a parameter tuple from a pair of strings.
+   * A convenience method for tests.
+   *
+   * @param p the parameter name
+   * @param v the parameter value
+   * @return (ParameterName, ParameterValue)
+   * @throws IllegalArgumentException if key is not defined
+   */
+  @throws[IllegalArgumentException]
+  protected[core] def apply(p: String, v: String): Parameters = {
+    require(p != null && p.trim.nonEmpty, "key undefined")
+    Parameters() + (new ParameterName(ArgNormalizer.trim(p)),
+    new ParameterValue(Option(v) map { _.trim.toJson } getOrElse JsNull))
+  }
+
+  /**
+   * Creates a parameter tuple from a parameter name and JsValue.
+   *
+   * @param p the parameter name
+   * @param v the parameter value
+   * @return (ParameterName, ParameterValue)
+   * @throws IllegalArgumentException if key is not defined
+   */
+  @throws[IllegalArgumentException]
+  protected[core] def apply(p: String, v: JsValue): Parameters = {
+    require(p != null && p.trim.nonEmpty, "key undefined")
+    Parameters() + (new ParameterName(ArgNormalizer.trim(p)),
+    new ParameterValue(Option(v) getOrElse JsNull))
+  }
+
+  override protected[core] implicit val serdes = new RootJsonFormat[Parameters] {
+    def write(p: Parameters) = p.toJsArray
 
     /**
-     * Creates a parameter tuple from a pair of strings.
-     * A convenience method for tests.
+     * Gets parameters as a Parameters instances. The argument should be a JArray
+     * [{key,value}], otherwise an IllegalParameter is thrown.
      *
-     * @param p the parameter name
-     * @param v the parameter value
-     * @return (ParameterName, ParameterValue)
-     * @throws IllegalArgumentException if key is not defined
+     * @param parameters the JSON representation of an parameter array
+     * @return Parameters instance if parameters conforms to schema
      */
-    @throws[IllegalArgumentException]
-    protected[core] def apply(p: String, v: String): Parameters = {
-        require(p != null && p.trim.nonEmpty, "key undefined")
-        Parameters() + (
-            new ParameterName(ArgNormalizer.trim(p)),
-            new ParameterValue(Option(v) map { _.trim.toJson } getOrElse JsNull))
-    }
+    def read(value: JsValue) =
+      Try {
+        val JsArray(params) = value
+        params
+      } flatMap {
+        read(_)
+      } getOrElse deserializationError("parameters malformed!")
 
     /**
-     * Creates a parameter tuple from a parameter name and JsValue.
+     * Gets parameters as a Parameters instances.
+     * The argument should be a [{key,value}].
      *
-     * @param p the parameter name
-     * @param v the parameter value
-     * @return (ParameterName, ParameterValue)
-     * @throws IllegalArgumentException if key is not defined
+     * @param parameters the JSON representation of an parameter array
+     * @return Parameters instance if parameters conforms to schema
      */
-    @throws[IllegalArgumentException]
-    protected[core] def apply(p: String, v: JsValue): Parameters = {
-        require(p != null && p.trim.nonEmpty, "key undefined")
-        Parameters() + (
-            new ParameterName(ArgNormalizer.trim(p)),
-            new ParameterValue(Option(v) getOrElse JsNull))
-    }
-
-    override protected[core] implicit val serdes = new RootJsonFormat[Parameters] {
-        def write(p: Parameters) = p.toJsArray
-
-        /**
-         * Gets parameters as a Parameters instances. The argument should be a JArray
-         * [{key,value}], otherwise an IllegalParameter is thrown.
-         *
-         * @param parameters the JSON representation of an parameter array
-         * @return Parameters instance if parameters conforms to schema
-         */
-        def read(value: JsValue) = Try {
-            val JsArray(params) = value
-            params
-        } flatMap {
-            read(_)
-        } getOrElse deserializationError("parameters malformed!")
-
-        /**
-         * Gets parameters as a Parameters instances.
-         * The argument should be a [{key,value}].
-         *
-         * @param parameters the JSON representation of an parameter array
-         * @return Parameters instance if parameters conforms to schema
-         */
-        def read(params: Vector[JsValue]) = Try {
-            new Parameters(params map {
-                _.asJsObject.getFields("key", "value") match {
-                    case Seq(JsString(k), v: JsValue) =>
-                        val key = new ParameterName(k)
-                        val value = new ParameterValue(v)
-                        (key, value)
-                }
-            } toMap)
+    def read(params: Vector[JsValue]) = Try {
+      new Parameters(params map {
+        _.asJsObject.getFields("key", "value") match {
+          case Seq(JsString(k), v: JsValue) =>
+            val key = new ParameterName(k)
+            val value = new ParameterValue(v)
+            (key, value)
         }
+      } toMap)
     }
+  }
 }

--- a/common/scala/src/main/scala/whisk/core/entity/Secret.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Secret.scala
@@ -33,49 +33,51 @@ import spray.json.deserializationError
  * @param key the secret key, required not null or empty
  */
 protected[core] class Secret private (val key: String) extends AnyVal {
-    protected[core] def asString = toString
-    protected[entity] def toJson = JsString(toString)
-    override def toString = key
+  protected[core] def asString = toString
+  protected[entity] def toJson = JsString(toString)
+  override def toString = key
 }
 
 protected[core] object Secret extends ArgNormalizer[Secret] {
-    /** Minimum secret length */
-    private val MIN_LENGTH = 64
 
-    /** Maximum secret length */
-    private val MAX_LENGTH = 64
+  /** Minimum secret length */
+  private val MIN_LENGTH = 64
 
-    /**
-     * Creates a Secret from a string. The string must be a valid secret already.
-     *
-     * @param str the secret as string, at least 64 characters
-     * @return Secret instance
-     * @throws IllegalArgumentException is argument is not a valid Secret
-     */
-    @throws[IllegalArgumentException]
-    override protected[entity] def factory(str: String): Secret = {
-        require(str.length >= MIN_LENGTH, s"secret must be at least $MIN_LENGTH characters")
-        require(str.length <= MAX_LENGTH, s"secret must be at most $MAX_LENGTH characters")
-        new Secret(str)
-    }
+  /** Maximum secret length */
+  private val MAX_LENGTH = 64
 
-    /**
-     * Creates a new random secret.
-     *
-     * @return Secret
-     */
-    protected[core] def apply(): Secret = {
-        Secret(rand.alphanumeric.take(MIN_LENGTH).mkString)
-    }
+  /**
+   * Creates a Secret from a string. The string must be a valid secret already.
+   *
+   * @param str the secret as string, at least 64 characters
+   * @return Secret instance
+   * @throws IllegalArgumentException is argument is not a valid Secret
+   */
+  @throws[IllegalArgumentException]
+  override protected[entity] def factory(str: String): Secret = {
+    require(str.length >= MIN_LENGTH, s"secret must be at least $MIN_LENGTH characters")
+    require(str.length <= MAX_LENGTH, s"secret must be at most $MAX_LENGTH characters")
+    new Secret(str)
+  }
 
-    implicit val serdes = new RootJsonFormat[Secret] {
-        def write(s: Secret) = s.toJson
+  /**
+   * Creates a new random secret.
+   *
+   * @return Secret
+   */
+  protected[core] def apply(): Secret = {
+    Secret(rand.alphanumeric.take(MIN_LENGTH).mkString)
+  }
 
-        def read(value: JsValue) = Try {
-            val JsString(s) = value
-            Secret(s)
-        } getOrElse deserializationError("secret malformed")
-    }
+  implicit val serdes = new RootJsonFormat[Secret] {
+    def write(s: Secret) = s.toJson
 
-    private val rand = new scala.util.Random(new java.security.SecureRandom())
+    def read(value: JsValue) =
+      Try {
+        val JsString(s) = value
+        Secret(s)
+      } getOrElse deserializationError("secret malformed")
+  }
+
+  private val rand = new scala.util.Random(new java.security.SecureRandom())
 }

--- a/common/scala/src/main/scala/whisk/core/entity/SemVer.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/SemVer.scala
@@ -36,66 +36,67 @@ import scala.util.Try
  */
 protected[core] class SemVer private (private val version: (Int, Int, Int)) extends AnyVal {
 
-    protected[core] def major = version._1
-    protected[core] def minor = version._2
-    protected[core] def patch = version._3
+  protected[core] def major = version._1
+  protected[core] def minor = version._2
+  protected[core] def patch = version._3
 
-    protected[core] def upMajor = SemVer(major + 1, minor, patch)
-    protected[core] def upMinor = SemVer(major, minor + 1, patch)
-    protected[core] def upPatch = SemVer(major, minor, patch + 1)
+  protected[core] def upMajor = SemVer(major + 1, minor, patch)
+  protected[core] def upMinor = SemVer(major, minor + 1, patch)
+  protected[core] def upPatch = SemVer(major, minor, patch + 1)
 
-    protected[entity] def toJson = JsString(toString)
-    override def toString = s"$major.$minor.$patch"
+  protected[entity] def toJson = JsString(toString)
+  override def toString = s"$major.$minor.$patch"
 }
 
 protected[core] object SemVer {
-    protected[core] val REGEX = """(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"""
+  protected[core] val REGEX = """(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"""
 
-    /** Default semantic version */
-    protected[core] def apply() = new SemVer(0, 0, 1)
+  /** Default semantic version */
+  protected[core] def apply() = new SemVer(0, 0, 1)
 
-    /**
-     * Creates a semantic version.
-     *
-     * @param major the major >= 0
-     * @param minor the minor >= 0
-     * @param patch the patch >= 0
-     * @return SemVer instance
-     * @throws IllegalArgumentException if the parameters results in an invalid semantic version
-     */
-    protected[core] def apply(major: Int, minor: Int, patch: Int): SemVer = {
-        if ((major == 0 && minor == 0 && patch == 0) || (major < 0 || minor < 0 || patch < 0)) {
-            throw new IllegalArgumentException(s"bad semantic version $major.$minor.$patch must not be negative")
-        } else new SemVer(major, minor, patch)
+  /**
+   * Creates a semantic version.
+   *
+   * @param major the major >= 0
+   * @param minor the minor >= 0
+   * @param patch the patch >= 0
+   * @return SemVer instance
+   * @throws IllegalArgumentException if the parameters results in an invalid semantic version
+   */
+  protected[core] def apply(major: Int, minor: Int, patch: Int): SemVer = {
+    if ((major == 0 && minor == 0 && patch == 0) || (major < 0 || minor < 0 || patch < 0)) {
+      throw new IllegalArgumentException(s"bad semantic version $major.$minor.$patch must not be negative")
+    } else new SemVer(major, minor, patch)
+  }
+
+  /**
+   * Parses a string representation of a semantic version and creates
+   * a instance of SemVer. If the string is not properly formatted, an
+   * IllegalSemVer exception is thrown.
+   *
+   * @param str to parse to extract semantic version
+   * @return SemVer instance
+   * @thrown IllegalArgumentException if string is not a valid semantic version
+   */
+  protected[entity] def apply(str: String): SemVer = {
+    try {
+      val parts = if (str != null && str.nonEmpty) str.split('.') else Array[String]()
+      val major = if (parts.size >= 1) parts(0).toInt else 0
+      val minor = if (parts.size >= 2) parts(1).toInt else 0
+      val patch = if (parts.size >= 3) parts(2).toInt else 0
+      SemVer(major, minor, patch)
+    } catch {
+      case _: Throwable => throw new IllegalArgumentException(s"bad semantic version $str")
     }
+  }
 
-    /**
-     * Parses a string representation of a semantic version and creates
-     * a instance of SemVer. If the string is not properly formatted, an
-     * IllegalSemVer exception is thrown.
-     *
-     * @param str to parse to extract semantic version
-     * @return SemVer instance
-     * @thrown IllegalArgumentException if string is not a valid semantic version
-     */
-    protected[entity] def apply(str: String): SemVer = {
-        try {
-            val parts = if (str != null && str.nonEmpty) str.split('.') else Array[String]()
-            val major = if (parts.size >= 1) parts(0).toInt else 0
-            val minor = if (parts.size >= 2) parts(1).toInt else 0
-            val patch = if (parts.size >= 3) parts(2).toInt else 0
-            SemVer(major, minor, patch)
-        } catch {
-            case _: Throwable => throw new IllegalArgumentException(s"bad semantic version $str")
-        }
-    }
+  implicit val serdes = new RootJsonFormat[SemVer] {
+    def write(v: SemVer) = v.toJson
 
-    implicit val serdes = new RootJsonFormat[SemVer] {
-        def write(v: SemVer) = v.toJson
-
-        def read(value: JsValue) = Try {
-            val JsString(v) = value
-            SemVer(v)
-        } getOrElse deserializationError("semantic version malformed")
-    }
+    def read(value: JsValue) =
+      Try {
+        val JsString(v) = value
+        SemVer(v)
+      } getOrElse deserializationError("semantic version malformed")
+  }
 }

--- a/common/scala/src/main/scala/whisk/core/entity/Size.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Size.scala
@@ -21,107 +21,108 @@ import java.nio.charset.StandardCharsets
 
 object SizeUnits extends Enumeration {
 
-    sealed abstract class Unit() {
-        def toBytes(n: Long): Long
-        def toKBytes(n: Long): Long
-        def toMBytes(n: Long): Long
-    }
+  sealed abstract class Unit() {
+    def toBytes(n: Long): Long
+    def toKBytes(n: Long): Long
+    def toMBytes(n: Long): Long
+  }
 
-    case object BYTE extends Unit {
-        def toBytes(n: Long): Long = n
-        def toKBytes(n: Long): Long = n / 1024
-        def toMBytes(n: Long): Long = n / 1024 / 1024
-    }
-    case object KB extends Unit {
-        def toBytes(n: Long): Long = n * 1024
-        def toKBytes(n: Long): Long = n
-        def toMBytes(n: Long): Long = n / 1024
-    }
-    case object MB extends Unit {
-        def toBytes(n: Long): Long = n * 1024 * 1024
-        def toKBytes(n: Long): Long = n * 1024
-        def toMBytes(n: Long): Long = n
-    }
+  case object BYTE extends Unit {
+    def toBytes(n: Long): Long = n
+    def toKBytes(n: Long): Long = n / 1024
+    def toMBytes(n: Long): Long = n / 1024 / 1024
+  }
+  case object KB extends Unit {
+    def toBytes(n: Long): Long = n * 1024
+    def toKBytes(n: Long): Long = n
+    def toMBytes(n: Long): Long = n / 1024
+  }
+  case object MB extends Unit {
+    def toBytes(n: Long): Long = n * 1024 * 1024
+    def toKBytes(n: Long): Long = n * 1024
+    def toMBytes(n: Long): Long = n
+  }
 }
 
 case class ByteSize(size: Long, unit: SizeUnits.Unit) extends Ordered[ByteSize] {
 
-    require(size >= 0, "a negative size of an object is not allowed.")
+  require(size >= 0, "a negative size of an object is not allowed.")
 
-    def toBytes = unit.toBytes(size)
-    def toKB = unit.toKBytes(size)
-    def toMB = unit.toMBytes(size)
+  def toBytes = unit.toBytes(size)
+  def toKB = unit.toKBytes(size)
+  def toMB = unit.toMBytes(size)
 
-    def +(other: ByteSize): ByteSize = {
-        val commonUnit = SizeUnits.BYTE
-        val commonSize = other.toBytes + toBytes
-        ByteSize(commonSize, commonUnit)
+  def +(other: ByteSize): ByteSize = {
+    val commonUnit = SizeUnits.BYTE
+    val commonSize = other.toBytes + toBytes
+    ByteSize(commonSize, commonUnit)
+  }
+
+  def -(other: ByteSize): ByteSize = {
+    val commonUnit = SizeUnits.BYTE
+    val commonSize = toBytes - other.toBytes
+    ByteSize(commonSize, commonUnit)
+  }
+
+  def compare(other: ByteSize) = toBytes compare other.toBytes
+
+  override def toString = {
+    unit match {
+      case SizeUnits.BYTE => s"$size B"
+      case SizeUnits.KB   => s"$size KB"
+      case SizeUnits.MB   => s"$size MB"
     }
-
-    def -(other: ByteSize): ByteSize = {
-        val commonUnit = SizeUnits.BYTE
-        val commonSize = toBytes - other.toBytes
-        ByteSize(commonSize, commonUnit)
-    }
-
-    def compare(other: ByteSize) = toBytes compare other.toBytes
-
-    override def toString = {
-        unit match {
-            case SizeUnits.BYTE => s"$size B"
-            case SizeUnits.KB   => s"$size KB"
-            case SizeUnits.MB   => s"$size MB"
-        }
-    }
+  }
 }
 
 object ByteSize {
-    def fromString(sizeString: String): ByteSize = {
-        val unitprefix = sizeString.takeRight(1)
-        val size = sizeString.dropRight(1).toLong
+  def fromString(sizeString: String): ByteSize = {
+    val unitprefix = sizeString.takeRight(1)
+    val size = sizeString.dropRight(1).toLong
 
-        val unit = unitprefix match {
-            case "B" => SizeUnits.BYTE
-            case "K" => SizeUnits.KB
-            case "M" => SizeUnits.MB
-            case _   => throw new IllegalArgumentException("""Size Unit not supported. Only "B", "K" and "M" are supported.""")
-        }
-
-        ByteSize(size, unit)
+    val unit = unitprefix match {
+      case "B" => SizeUnits.BYTE
+      case "K" => SizeUnits.KB
+      case "M" => SizeUnits.MB
+      case _   => throw new IllegalArgumentException("""Size Unit not supported. Only "B", "K" and "M" are supported.""")
     }
+
+    ByteSize(size, unit)
+  }
 }
 
 object size {
-    implicit class SizeInt(n: Int) extends SizeConversion {
-        def sizeIn(unit: SizeUnits.Unit): ByteSize = ByteSize(n, unit)
-    }
+  implicit class SizeInt(n: Int) extends SizeConversion {
+    def sizeIn(unit: SizeUnits.Unit): ByteSize = ByteSize(n, unit)
+  }
 
-    implicit class SizeLong(n: Long) extends SizeConversion {
-        def sizeIn(unit: SizeUnits.Unit): ByteSize = ByteSize(n, unit)
-    }
+  implicit class SizeLong(n: Long) extends SizeConversion {
+    def sizeIn(unit: SizeUnits.Unit): ByteSize = ByteSize(n, unit)
+  }
 
-    implicit class SizeString(n: String) extends SizeConversion {
-        def sizeIn(unit: SizeUnits.Unit): ByteSize = ByteSize(n.getBytes(StandardCharsets.UTF_8).length, unit)
-    }
+  implicit class SizeString(n: String) extends SizeConversion {
+    def sizeIn(unit: SizeUnits.Unit): ByteSize = ByteSize(n.getBytes(StandardCharsets.UTF_8).length, unit)
+  }
 
-    implicit class SizeOptionString(n: Option[String]) extends SizeConversion {
-        def sizeIn(unit: SizeUnits.Unit): ByteSize = n map { s =>
-            s.sizeIn(unit)
-        } getOrElse {
-            ByteSize(0, unit)
-        }
-    }
+  implicit class SizeOptionString(n: Option[String]) extends SizeConversion {
+    def sizeIn(unit: SizeUnits.Unit): ByteSize =
+      n map { s =>
+        s.sizeIn(unit)
+      } getOrElse {
+        ByteSize(0, unit)
+      }
+  }
 }
 
 trait SizeConversion {
-    def B = sizeIn(SizeUnits.BYTE)
-    def KB = sizeIn(SizeUnits.KB)
-    def MB = sizeIn(SizeUnits.MB)
-    def bytes = B
-    def kilobytes = KB
-    def megabytes = MB
+  def B = sizeIn(SizeUnits.BYTE)
+  def KB = sizeIn(SizeUnits.KB)
+  def MB = sizeIn(SizeUnits.MB)
+  def bytes = B
+  def kilobytes = KB
+  def megabytes = MB
 
-    def sizeInBytes = sizeIn(SizeUnits.BYTE)
+  def sizeInBytes = sizeIn(SizeUnits.BYTE)
 
-    def sizeIn(unit: SizeUnits.Unit): ByteSize
+  def sizeIn(unit: SizeUnits.Unit): ByteSize
 }

--- a/common/scala/src/main/scala/whisk/core/entity/Subject.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Subject.scala
@@ -25,45 +25,47 @@ import spray.json.RootJsonFormat
 import spray.json.deserializationError
 
 protected[core] class Subject private (private val subject: String) extends AnyVal {
-    protected[core] def asString = subject // to make explicit that this is a string conversion
-    protected[entity] def toJson = JsString(subject)
-    override def toString = subject
+  protected[core] def asString = subject // to make explicit that this is a string conversion
+  protected[entity] def toJson = JsString(subject)
+  override def toString = subject
 }
 
 protected[core] object Subject extends ArgNormalizer[Subject] {
-    /** Minimum subject length */
-    protected[core] val MIN_LENGTH = 5
 
-    /**
-     * Creates a Subject from a string.
-     *
-     * @param str the subject name, at least 6 characters
-     * @return Subject instance
-     * @throws IllegalArgumentException is argument is undefined
-     */
-    @throws[IllegalArgumentException]
-    override protected[entity] def factory(str: String): Subject = {
-        require(str.length >= MIN_LENGTH, s"subject must be at least $MIN_LENGTH characters")
-        new Subject(str)
-    }
+  /** Minimum subject length */
+  protected[core] val MIN_LENGTH = 5
 
-    /**
-     * Creates a random subject
-     *
-     * @return Subject
-     */
-    protected[core] def apply(): Subject = {
-        Subject("anon-" + rand.alphanumeric.take(27).mkString)
-    }
+  /**
+   * Creates a Subject from a string.
+   *
+   * @param str the subject name, at least 6 characters
+   * @return Subject instance
+   * @throws IllegalArgumentException is argument is undefined
+   */
+  @throws[IllegalArgumentException]
+  override protected[entity] def factory(str: String): Subject = {
+    require(str.length >= MIN_LENGTH, s"subject must be at least $MIN_LENGTH characters")
+    new Subject(str)
+  }
 
-    override protected[core] implicit val serdes = new RootJsonFormat[Subject] {
-        def write(s: Subject) = s.toJson
+  /**
+   * Creates a random subject
+   *
+   * @return Subject
+   */
+  protected[core] def apply(): Subject = {
+    Subject("anon-" + rand.alphanumeric.take(27).mkString)
+  }
 
-        def read(value: JsValue) = Try {
-            val JsString(s) = value
-            Subject(s)
-        } getOrElse deserializationError("subject malformed")
-    }
+  override protected[core] implicit val serdes = new RootJsonFormat[Subject] {
+    def write(s: Subject) = s.toJson
 
-    private val rand = new scala.util.Random()
+    def read(value: JsValue) =
+      Try {
+        val JsString(s) = value
+        Subject(s)
+      } getOrElse deserializationError("subject malformed")
+  }
+
+  private val rand = new scala.util.Random()
 }

--- a/common/scala/src/main/scala/whisk/core/entity/UUID.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/UUID.scala
@@ -34,38 +34,40 @@ import spray.json.deserializationError
  * @param uuid the uuid, required not null
  */
 protected[core] class UUID private (private val uuid: java.util.UUID) extends AnyVal {
-    protected[core] def asString = toString
-    protected[core] def snippet = toString.substring(0, 8)
-    protected[entity] def toJson = JsString(toString)
-    override def toString = uuid.toString
+  protected[core] def asString = toString
+  protected[core] def snippet = toString.substring(0, 8)
+  protected[entity] def toJson = JsString(toString)
+  override def toString = uuid.toString
 }
 
 protected[core] object UUID extends ArgNormalizer[UUID] {
-    /**
-     * Creates a UUID from a string. The string must be a valid UUID.
-     *
-     * @param str the uuid as string
-     * @return UUID instance
-     * @throws IllegalArgumentException is argument is not a valid UUID
-     */
-    @throws[IllegalArgumentException]
-    override protected[entity] def factory(str: String): UUID = {
-        new UUID(java.util.UUID.fromString(str))
-    }
 
-    /**
-     * Generates a random UUID using java.util.UUID factory.
-     *
-     * @return new UUID
-     */
-    protected[core] def apply(): UUID = new UUID(java.util.UUID.randomUUID())
+  /**
+   * Creates a UUID from a string. The string must be a valid UUID.
+   *
+   * @param str the uuid as string
+   * @return UUID instance
+   * @throws IllegalArgumentException is argument is not a valid UUID
+   */
+  @throws[IllegalArgumentException]
+  override protected[entity] def factory(str: String): UUID = {
+    new UUID(java.util.UUID.fromString(str))
+  }
 
-    implicit val serdes = new RootJsonFormat[UUID] {
-        def write(u: UUID) = u.toJson
+  /**
+   * Generates a random UUID using java.util.UUID factory.
+   *
+   * @return new UUID
+   */
+  protected[core] def apply(): UUID = new UUID(java.util.UUID.randomUUID())
 
-        def read(value: JsValue) = Try {
-            val JsString(u) = value
-            UUID(u)
-        } getOrElse deserializationError("uuid malformed")
-    }
+  implicit val serdes = new RootJsonFormat[UUID] {
+    def write(u: UUID) = u.toJson
+
+    def read(value: JsValue) =
+      Try {
+        val JsString(u) = value
+        UUID(u)
+      } getOrElse deserializationError("uuid malformed")
+  }
 }

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAuth.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAuth.scala
@@ -28,19 +28,18 @@ import scala.util.Try
 protected[core] case class WhiskNamespace(name: EntityName, authkey: AuthKey)
 
 protected[core] object WhiskNamespace extends DefaultJsonProtocol {
-    implicit val serdes = new RootJsonFormat[WhiskNamespace] {
-        def write(w: WhiskNamespace) = JsObject(
-            "name" -> w.name.toJson,
-            "uuid" -> w.authkey.uuid.toJson,
-            "key" -> w.authkey.key.toJson)
+  implicit val serdes = new RootJsonFormat[WhiskNamespace] {
+    def write(w: WhiskNamespace) =
+      JsObject("name" -> w.name.toJson, "uuid" -> w.authkey.uuid.toJson, "key" -> w.authkey.key.toJson)
 
-        def read(value: JsValue) = Try {
-            value.asJsObject.getFields("name", "uuid", "key") match {
-                case Seq(JsString(n), JsString(u), JsString(k)) =>
-                    WhiskNamespace(EntityName(n), AuthKey(UUID(u), Secret(k)))
-            }
-        } getOrElse deserializationError("namespace record malformed")
-    }
+    def read(value: JsValue) =
+      Try {
+        value.asJsObject.getFields("name", "uuid", "key") match {
+          case Seq(JsString(n), JsString(u), JsString(k)) =>
+            WhiskNamespace(EntityName(n), AuthKey(UUID(u), Secret(k)))
+        }
+      } getOrElse deserializationError("namespace record malformed")
+  }
 }
 
 /**
@@ -48,20 +47,15 @@ protected[core] object WhiskNamespace extends DefaultJsonProtocol {
  * top-level authkey is given but each subject has a set of namespaces,
  * which in turn have the keys.
  */
-protected[core] case class WhiskAuth(
-    subject: Subject,
-    namespaces: Set[WhiskNamespace])
-    extends WhiskDocument {
+protected[core] case class WhiskAuth(subject: Subject, namespaces: Set[WhiskNamespace]) extends WhiskDocument {
 
-    override def docid = DocId(subject.asString)
+  override def docid = DocId(subject.asString)
 
-    def toJson = JsObject(
-        "subject" -> subject.toJson,
-        "namespaces" -> namespaces.toJson)
+  def toJson = JsObject("subject" -> subject.toJson, "namespaces" -> namespaces.toJson)
 }
 
 protected[core] object WhiskAuth extends DefaultJsonProtocol {
-    // Need to explicitly set field names since WhiskAuth extends WhiskDocument
-    // which defines more than the 2 "standard" fields
-    implicit val serdes = jsonFormat(WhiskAuth.apply, "subject", "namespaces")
+  // Need to explicitly set field names since WhiskAuth extends WhiskDocument
+  // which defines more than the 2 "standard" fields
+  implicit val serdes = jsonFormat(WhiskAuth.apply, "subject", "namespaces")
 }

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskEntity.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskEntity.scala
@@ -43,66 +43,67 @@ import whisk.http.Messages
 @throws[IllegalArgumentException]
 abstract class WhiskEntity protected[entity] (en: EntityName) extends WhiskDocument {
 
-    val namespace: EntityPath
-    val name = en
-    val version: SemVer
-    val publish: Boolean
-    val annotations: Parameters
-    val updated = Instant.now(Clock.systemUTC())
+  val namespace: EntityPath
+  val name = en
+  val version: SemVer
+  val publish: Boolean
+  val annotations: Parameters
+  val updated = Instant.now(Clock.systemUTC())
 
-    /**
-     * The name of the entity qualified with its namespace and version for
-     * creating unique keys in backend services.
-     */
-    final def fullyQualifiedName(withVersion: Boolean) = FullyQualifiedEntityName(namespace, en, if (withVersion) Some(version) else None)
+  /**
+   * The name of the entity qualified with its namespace and version for
+   * creating unique keys in backend services.
+   */
+  final def fullyQualifiedName(withVersion: Boolean) =
+    FullyQualifiedEntityName(namespace, en, if (withVersion) Some(version) else None)
 
-    /** The primary key for the entity in the datastore */
-    override final def docid = fullyQualifiedName(false).toDocId
+  /** The primary key for the entity in the datastore */
+  override final def docid = fullyQualifiedName(false).toDocId
 
-    /**
-     * Returns a JSON object with the fields specific to this abstract class.
-     */
-    protected def entityDocumentRecord: JsObject = JsObject(
-        "name" -> JsString(name.toString),
-        "updated" -> JsNumber(updated.toEpochMilli()))
+  /**
+   * Returns a JSON object with the fields specific to this abstract class.
+   */
+  protected def entityDocumentRecord: JsObject =
+    JsObject("name" -> JsString(name.toString), "updated" -> JsNumber(updated.toEpochMilli()))
 
-    override def toDocumentRecord: JsObject = {
-        val extraFields = entityDocumentRecord.fields
-        val base = super.toDocumentRecord
+  override def toDocumentRecord: JsObject = {
+    val extraFields = entityDocumentRecord.fields
+    val base = super.toDocumentRecord
 
-        // In this order to make sure the subclass can rewrite using toJson.
-        JsObject(extraFields ++ base.fields)
-    }
+    // In this order to make sure the subclass can rewrite using toJson.
+    JsObject(extraFields ++ base.fields)
+  }
 
-    /**
-     * @return the primary key (name) of the entity as a pithy description
-     */
-    override def toString = s"${this.getClass.getSimpleName}/${fullyQualifiedName(true)}"
+  /**
+   * @return the primary key (name) of the entity as a pithy description
+   */
+  override def toString = s"${this.getClass.getSimpleName}/${fullyQualifiedName(true)}"
 
-    /**
-     * A JSON view of the entity, that should match the result returned in a list operation.
-     * This should be synchronized with the views computed in wipeTransientDBs.sh.
-     */
-    def summaryAsJson = JsObject(
-        "namespace" -> namespace.toJson,
-        "name" -> name.toJson,
-        "version" -> version.toJson,
-        WhiskEntity.sharedFieldName -> JsBoolean(publish),
-        "annotations" -> annotations.toJsArray)
+  /**
+   * A JSON view of the entity, that should match the result returned in a list operation.
+   * This should be synchronized with the views computed in wipeTransientDBs.sh.
+   */
+  def summaryAsJson =
+    JsObject(
+      "namespace" -> namespace.toJson,
+      "name" -> name.toJson,
+      "version" -> version.toJson,
+      WhiskEntity.sharedFieldName -> JsBoolean(publish),
+      "annotations" -> annotations.toJsArray)
 }
 
 object WhiskEntity {
 
-    val sharedFieldName = "publish"
-    val paramsFieldName = "parameters"
-    val annotationsFieldName = "annotations"
+  val sharedFieldName = "publish"
+  val paramsFieldName = "parameters"
+  val annotationsFieldName = "annotations"
 
-    /**
-     * Gets fully qualified name of an activation based on its namespace and activation id.
-     */
-    def qualifiedName(namespace: EntityPath, activationId: ActivationId) = {
-        s"$namespace${EntityPath.PATHSEP}$activationId"
-    }
+  /**
+   * Gets fully qualified name of an activation based on its namespace and activation id.
+   */
+  def qualifiedName(namespace: EntityPath, activationId: ActivationId) = {
+    s"$namespace${EntityPath.PATHSEP}$activationId"
+  }
 }
 
 /**
@@ -110,73 +111,80 @@ object WhiskEntity {
  * avoid multiple implicit alternatives when working with one of the subtypes.
  */
 object WhiskEntityJsonFormat extends RootJsonFormat[WhiskEntity] {
-    // THE ORDER MATTERS! E.g. some triggers can deserialize as packages, but not
-    // the other way around. Try most specific first!
-    private def readers: Stream[JsValue => WhiskEntity] = Stream(
-        WhiskAction.serdes.read,
-        WhiskActivation.serdes.read,
-        WhiskRule.serdes.read,
-        WhiskTrigger.serdes.read,
-        WhiskPackage.serdes.read)
+  // THE ORDER MATTERS! E.g. some triggers can deserialize as packages, but not
+  // the other way around. Try most specific first!
+  private def readers: Stream[JsValue => WhiskEntity] =
+    Stream(
+      WhiskAction.serdes.read,
+      WhiskActivation.serdes.read,
+      WhiskRule.serdes.read,
+      WhiskTrigger.serdes.read,
+      WhiskPackage.serdes.read)
 
-    // Not necessarily the smartest way to go about this. In theory, whenever
-    // a more precise type is known, this method shouldn't be used.
-    override def read(js: JsValue): WhiskEntity = {
-        val successes: Stream[WhiskEntity] = readers.flatMap(r => Try(r(js)).toOption)
-        successes.headOption.getOrElse {
-            throw DocumentUnreadable(Messages.corruptedEntity)
-        }
+  // Not necessarily the smartest way to go about this. In theory, whenever
+  // a more precise type is known, this method shouldn't be used.
+  override def read(js: JsValue): WhiskEntity = {
+    val successes: Stream[WhiskEntity] = readers.flatMap(r => Try(r(js)).toOption)
+    successes.headOption.getOrElse {
+      throw DocumentUnreadable(Messages.corruptedEntity)
     }
+  }
 
-    override def write(we: WhiskEntity): JsValue = we match {
-        case a: WhiskAction     => WhiskAction.serdes.write(a)
-        case a: WhiskActivation => WhiskActivation.serdes.write(a)
-        case p: WhiskPackage    => WhiskPackage.serdes.write(p)
-        case r: WhiskRule       => WhiskRule.serdes.write(r)
-        case t: WhiskTrigger    => WhiskTrigger.serdes.write(t)
-    }
+  override def write(we: WhiskEntity): JsValue = we match {
+    case a: WhiskAction     => WhiskAction.serdes.write(a)
+    case a: WhiskActivation => WhiskActivation.serdes.write(a)
+    case p: WhiskPackage    => WhiskPackage.serdes.write(p)
+    case r: WhiskRule       => WhiskRule.serdes.write(r)
+    case t: WhiskTrigger    => WhiskTrigger.serdes.write(t)
+  }
 }
 
 /**
  * Trait for the objects we want to size. The size will be defined as ByteSize.
  */
 trait ByteSizeable {
-    /**
-     * Method to calculate the size of the object.
-     * The size of the object is defined as the sum of sizes of all parameters, that is stored in the object.
-     *
-     * @return the size of the object as ByteSize
-     */
-    def size: ByteSize
+
+  /**
+   * Method to calculate the size of the object.
+   * The size of the object is defined as the sum of sizes of all parameters, that is stored in the object.
+   *
+   * @return the size of the object as ByteSize
+   */
+  def size: ByteSize
 }
 
 object LimitedWhiskEntityPut extends DefaultJsonProtocol {
-    implicit val serdes = jsonFormat3(LimitedWhiskEntityPut.apply)
+  implicit val serdes = jsonFormat3(LimitedWhiskEntityPut.apply)
 }
 
 case class SizeError(field: String, is: ByteSize, allowed: ByteSize)
 
-case class LimitedWhiskEntityPut(
-    exec: Option[Exec] = None,
-    parameters: Option[Parameters] = None,
-    annotations: Option[Parameters] = None) {
+case class LimitedWhiskEntityPut(exec: Option[Exec] = None,
+                                 parameters: Option[Parameters] = None,
+                                 annotations: Option[Parameters] = None) {
 
-    def isWithinSizeLimits: Option[SizeError] = {
-        exec.flatMap { e =>
-            val is = e.size
-            if (is <= Exec.sizeLimit) None else Some {
-                SizeError(WhiskAction.execFieldName, is, Exec.sizeLimit)
-            }
-        } orElse parameters.flatMap { p =>
-            val is = p.size
-            if (is <= Parameters.sizeLimit) None else Some {
-                SizeError(WhiskEntity.paramsFieldName, is, Parameters.sizeLimit)
-            }
-        } orElse annotations.flatMap { a =>
-            val is = a.size
-            if (is <= Parameters.sizeLimit) None else Some {
-                SizeError(WhiskEntity.annotationsFieldName, is, Parameters.sizeLimit)
-            }
+  def isWithinSizeLimits: Option[SizeError] = {
+    exec.flatMap { e =>
+      val is = e.size
+      if (is <= Exec.sizeLimit) None
+      else
+        Some {
+          SizeError(WhiskAction.execFieldName, is, Exec.sizeLimit)
+        }
+    } orElse parameters.flatMap { p =>
+      val is = p.size
+      if (is <= Parameters.sizeLimit) None
+      else
+        Some {
+          SizeError(WhiskEntity.paramsFieldName, is, Parameters.sizeLimit)
+        }
+    } orElse annotations.flatMap { a =>
+      val is = a.size
+      if (is <= Parameters.sizeLimit) None
+      else
+        Some {
+          SizeError(WhiskEntity.annotationsFieldName, is, Parameters.sizeLimit)
         }
     }
+  }
 }

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskRule.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskRule.scala
@@ -34,21 +34,20 @@ import whisk.core.database.DocumentFactory
  * WhiskRulePut is a restricted WhiskRule view that eschews properties
  * that are auto-assigned or derived from URI: namespace, name, status.
  */
-case class WhiskRulePut(
-    trigger: Option[FullyQualifiedEntityName] = None,
-    action: Option[FullyQualifiedEntityName] = None,
-    version: Option[SemVer] = None,
-    publish: Option[Boolean] = None,
-    annotations: Option[Parameters] = None) {
+case class WhiskRulePut(trigger: Option[FullyQualifiedEntityName] = None,
+                        action: Option[FullyQualifiedEntityName] = None,
+                        version: Option[SemVer] = None,
+                        publish: Option[Boolean] = None,
+                        annotations: Option[Parameters] = None) {
 
-    /**
-     * Resolves the trigger and action name if they contains the default namespace.
-     */
-    protected[core] def resolve(namespace: EntityName): WhiskRulePut = {
-        val t = trigger map { _.resolve(namespace) }
-        val a = action map { _.resolve(namespace) }
-        WhiskRulePut(t, a, version, publish, annotations)
-    }
+  /**
+   * Resolves the trigger and action name if they contains the default namespace.
+   */
+  protected[core] def resolve(namespace: EntityName): WhiskRulePut = {
+    val t = trigger map { _.resolve(namespace) }
+    val a = action map { _.resolve(namespace) }
+    WhiskRulePut(t, a, version, publish, annotations)
+  }
 }
 
 /**
@@ -70,19 +69,18 @@ case class WhiskRulePut(
  * @throws IllegalArgumentException if any argument is undefined
  */
 @throws[IllegalArgumentException]
-case class WhiskRule(
-    namespace: EntityPath,
-    override val name: EntityName,
-    trigger: FullyQualifiedEntityName,
-    action: FullyQualifiedEntityName,
-    version: SemVer = SemVer(),
-    publish: Boolean = false,
-    annotations: Parameters = Parameters())
+case class WhiskRule(namespace: EntityPath,
+                     override val name: EntityName,
+                     trigger: FullyQualifiedEntityName,
+                     action: FullyQualifiedEntityName,
+                     version: SemVer = SemVer(),
+                     publish: Boolean = false,
+                     annotations: Parameters = Parameters())
     extends WhiskEntity(name) {
 
-    def withStatus(s: Status) = WhiskRuleResponse(namespace, name, s, trigger, action, version, publish, annotations)
+  def withStatus(s: Status) = WhiskRuleResponse(namespace, name, s, trigger, action, version, publish, annotations)
 
-    def toJson = WhiskRule.serdes.write(this).asJsObject
+  def toJson = WhiskRule.serdes.write(this).asJsObject
 }
 
 /**
@@ -99,17 +97,16 @@ case class WhiskRule(
  * @param publish true to share the action or false otherwise
  * @param annotation the set of annotations to attribute to the rule
  */
-case class WhiskRuleResponse(
-    namespace: EntityPath,
-    name: EntityName,
-    status: Status,
-    trigger: FullyQualifiedEntityName,
-    action: FullyQualifiedEntityName,
-    version: SemVer = SemVer(),
-    publish: Boolean = false,
-    annotations: Parameters = Parameters()) {
+case class WhiskRuleResponse(namespace: EntityPath,
+                             name: EntityName,
+                             status: Status,
+                             trigger: FullyQualifiedEntityName,
+                             action: FullyQualifiedEntityName,
+                             version: SemVer = SemVer(),
+                             publish: Boolean = false,
+                             annotations: Parameters = Parameters()) {
 
-    def toWhiskRule = WhiskRule(namespace, name, trigger, action, version, publish, annotations)
+  def toWhiskRule = WhiskRule(namespace, name, trigger, action, version, publish, annotations)
 }
 
 /**
@@ -130,117 +127,117 @@ case class WhiskRuleResponse(
  * @param status, one of allowed status strings
  */
 class Status private (private val status: String) extends AnyVal {
-    override def toString = status
+  override def toString = status
 }
 
 protected[core] object Status extends ArgNormalizer[Status] {
-    val ACTIVE = new Status("active")
-    val INACTIVE = new Status("inactive")
+  val ACTIVE = new Status("active")
+  val INACTIVE = new Status("inactive")
 
-    protected[core] def next(status: Status): Status = {
-        status match {
-            case ACTIVE   => INACTIVE
-            case INACTIVE => ACTIVE
-        }
+  protected[core] def next(status: Status): Status = {
+    status match {
+      case ACTIVE   => INACTIVE
+      case INACTIVE => ACTIVE
     }
+  }
 
-    /**
-     * Creates a rule Status from a string.
-     *
-     * @param str the rule status as string
-     * @return Status instance
-     * @throws IllegalArgumentException is argument is undefined or not a valid status
-     */
-    @throws[IllegalArgumentException]
-    override protected[entity] def factory(str: String): Status = {
-        val status = new Status(str)
-        require(status == ACTIVE || status == INACTIVE,
-            s"$str is not a recognized rule state")
-        status
-    }
+  /**
+   * Creates a rule Status from a string.
+   *
+   * @param str the rule status as string
+   * @return Status instance
+   * @throws IllegalArgumentException is argument is undefined or not a valid status
+   */
+  @throws[IllegalArgumentException]
+  override protected[entity] def factory(str: String): Status = {
+    val status = new Status(str)
+    require(status == ACTIVE || status == INACTIVE, s"$str is not a recognized rule state")
+    status
+  }
 
-    override protected[core] implicit val serdes = new RootJsonFormat[Status] {
-        def write(s: Status) = JsString(s.status)
+  override protected[core] implicit val serdes = new RootJsonFormat[Status] {
+    def write(s: Status) = JsString(s.status)
 
-        def read(value: JsValue) = Try {
-            val JsString(v) = value
-            Status(v)
-        } match {
-            case Success(s) => s
-            case Failure(t) => deserializationError(t.getMessage)
-        }
-    }
+    def read(value: JsValue) =
+      Try {
+        val JsString(v) = value
+        Status(v)
+      } match {
+        case Success(s) => s
+        case Failure(t) => deserializationError(t.getMessage)
+      }
+  }
 
-    /**
-     * A serializer for status POST entities. This is a restricted
-     * Status view with only ACTIVE and INACTIVE values allowed.
-     */
-    protected[core] val serdesRestricted = new RootJsonFormat[Status] {
-        def write(s: Status) = JsObject("status" -> JsString(s.status))
+  /**
+   * A serializer for status POST entities. This is a restricted
+   * Status view with only ACTIVE and INACTIVE values allowed.
+   */
+  protected[core] val serdesRestricted = new RootJsonFormat[Status] {
+    def write(s: Status) = JsObject("status" -> JsString(s.status))
 
-        def read(value: JsValue) = Try {
-            val JsObject(fields) = value
-            val JsString(s) = fields("status")
-            Status(s)
-        } match {
-            case Success(status) =>
-                if (status == ACTIVE || status == INACTIVE) {
-                    status
-                } else {
-                    val msg = s"""'$status' is not a recognized rule state, must be one of ['${Status.ACTIVE}', '${Status.INACTIVE}']"""
-                    deserializationError(msg)
-                }
-            case Failure(t) => deserializationError(t.getMessage)
-        }
-    }
+    def read(value: JsValue) =
+      Try {
+        val JsObject(fields) = value
+        val JsString(s) = fields("status")
+        Status(s)
+      } match {
+        case Success(status) =>
+          if (status == ACTIVE || status == INACTIVE) {
+            status
+          } else {
+            val msg =
+              s"""'$status' is not a recognized rule state, must be one of ['${Status.ACTIVE}', '${Status.INACTIVE}']"""
+            deserializationError(msg)
+          }
+        case Failure(t) => deserializationError(t.getMessage)
+      }
+  }
 }
 
-object WhiskRule
-    extends DocumentFactory[WhiskRule]
-    with WhiskEntityQueries[WhiskRule]
-    with DefaultJsonProtocol {
+object WhiskRule extends DocumentFactory[WhiskRule] with WhiskEntityQueries[WhiskRule] with DefaultJsonProtocol {
 
-    override val collectionName = "rules"
+  override val collectionName = "rules"
 
-    private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
-    private val caseClassSerdes = jsonFormat7(WhiskRule.apply)
+  private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
+  private val caseClassSerdes = jsonFormat7(WhiskRule.apply)
 
-    override implicit val serdes = new RootJsonFormat[WhiskRule] {
-        def write(r: WhiskRule) = caseClassSerdes.write(r)
+  override implicit val serdes = new RootJsonFormat[WhiskRule] {
+    def write(r: WhiskRule) = caseClassSerdes.write(r)
 
-        def read(value: JsValue) = Try {
-            caseClassSerdes.read(value)
-        } recover {
-            case DeserializationException(_, _, List("trigger")) | DeserializationException(_, _, List("action")) =>
-                val namespace = value.asJsObject.fields("namespace").convertTo[EntityPath]
-                val actionName = value.asJsObject.fields("action")
-                val triggerName = value.asJsObject.fields("trigger")
+    def read(value: JsValue) =
+      Try {
+        caseClassSerdes.read(value)
+      } recover {
+        case DeserializationException(_, _, List("trigger")) | DeserializationException(_, _, List("action")) =>
+          val namespace = value.asJsObject.fields("namespace").convertTo[EntityPath]
+          val actionName = value.asJsObject.fields("action")
+          val triggerName = value.asJsObject.fields("trigger")
 
-                val refs = Seq(actionName, triggerName).map { name =>
-                    Try {
-                        FullyQualifiedEntityName(namespace, EntityName.serdes.read(name))
-                    } match {
-                        case Success(n) => n
-                        case Failure(t) => deserializationError(t.getMessage)
-                    }
-                }
-                val fields = value.asJsObject.fields + ("action" -> refs(0).toDocId.toJson) + ("trigger" -> refs(1).toDocId.toJson)
-                caseClassSerdes.read(JsObject(fields))
-        } match {
-            case Success(r) => r
-            case Failure(t) => deserializationError(t.getMessage)
-        }
-    }
+          val refs = Seq(actionName, triggerName).map { name =>
+            Try {
+              FullyQualifiedEntityName(namespace, EntityName.serdes.read(name))
+            } match {
+              case Success(n) => n
+              case Failure(t) => deserializationError(t.getMessage)
+            }
+          }
+          val fields = value.asJsObject.fields + ("action" -> refs(0).toDocId.toJson) + ("trigger" -> refs(1).toDocId.toJson)
+          caseClassSerdes.read(JsObject(fields))
+      } match {
+        case Success(r) => r
+        case Failure(t) => deserializationError(t.getMessage)
+      }
+  }
 
-    override val cacheEnabled = false
+  override val cacheEnabled = false
 }
 
 object WhiskRuleResponse extends DefaultJsonProtocol {
-    private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
-    implicit val serdes = jsonFormat8(WhiskRuleResponse.apply)
+  private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
+  implicit val serdes = jsonFormat8(WhiskRuleResponse.apply)
 }
 
 object WhiskRulePut extends DefaultJsonProtocol {
-    private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
-    implicit val serdes = jsonFormat5(WhiskRulePut.apply)
+  private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
+  implicit val serdes = jsonFormat5(WhiskRulePut.apply)
 }

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
@@ -47,87 +47,90 @@ import whisk.core.database.StaleParameter
 import whisk.spi.SpiLoader
 
 package object types {
-    type AuthStore = ArtifactStore[WhiskAuth]
-    type EntityStore = ArtifactStore[WhiskEntity]
-    type ActivationStore = ArtifactStore[WhiskActivation]
+  type AuthStore = ArtifactStore[WhiskAuth]
+  type EntityStore = ArtifactStore[WhiskEntity]
+  type ActivationStore = ArtifactStore[WhiskActivation]
 }
-protected[core] trait WhiskDocument
-    extends DocumentSerializer
-    with DocumentRevisionProvider {
+protected[core] trait WhiskDocument extends DocumentSerializer with DocumentRevisionProvider {
 
-    /**
-     * Gets unique document identifier for the document.
-     */
-    protected def docid: DocId
+  /**
+   * Gets unique document identifier for the document.
+   */
+  protected def docid: DocId
 
-    /**
-     * Creates DocId from the unique document identifier and the
-     * document revision if one exists.
-     */
-    protected[core] final def docinfo: DocInfo = DocInfo(docid, rev)
+  /**
+   * Creates DocId from the unique document identifier and the
+   * document revision if one exists.
+   */
+  protected[core] final def docinfo: DocInfo = DocInfo(docid, rev)
 
-    /**
-     * The representation as JSON, e.g. for REST calls. Does not include id/rev.
-     */
-    def toJson: JsObject
+  /**
+   * The representation as JSON, e.g. for REST calls. Does not include id/rev.
+   */
+  def toJson: JsObject
 
-    /**
-     * Database JSON representation. Includes id/rev when appropriate. May
-     * differ from `toJson` in exceptional cases.
-     */
-    override def toDocumentRecord: JsObject = {
-        val id = docid.id
-        val revOrNull = rev.rev
+  /**
+   * Database JSON representation. Includes id/rev when appropriate. May
+   * differ from `toJson` in exceptional cases.
+   */
+  override def toDocumentRecord: JsObject = {
+    val id = docid.id
+    val revOrNull = rev.rev
 
-        // Building up the fields.
-        val base = this.toJson.fields
-        val withId = base + ("_id" -> JsString(id))
-        val withRev = if (revOrNull == null) withId else { withId + ("_rev" -> JsString(revOrNull)) }
-        JsObject(withRev)
-    }
+    // Building up the fields.
+    val base = this.toJson.fields
+    val withId = base + ("_id" -> JsString(id))
+    val withRev = if (revOrNull == null) withId else { withId + ("_rev" -> JsString(revOrNull)) }
+    JsObject(withRev)
+  }
 }
 
 object WhiskAuthStore {
-    def requiredProperties =
-        Map(dbProvider -> null,
-            dbProtocol -> null,
-            dbUsername -> null,
-            dbPassword -> null,
-            dbHost -> null,
-            dbPort -> null,
-            dbAuths -> null)
+  def requiredProperties =
+    Map(
+      dbProvider -> null,
+      dbProtocol -> null,
+      dbUsername -> null,
+      dbPassword -> null,
+      dbHost -> null,
+      dbPort -> null,
+      dbAuths -> null)
 
-    def datastore(config: WhiskConfig)(implicit system: ActorSystem, logging: Logging) =
-        SpiLoader.get[ArtifactStoreProvider].makeStore[WhiskAuth](config, _.dbAuths)
+  def datastore(config: WhiskConfig)(implicit system: ActorSystem, logging: Logging) =
+    SpiLoader.get[ArtifactStoreProvider].makeStore[WhiskAuth](config, _.dbAuths)
 }
 
 object WhiskEntityStore {
-    def requiredProperties =
-        Map(dbProvider -> null,
-            dbProtocol -> null,
-            dbUsername -> null,
-            dbPassword -> null,
-            dbHost -> null,
-            dbPort -> null,
-            dbWhisk -> null)
+  def requiredProperties =
+    Map(
+      dbProvider -> null,
+      dbProtocol -> null,
+      dbUsername -> null,
+      dbPassword -> null,
+      dbHost -> null,
+      dbPort -> null,
+      dbWhisk -> null)
 
-    def datastore(config: WhiskConfig)(implicit system: ActorSystem, logging: Logging) =
-        SpiLoader.get[ArtifactStoreProvider].makeStore[WhiskEntity](config, _.dbWhisk)(WhiskEntityJsonFormat, system, logging)
+  def datastore(config: WhiskConfig)(implicit system: ActorSystem, logging: Logging) =
+    SpiLoader
+      .get[ArtifactStoreProvider]
+      .makeStore[WhiskEntity](config, _.dbWhisk)(WhiskEntityJsonFormat, system, logging)
 
 }
 
 object WhiskActivationStore {
-    def requiredProperties =
-        Map(dbProvider -> null,
-            dbProtocol -> null,
-            dbUsername -> null,
-            dbPassword -> null,
-            dbHost -> null,
-            dbPort -> null,
-            dbActivations -> null)
+  def requiredProperties =
+    Map(
+      dbProvider -> null,
+      dbProtocol -> null,
+      dbUsername -> null,
+      dbPassword -> null,
+      dbHost -> null,
+      dbPort -> null,
+      dbActivations -> null)
 
-    def datastore(config: WhiskConfig)(implicit system: ActorSystem, logging: Logging) =
-        SpiLoader.get[ArtifactStoreProvider].makeStore[WhiskActivation](config, _.dbActivations)
+  def datastore(config: WhiskConfig)(implicit system: ActorSystem, logging: Logging) =
+    SpiLoader.get[ArtifactStoreProvider].makeStore[WhiskActivation](config, _.dbActivations)
 }
 
 /**
@@ -163,194 +166,212 @@ object WhiskActivationStore {
  * the required views are installed by wipeTransientDBs.sh.
  */
 object WhiskEntityQueries {
-    val TOP = "\ufff0"
-    val WHISKVIEW = "whisks"
-    val ALL = "all"
-    val ENTITIES = "entities"
+  val TOP = "\ufff0"
+  val WHISKVIEW = "whisks"
+  val ALL = "all"
+  val ENTITIES = "entities"
 
-    /**
-     * Determines the view name for the collection. There are two cases: a view
-     * that is namespace specific, or namespace agnostic..
-     */
-    def viewname(collection: String, allNamespaces: Boolean = false): String = {
-        if (!allNamespaces) {
-            s"$WHISKVIEW/$collection"
-        } else s"$WHISKVIEW/$collection-all"
-    }
+  /**
+   * Determines the view name for the collection. There are two cases: a view
+   * that is namespace specific, or namespace agnostic..
+   */
+  def viewname(collection: String, allNamespaces: Boolean = false): String = {
+    if (!allNamespaces) {
+      s"$WHISKVIEW/$collection"
+    } else s"$WHISKVIEW/$collection-all"
+  }
 
-    /**
-     * Queries the datastore for all entities in a namespace, and converts the list of entities
-     * to a map that collects the entities by their type.
-     */
-    def listAllInNamespace[A <: WhiskEntity](
-        db: ArtifactStore[A],
-        namespace: EntityPath,
-        includeDocs: Boolean,
-        stale: StaleParameter = StaleParameter.No)(
-            implicit transid: TransactionId): Future[Map[String, List[JsObject]]] = {
-        implicit val ec = db.executionContext
-        val startKey = List(namespace.toString)
-        val endKey = List(namespace.toString, TOP)
-        db.query(viewname(ALL), startKey, endKey, 0, 0, includeDocs, descending = true, reduce = false, stale = stale) map {
-            _ map {
-                row =>
-                    val value = row.fields("value").asJsObject
-                    val JsString(collection) = value.fields("collection")
-                    (collection, JsObject(value.fields.filterNot { _._1 == "collection" }))
-            } groupBy { _._1 } mapValues { _.map(_._2) }
-        }
+  /**
+   * Queries the datastore for all entities in a namespace, and converts the list of entities
+   * to a map that collects the entities by their type.
+   */
+  def listAllInNamespace[A <: WhiskEntity](
+    db: ArtifactStore[A],
+    namespace: EntityPath,
+    includeDocs: Boolean,
+    stale: StaleParameter = StaleParameter.No)(implicit transid: TransactionId): Future[Map[String, List[JsObject]]] = {
+    implicit val ec = db.executionContext
+    val startKey = List(namespace.toString)
+    val endKey = List(namespace.toString, TOP)
+    db.query(viewname(ALL), startKey, endKey, 0, 0, includeDocs, descending = true, reduce = false, stale = stale) map {
+      _ map { row =>
+        val value = row.fields("value").asJsObject
+        val JsString(collection) = value.fields("collection")
+        (collection, JsObject(value.fields.filterNot { _._1 == "collection" }))
+      } groupBy { _._1 } mapValues { _.map(_._2) }
     }
+  }
 
-    /**
-     * Queries the datastore for all entities without activations in a namespace, and converts the list of entities
-     * to a map that collects the entities by their type.
-     */
-    def listEntitiesInNamespace[A <: WhiskEntity](
-        db: ArtifactStore[A],
-        namespace: EntityPath,
-        includeDocs: Boolean,
-        stale: StaleParameter = StaleParameter.No)(
-            implicit transid: TransactionId): Future[Map[String, List[JsObject]]] = {
-        implicit val ec = db.executionContext
-        val startKey = List(namespace.toString)
-        val endKey = List(namespace.toString, TOP)
-        db.query(viewname(ENTITIES), startKey, endKey, 0, 0, includeDocs, descending = true, reduce = false, stale = stale) map {
-            _ map {
-                row =>
-                    val value = row.fields("value").asJsObject
-                    val JsString(collection) = value.fields("collection")
-                    (collection, JsObject(value.fields.filterNot { _._1 == "collection" }))
-            } groupBy { _._1 } mapValues { _.map(_._2) }
-        }
+  /**
+   * Queries the datastore for all entities without activations in a namespace, and converts the list of entities
+   * to a map that collects the entities by their type.
+   */
+  def listEntitiesInNamespace[A <: WhiskEntity](
+    db: ArtifactStore[A],
+    namespace: EntityPath,
+    includeDocs: Boolean,
+    stale: StaleParameter = StaleParameter.No)(implicit transid: TransactionId): Future[Map[String, List[JsObject]]] = {
+    implicit val ec = db.executionContext
+    val startKey = List(namespace.toString)
+    val endKey = List(namespace.toString, TOP)
+    db.query(viewname(ENTITIES), startKey, endKey, 0, 0, includeDocs, descending = true, reduce = false, stale = stale) map {
+      _ map { row =>
+        val value = row.fields("value").asJsObject
+        val JsString(collection) = value.fields("collection")
+        (collection, JsObject(value.fields.filterNot { _._1 == "collection" }))
+      } groupBy { _._1 } mapValues { _.map(_._2) }
     }
+  }
 
-    def listCollectionInAnyNamespace[A <: WhiskEntity, T](
-        db: ArtifactStore[A],
-        collection: String,
-        skip: Int,
-        limit: Int,
-        reduce: Boolean,
-        since: Option[Instant] = None,
-        upto: Option[Instant] = None,
-        stale: StaleParameter = StaleParameter.No,
-        convert: Option[JsObject => Try[T]])(
-            implicit transid: TransactionId): Future[Either[List[JsObject], List[T]]] = {
-        val startKey = List(since map { _.toEpochMilli } getOrElse 0)
-        val endKey = List(upto map { _.toEpochMilli } getOrElse TOP, TOP)
-        query(db, viewname(collection, true), startKey, endKey, skip, limit, reduce, stale, convert)
-    }
+  def listCollectionInAnyNamespace[A <: WhiskEntity, T](
+    db: ArtifactStore[A],
+    collection: String,
+    skip: Int,
+    limit: Int,
+    reduce: Boolean,
+    since: Option[Instant] = None,
+    upto: Option[Instant] = None,
+    stale: StaleParameter = StaleParameter.No,
+    convert: Option[JsObject => Try[T]])(implicit transid: TransactionId): Future[Either[List[JsObject], List[T]]] = {
+    val startKey = List(since map { _.toEpochMilli } getOrElse 0)
+    val endKey = List(upto map { _.toEpochMilli } getOrElse TOP, TOP)
+    query(db, viewname(collection, true), startKey, endKey, skip, limit, reduce, stale, convert)
+  }
 
-    def listCollectionInNamespace[A <: WhiskEntity, T](
-        db: ArtifactStore[A],
-        collection: String,
-        namespace: EntityPath,
-        skip: Int,
-        limit: Int,
-        since: Option[Instant] = None,
-        upto: Option[Instant] = None,
-        stale: StaleParameter = StaleParameter.No,
-        convert: Option[JsObject => Try[T]])(
-            implicit transid: TransactionId): Future[Either[List[JsObject], List[T]]] = {
-        val startKey = List(namespace.toString, since map { _.toEpochMilli } getOrElse 0)
-        val endKey = List(namespace.toString, upto map { _.toEpochMilli } getOrElse TOP, TOP)
-        query(db, viewname(collection), startKey, endKey, skip, limit, reduce = false, stale, convert)
-    }
+  def listCollectionInNamespace[A <: WhiskEntity, T](
+    db: ArtifactStore[A],
+    collection: String,
+    namespace: EntityPath,
+    skip: Int,
+    limit: Int,
+    since: Option[Instant] = None,
+    upto: Option[Instant] = None,
+    stale: StaleParameter = StaleParameter.No,
+    convert: Option[JsObject => Try[T]])(implicit transid: TransactionId): Future[Either[List[JsObject], List[T]]] = {
+    val startKey = List(namespace.toString, since map { _.toEpochMilli } getOrElse 0)
+    val endKey = List(namespace.toString, upto map { _.toEpochMilli } getOrElse TOP, TOP)
+    query(db, viewname(collection), startKey, endKey, skip, limit, reduce = false, stale, convert)
+  }
 
-    def listCollectionByName[A <: WhiskEntity, T](
-        db: ArtifactStore[A],
-        collection: String,
-        namespace: EntityPath,
-        name: EntityName,
-        skip: Int,
-        limit: Int,
-        since: Option[Instant] = None,
-        upto: Option[Instant] = None,
-        stale: StaleParameter = StaleParameter.No,
-        convert: Option[JsObject => Try[T]])(
-            implicit transid: TransactionId): Future[Either[List[JsObject], List[T]]] = {
-        val startKey = List(namespace.addPath(name).toString, since map { _.toEpochMilli } getOrElse 0)
-        val endKey = List(namespace.addPath(name).toString, upto map { _.toEpochMilli } getOrElse TOP, TOP)
-        query(db, viewname(collection), startKey, endKey, skip, limit, reduce = false, stale, convert)
-    }
+  def listCollectionByName[A <: WhiskEntity, T](
+    db: ArtifactStore[A],
+    collection: String,
+    namespace: EntityPath,
+    name: EntityName,
+    skip: Int,
+    limit: Int,
+    since: Option[Instant] = None,
+    upto: Option[Instant] = None,
+    stale: StaleParameter = StaleParameter.No,
+    convert: Option[JsObject => Try[T]])(implicit transid: TransactionId): Future[Either[List[JsObject], List[T]]] = {
+    val startKey = List(namespace.addPath(name).toString, since map { _.toEpochMilli } getOrElse 0)
+    val endKey = List(namespace.addPath(name).toString, upto map { _.toEpochMilli } getOrElse TOP, TOP)
+    query(db, viewname(collection), startKey, endKey, skip, limit, reduce = false, stale, convert)
+  }
 
-    private def query[A <: WhiskEntity, T](
-        db: ArtifactStore[A],
-        view: String,
-        startKey: List[Any],
-        endKey: List[Any],
-        skip: Int,
-        limit: Int,
-        reduce: Boolean,
-        stale: StaleParameter = StaleParameter.No,
-        convert: Option[JsObject => Try[T]])(
-            implicit transid: TransactionId): Future[Either[List[JsObject], List[T]]] = {
-        implicit val ec = db.executionContext
-        val includeDocs = convert.isDefined
-        db.query(view, startKey, endKey, skip, limit, includeDocs, true, reduce, stale) map {
-            rows =>
-                convert map { fn =>
-                    Right(rows flatMap { row => fn(row.fields("doc").asJsObject) toOption })
-                } getOrElse {
-                    Left(rows flatMap { normalizeRow(_, reduce) toOption })
-                }
-        }
+  private def query[A <: WhiskEntity, T](
+    db: ArtifactStore[A],
+    view: String,
+    startKey: List[Any],
+    endKey: List[Any],
+    skip: Int,
+    limit: Int,
+    reduce: Boolean,
+    stale: StaleParameter = StaleParameter.No,
+    convert: Option[JsObject => Try[T]])(implicit transid: TransactionId): Future[Either[List[JsObject], List[T]]] = {
+    implicit val ec = db.executionContext
+    val includeDocs = convert.isDefined
+    db.query(view, startKey, endKey, skip, limit, includeDocs, true, reduce, stale) map { rows =>
+      convert map { fn =>
+        Right(rows flatMap { row =>
+          fn(row.fields("doc").asJsObject) toOption
+        })
+      } getOrElse {
+        Left(rows flatMap { normalizeRow(_, reduce) toOption })
+      }
     }
+  }
 
-    /**
-     * Normalizes the raw JsObject response from the datastore since the
-     * response differs in the case of a reduction.
-     */
-    protected def normalizeRow(row: JsObject, reduce: Boolean) = Try {
-        if (!reduce) {
-            row.fields("value").asJsObject
-        } else row
-    }
+  /**
+   * Normalizes the raw JsObject response from the datastore since the
+   * response differs in the case of a reduction.
+   */
+  protected def normalizeRow(row: JsObject, reduce: Boolean) = Try {
+    if (!reduce) {
+      row.fields("value").asJsObject
+    } else row
+  }
 }
 
 trait WhiskEntityQueries[T] {
-    val collectionName: String
-    val serdes: RootJsonFormat[T]
+  val collectionName: String
+  val serdes: RootJsonFormat[T]
 
-    def listCollectionInAnyNamespace[A <: WhiskEntity, T](
-        db: ArtifactStore[A],
-        skip: Int,
-        limit: Int,
-        docs: Boolean = false,
-        reduce: Boolean = false,
-        since: Option[Instant] = None,
-        upto: Option[Instant] = None,
-        stale: StaleParameter = StaleParameter.No)(
-            implicit transid: TransactionId) = {
-        val convert = if (docs) Some((o: JsObject) => Try { serdes.read(o) }) else None
-        WhiskEntityQueries.listCollectionInAnyNamespace(db, collectionName, skip, limit, reduce, since, upto, stale, convert)
-    }
+  def listCollectionInAnyNamespace[A <: WhiskEntity, T](
+    db: ArtifactStore[A],
+    skip: Int,
+    limit: Int,
+    docs: Boolean = false,
+    reduce: Boolean = false,
+    since: Option[Instant] = None,
+    upto: Option[Instant] = None,
+    stale: StaleParameter = StaleParameter.No)(implicit transid: TransactionId) = {
+    val convert = if (docs) Some((o: JsObject) => Try { serdes.read(o) }) else None
+    WhiskEntityQueries.listCollectionInAnyNamespace(
+      db,
+      collectionName,
+      skip,
+      limit,
+      reduce,
+      since,
+      upto,
+      stale,
+      convert)
+  }
 
-    def listCollectionInNamespace[A <: WhiskEntity, T](
-        db: ArtifactStore[A],
-        namespace: EntityPath,
-        skip: Int,
-        limit: Int,
-        docs: Boolean = false,
-        since: Option[Instant] = None,
-        upto: Option[Instant] = None,
-        stale: StaleParameter = StaleParameter.No)(
-            implicit transid: TransactionId) = {
-        val convert = if (docs) Some((o: JsObject) => Try { serdes.read(o) }) else None
-        WhiskEntityQueries.listCollectionInNamespace(db, collectionName, namespace, skip, limit, since, upto, stale, convert)
-    }
+  def listCollectionInNamespace[A <: WhiskEntity, T](
+    db: ArtifactStore[A],
+    namespace: EntityPath,
+    skip: Int,
+    limit: Int,
+    docs: Boolean = false,
+    since: Option[Instant] = None,
+    upto: Option[Instant] = None,
+    stale: StaleParameter = StaleParameter.No)(implicit transid: TransactionId) = {
+    val convert = if (docs) Some((o: JsObject) => Try { serdes.read(o) }) else None
+    WhiskEntityQueries.listCollectionInNamespace(
+      db,
+      collectionName,
+      namespace,
+      skip,
+      limit,
+      since,
+      upto,
+      stale,
+      convert)
+  }
 
-    def listCollectionByName[A <: WhiskEntity, T](
-        db: ArtifactStore[A],
-        namespace: EntityPath,
-        name: EntityName,
-        skip: Int,
-        limit: Int,
-        docs: Boolean = false,
-        since: Option[Instant] = None,
-        upto: Option[Instant] = None,
-        stale: StaleParameter = StaleParameter.No)(
-            implicit transid: TransactionId) = {
-        val convert = if (docs) Some((o: JsObject) => Try { serdes.read(o) }) else None
-        WhiskEntityQueries.listCollectionByName(db, collectionName, namespace, name, skip, limit, since, upto, stale, convert)
-    }
+  def listCollectionByName[A <: WhiskEntity, T](
+    db: ArtifactStore[A],
+    namespace: EntityPath,
+    name: EntityName,
+    skip: Int,
+    limit: Int,
+    docs: Boolean = false,
+    since: Option[Instant] = None,
+    upto: Option[Instant] = None,
+    stale: StaleParameter = StaleParameter.No)(implicit transid: TransactionId) = {
+    val convert = if (docs) Some((o: JsObject) => Try { serdes.read(o) }) else None
+    WhiskEntityQueries.listCollectionByName(
+      db,
+      collectionName,
+      namespace,
+      name,
+      skip,
+      limit,
+      since,
+      upto,
+      stale,
+      convert)
+  }
 }

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskTrigger.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskTrigger.scala
@@ -25,12 +25,11 @@ import spray.json._
  * WhiskTriggerPut is a restricted WhiskTrigger view that eschews properties
  * that are auto-assigned or derived from URI: namespace and name.
  */
-case class WhiskTriggerPut(
-    parameters: Option[Parameters] = None,
-    limits: Option[TriggerLimits] = None,
-    version: Option[SemVer] = None,
-    publish: Option[Boolean] = None,
-    annotations: Option[Parameters] = None)
+case class WhiskTriggerPut(parameters: Option[Parameters] = None,
+                           limits: Option[TriggerLimits] = None,
+                           version: Option[SemVer] = None,
+                           publish: Option[Boolean] = None,
+                           annotations: Option[Parameters] = None)
 
 /**
  * Representation of a rule to be stored inside a trigger. Contains all
@@ -40,9 +39,7 @@ case class WhiskTriggerPut(
  * @param action the fully qualified name of the action to be fired
  * @param status status of the rule
  */
-case class ReducedRule(
-    action: FullyQualifiedEntityName,
-    status: Status)
+case class ReducedRule(action: FullyQualifiedEntityName, status: Status)
 
 /**
  * A WhiskTrigger provides an abstraction of the meta-data
@@ -62,50 +59,49 @@ case class ReducedRule(
  * @throws IllegalArgumentException if any argument is undefined
  */
 @throws[IllegalArgumentException]
-case class WhiskTrigger(
-    namespace: EntityPath,
-    override val name: EntityName,
-    parameters: Parameters = Parameters(),
-    limits: TriggerLimits = TriggerLimits(),
-    version: SemVer = SemVer(),
-    publish: Boolean = false,
-    annotations: Parameters = Parameters(),
-    rules: Option[Map[FullyQualifiedEntityName, ReducedRule]] = None)
+case class WhiskTrigger(namespace: EntityPath,
+                        override val name: EntityName,
+                        parameters: Parameters = Parameters(),
+                        limits: TriggerLimits = TriggerLimits(),
+                        version: SemVer = SemVer(),
+                        publish: Boolean = false,
+                        annotations: Parameters = Parameters(),
+                        rules: Option[Map[FullyQualifiedEntityName, ReducedRule]] = None)
     extends WhiskEntity(name) {
 
-    require(limits != null, "limits undefined")
+  require(limits != null, "limits undefined")
 
-    def toJson = WhiskTrigger.serdes.write(this).asJsObject
+  def toJson = WhiskTrigger.serdes.write(this).asJsObject
 
-    def withoutRules = copy(rules = None).revision[WhiskTrigger](rev)
+  def withoutRules = copy(rules = None).revision[WhiskTrigger](rev)
 
-    /**
-     * Inserts the rulename, its status and the action to be fired into the trigger.
-     *
-     * @param rulename The fully qualified name of the rule, that will be fired by this trigger.
-     * @param rule The rule, that will be fired by this trigger. It's from type ReducedRule. This type
-     * contains the fully qualified name of the action to be fired by the rule and the status of the rule.
-     */
-    def addRule(rulename: FullyQualifiedEntityName, rule: ReducedRule) = {
-        val entry = rulename -> rule
-        val links = rules getOrElse Map.empty[FullyQualifiedEntityName, ReducedRule]
-        copy(rules = Some(links + entry)).revision[WhiskTrigger](docinfo.rev)
-    }
+  /**
+   * Inserts the rulename, its status and the action to be fired into the trigger.
+   *
+   * @param rulename The fully qualified name of the rule, that will be fired by this trigger.
+   * @param rule The rule, that will be fired by this trigger. It's from type ReducedRule. This type
+   * contains the fully qualified name of the action to be fired by the rule and the status of the rule.
+   */
+  def addRule(rulename: FullyQualifiedEntityName, rule: ReducedRule) = {
+    val entry = rulename -> rule
+    val links = rules getOrElse Map.empty[FullyQualifiedEntityName, ReducedRule]
+    copy(rules = Some(links + entry)).revision[WhiskTrigger](docinfo.rev)
+  }
 
-    /**
-     * Removes the rule from the trigger.
-     *
-     * @param rule The fully qualified name of the rule, that should be removed from the
-     * trigger. After removing the rule, it won't be fired anymore by this trigger.
-     */
-    def removeRule(rule: FullyQualifiedEntityName) = {
-        copy(rules = rules.map(_ - rule)).revision[WhiskTrigger](docinfo.rev)
-    }
+  /**
+   * Removes the rule from the trigger.
+   *
+   * @param rule The fully qualified name of the rule, that should be removed from the
+   * trigger. After removing the rule, it won't be fired anymore by this trigger.
+   */
+  def removeRule(rule: FullyQualifiedEntityName) = {
+    copy(rules = rules.map(_ - rule)).revision[WhiskTrigger](docinfo.rev)
+  }
 }
 
 object ReducedRule extends DefaultJsonProtocol {
-    private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
-    implicit val serdes = jsonFormat2(ReducedRule.apply)
+  private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
+  implicit val serdes = jsonFormat2(ReducedRule.apply)
 }
 
 object WhiskTrigger
@@ -113,14 +109,14 @@ object WhiskTrigger
     with WhiskEntityQueries[WhiskTrigger]
     with DefaultJsonProtocol {
 
-    override val collectionName = "triggers"
+  override val collectionName = "triggers"
 
-    private implicit val fqnSerdesAsDocId = FullyQualifiedEntityName.serdesAsDocId
-    override implicit val serdes = jsonFormat8(WhiskTrigger.apply)
+  private implicit val fqnSerdesAsDocId = FullyQualifiedEntityName.serdesAsDocId
+  override implicit val serdes = jsonFormat8(WhiskTrigger.apply)
 
-    override val cacheEnabled = true
+  override val cacheEnabled = true
 }
 
 object WhiskTriggerPut extends DefaultJsonProtocol {
-    implicit val serdes = jsonFormat5(WhiskTriggerPut.apply)
+  implicit val serdes = jsonFormat5(WhiskTriggerPut.apply)
 }

--- a/common/scala/src/main/scala/whisk/http/BasicRasService.scala
+++ b/common/scala/src/main/scala/whisk/http/BasicRasService.scala
@@ -28,17 +28,17 @@ import whisk.common.TransactionId
  */
 trait BasicRasService extends BasicHttpService {
 
-    override def routes(implicit transid: TransactionId) = ping
+  override def routes(implicit transid: TransactionId) = ping
 
-    override def loglevelForRoute(route: String): Logging.LogLevel = {
-        if (route == "/ping") {
-            Logging.DebugLevel
-        } else {
-            super.loglevelForRoute(route)
-        }
+  override def loglevelForRoute(route: String): Logging.LogLevel = {
+    if (route == "/ping") {
+      Logging.DebugLevel
+    } else {
+      super.loglevelForRoute(route)
     }
+  }
 
-    val ping = path("ping") {
-        get { complete("pong") }
-    }
+  val ping = path("ping") {
+    get { complete("pong") }
+  }
 }

--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -38,130 +38,138 @@ import whisk.core.entity.Exec
 import whisk.core.entity.ActivationId
 
 object Messages {
-    /** Standard message for reporting resource conflicts. */
-    val conflictMessage = "Concurrent modification to resource detected."
 
-    /**
-     * Standard message for reporting resource conformance error when trying to access
-     * a resource from a different collection.
-     */
-    val conformanceMessage = "Resource by this name exists but is not in this collection."
-    val corruptedEntity = "Resource is corrupted and cannot be read."
+  /** Standard message for reporting resource conflicts. */
+  val conflictMessage = "Concurrent modification to resource detected."
 
-    /**
-     * Standard message for reporting deprecated runtimes.
-     */
-    def runtimeDeprecated(e: Exec) = s"The '${e.kind}' runtime is no longer supported. You may read and delete but not update or invoke this action."
+  /**
+   * Standard message for reporting resource conformance error when trying to access
+   * a resource from a different collection.
+   */
+  val conformanceMessage = "Resource by this name exists but is not in this collection."
+  val corruptedEntity = "Resource is corrupted and cannot be read."
 
-    /** Standard message for resource not found. */
-    val resourceDoesNotExist = "The requested resource does not exist."
+  /**
+   * Standard message for reporting deprecated runtimes.
+   */
+  def runtimeDeprecated(e: Exec) =
+    s"The '${e.kind}' runtime is no longer supported. You may read and delete but not update or invoke this action."
 
-    /** Standard message for too many activation requests within a rolling time window. */
-    val tooManyRequests = "Too many requests in a given amount of time for namespace."
+  /** Standard message for resource not found. */
+  val resourceDoesNotExist = "The requested resource does not exist."
 
-    /** Standard message for too many concurrent activation requests within a time window. */
-    val tooManyConcurrentRequests = "Too many concurrent requests in flight for namespace."
+  /** Standard message for too many activation requests within a rolling time window. */
+  val tooManyRequests = "Too many requests in a given amount of time for namespace."
 
-    /** System overload message. */
-    val systemOverloaded = "System is overloaded, try again later."
+  /** Standard message for too many concurrent activation requests within a time window. */
+  val tooManyConcurrentRequests = "Too many concurrent requests in flight for namespace."
 
-    /** Standard message when supplied authkey is not authorized for an operation. */
-    val notAuthorizedtoOperateOnResource = "The supplied authentication is not authorized to access this resource."
+  /** System overload message. */
+  val systemOverloaded = "System is overloaded, try again later."
 
-    /** Standard error message for malformed fully qualified entity names. */
-    val malformedFullyQualifiedEntityName = "The fully qualified name of the entity must contain at least the namespace and the name of the entity."
-    def entityNameTooLong(error: SizeError) = {
-        s"${error.field} longer than allowed: ${error.is.toBytes} > ${error.allowed.toBytes}."
+  /** Standard message when supplied authkey is not authorized for an operation. */
+  val notAuthorizedtoOperateOnResource = "The supplied authentication is not authorized to access this resource."
+
+  /** Standard error message for malformed fully qualified entity names. */
+  val malformedFullyQualifiedEntityName =
+    "The fully qualified name of the entity must contain at least the namespace and the name of the entity."
+  def entityNameTooLong(error: SizeError) = {
+    s"${error.field} longer than allowed: ${error.is.toBytes} > ${error.allowed.toBytes}."
+  }
+  val entityNameIllegal = "The name of the entity contains illegal characters."
+  val namespaceIllegal = "The namespace contains illegal characters."
+
+  /** Standard error for malformed activation id. */
+  val activationIdIllegal = "The activation id is not valid."
+  def activationIdLengthError(error: SizeError) = {
+    s"${error.field} length is ${error.is.toBytes} but must be ${error.allowed.toBytes}."
+  }
+
+  /** Error messages for sequence actions. */
+  val sequenceIsTooLong = "Too many actions in the sequence."
+  val sequenceNoComponent = "No component specified for the sequence."
+  val sequenceIsCyclic = "Sequence may not refer to itself."
+  val sequenceComponentNotFound = "Sequence component does not exist."
+
+  /** Error message for packages. */
+  val bindingDoesNotExist = "Binding references a package that does not exist."
+  val packageCannotBecomeBinding = "Resource is a package and cannot be converted into a binding."
+  val bindingCannotReferenceBinding = "Cannot bind to another package binding."
+  val requestedBindingIsNotValid = "Cannot bind to a resource that is not a package."
+  val notAllowedOnBinding = "Operation not permitted on package binding."
+
+  /** Error messages for sequence activations. */
+  def sequenceRetrieveActivationTimeout(id: ActivationId) =
+    s"Timeout reached when retrieving activation $id for sequence component."
+  val sequenceActivationFailure = "Sequence failed."
+
+  /** Error messages for bad requests where parameters do not conform. */
+  val parametersNotAllowed = "Request defines parameters that are not allowed (e.g., reserved properties)."
+  def invalidTimeout(max: FiniteDuration) = s"Timeout must be number of milliseconds up to ${max.toMillis}."
+
+  /** Error messages for activations. */
+  val abnormalInitialization = "The action did not initialize and exited unexpectedly."
+  val abnormalRun = "The action did not produce a valid response and exited unexpectedly."
+  def badEntityName(value: String) = s"Parameter is not a valid value for a entity name: $value"
+  def badNamespace(value: String) = s"Parameter is not a valid value for a namespace: $value"
+  def badEpoch(value: String) = s"Parameter is not a valid value for epoch seconds: $value"
+
+  /** Error message for size conformance. */
+  def entityTooBig(error: SizeError) = {
+    s"${error.field} larger than allowed: ${error.is.toBytes} > ${error.allowed.toBytes} bytes."
+  }
+  def maxActivationLimitExceeded(value: Int, max: Int) = s"Activation limit of $value exceeds maximum limit of $max."
+
+  def truncateLogs(limit: ByteSize) = {
+    s"Logs were truncated because the total bytes size exceeds the limit of ${limit.toBytes} bytes."
+  }
+
+  /** Error for meta api. */
+  val propertyNotFound = "Response does not include requested property."
+  def invalidMedia(m: MediaType) = s"Response is not valid '${m.value}'."
+  def contentTypeExtensionNotSupported(extensions: Set[String]) = {
+    s"""Extension must be specified and one of ${extensions.mkString("[", ", ", "]")}."""
+  }
+  val unsupportedContentType = """Content type is not supported."""
+  def unsupportedContentType(m: MediaType) = s"""Content type '${m.value}' is not supported."""
+  val errorExtractingRequestBody = "Failed extracting request body."
+
+  val responseNotReady = "Response not yet ready."
+  val httpUnknownContentType = "Response did not specify a known content-type."
+  val httpContentTypeError = "Response type in header did not match generated content type."
+  val errorProcessingRequest = "There was an error processing your request."
+
+  def invalidInitResponse(actualResponse: String) = {
+    "The action failed during initialization" + {
+      Option(actualResponse) filter { _.nonEmpty } map { s =>
+        s": $s"
+      } getOrElse "."
     }
-    val entityNameIllegal = "The name of the entity contains illegal characters."
-    val namespaceIllegal = "The namespace contains illegal characters."
+  }
 
-    /** Standard error for malformed activation id. */
-    val activationIdIllegal = "The activation id is not valid."
-    def activationIdLengthError(error: SizeError) = {
-        s"${error.field} length is ${error.is.toBytes} but must be ${error.allowed.toBytes}."
+  def invalidRunResponse(actualResponse: String) = {
+    "The action did not produce a valid JSON response" + {
+      Option(actualResponse) filter { _.nonEmpty } map { s =>
+        s": $s"
+      } getOrElse "."
     }
+  }
 
-    /** Error messages for sequence actions. */
-    val sequenceIsTooLong = "Too many actions in the sequence."
-    val sequenceNoComponent = "No component specified for the sequence."
-    val sequenceIsCyclic = "Sequence may not refer to itself."
-    val sequenceComponentNotFound = "Sequence component does not exist."
+  def truncatedResponse(length: ByteSize, maxLength: ByteSize): String = {
+    s"The action produced a response that exceeded the allowed length: ${length.toBytes} > ${maxLength.toBytes} bytes."
+  }
 
-    /** Error message for packages. */
-    val bindingDoesNotExist = "Binding references a package that does not exist."
-    val packageCannotBecomeBinding = "Resource is a package and cannot be converted into a binding."
-    val bindingCannotReferenceBinding = "Cannot bind to another package binding."
-    val requestedBindingIsNotValid = "Cannot bind to a resource that is not a package."
-    val notAllowedOnBinding = "Operation not permitted on package binding."
+  def truncatedResponse(trunk: String, length: ByteSize, maxLength: ByteSize): String = {
+    s"${truncatedResponse(length, maxLength)} The truncated response was: $trunk"
+  }
 
-    /** Error messages for sequence activations. */
-    def sequenceRetrieveActivationTimeout(id: ActivationId) = s"Timeout reached when retrieving activation $id for sequence component."
-    val sequenceActivationFailure = "Sequence failed."
-
-    /** Error messages for bad requests where parameters do not conform. */
-    val parametersNotAllowed = "Request defines parameters that are not allowed (e.g., reserved properties)."
-    def invalidTimeout(max: FiniteDuration) = s"Timeout must be number of milliseconds up to ${max.toMillis}."
-
-    /** Error messages for activations. */
-    val abnormalInitialization = "The action did not initialize and exited unexpectedly."
-    val abnormalRun = "The action did not produce a valid response and exited unexpectedly."
-    def badEntityName(value: String) = s"Parameter is not a valid value for a entity name: $value"
-    def badNamespace(value: String) = s"Parameter is not a valid value for a namespace: $value"
-    def badEpoch(value: String) = s"Parameter is not a valid value for epoch seconds: $value"
-
-    /** Error message for size conformance. */
-    def entityTooBig(error: SizeError) = {
-        s"${error.field} larger than allowed: ${error.is.toBytes} > ${error.allowed.toBytes} bytes."
+  def timedoutActivation(timeout: Duration, init: Boolean) = {
+    s"The action exceeded its time limits of ${timeout.toMillis} milliseconds" + {
+      if (!init) "." else " during initialization."
     }
-    def maxActivationLimitExceeded(value: Int, max: Int) = s"Activation limit of $value exceeds maximum limit of $max."
+  }
 
-    def truncateLogs(limit: ByteSize) = {
-        s"Logs were truncated because the total bytes size exceeds the limit of ${limit.toBytes} bytes."
-    }
-
-    /** Error for meta api. */
-    val propertyNotFound = "Response does not include requested property."
-    def invalidMedia(m: MediaType) = s"Response is not valid '${m.value}'."
-    def contentTypeExtensionNotSupported(extensions: Set[String]) = {
-        s"""Extension must be specified and one of ${extensions.mkString("[", ", ", "]")}."""
-    }
-    val unsupportedContentType = """Content type is not supported."""
-    def unsupportedContentType(m: MediaType) = s"""Content type '${m.value}' is not supported."""
-    val errorExtractingRequestBody = "Failed extracting request body."
-
-    val responseNotReady = "Response not yet ready."
-    val httpUnknownContentType = "Response did not specify a known content-type."
-    val httpContentTypeError = "Response type in header did not match generated content type."
-    val errorProcessingRequest = "There was an error processing your request."
-
-    def invalidInitResponse(actualResponse: String) = {
-        "The action failed during initialization" + {
-            Option(actualResponse) filter { _.nonEmpty } map { s => s": $s" } getOrElse "."
-        }
-    }
-
-    def invalidRunResponse(actualResponse: String) = {
-        "The action did not produce a valid JSON response" + {
-            Option(actualResponse) filter { _.nonEmpty } map { s => s": $s" } getOrElse "."
-        }
-    }
-
-    def truncatedResponse(length: ByteSize, maxLength: ByteSize): String = {
-        s"The action produced a response that exceeded the allowed length: ${length.toBytes} > ${maxLength.toBytes} bytes."
-    }
-
-    def truncatedResponse(trunk: String, length: ByteSize, maxLength: ByteSize): String = {
-        s"${truncatedResponse(length, maxLength)} The truncated response was: $trunk"
-    }
-
-    def timedoutActivation(timeout: Duration, init: Boolean) = {
-        s"The action exceeded its time limits of ${timeout.toMillis} milliseconds" + {
-            if (!init) "." else " during initialization."
-        }
-    }
-
-    val actionRemovedWhileInvoking = "Action could not be found or may have been deleted."
+  val actionRemovedWhileInvoking = "Action could not be found or may have been deleted."
 }
 
 /** Replaces rejections with Json object containing cause and transaction id. */
@@ -169,42 +177,42 @@ case class ErrorResponse(error: String, code: TransactionId)
 
 object ErrorResponse extends Directives with DefaultJsonProtocol {
 
-    def terminate(status: StatusCode, error: String)(
-        implicit transid: TransactionId, jsonPrinter: JsonPrinter): StandardRoute = {
-        terminate(status, Option(error) filter { _.trim.nonEmpty } map {
-            e => Some(ErrorResponse(e.trim, transid))
-        } getOrElse None)
-    }
+  def terminate(status: StatusCode, error: String)(implicit transid: TransactionId,
+                                                   jsonPrinter: JsonPrinter): StandardRoute = {
+    terminate(status, Option(error) filter { _.trim.nonEmpty } map { e =>
+      Some(ErrorResponse(e.trim, transid))
+    } getOrElse None)
+  }
 
-    def terminate(status: StatusCode, error: Option[ErrorResponse] = None, asJson: Boolean = true)(
-        implicit transid: TransactionId, jsonPrinter: JsonPrinter): StandardRoute = {
-        val errorResponse = error getOrElse response(status)
-        if (asJson) {
-            complete(status, errorResponse)
-        } else {
-            complete(status, s"${errorResponse.error} (code: ${errorResponse.code})")
+  def terminate(status: StatusCode, error: Option[ErrorResponse] = None, asJson: Boolean = true)(
+    implicit transid: TransactionId,
+    jsonPrinter: JsonPrinter): StandardRoute = {
+    val errorResponse = error getOrElse response(status)
+    if (asJson) {
+      complete(status, errorResponse)
+    } else {
+      complete(status, s"${errorResponse.error} (code: ${errorResponse.code})")
+    }
+  }
+
+  def response(status: StatusCode)(implicit transid: TransactionId): ErrorResponse = status match {
+    case NotFound  => ErrorResponse(Messages.resourceDoesNotExist, transid)
+    case Forbidden => ErrorResponse(Messages.notAuthorizedtoOperateOnResource, transid)
+    case _         => ErrorResponse(status.defaultMessage, transid)
+  }
+
+  implicit val serializer = new RootJsonFormat[ErrorResponse] {
+    def write(er: ErrorResponse) = JsObject("error" -> er.error.toJson, "code" -> er.code.meta.id.toJson)
+
+    def read(v: JsValue) =
+      Try {
+        v.asJsObject.getFields("error", "code") match {
+          case Seq(JsString(error), JsNumber(code)) =>
+            ErrorResponse(error, TransactionId(code))
+          case Seq(JsString(error)) =>
+            ErrorResponse(error, TransactionId.unknown)
         }
-    }
-
-    def response(status: StatusCode)(implicit transid: TransactionId): ErrorResponse = status match {
-        case NotFound  => ErrorResponse(Messages.resourceDoesNotExist, transid)
-        case Forbidden => ErrorResponse(Messages.notAuthorizedtoOperateOnResource, transid)
-        case _         => ErrorResponse(status.defaultMessage, transid)
-    }
-
-    implicit val serializer = new RootJsonFormat[ErrorResponse] {
-        def write(er: ErrorResponse) = JsObject(
-            "error" -> er.error.toJson,
-            "code" -> er.code.meta.id.toJson)
-
-        def read(v: JsValue) = Try {
-            v.asJsObject.getFields("error", "code") match {
-                case Seq(JsString(error), JsNumber(code)) =>
-                    ErrorResponse(error, TransactionId(code))
-                case Seq(JsString(error)) =>
-                    ErrorResponse(error, TransactionId.unknown)
-            }
-        } getOrElse deserializationError("error response malformed")
-    }
+      } getOrElse deserializationError("error response malformed")
+  }
 
 }

--- a/common/scala/src/main/scala/whisk/spi/SpiLoader.scala
+++ b/common/scala/src/main/scala/whisk/spi/SpiLoader.scala
@@ -23,26 +23,29 @@ import com.typesafe.config.ConfigFactory
 trait Spi
 
 trait SpiClassResolver {
-    /** Resolves the implementation for a given type */
-    def getClassNameForType[T : Manifest]: String
+
+  /** Resolves the implementation for a given type */
+  def getClassNameForType[T: Manifest]: String
 }
 
 object SpiLoader {
-    /**
-     * Instantiates an object of the given type.
-     *
-     * The ClassName to load is resolved via the SpiClassResolver in scode, which defaults to
-     * a TypesafeConfig based resolver.
-     */
-    def get[A <: Spi : Manifest](implicit resolver: SpiClassResolver = TypesafeConfigClassResolver): A = {
-        val clazz = Class.forName(resolver.getClassNameForType[A] + "$")
-        clazz.getField("MODULE$").get(clazz).asInstanceOf[A]
-    }
+
+  /**
+   * Instantiates an object of the given type.
+   *
+   * The ClassName to load is resolved via the SpiClassResolver in scode, which defaults to
+   * a TypesafeConfig based resolver.
+   */
+  def get[A <: Spi: Manifest](implicit resolver: SpiClassResolver = TypesafeConfigClassResolver): A = {
+    val clazz = Class.forName(resolver.getClassNameForType[A] + "$")
+    clazz.getField("MODULE$").get(clazz).asInstanceOf[A]
+  }
 }
 
 /** Lookup the classname for the SPI impl based on a key in the provided Config */
 object TypesafeConfigClassResolver extends SpiClassResolver {
-    private val config = ConfigFactory.load()
+  private val config = ConfigFactory.load()
 
-    override def getClassNameForType[T : Manifest]: String = config.getString("whisk.spi." + manifest[T].runtimeClass.getSimpleName)
+  override def getClassNameForType[T: Manifest]: String =
+    config.getString("whisk.spi." + manifest[T].runtimeClass.getSimpleName)
 }

--- a/common/scala/src/main/scala/whisk/utils/ExecutionContextFactory.scala
+++ b/common/scala/src/main/scala/whisk/utils/ExecutionContextFactory.scala
@@ -26,49 +26,50 @@ import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 
 import akka.actor.ActorSystem
-import akka.pattern.{ after => expire }
+import akka.pattern.{after => expire}
 
 object ExecutionContextFactory {
 
-    // Future.firstCompletedOf has a memory drag bug
-    // https://stackoverflow.com/questions/36420697/about-future-firstcompletedof-and-garbage-collect-mechanism
-    def firstCompletedOf[T](futures: TraversableOnce[Future[T]])(implicit executor: ExecutionContext): Future[T] = {
-        val p = Promise[T]()
-        val pref = new java.util.concurrent.atomic.AtomicReference(p)
-        val completeFirst: Try[T] => Unit = { result: Try[T] =>
-            val promise = pref.getAndSet(null)
-            if (promise != null) {
-                promise.tryComplete(result)
-            }
-        }
-        futures foreach { _ onComplete completeFirst }
-        p.future
+  // Future.firstCompletedOf has a memory drag bug
+  // https://stackoverflow.com/questions/36420697/about-future-firstcompletedof-and-garbage-collect-mechanism
+  def firstCompletedOf[T](futures: TraversableOnce[Future[T]])(implicit executor: ExecutionContext): Future[T] = {
+    val p = Promise[T]()
+    val pref = new java.util.concurrent.atomic.AtomicReference(p)
+    val completeFirst: Try[T] => Unit = { result: Try[T] =>
+      val promise = pref.getAndSet(null)
+      if (promise != null) {
+        promise.tryComplete(result)
+      }
+    }
+    futures foreach { _ onComplete completeFirst }
+    p.future
+  }
+
+  implicit class FutureExtensions[T](f: Future[T]) {
+    def withTimeout(timeout: FiniteDuration, msg: => Throwable)(implicit system: ActorSystem): Future[T] = {
+      implicit val ec = system.dispatcher
+      firstCompletedOf(Seq(f, expire(timeout, system.scheduler)(Future.failed(msg))))
     }
 
-    implicit class FutureExtensions[T](f: Future[T]) {
-        def withTimeout(timeout: FiniteDuration, msg: => Throwable)(implicit system: ActorSystem): Future[T] = {
-            implicit val ec = system.dispatcher
-            firstCompletedOf(Seq(f, expire(timeout, system.scheduler)(Future.failed(msg))))
-        }
-
-        def withAlternativeAfterTimeout(timeout: FiniteDuration, alt: => Future[T])(implicit system: ActorSystem): Future[T] = {
-            implicit val ec = system.dispatcher
-            firstCompletedOf(Seq(f, expire(timeout, system.scheduler)(alt)))
-        }
+    def withAlternativeAfterTimeout(timeout: FiniteDuration, alt: => Future[T])(
+      implicit system: ActorSystem): Future[T] = {
+      implicit val ec = system.dispatcher
+      firstCompletedOf(Seq(f, expire(timeout, system.scheduler)(alt)))
     }
+  }
 
-    /**
-     * Makes an execution context for Futures using Executors.newCachedThreadPool. From the javadoc:
-     *
-     * Creates a thread pool that creates new threads as needed, but will reuse previously constructed threads
-     * when they are available. These pools will typically improve the performance of programs that execute many
-     * short-lived asynchronous tasks. Calls to execute will reuse previously constructed threads if available.
-     * If no existing thread is available, a new thread will be created and added to the pool. Threads that have
-     * not been used for sixty seconds are terminated and removed from the cache. Thus, a pool that remains idle
-     * for long enough will not consume any resources. Note that pools with similar properties but different details
-     * (for example, timeout parameters) may be created using ThreadPoolExecutor constructors.
-     */
-    def makeCachedThreadPoolExecutionContext(): ExecutionContext = {
-        ExecutionContext.fromExecutor(Executors.newCachedThreadPool())
-    }
+  /**
+   * Makes an execution context for Futures using Executors.newCachedThreadPool. From the javadoc:
+   *
+   * Creates a thread pool that creates new threads as needed, but will reuse previously constructed threads
+   * when they are available. These pools will typically improve the performance of programs that execute many
+   * short-lived asynchronous tasks. Calls to execute will reuse previously constructed threads if available.
+   * If no existing thread is available, a new thread will be created and added to the pool. Threads that have
+   * not been used for sixty seconds are terminated and removed from the cache. Thus, a pool that remains idle
+   * for long enough will not consume any resources. Note that pools with similar properties but different details
+   * (for example, timeout parameters) may be created using ThreadPoolExecutor constructors.
+   */
+  def makeCachedThreadPoolExecutionContext(): ExecutionContext = {
+    ExecutionContext.fromExecutor(Executors.newCachedThreadPool())
+  }
 }

--- a/common/scala/src/main/scala/whisk/utils/JsHelpers.scala
+++ b/common/scala/src/main/scala/whisk/utils/JsHelpers.scala
@@ -21,22 +21,23 @@ import spray.json.JsObject
 import spray.json.JsValue
 
 object JsHelpers {
-    def getFieldPath(js: JsObject, path: List[String]): Option[JsValue] = {
-        path match {
-            case Nil      => Option(js)
-            case p :: Nil => js.fields.get(p)
-            case p :: tail => js.fields.get(p) match {
-                case Some(o: JsObject) => getFieldPath(o, tail)
-                case Some(_)           => None // head exists but value is not an object so cannot project further
-                case None              => None // head doesn't exist, cannot project further
-            }
+  def getFieldPath(js: JsObject, path: List[String]): Option[JsValue] = {
+    path match {
+      case Nil      => Option(js)
+      case p :: Nil => js.fields.get(p)
+      case p :: tail =>
+        js.fields.get(p) match {
+          case Some(o: JsObject) => getFieldPath(o, tail)
+          case Some(_)           => None // head exists but value is not an object so cannot project further
+          case None              => None // head doesn't exist, cannot project further
         }
     }
+  }
 
-    def getFieldPath(js: JsObject, path: String*): Option[JsValue] = {
-        getFieldPath(js, path.toList)
-    }
+  def getFieldPath(js: JsObject, path: String*): Option[JsValue] = {
+    getFieldPath(js, path.toList)
+  }
 
-    def fieldPathExists(js: JsObject, path: List[String]): Boolean = getFieldPath(js, path).isDefined
-    def fieldPathExists(js: JsObject, path: String*): Boolean = fieldPathExists(js, path.toList)
+  def fieldPathExists(js: JsObject, path: List[String]): Boolean = getFieldPath(js, path).isDefined
+  def fieldPathExists(js: JsObject, path: String*): Boolean = fieldPathExists(js, path.toList)
 }

--- a/common/scala/src/main/scala/whisk/utils/Retry.scala
+++ b/common/scala/src/main/scala/whisk/utils/Retry.scala
@@ -25,25 +25,30 @@ import scala.util.Try
 import scala.language.postfixOps
 
 object retry {
-    /**
-     * Retry a method which returns a value or throws an exception on failure, up to N times,
-     * and optionally sleeping up to specified duration between retries.
-     *
-     * @param fn the method to retry, fn is expected to throw an exception if it fails, else should return a value of type T
-     * @param N the maximum number of times to apply fn, must be >= 1
-     * @param waitBeforeRetry an option specifying duration to wait before retrying method, will not wait if none given
-     * @return the result of fn iff it is successful
-     * @throws exception from fn (or an illegal argument exception if N is < 1)
-     */
-    def apply[T](fn: => T, N: Int = 3, waitBeforeRetry: Option[Duration] = Some(1 millisecond)): T = {
-        require(N >= 1, "maximum number of fn applications must be greater than 1")
-        waitBeforeRetry map { t => Thread.sleep(t.toMillis) } // initial wait if any
-        Try { fn } match {
-            case Success(r) => r
-            case _ if N > 1 =>
-                waitBeforeRetry map { t => Thread.sleep(t.toMillis) }
-                retry(fn, N - 1, waitBeforeRetry)
-            case Failure(t) => throw t
+
+  /**
+   * Retry a method which returns a value or throws an exception on failure, up to N times,
+   * and optionally sleeping up to specified duration between retries.
+   *
+   * @param fn the method to retry, fn is expected to throw an exception if it fails, else should return a value of type T
+   * @param N the maximum number of times to apply fn, must be >= 1
+   * @param waitBeforeRetry an option specifying duration to wait before retrying method, will not wait if none given
+   * @return the result of fn iff it is successful
+   * @throws exception from fn (or an illegal argument exception if N is < 1)
+   */
+  def apply[T](fn: => T, N: Int = 3, waitBeforeRetry: Option[Duration] = Some(1 millisecond)): T = {
+    require(N >= 1, "maximum number of fn applications must be greater than 1")
+    waitBeforeRetry map { t =>
+      Thread.sleep(t.toMillis)
+    } // initial wait if any
+    Try { fn } match {
+      case Success(r) => r
+      case _ if N > 1 =>
+        waitBeforeRetry map { t =>
+          Thread.sleep(t.toMillis)
         }
+        retry(fn, N - 1, waitBeforeRetry)
+      case Failure(t) => throw t
     }
+  }
 }

--- a/core/controller/build.gradle
+++ b/core/controller/build.gradle
@@ -1,9 +1,6 @@
 apply plugin: 'scala'
 apply plugin: 'application'
 apply plugin: 'eclipse'
-apply plugin: 'scalafmt'
-
-scalafmt.configFilePath = gradle.scalafmt.config
 
 ext.dockerImageName = 'controller'
 apply from: '../../gradle/docker.gradle'

--- a/core/controller/build.gradle
+++ b/core/controller/build.gradle
@@ -1,12 +1,3 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath "cz.alenkacz:gradle-scalafmt:${gradle.scalafmt.version}"
-    }
-}
-
 apply plugin: 'scala'
 apply plugin: 'application'
 apply plugin: 'eclipse'

--- a/core/controller/build.gradle
+++ b/core/controller/build.gradle
@@ -1,6 +1,18 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath "cz.alenkacz:gradle-scalafmt:${gradle.scalafmt.version}"
+    }
+}
+
 apply plugin: 'scala'
 apply plugin: 'application'
 apply plugin: 'eclipse'
+apply plugin: 'scalafmt'
+
+scalafmt.configFilePath = gradle.scalafmt.config
 
 ext.dockerImageName = 'controller'
 apply from: '../../gradle/docker.gradle'

--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -20,7 +20,7 @@ package whisk.core.controller
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.language.postfixOps
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 
 import org.apache.kafka.common.errors.RecordTooLargeException
 
@@ -58,592 +58,613 @@ import whisk.core.entitlement.Privilege._
  * in order to implement the actions API.
  */
 object WhiskActionsApi {
-    def requiredProperties = Map(WhiskConfig.actionSequenceMaxLimit -> null)
+  def requiredProperties = Map(WhiskConfig.actionSequenceMaxLimit -> null)
 
-    /** Grace period after action timeout limit to poll for result. */
-    protected[core] val blockingInvokeGrace = 5 seconds
+  /** Grace period after action timeout limit to poll for result. */
+  protected[core] val blockingInvokeGrace = 5 seconds
 
-    /**
-     * Max duration to wait for a blocking activation.
-     * This is the default timeout on a POST request.
-     */
-    protected[core] val maxWaitForBlockingActivation = 60 seconds
+  /**
+   * Max duration to wait for a blocking activation.
+   * This is the default timeout on a POST request.
+   */
+  protected[core] val maxWaitForBlockingActivation = 60 seconds
 }
 
 /** A trait implementing the actions API. */
-trait WhiskActionsApi
-    extends WhiskCollectionAPI
-    with PostActionActivation
-    with ReferencedEntities {
-    services: WhiskServices =>
+trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with ReferencedEntities {
+  services: WhiskServices =>
 
-    protected override val collection = Collection(Collection.ACTIONS)
+  protected override val collection = Collection(Collection.ACTIONS)
 
-    /** An actor system for timed based futures. */
-    protected implicit val actorSystem: ActorSystem
+  /** An actor system for timed based futures. */
+  protected implicit val actorSystem: ActorSystem
 
-    /** Database service to CRUD actions. */
-    protected val entityStore: EntityStore
+  /** Database service to CRUD actions. */
+  protected val entityStore: EntityStore
 
-    /** Notification service for cache invalidation. */
-    protected implicit val cacheChangeNotification: Some[CacheChangeNotification]
+  /** Notification service for cache invalidation. */
+  protected implicit val cacheChangeNotification: Some[CacheChangeNotification]
 
-    /** Database service to get activations. */
-    protected val activationStore: ActivationStore
+  /** Database service to get activations. */
+  protected val activationStore: ActivationStore
 
-    /** Entity normalizer to JSON object. */
-    import RestApiCommons.emptyEntityToJsObject
+  /** Entity normalizer to JSON object. */
+  import RestApiCommons.emptyEntityToJsObject
 
-    /** JSON response formatter. */
-    import RestApiCommons.jsonDefaultResponsePrinter
+  /** JSON response formatter. */
+  import RestApiCommons.jsonDefaultResponsePrinter
 
-    /**
-     * Handles operations on action resources, which encompass these cases:
-     *
-     * 1. ns/foo     -> subject must be authorized for one of { action(ns, *), action(ns, foo) },
-     *                  resource resolves to { action(ns, foo) }
-     *
-     * 2. ns/bar/foo -> where bar is a package
-     *                  subject must be authorized for one of { package(ns, *), package(ns, bar), action(ns.bar, foo) }
-     *                  resource resolves to { action(ns.bar, foo) }
-     *
-     * 3. ns/baz/foo -> where baz is a binding to ns'.bar
-     *                  subject must be authorized for one of { package(ns, *), package(ns, baz) }
-     *                  *and* one of { package(ns', *), package(ns', bar), action(ns'.bar, foo) }
-     *                  resource resolves to { action(ns'.bar, foo) }
-     *
-     * Note that package(ns, xyz) == action(ns.xyz, *) and if subject has rights to package(ns, xyz)
-     * then they also have rights to action(ns.xyz, *) since sharing is done at the package level and
-     * is not more granular; hence a check on action(ns.xyz, abc) is eschewed.
-     *
-     * Only list is supported for these resources:
-     *
-     * 4. ns/bar/    -> where bar is a package
-     *                  subject must be authorized for one of { package(ns, *), package(ns, bar) }
-     *                  resource resolves to { action(ns.bar, *) }
-     *
-     * 5. ns/baz/    -> where baz is a binding to ns'.bar
-     *                  subject must be authorized for one of { package(ns, *), package(ns, baz) }
-     *                  *and* one of { package(ns', *), package(ns', bar) }
-     *                  resource resolves to { action(ns.bar, *) }
-     */
-    protected override def innerRoutes(user: Identity, ns: EntityPath)(implicit transid: TransactionId) = {
-        (entityPrefix & entityOps & requestMethod) { (segment, m) =>
-            entityname(segment) { outername =>
-                pathEnd {
-                    // matched /namespace/collection/name
-                    // this is an action in default package, authorize and dispatch
-                    authorizeAndDispatch(m, user, Resource(ns, collection, Some(outername)))
-                } ~ (get & pathSingleSlash) {
-                    // matched GET /namespace/collection/package-name/
-                    // list all actions in package iff subject is entitled to READ package
-                    val resource = Resource(ns, Collection(Collection.PACKAGES), Some(outername))
-                    onComplete(entitlementProvider.check(user, Privilege.READ, resource)) {
-                        case Success(_) => listPackageActions(user, FullyQualifiedEntityName(ns, EntityName(outername)))
-                        case Failure(f) => super.handleEntitlementFailure(f)
-                    }
-                } ~ (entityPrefix & pathEnd) { segment =>
-                    entityname(segment) { innername =>
-                        // matched /namespace/collection/package-name/action-name
-                        // this is an action in a named package
-                        val packageDocId = FullyQualifiedEntityName(ns, EntityName(outername)).toDocId
-                        val packageResource = Resource(ns.addPath(EntityName(outername)), collection, Some(innername))
+  /**
+   * Handles operations on action resources, which encompass these cases:
+   *
+   * 1. ns/foo     -> subject must be authorized for one of { action(ns, *), action(ns, foo) },
+   *                  resource resolves to { action(ns, foo) }
+   *
+   * 2. ns/bar/foo -> where bar is a package
+   *                  subject must be authorized for one of { package(ns, *), package(ns, bar), action(ns.bar, foo) }
+   *                  resource resolves to { action(ns.bar, foo) }
+   *
+   * 3. ns/baz/foo -> where baz is a binding to ns'.bar
+   *                  subject must be authorized for one of { package(ns, *), package(ns, baz) }
+   *                  *and* one of { package(ns', *), package(ns', bar), action(ns'.bar, foo) }
+   *                  resource resolves to { action(ns'.bar, foo) }
+   *
+   * Note that package(ns, xyz) == action(ns.xyz, *) and if subject has rights to package(ns, xyz)
+   * then they also have rights to action(ns.xyz, *) since sharing is done at the package level and
+   * is not more granular; hence a check on action(ns.xyz, abc) is eschewed.
+   *
+   * Only list is supported for these resources:
+   *
+   * 4. ns/bar/    -> where bar is a package
+   *                  subject must be authorized for one of { package(ns, *), package(ns, bar) }
+   *                  resource resolves to { action(ns.bar, *) }
+   *
+   * 5. ns/baz/    -> where baz is a binding to ns'.bar
+   *                  subject must be authorized for one of { package(ns, *), package(ns, baz) }
+   *                  *and* one of { package(ns', *), package(ns', bar) }
+   *                  resource resolves to { action(ns.bar, *) }
+   */
+  protected override def innerRoutes(user: Identity, ns: EntityPath)(implicit transid: TransactionId) = {
+    (entityPrefix & entityOps & requestMethod) { (segment, m) =>
+      entityname(segment) { outername =>
+        pathEnd {
+          // matched /namespace/collection/name
+          // this is an action in default package, authorize and dispatch
+          authorizeAndDispatch(m, user, Resource(ns, collection, Some(outername)))
+        } ~ (get & pathSingleSlash) {
+          // matched GET /namespace/collection/package-name/
+          // list all actions in package iff subject is entitled to READ package
+          val resource = Resource(ns, Collection(Collection.PACKAGES), Some(outername))
+          onComplete(entitlementProvider.check(user, Privilege.READ, resource)) {
+            case Success(_) => listPackageActions(user, FullyQualifiedEntityName(ns, EntityName(outername)))
+            case Failure(f) => super.handleEntitlementFailure(f)
+          }
+        } ~ (entityPrefix & pathEnd) { segment =>
+          entityname(segment) { innername =>
+            // matched /namespace/collection/package-name/action-name
+            // this is an action in a named package
+            val packageDocId = FullyQualifiedEntityName(ns, EntityName(outername)).toDocId
+            val packageResource = Resource(ns.addPath(EntityName(outername)), collection, Some(innername))
 
-                        val right = collection.determineRight(m, Some(innername))
-                        onComplete(entitlementProvider.check(user, right, packageResource)) {
-                            case Success(_) =>
-                                getEntity(WhiskPackage, entityStore, packageDocId, Some {
-                                    if (right == Privilege.READ || right == Privilege.ACTIVATE) {
-                                        // need to merge package with action, hence authorize subject for package
-                                        // access (if binding, then subject must be authorized for both the binding
-                                        // and the referenced package)
-                                        //
-                                        // NOTE: it is an error if either the package or the action does not exist,
-                                        // the former manifests as unauthorized and the latter as not found
-                                        mergeActionWithPackageAndDispatch(m, user, EntityName(innername)) _
-                                    } else {
-                                        // these packaged action operations do not need merging with the package,
-                                        // but may not be permitted if this is a binding, or if the subject does
-                                        // not have PUT and DELETE rights to the package itself
-                                        (wp: WhiskPackage) =>
-                                            wp.binding map {
-                                                _ => terminate(BadRequest, Messages.notAllowedOnBinding)
-                                            } getOrElse {
-                                                val actionResource = Resource(wp.fullPath, collection, Some(innername))
-                                                dispatchOp(user, right, actionResource)
-                                            }
-                                    }
-                                })
-                            case Failure(f) => super.handleEntitlementFailure(f)
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * Creates or updates action if it already exists. The PUT content is deserialized into a WhiskActionPut
-     * which is a subset of WhiskAction (it eschews the namespace and entity name since the former is derived
-     * from the authenticated user and the latter is derived from the URI). The WhiskActionPut is merged with
-     * the existing WhiskAction in the datastore, overriding old values with new values that are defined.
-     * Any values not defined in the PUT content are replaced with old values.
-     *
-     * Responses are one of (Code, Message)
-     * - 200 WhiskAction as JSON
-     * - 400 Bad Request
-     * - 409 Conflict
-     * - 500 Internal Server Error
-     */
-    override def create(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
-        parameter('overwrite ? false) { overwrite =>
-            entity(as[WhiskActionPut]) { content =>
-                val request = content.resolve(user.namespace)
-
-                onComplete(entitleReferencedEntities(user, Privilege.READ, request.exec)) {
-                    case Success(_) =>
-                        putEntity(WhiskAction, entityStore, entityName.toDocId, overwrite,
-                            update(user, request)_, () => { make(user, entityName, request) })
-                    case Failure(f) =>
-                        super.handleEntitlementFailure(f)
-                }
-            }
-        }
-    }
-
-    /**
-     * Invokes action if it exists. The POST content is deserialized into a Payload and posted
-     * to the loadbalancer.
-     *
-     * Responses are one of (Code, Message)
-     * - 200 Activation as JSON if blocking or just the result JSON iff '&result=true'
-     * - 202 ActivationId as JSON (this is issued on non-blocking activation or blocking activation that times out)
-     * - 404 Not Found
-     * - 502 Bad Gateway
-     * - 500 Internal Server Error
-     */
-    override def activate(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(implicit transid: TransactionId) = {
-        parameter('blocking ? false, 'result ? false, 'timeout.as[FiniteDuration] ? WhiskActionsApi.maxWaitForBlockingActivation) { (blocking, result, waitOverride) =>
-            entity(as[Option[JsObject]]) { payload =>
-                getEntity(WhiskAction, entityStore, entityName.toDocId, Some {
-                    act: WhiskAction =>
-                        // resolve the action --- special case for sequences that may contain components with '_' as default package
-                        val action = act.resolve(user.namespace)
-                        onComplete(entitleReferencedEntities(user, Privilege.ACTIVATE, Some(action.exec))) {
-                            case Success(_) =>
-                                val actionWithMergedParams = env.map(action.inherit(_)) getOrElse action
-                                val waitForResponse = if (blocking) Some(waitOverride) else None
-                                onComplete(invokeAction(user, actionWithMergedParams, payload, waitForResponse, cause = None)) {
-                                    case Success(Left(activationId)) =>
-                                        // non-blocking invoke or blocking invoke which got queued instead
-                                        complete(Accepted, activationId.toJsObject)
-                                    case Success(Right(activation)) =>
-                                        val response = if (result) activation.resultAsJson else activation.toExtendedJson
-
-                                        if (activation.response.isSuccess) {
-                                            complete(OK, response)
-                                        } else if (activation.response.isApplicationError) {
-                                            // actions that result is ApplicationError status are considered a 'success'
-                                            // and will have an 'error' property in the result - the HTTP status is OK
-                                            // and clients must check the response status if it exists
-                                            // NOTE: response status will not exist in the JSON object if ?result == true
-                                            // and instead clients must check if 'error' is in the JSON
-                                            // PRESERVING OLD BEHAVIOR and will address defect in separate change
-                                            complete(BadGateway, response)
-                                        } else if (activation.response.isContainerError) {
-                                            complete(BadGateway, response)
-                                        } else {
-                                            complete(InternalServerError, response)
-                                        }
-                                    case Failure(t: RecordTooLargeException) =>
-                                        logging.info(this, s"[POST] action payload was too large")
-                                        terminate(RequestEntityTooLarge)
-                                    case Failure(RejectRequest(code, message)) =>
-                                        logging.info(this, s"[POST] action rejected with code $code: $message")
-                                        terminate(code, message)
-                                    case Failure(t: Throwable) =>
-                                        logging.error(this, s"[POST] action activation failed: ${t.getMessage}")
-                                        terminate(InternalServerError)
-                                }
-
-                            case Failure(f) =>
-                                super.handleEntitlementFailure(f)
-                        }
+            val right = collection.determineRight(m, Some(innername))
+            onComplete(entitlementProvider.check(user, right, packageResource)) {
+              case Success(_) =>
+                getEntity(WhiskPackage, entityStore, packageDocId, Some {
+                  if (right == Privilege.READ || right == Privilege.ACTIVATE) {
+                    // need to merge package with action, hence authorize subject for package
+                    // access (if binding, then subject must be authorized for both the binding
+                    // and the referenced package)
+                    //
+                    // NOTE: it is an error if either the package or the action does not exist,
+                    // the former manifests as unauthorized and the latter as not found
+                    mergeActionWithPackageAndDispatch(m, user, EntityName(innername)) _
+                  } else {
+                    // these packaged action operations do not need merging with the package,
+                    // but may not be permitted if this is a binding, or if the subject does
+                    // not have PUT and DELETE rights to the package itself
+                    (wp: WhiskPackage) =>
+                      wp.binding map { _ =>
+                        terminate(BadRequest, Messages.notAllowedOnBinding)
+                      } getOrElse {
+                        val actionResource = Resource(wp.fullPath, collection, Some(innername))
+                        dispatchOp(user, right, actionResource)
+                      }
+                  }
                 })
+              case Failure(f) => super.handleEntitlementFailure(f)
             }
+          }
         }
+      }
     }
+  }
 
-    /**
-     * Deletes action.
-     *
-     * Responses are one of (Code, Message)
-     * - 200 WhiskAction as JSON
-     * - 404 Not Found
-     * - 409 Conflict
-     * - 500 Internal Server Error
-     */
-    override def remove(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
-        deleteEntity(WhiskAction, entityStore, entityName.toDocId, (a: WhiskAction) => Future.successful({}))
-    }
+  /**
+   * Creates or updates action if it already exists. The PUT content is deserialized into a WhiskActionPut
+   * which is a subset of WhiskAction (it eschews the namespace and entity name since the former is derived
+   * from the authenticated user and the latter is derived from the URI). The WhiskActionPut is merged with
+   * the existing WhiskAction in the datastore, overriding old values with new values that are defined.
+   * Any values not defined in the PUT content are replaced with old values.
+   *
+   * Responses are one of (Code, Message)
+   * - 200 WhiskAction as JSON
+   * - 400 Bad Request
+   * - 409 Conflict
+   * - 500 Internal Server Error
+   */
+  override def create(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
+    parameter('overwrite ? false) { overwrite =>
+      entity(as[WhiskActionPut]) { content =>
+        val request = content.resolve(user.namespace)
 
-    /**
-     * Gets action. The action name is prefixed with the namespace to create the primary index key.
-     *
-     * Responses are one of (Code, Message)
-     * - 200 WhiskAction has JSON
-     * - 404 Not Found
-     * - 500 Internal Server Error
-     */
-    override def fetch(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(implicit transid: TransactionId) = {
-        getEntity(WhiskAction, entityStore, entityName.toDocId, Some { action: WhiskAction =>
-            val mergedAction = env map { action inherit _ } getOrElse action
-            complete(OK, mergedAction)
-        })
-    }
-
-    /**
-     * Gets all actions in a path.
-     *
-     * Responses are one of (Code, Message)
-     * - 200 [] or [WhiskAction as JSON]
-     * - 500 Internal Server Error
-     */
-    override def list(user: Identity, namespace: EntityPath, excludePrivate: Boolean)(implicit transid: TransactionId) = {
-        // for consistency, all the collections should support the same list API
-        // but because supporting docs on actions is difficult, the API does not
-        // offer an option to fetch entities with full docs yet.
-        //
-        // the complication with actions is that providing docs on actions in
-        // package bindings is cannot be do readily done with a couchdb view
-        // and would require finding all bindings in namespace and
-        // joining the actions explicitly here.
-        val docs = false
-        parameter('skip ? 0, 'limit ? collection.listLimit, 'count ? false) {
-            (skip, limit, count) =>
-                listEntities {
-                    WhiskAction.listCollectionInNamespace(entityStore, namespace, skip, limit, docs) map {
-                        list =>
-                            val actions = if (docs) {
-                                list.right.get map { WhiskAction.serdes.write(_) }
-                            } else list.left.get
-                            FilterEntityList.filter(actions, excludePrivate)
-                    }
-                }
+        onComplete(entitleReferencedEntities(user, Privilege.READ, request.exec)) {
+          case Success(_) =>
+            putEntity(WhiskAction, entityStore, entityName.toDocId, overwrite, update(user, request) _, () => {
+              make(user, entityName, request)
+            })
+          case Failure(f) =>
+            super.handleEntitlementFailure(f)
         }
+      }
     }
+  }
 
-    /** Replaces default namespaces in a vector of components from a sequence with appropriate namespace. */
-    private def resolveDefaultNamespace(components: Vector[FullyQualifiedEntityName], user: Identity): Vector[FullyQualifiedEntityName] = {
-        // if components are part of the default namespace, they contain `_`; replace it!
-        val resolvedComponents = components map { c => FullyQualifiedEntityName(c.path.resolveNamespace(user.namespace), c.name) }
-        resolvedComponents
-    }
+  /**
+   * Invokes action if it exists. The POST content is deserialized into a Payload and posted
+   * to the loadbalancer.
+   *
+   * Responses are one of (Code, Message)
+   * - 200 Activation as JSON if blocking or just the result JSON iff '&result=true'
+   * - 202 ActivationId as JSON (this is issued on non-blocking activation or blocking activation that times out)
+   * - 404 Not Found
+   * - 502 Bad Gateway
+   * - 500 Internal Server Error
+   */
+  override def activate(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(
+    implicit transid: TransactionId) = {
+    parameter(
+      'blocking ? false,
+      'result ? false,
+      'timeout.as[FiniteDuration] ? WhiskActionsApi.maxWaitForBlockingActivation) { (blocking, result, waitOverride) =>
+      entity(as[Option[JsObject]]) { payload =>
+        getEntity(WhiskAction, entityStore, entityName.toDocId, Some {
+          act: WhiskAction =>
+            // resolve the action --- special case for sequences that may contain components with '_' as default package
+            val action = act.resolve(user.namespace)
+            onComplete(entitleReferencedEntities(user, Privilege.ACTIVATE, Some(action.exec))) {
+              case Success(_) =>
+                val actionWithMergedParams = env.map(action.inherit(_)) getOrElse action
+                val waitForResponse = if (blocking) Some(waitOverride) else None
+                onComplete(invokeAction(user, actionWithMergedParams, payload, waitForResponse, cause = None)) {
+                  case Success(Left(activationId)) =>
+                    // non-blocking invoke or blocking invoke which got queued instead
+                    complete(Accepted, activationId.toJsObject)
+                  case Success(Right(activation)) =>
+                    val response = if (result) activation.resultAsJson else activation.toExtendedJson
 
-    /** Replaces default namespaces in an action sequence with appropriate namespace. */
-    private def resolveDefaultNamespace(seq: SequenceExec, user: Identity): SequenceExec = {
-        // if components are part of the default namespace, they contain `_`; replace it!
-        val resolvedComponents = resolveDefaultNamespace(seq.components, user)
-        new SequenceExec(resolvedComponents)
-    }
-
-    /**
-     * Creates a WhiskAction instance from the PUT request.
-     */
-    private def makeWhiskAction(content: WhiskActionPut, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
-        val exec = content.exec.get
-        val limits = content.limits map { l =>
-            ActionLimits(
-                l.timeout getOrElse TimeLimit(),
-                l.memory getOrElse MemoryLimit(),
-                l.logs getOrElse LogLimit())
-        } getOrElse ActionLimits()
-        // This is temporary while we are making sequencing directly supported in the controller.
-        // The parameter override allows this to work with Pipecode.code. Any parameters other
-        // than the action sequence itself are discarded and have no effect.
-        // Note: While changing the implementation of sequences, components now store the fully qualified entity names
-        // (which loses the leading "/"). Adding it back while both versions of the code are in place.
-        val parameters = exec match {
-            case seq: SequenceExec => Parameters("_actions", JsArray(seq.components map { _.qualifiedNameWithLeadingSlash.toJson }))
-            case _                 => content.parameters getOrElse Parameters()
-        }
-
-        WhiskAction(
-            entityName.path,
-            entityName.name,
-            exec,
-            parameters,
-            limits,
-            content.version getOrElse SemVer(),
-            content.publish getOrElse false,
-            (content.annotations getOrElse Parameters()) ++ execAnnotation(exec))
-    }
-
-    /** For a sequence action, gather referenced entities and authorize access. */
-    private def entitleReferencedEntities(user: Identity, right: Privilege, exec: Option[Exec])(
-        implicit transid: TransactionId) = {
-        exec match {
-            case Some(seq: SequenceExec) =>
-                logging.info(this, "checking if sequence components are accessible")
-                entitlementProvider.check(user, right, referencedEntities(seq))
-            case _ => Future.successful(true)
-        }
-    }
-
-    /** Creates a WhiskAction from PUT content, generating default values where necessary. */
-    private def make(user: Identity, entityName: FullyQualifiedEntityName, content: WhiskActionPut)(implicit transid: TransactionId) = {
-        content.exec map {
-            case seq: SequenceExec =>
-                // check that the sequence conforms to max length and no recursion rules
-                checkSequenceActionLimits(entityName, seq.components) map {
-                    _ => makeWhiskAction(content.replace(seq), entityName)
-                }
-            case supportedExec if !supportedExec.deprecated =>
-                Future successful makeWhiskAction(content, entityName)
-            case deprecatedExec =>
-                Future failed RejectRequest(BadRequest, runtimeDeprecated(deprecatedExec))
-
-        } getOrElse Future.failed(RejectRequest(BadRequest, "exec undefined"))
-    }
-
-    /** Updates a WhiskAction from PUT content, merging old action where necessary. */
-    private def update(user: Identity, content: WhiskActionPut)(action: WhiskAction)(implicit transid: TransactionId) = {
-        content.exec map {
-            case seq: SequenceExec =>
-                // check that the sequence conforms to max length and no recursion rules
-                checkSequenceActionLimits(FullyQualifiedEntityName(action.namespace, action.name), seq.components) map {
-                    _ => updateWhiskAction(content.replace(seq), action)
-                }
-            case supportedExec if !supportedExec.deprecated =>
-                Future successful updateWhiskAction(content, action)
-            case deprecatedExec =>
-                Future failed RejectRequest(BadRequest, runtimeDeprecated(deprecatedExec))
-        } getOrElse {
-            if (!action.exec.deprecated) {
-                Future successful updateWhiskAction(content, action)
-            } else {
-                Future failed RejectRequest(BadRequest, runtimeDeprecated(action.exec))
-            }
-        }
-    }
-
-    /**
-     * Updates a WhiskAction instance from the PUT request.
-     */
-    private def updateWhiskAction(content: WhiskActionPut, action: WhiskAction)(implicit transid: TransactionId) = {
-        val limits = content.limits map { l =>
-            ActionLimits(l.timeout getOrElse action.limits.timeout, l.memory getOrElse action.limits.memory, l.logs getOrElse action.limits.logs)
-        } getOrElse action.limits
-
-        // This is temporary while we are making sequencing directly supported in the controller.
-        // Actions that are updated with a sequence will have their parameter property overridden.
-        // Actions that are updated with non-sequence actions will either set the parameter property according to
-        // the content provided, or if that is not defined, and iff the previous version of the action was not a
-        // sequence, inherit previous parameters. This is because sequence parameters are special and should not
-        // leak to non-sequence actions.
-        // If updating an action but not specifying a new exec type, then preserve the previous parameters if the
-        // existing type of the action is a sequence (regardless of what parameters may be defined in the content)
-        // otherwise, parameters are inferred from the content or previous values.
-        // Note: While changing the implementation of sequences, components now store the fully qualified entity names
-        // (which loses the leading "/"). Adding it back while both versions of the code are in place. This will disappear completely
-        // once the version of sequences with "pipe.js" is removed.
-        val parameters = content.exec map {
-            case seq: SequenceExec => Parameters("_actions", JsArray(seq.components map { c => JsString("/" + c.toString) }))
-            case _ => content.parameters getOrElse {
-                action.exec match {
-                    case seq: SequenceExec => Parameters()
-                    case _                 => action.parameters
-                }
-            }
-        } getOrElse {
-            action.exec match {
-                case seq: SequenceExec => action.parameters // discard content.parameters
-                case _                 => content.parameters getOrElse action.parameters
-            }
-        }
-
-        val exec = content.exec getOrElse action.exec
-
-        WhiskAction(
-            action.namespace,
-            action.name,
-            exec,
-            parameters,
-            limits,
-            content.version getOrElse action.version.upPatch,
-            content.publish getOrElse action.publish,
-            (content.annotations getOrElse action.annotations) ++ execAnnotation(exec)).
-            revision[WhiskAction](action.docinfo.rev)
-    }
-
-    /**
-     * Lists actions in package or binding. The router authorized the subject for the package
-     * (if binding, then authorized subject for both the binding and the references package)
-     * and iff authorized, this method is reached to lists actions.
-     *
-     * Note that when listing actions in a binding, the namespace on the actions will be that
-     * of the referenced packaged, not the binding.
-     */
-    private def listPackageActions(user: Identity, pkgName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
-        // get the package to determine if it is a package or reference
-        // (this will set the appropriate namespace), and then list actions
-        // NOTE: these fetches are redundant with those from the authorization
-        // and should hit the cache to ameliorate the cost; this can be improved
-        // but requires communicating back from the authorization service the
-        // resolved namespace
-        getEntity(WhiskPackage, entityStore, pkgName.toDocId, Some { (wp: WhiskPackage) =>
-            val pkgns = wp.binding map { b =>
-                logging.info(this, s"list actions in package binding '${wp.name}' -> '$b'")
-                b.namespace.addPath(b.name)
-            } getOrElse {
-                logging.info(this, s"list actions in package '${wp.name}'")
-                pkgName.path.addPath(wp.name)
-            }
-            // list actions in resolved namespace
-            // NOTE: excludePrivate is false since the subject is authorize to access
-            // the package; in the future, may wish to exclude private actions in a
-            // public package instead
-            list(user, pkgns, excludePrivate = false)
-        })
-    }
-
-    /**
-     * Constructs a WhiskPackage that is a merger of a package with its packing binding (if any).
-     * This resolves a reference versus an actual package and merge parameters as needed.
-     * Once the package is resolved, the operation is dispatched to the action in the package
-     * namespace.
-     */
-    private def mergeActionWithPackageAndDispatch(method: HttpMethod, user: Identity, action: EntityName, ref: Option[WhiskPackage] = None)(wp: WhiskPackage)(
-        implicit transid: TransactionId): RequestContext => Future[RouteResult] = {
-        wp.binding map {
-            case b: Binding =>
-                val docid = b.fullyQualifiedName.toDocId
-                logging.info(this, s"fetching package '$docid' for reference")
-                // already checked that subject is authorized for package and binding;
-                // this fetch is redundant but should hit the cache to ameliorate cost
-                getEntity(WhiskPackage, entityStore, docid, Some {
-                    mergeActionWithPackageAndDispatch(method, user, action, Some { wp }) _
-                })
-        } getOrElse {
-            // a subject has implied rights to all resources in a package, so dispatch
-            // operation without further entitlement checks
-            val params = { ref map { _ inherit wp.parameters } getOrElse wp } parameters
-            val ns = wp.namespace.addPath(wp.name) // the package namespace
-            val resource = Resource(ns, collection, Some { action.asString }, Some { params })
-            val right = collection.determineRight(method, resource.entity)
-            logging.info(this, s"merged package parameters and rebased action to '$ns")
-            dispatchOp(user, right, resource)
-        }
-    }
-
-    /**
-     * Checks that the sequence is not cyclic and that the number of atomic actions in the "inlined" sequence is lower than max allowed.
-     *
-     * @param sequenceAction is the action sequence to check
-     * @param components the components of the sequence
-     */
-    private def checkSequenceActionLimits(sequenceAction: FullyQualifiedEntityName, components: Vector[FullyQualifiedEntityName])(
-        implicit transid: TransactionId): Future[Unit] = {
-        // first checks that current sequence length is allowed
-        // then traverses all actions in the sequence, inlining any that are sequences
-        val future = if (components.size > actionSequenceLimit) {
-            Future.failed(TooManyActionsInSequence())
-        } else if (components.size == 0) {
-            Future.failed(NoComponentInSequence())
-        } else {
-            // resolve the action document id (if it's in a package/binding);
-            // this assumes that entityStore is the same for actions and packages
-            WhiskAction.resolveAction(entityStore, sequenceAction) flatMap { resolvedSeq =>
-                val atomicActionCnt = countAtomicActionsAndCheckCycle(resolvedSeq, components)
-                atomicActionCnt map { count =>
-                    logging.debug(this, s"sequence '$sequenceAction' atomic action count $count")
-                    if (count > actionSequenceLimit) {
-                        throw TooManyActionsInSequence()
-                    }
-                }
-            }
-        }
-
-        future recoverWith {
-            case _: TooManyActionsInSequence => Future failed RejectRequest(BadRequest, sequenceIsTooLong)
-            case _: NoComponentInSequence    => Future failed RejectRequest(BadRequest, sequenceNoComponent)
-            case _: SequenceWithCycle        => Future failed RejectRequest(BadRequest, sequenceIsCyclic)
-            case _: NoDocumentException      => Future failed RejectRequest(BadRequest, sequenceComponentNotFound)
-        }
-    }
-
-    /**
-     * Counts the number of atomic actions in a sequence and checks for potential cycles. The latter is done
-     * by inlining any sequence components that are themselves sequences and checking if there if a reference to
-     * the given original sequence.
-     *
-     * @param origSequence the original sequence that is updated/created which generated the checks
-     * @param the components of the a sequence to check if they reference the original sequence
-     * @return Future with the number of atomic actions in the current sequence or an appropriate error if there is a cycle or a non-existent action reference
-     */
-    private def countAtomicActionsAndCheckCycle(origSequence: FullyQualifiedEntityName, components: Vector[FullyQualifiedEntityName])(
-        implicit transid: TransactionId): Future[Int] = {
-        if (components.size > actionSequenceLimit) {
-            Future.failed(TooManyActionsInSequence())
-        } else {
-            // resolve components wrt any package bindings
-            val resolvedComponentsFutures = components map { c => WhiskAction.resolveAction(entityStore, c) }
-            // traverse the sequence structure by checking each of its components and do the following:
-            // 1. check whether any action (sequence or not) referred by the sequence (directly or indirectly)
-            //    is the same as the original sequence (aka origSequence)
-            // 2. count the atomic actions each component has (by "inlining" all sequences)
-            val actionCountsFutures = resolvedComponentsFutures map {
-                _ flatMap { resolvedComponent =>
-                    // check whether this component is the same as origSequence
-                    // this can happen when updating an atomic action to become a sequence
-                    if (origSequence == resolvedComponent) {
-                        Future failed SequenceWithCycle()
+                    if (activation.response.isSuccess) {
+                      complete(OK, response)
+                    } else if (activation.response.isApplicationError) {
+                      // actions that result is ApplicationError status are considered a 'success'
+                      // and will have an 'error' property in the result - the HTTP status is OK
+                      // and clients must check the response status if it exists
+                      // NOTE: response status will not exist in the JSON object if ?result == true
+                      // and instead clients must check if 'error' is in the JSON
+                      // PRESERVING OLD BEHAVIOR and will address defect in separate change
+                      complete(BadGateway, response)
+                    } else if (activation.response.isContainerError) {
+                      complete(BadGateway, response)
                     } else {
-                        // check whether component is a sequence or an atomic action
-                        // if the component does not exist, the future will fail with appropriate error
-                        WhiskAction.get(entityStore, resolvedComponent.toDocId) flatMap { wskComponent =>
-                            wskComponent.exec match {
-                                case SequenceExec(seqComponents) =>
-                                    // sequence action, count the number of atomic actions in this sequence
-                                    countAtomicActionsAndCheckCycle(origSequence, seqComponents)
-                                case _ => Future successful 1 // atomic action count is one
-                            }
-                        }
+                      complete(InternalServerError, response)
                     }
+                  case Failure(t: RecordTooLargeException) =>
+                    logging.info(this, s"[POST] action payload was too large")
+                    terminate(RequestEntityTooLarge)
+                  case Failure(RejectRequest(code, message)) =>
+                    logging.info(this, s"[POST] action rejected with code $code: $message")
+                    terminate(code, message)
+                  case Failure(t: Throwable) =>
+                    logging.error(this, s"[POST] action activation failed: ${t.getMessage}")
+                    terminate(InternalServerError)
                 }
+
+              case Failure(f) =>
+                super.handleEntitlementFailure(f)
             }
-            // collapse the futures in one future
-            val actionCountsFuture = Future.sequence(actionCountsFutures)
-            // sum up all individual action counts per component
-            val totalActionCount = actionCountsFuture map { actionCounts => actionCounts.foldLeft(0)(_ + _) }
-            totalActionCount
+        })
+      }
+    }
+  }
+
+  /**
+   * Deletes action.
+   *
+   * Responses are one of (Code, Message)
+   * - 200 WhiskAction as JSON
+   * - 404 Not Found
+   * - 409 Conflict
+   * - 500 Internal Server Error
+   */
+  override def remove(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
+    deleteEntity(WhiskAction, entityStore, entityName.toDocId, (a: WhiskAction) => Future.successful({}))
+  }
+
+  /**
+   * Gets action. The action name is prefixed with the namespace to create the primary index key.
+   *
+   * Responses are one of (Code, Message)
+   * - 200 WhiskAction has JSON
+   * - 404 Not Found
+   * - 500 Internal Server Error
+   */
+  override def fetch(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(
+    implicit transid: TransactionId) = {
+    getEntity(WhiskAction, entityStore, entityName.toDocId, Some { action: WhiskAction =>
+      val mergedAction = env map { action inherit _ } getOrElse action
+      complete(OK, mergedAction)
+    })
+  }
+
+  /**
+   * Gets all actions in a path.
+   *
+   * Responses are one of (Code, Message)
+   * - 200 [] or [WhiskAction as JSON]
+   * - 500 Internal Server Error
+   */
+  override def list(user: Identity, namespace: EntityPath, excludePrivate: Boolean)(implicit transid: TransactionId) = {
+    // for consistency, all the collections should support the same list API
+    // but because supporting docs on actions is difficult, the API does not
+    // offer an option to fetch entities with full docs yet.
+    //
+    // the complication with actions is that providing docs on actions in
+    // package bindings is cannot be do readily done with a couchdb view
+    // and would require finding all bindings in namespace and
+    // joining the actions explicitly here.
+    val docs = false
+    parameter('skip ? 0, 'limit ? collection.listLimit, 'count ? false) { (skip, limit, count) =>
+      listEntities {
+        WhiskAction.listCollectionInNamespace(entityStore, namespace, skip, limit, docs) map { list =>
+          val actions = if (docs) {
+            list.right.get map { WhiskAction.serdes.write(_) }
+          } else list.left.get
+          FilterEntityList.filter(actions, excludePrivate)
         }
+      }
+    }
+  }
+
+  /** Replaces default namespaces in a vector of components from a sequence with appropriate namespace. */
+  private def resolveDefaultNamespace(components: Vector[FullyQualifiedEntityName],
+                                      user: Identity): Vector[FullyQualifiedEntityName] = {
+    // if components are part of the default namespace, they contain `_`; replace it!
+    val resolvedComponents = components map { c =>
+      FullyQualifiedEntityName(c.path.resolveNamespace(user.namespace), c.name)
+    }
+    resolvedComponents
+  }
+
+  /** Replaces default namespaces in an action sequence with appropriate namespace. */
+  private def resolveDefaultNamespace(seq: SequenceExec, user: Identity): SequenceExec = {
+    // if components are part of the default namespace, they contain `_`; replace it!
+    val resolvedComponents = resolveDefaultNamespace(seq.components, user)
+    new SequenceExec(resolvedComponents)
+  }
+
+  /**
+   * Creates a WhiskAction instance from the PUT request.
+   */
+  private def makeWhiskAction(content: WhiskActionPut, entityName: FullyQualifiedEntityName)(
+    implicit transid: TransactionId) = {
+    val exec = content.exec.get
+    val limits = content.limits map { l =>
+      ActionLimits(l.timeout getOrElse TimeLimit(), l.memory getOrElse MemoryLimit(), l.logs getOrElse LogLimit())
+    } getOrElse ActionLimits()
+    // This is temporary while we are making sequencing directly supported in the controller.
+    // The parameter override allows this to work with Pipecode.code. Any parameters other
+    // than the action sequence itself are discarded and have no effect.
+    // Note: While changing the implementation of sequences, components now store the fully qualified entity names
+    // (which loses the leading "/"). Adding it back while both versions of the code are in place.
+    val parameters = exec match {
+      case seq: SequenceExec =>
+        Parameters("_actions", JsArray(seq.components map { _.qualifiedNameWithLeadingSlash.toJson }))
+      case _ => content.parameters getOrElse Parameters()
     }
 
-    /**
-     * Constructs an "exec" annotation. This is redundant with the exec kind
-     * information available in WhiskAction but necessary for some clients which
-     * fetch action lists but cannot determine action kinds without fetching them.
-     * An alternative is to include the exec in the action list "view" but this
-     * will require an API change. So using an annotation instead.
-     */
-    private def execAnnotation(exec: Exec): Parameters = {
-        Parameters(WhiskAction.execFieldName, exec.kind)
+    WhiskAction(
+      entityName.path,
+      entityName.name,
+      exec,
+      parameters,
+      limits,
+      content.version getOrElse SemVer(),
+      content.publish getOrElse false,
+      (content.annotations getOrElse Parameters()) ++ execAnnotation(exec))
+  }
+
+  /** For a sequence action, gather referenced entities and authorize access. */
+  private def entitleReferencedEntities(user: Identity, right: Privilege, exec: Option[Exec])(
+    implicit transid: TransactionId) = {
+    exec match {
+      case Some(seq: SequenceExec) =>
+        logging.info(this, "checking if sequence components are accessible")
+        entitlementProvider.check(user, right, referencedEntities(seq))
+      case _ => Future.successful(true)
+    }
+  }
+
+  /** Creates a WhiskAction from PUT content, generating default values where necessary. */
+  private def make(user: Identity, entityName: FullyQualifiedEntityName, content: WhiskActionPut)(
+    implicit transid: TransactionId) = {
+    content.exec map {
+      case seq: SequenceExec =>
+        // check that the sequence conforms to max length and no recursion rules
+        checkSequenceActionLimits(entityName, seq.components) map { _ =>
+          makeWhiskAction(content.replace(seq), entityName)
+        }
+      case supportedExec if !supportedExec.deprecated =>
+        Future successful makeWhiskAction(content, entityName)
+      case deprecatedExec =>
+        Future failed RejectRequest(BadRequest, runtimeDeprecated(deprecatedExec))
+
+    } getOrElse Future.failed(RejectRequest(BadRequest, "exec undefined"))
+  }
+
+  /** Updates a WhiskAction from PUT content, merging old action where necessary. */
+  private def update(user: Identity, content: WhiskActionPut)(action: WhiskAction)(implicit transid: TransactionId) = {
+    content.exec map {
+      case seq: SequenceExec =>
+        // check that the sequence conforms to max length and no recursion rules
+        checkSequenceActionLimits(FullyQualifiedEntityName(action.namespace, action.name), seq.components) map { _ =>
+          updateWhiskAction(content.replace(seq), action)
+        }
+      case supportedExec if !supportedExec.deprecated =>
+        Future successful updateWhiskAction(content, action)
+      case deprecatedExec =>
+        Future failed RejectRequest(BadRequest, runtimeDeprecated(deprecatedExec))
+    } getOrElse {
+      if (!action.exec.deprecated) {
+        Future successful updateWhiskAction(content, action)
+      } else {
+        Future failed RejectRequest(BadRequest, runtimeDeprecated(action.exec))
+      }
+    }
+  }
+
+  /**
+   * Updates a WhiskAction instance from the PUT request.
+   */
+  private def updateWhiskAction(content: WhiskActionPut, action: WhiskAction)(implicit transid: TransactionId) = {
+    val limits = content.limits map { l =>
+      ActionLimits(
+        l.timeout getOrElse action.limits.timeout,
+        l.memory getOrElse action.limits.memory,
+        l.logs getOrElse action.limits.logs)
+    } getOrElse action.limits
+
+    // This is temporary while we are making sequencing directly supported in the controller.
+    // Actions that are updated with a sequence will have their parameter property overridden.
+    // Actions that are updated with non-sequence actions will either set the parameter property according to
+    // the content provided, or if that is not defined, and iff the previous version of the action was not a
+    // sequence, inherit previous parameters. This is because sequence parameters are special and should not
+    // leak to non-sequence actions.
+    // If updating an action but not specifying a new exec type, then preserve the previous parameters if the
+    // existing type of the action is a sequence (regardless of what parameters may be defined in the content)
+    // otherwise, parameters are inferred from the content or previous values.
+    // Note: While changing the implementation of sequences, components now store the fully qualified entity names
+    // (which loses the leading "/"). Adding it back while both versions of the code are in place. This will disappear completely
+    // once the version of sequences with "pipe.js" is removed.
+    val parameters = content.exec map {
+      case seq: SequenceExec =>
+        Parameters("_actions", JsArray(seq.components map { c =>
+          JsString("/" + c.toString)
+        }))
+      case _ =>
+        content.parameters getOrElse {
+          action.exec match {
+            case seq: SequenceExec => Parameters()
+            case _                 => action.parameters
+          }
+        }
+    } getOrElse {
+      action.exec match {
+        case seq: SequenceExec => action.parameters // discard content.parameters
+        case _                 => content.parameters getOrElse action.parameters
+      }
     }
 
-    /** Max atomic action count allowed for sequences. */
-    private lazy val actionSequenceLimit = whiskConfig.actionSequenceLimit.toInt
+    val exec = content.exec getOrElse action.exec
 
-    implicit val stringToFiniteDuration: Unmarshaller[String, FiniteDuration] = {
-        Unmarshaller.strict[String, FiniteDuration] { value =>
-            val max = WhiskActionsApi.maxWaitForBlockingActivation.toMillis
+    WhiskAction(
+      action.namespace,
+      action.name,
+      exec,
+      parameters,
+      limits,
+      content.version getOrElse action.version.upPatch,
+      content.publish getOrElse action.publish,
+      (content.annotations getOrElse action.annotations) ++ execAnnotation(exec))
+      .revision[WhiskAction](action.docinfo.rev)
+  }
 
-            Try { value.toInt } match {
-                case Success(i) if i > 0 && i <= max => i.milliseconds
-                case _                               => throw new IllegalArgumentException(Messages.invalidTimeout(WhiskActionsApi.maxWaitForBlockingActivation))
+  /**
+   * Lists actions in package or binding. The router authorized the subject for the package
+   * (if binding, then authorized subject for both the binding and the references package)
+   * and iff authorized, this method is reached to lists actions.
+   *
+   * Note that when listing actions in a binding, the namespace on the actions will be that
+   * of the referenced packaged, not the binding.
+   */
+  private def listPackageActions(user: Identity, pkgName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
+    // get the package to determine if it is a package or reference
+    // (this will set the appropriate namespace), and then list actions
+    // NOTE: these fetches are redundant with those from the authorization
+    // and should hit the cache to ameliorate the cost; this can be improved
+    // but requires communicating back from the authorization service the
+    // resolved namespace
+    getEntity(WhiskPackage, entityStore, pkgName.toDocId, Some { (wp: WhiskPackage) =>
+      val pkgns = wp.binding map { b =>
+        logging.info(this, s"list actions in package binding '${wp.name}' -> '$b'")
+        b.namespace.addPath(b.name)
+      } getOrElse {
+        logging.info(this, s"list actions in package '${wp.name}'")
+        pkgName.path.addPath(wp.name)
+      }
+      // list actions in resolved namespace
+      // NOTE: excludePrivate is false since the subject is authorize to access
+      // the package; in the future, may wish to exclude private actions in a
+      // public package instead
+      list(user, pkgns, excludePrivate = false)
+    })
+  }
+
+  /**
+   * Constructs a WhiskPackage that is a merger of a package with its packing binding (if any).
+   * This resolves a reference versus an actual package and merge parameters as needed.
+   * Once the package is resolved, the operation is dispatched to the action in the package
+   * namespace.
+   */
+  private def mergeActionWithPackageAndDispatch(method: HttpMethod,
+                                                user: Identity,
+                                                action: EntityName,
+                                                ref: Option[WhiskPackage] = None)(wp: WhiskPackage)(
+    implicit transid: TransactionId): RequestContext => Future[RouteResult] = {
+    wp.binding map {
+      case b: Binding =>
+        val docid = b.fullyQualifiedName.toDocId
+        logging.info(this, s"fetching package '$docid' for reference")
+        // already checked that subject is authorized for package and binding;
+        // this fetch is redundant but should hit the cache to ameliorate cost
+        getEntity(WhiskPackage, entityStore, docid, Some {
+          mergeActionWithPackageAndDispatch(method, user, action, Some { wp }) _
+        })
+    } getOrElse {
+      // a subject has implied rights to all resources in a package, so dispatch
+      // operation without further entitlement checks
+      val params = { ref map { _ inherit wp.parameters } getOrElse wp } parameters
+      val ns = wp.namespace.addPath(wp.name) // the package namespace
+      val resource = Resource(ns, collection, Some { action.asString }, Some { params })
+      val right = collection.determineRight(method, resource.entity)
+      logging.info(this, s"merged package parameters and rebased action to '$ns")
+      dispatchOp(user, right, resource)
+    }
+  }
+
+  /**
+   * Checks that the sequence is not cyclic and that the number of atomic actions in the "inlined" sequence is lower than max allowed.
+   *
+   * @param sequenceAction is the action sequence to check
+   * @param components the components of the sequence
+   */
+  private def checkSequenceActionLimits(
+    sequenceAction: FullyQualifiedEntityName,
+    components: Vector[FullyQualifiedEntityName])(implicit transid: TransactionId): Future[Unit] = {
+    // first checks that current sequence length is allowed
+    // then traverses all actions in the sequence, inlining any that are sequences
+    val future = if (components.size > actionSequenceLimit) {
+      Future.failed(TooManyActionsInSequence())
+    } else if (components.size == 0) {
+      Future.failed(NoComponentInSequence())
+    } else {
+      // resolve the action document id (if it's in a package/binding);
+      // this assumes that entityStore is the same for actions and packages
+      WhiskAction.resolveAction(entityStore, sequenceAction) flatMap { resolvedSeq =>
+        val atomicActionCnt = countAtomicActionsAndCheckCycle(resolvedSeq, components)
+        atomicActionCnt map { count =>
+          logging.debug(this, s"sequence '$sequenceAction' atomic action count $count")
+          if (count > actionSequenceLimit) {
+            throw TooManyActionsInSequence()
+          }
+        }
+      }
+    }
+
+    future recoverWith {
+      case _: TooManyActionsInSequence => Future failed RejectRequest(BadRequest, sequenceIsTooLong)
+      case _: NoComponentInSequence    => Future failed RejectRequest(BadRequest, sequenceNoComponent)
+      case _: SequenceWithCycle        => Future failed RejectRequest(BadRequest, sequenceIsCyclic)
+      case _: NoDocumentException      => Future failed RejectRequest(BadRequest, sequenceComponentNotFound)
+    }
+  }
+
+  /**
+   * Counts the number of atomic actions in a sequence and checks for potential cycles. The latter is done
+   * by inlining any sequence components that are themselves sequences and checking if there if a reference to
+   * the given original sequence.
+   *
+   * @param origSequence the original sequence that is updated/created which generated the checks
+   * @param the components of the a sequence to check if they reference the original sequence
+   * @return Future with the number of atomic actions in the current sequence or an appropriate error if there is a cycle or a non-existent action reference
+   */
+  private def countAtomicActionsAndCheckCycle(
+    origSequence: FullyQualifiedEntityName,
+    components: Vector[FullyQualifiedEntityName])(implicit transid: TransactionId): Future[Int] = {
+    if (components.size > actionSequenceLimit) {
+      Future.failed(TooManyActionsInSequence())
+    } else {
+      // resolve components wrt any package bindings
+      val resolvedComponentsFutures = components map { c =>
+        WhiskAction.resolveAction(entityStore, c)
+      }
+      // traverse the sequence structure by checking each of its components and do the following:
+      // 1. check whether any action (sequence or not) referred by the sequence (directly or indirectly)
+      //    is the same as the original sequence (aka origSequence)
+      // 2. count the atomic actions each component has (by "inlining" all sequences)
+      val actionCountsFutures = resolvedComponentsFutures map {
+        _ flatMap { resolvedComponent =>
+          // check whether this component is the same as origSequence
+          // this can happen when updating an atomic action to become a sequence
+          if (origSequence == resolvedComponent) {
+            Future failed SequenceWithCycle()
+          } else {
+            // check whether component is a sequence or an atomic action
+            // if the component does not exist, the future will fail with appropriate error
+            WhiskAction.get(entityStore, resolvedComponent.toDocId) flatMap { wskComponent =>
+              wskComponent.exec match {
+                case SequenceExec(seqComponents) =>
+                  // sequence action, count the number of atomic actions in this sequence
+                  countAtomicActionsAndCheckCycle(origSequence, seqComponents)
+                case _ => Future successful 1 // atomic action count is one
+              }
             }
+          }
         }
+      }
+      // collapse the futures in one future
+      val actionCountsFuture = Future.sequence(actionCountsFutures)
+      // sum up all individual action counts per component
+      val totalActionCount = actionCountsFuture map { actionCounts =>
+        actionCounts.foldLeft(0)(_ + _)
+      }
+      totalActionCount
     }
+  }
+
+  /**
+   * Constructs an "exec" annotation. This is redundant with the exec kind
+   * information available in WhiskAction but necessary for some clients which
+   * fetch action lists but cannot determine action kinds without fetching them.
+   * An alternative is to include the exec in the action list "view" but this
+   * will require an API change. So using an annotation instead.
+   */
+  private def execAnnotation(exec: Exec): Parameters = {
+    Parameters(WhiskAction.execFieldName, exec.kind)
+  }
+
+  /** Max atomic action count allowed for sequences. */
+  private lazy val actionSequenceLimit = whiskConfig.actionSequenceLimit.toInt
+
+  implicit val stringToFiniteDuration: Unmarshaller[String, FiniteDuration] = {
+    Unmarshaller.strict[String, FiniteDuration] { value =>
+      val max = WhiskActionsApi.maxWaitForBlockingActivation.toMillis
+
+      Try { value.toInt } match {
+        case Success(i) if i > 0 && i <= max => i.milliseconds
+        case _ =>
+          throw new IllegalArgumentException(Messages.invalidTimeout(WhiskActionsApi.maxWaitForBlockingActivation))
+      }
+    }
+  }
 }
 
 private case class TooManyActionsInSequence() extends IllegalArgumentException

--- a/core/controller/src/main/scala/whisk/core/controller/Activations.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Activations.scala
@@ -43,175 +43,205 @@ import whisk.http.ErrorResponse.terminate
 import whisk.http.Messages
 
 object WhiskActivationsApi {
-    protected[core] val maxActivationLimit = 200
+  protected[core] val maxActivationLimit = 200
 }
 
 /** A trait implementing the activations API. */
-trait WhiskActivationsApi
-    extends Directives
-    with AuthenticatedRouteProvider
-    with AuthorizedRouteProvider
-    with ReadOps {
+trait WhiskActivationsApi extends Directives with AuthenticatedRouteProvider with AuthorizedRouteProvider with ReadOps {
 
-    protected override val collection = Collection(Collection.ACTIVATIONS)
+  protected override val collection = Collection(Collection.ACTIVATIONS)
 
-    /** JSON response formatter. */
-    import RestApiCommons.jsonDefaultResponsePrinter
+  /** JSON response formatter. */
+  import RestApiCommons.jsonDefaultResponsePrinter
 
-    /** Database service to GET activations. */
-    protected val activationStore: ActivationStore
+  /** Database service to GET activations. */
+  protected val activationStore: ActivationStore
 
-    /** Path to Actions REST API. */
-    protected val activationsPath = "activations"
+  /** Path to Actions REST API. */
+  protected val activationsPath = "activations"
 
-    /** Path to activation result and logs. */
-    private val resultPath = "result"
-    private val logsPath = "logs"
+  /** Path to activation result and logs. */
+  private val resultPath = "result"
+  private val logsPath = "logs"
 
-    /** Only GET is supported in this API. */
-    protected override lazy val entityOps = get
+  /** Only GET is supported in this API. */
+  protected override lazy val entityOps = get
 
-    /** Validated entity name as an ActivationId from the matched path segment. */
-    protected override def entityname(n: String) = {
-        val activationId = Try { ActivationId(n) }
-        validate(activationId.isSuccess, activationId match {
-            case Failure(DeserializationException(t, _, _)) => t
-            case _ => Messages.activationIdIllegal
-        }) & extract(_ => n)
+  /** Validated entity name as an ActivationId from the matched path segment. */
+  protected override def entityname(n: String) = {
+    val activationId = Try { ActivationId(n) }
+    validate(activationId.isSuccess, activationId match {
+      case Failure(DeserializationException(t, _, _)) => t
+      case _                                          => Messages.activationIdIllegal
+    }) & extract(_ => n)
+  }
+
+  /**
+   * Overrides because API allows for GET on /activations and /activations/[result|log] which
+   * would be rejected in the superclass.
+   */
+  override protected def innerRoutes(user: Identity, ns: EntityPath)(implicit transid: TransactionId) = {
+    (entityPrefix & entityOps & requestMethod) { (segment, m) =>
+      entityname(segment) {
+        // defer rest of the path processing to the fetch operation, which is
+        // the only operation supported on activations that reach the inner route
+        name =>
+          authorizeAndDispatch(m, user, Resource(ns, collection, Some(name)))
+      }
     }
+  }
 
-    /**
-     * Overrides because API allows for GET on /activations and /activations/[result|log] which
-     * would be rejected in the superclass.
-     */
-    override protected def innerRoutes(user: Identity, ns: EntityPath)(implicit transid: TransactionId) = {
-        (entityPrefix & entityOps & requestMethod) { (segment, m) =>
-            entityname(segment) {
-                // defer rest of the path processing to the fetch operation, which is
-                // the only operation supported on activations that reach the inner route
-                name => authorizeAndDispatch(m, user, Resource(ns, collection, Some(name)))
-            }
+  /** Dispatches resource to the proper handler depending on context. */
+  protected override def dispatchOp(user: Identity, op: Privilege, resource: Resource)(
+    implicit transid: TransactionId) = {
+    resource.entity match {
+      case Some(ActivationId(id)) =>
+        op match {
+          case READ => fetch(resource.namespace, id)
+          case _    => reject // should not get here
+        }
+      case None =>
+        op match {
+          case READ => list(resource.namespace)
+          case _    => reject // should not get here
         }
     }
+  }
 
-    /** Dispatches resource to the proper handler depending on context. */
-    protected override def dispatchOp(user: Identity, op: Privilege, resource: Resource)(implicit transid: TransactionId) = {
-        resource.entity match {
-            case Some(ActivationId(id)) => op match {
-                case READ => fetch(resource.namespace, id)
-                case _    => reject // should not get here
-            }
-            case None => op match {
-                case READ => list(resource.namespace)
-                case _    => reject // should not get here
-            }
-        }
-    }
+  /**
+   * Gets all activations in namespace. Filters by action name if parameter is given.
+   *
+   * Responses are one of (Code, Message)
+   * - 200 [] or [WhiskActivation as JSON]
+   * - 500 Internal Server Error
+   */
+  private def list(namespace: EntityPath)(implicit transid: TransactionId) = {
+    parameter(
+      'skip ? 0,
+      'limit ? collection.listLimit,
+      'count ? false,
+      'docs ? false,
+      'name.as[EntityName] ?,
+      'since.as[Instant] ?,
+      'upto.as[Instant] ?) { (skip, limit, count, docs, name, since, upto) =>
+      val cappedLimit = if (limit == 0) WhiskActivationsApi.maxActivationLimit else limit
 
-    /**
-     * Gets all activations in namespace. Filters by action name if parameter is given.
-     *
-     * Responses are one of (Code, Message)
-     * - 200 [] or [WhiskActivation as JSON]
-     * - 500 Internal Server Error
-     */
-    private def list(namespace: EntityPath)(implicit transid: TransactionId) = {
-        parameter('skip ? 0, 'limit ? collection.listLimit, 'count ? false, 'docs ? false, 'name.as[EntityName]?, 'since.as[Instant]?, 'upto.as[Instant]?) {
-            (skip, limit, count, docs, name, since, upto) =>
-                val cappedLimit = if (limit == 0) WhiskActivationsApi.maxActivationLimit else limit
-
-                // regardless of limit, cap at maxActivationLimit (200) records, client must paginate
-                if (cappedLimit <= WhiskActivationsApi.maxActivationLimit) {
-                    val activations = name match {
-                        case Some(action) =>
-                            WhiskActivation.listCollectionByName(activationStore, namespace, action, skip, cappedLimit, docs, since, upto, StaleParameter.UpdateAfter)
-                        case None =>
-                            WhiskActivation.listCollectionInNamespace(activationStore, namespace, skip, cappedLimit, docs, since, upto, StaleParameter.UpdateAfter)
-                    }
-
-                    listEntities {
-                        activations map {
-                            l =>
-                                if (docs) l.right.get map {
-                                    _.toExtendedJson
-                                }
-                                else l.left.get
-                        }
-                    }
-                } else {
-                    terminate(BadRequest, Messages.maxActivationLimitExceeded(limit, WhiskActivationsApi.maxActivationLimit))
-                }
-        }
-    }
-
-    /**
-     * Gets activation. The activation id is prefixed with the namespace to create the primary index key.
-     *
-     * Responses are one of (Code, Message)
-     * - 200 WhiskActivation as JSON
-     * - 404 Not Found
-     * - 500 Internal Server Error
-     */
-    private def fetch(namespace: EntityPath, activationId: ActivationId)(implicit transid: TransactionId) = {
-        val docid = DocId(WhiskEntity.qualifiedName(namespace, activationId))
-        pathEndOrSingleSlash {
-            getEntity(WhiskActivation, activationStore, docid, postProcess = Some((activation: WhiskActivation) =>
-                complete(activation.toExtendedJson)))
-
-        } ~ (pathPrefix(resultPath) & pathEnd) { fetchResponse(docid) } ~
-            (pathPrefix(logsPath) & pathEnd) { fetchLogs(docid) }
-    }
-
-    /**
-     * Gets activation result. The activation id is prefixed with the namespace to create the primary index key.
-     *
-     * Responses are one of (Code, Message)
-     * - 200 { result: ..., success: Boolean, statusMessage: String }
-     * - 404 Not Found
-     * - 500 Internal Server Error
-     */
-    private def fetchResponse(docid: DocId)(implicit transid: TransactionId) = {
-        getEntityAndProject(WhiskActivation, activationStore, docid,
-            (activation: WhiskActivation) => activation.response.toExtendedJson)
-    }
-
-    /**
-     * Gets activation logs. The activation id is prefixed with the namespace to create the primary index key.
-     *
-     * Responses are one of (Code, Message)
-     * - 200 { logs: String }
-     * - 404 Not Found
-     * - 500 Internal Server Error
-     */
-    private def fetchLogs(docid: DocId)(implicit transid: TransactionId) = {
-        getEntityAndProject(WhiskActivation, activationStore, docid,
-            (activation: WhiskActivation) => activation.logs.toJsonObject)
-    }
-
-    /** Custom unmarshaller for query parameters "name" into valid entity name. */
-    private implicit val stringToEntityName: Unmarshaller[String, EntityName] =
-        Unmarshaller.strict[String, EntityName] { value =>
-            Try { EntityName(value) } match {
-                case Success(e) => e
-                case Failure(t) => throw new IllegalArgumentException(Messages.badEntityName(value))
-            }
+      // regardless of limit, cap at maxActivationLimit (200) records, client must paginate
+      if (cappedLimit <= WhiskActivationsApi.maxActivationLimit) {
+        val activations = name match {
+          case Some(action) =>
+            WhiskActivation.listCollectionByName(
+              activationStore,
+              namespace,
+              action,
+              skip,
+              cappedLimit,
+              docs,
+              since,
+              upto,
+              StaleParameter.UpdateAfter)
+          case None =>
+            WhiskActivation.listCollectionInNamespace(
+              activationStore,
+              namespace,
+              skip,
+              cappedLimit,
+              docs,
+              since,
+              upto,
+              StaleParameter.UpdateAfter)
         }
 
-    /** Custom unmarshaller for query parameters "name" into valid namespace. */
-    private implicit val stringToNamespace: Unmarshaller[String, EntityPath] =
-        Unmarshaller.strict[String, EntityPath] { value =>
-            Try { EntityPath(value) } match {
-                case Success(e) => e
-                case Failure(t) => throw new IllegalArgumentException(Messages.badNamespace(value))
-            }
+        listEntities {
+          activations map { l =>
+            if (docs) l.right.get map {
+              _.toExtendedJson
+            } else l.left.get
+          }
         }
+      } else {
+        terminate(BadRequest, Messages.maxActivationLimitExceeded(limit, WhiskActivationsApi.maxActivationLimit))
+      }
+    }
+  }
 
-    /** Custom unmarshaller for query parameters "since" and "upto" into a valid Instant. */
-    private implicit val stringToInstantDeserializer: Unmarshaller[String, Instant] =
-        Unmarshaller.strict[String, Instant] { value =>
-            Try { Instant.ofEpochMilli(value.toLong) } match {
-                case Success(e) => e
-                case Failure(t) => throw new IllegalArgumentException(Messages.badEpoch(value))
-            }
-        }
+  /**
+   * Gets activation. The activation id is prefixed with the namespace to create the primary index key.
+   *
+   * Responses are one of (Code, Message)
+   * - 200 WhiskActivation as JSON
+   * - 404 Not Found
+   * - 500 Internal Server Error
+   */
+  private def fetch(namespace: EntityPath, activationId: ActivationId)(implicit transid: TransactionId) = {
+    val docid = DocId(WhiskEntity.qualifiedName(namespace, activationId))
+    pathEndOrSingleSlash {
+      getEntity(
+        WhiskActivation,
+        activationStore,
+        docid,
+        postProcess = Some((activation: WhiskActivation) => complete(activation.toExtendedJson)))
+
+    } ~ (pathPrefix(resultPath) & pathEnd) { fetchResponse(docid) } ~
+      (pathPrefix(logsPath) & pathEnd) { fetchLogs(docid) }
+  }
+
+  /**
+   * Gets activation result. The activation id is prefixed with the namespace to create the primary index key.
+   *
+   * Responses are one of (Code, Message)
+   * - 200 { result: ..., success: Boolean, statusMessage: String }
+   * - 404 Not Found
+   * - 500 Internal Server Error
+   */
+  private def fetchResponse(docid: DocId)(implicit transid: TransactionId) = {
+    getEntityAndProject(
+      WhiskActivation,
+      activationStore,
+      docid,
+      (activation: WhiskActivation) => activation.response.toExtendedJson)
+  }
+
+  /**
+   * Gets activation logs. The activation id is prefixed with the namespace to create the primary index key.
+   *
+   * Responses are one of (Code, Message)
+   * - 200 { logs: String }
+   * - 404 Not Found
+   * - 500 Internal Server Error
+   */
+  private def fetchLogs(docid: DocId)(implicit transid: TransactionId) = {
+    getEntityAndProject(
+      WhiskActivation,
+      activationStore,
+      docid,
+      (activation: WhiskActivation) => activation.logs.toJsonObject)
+  }
+
+  /** Custom unmarshaller for query parameters "name" into valid entity name. */
+  private implicit val stringToEntityName: Unmarshaller[String, EntityName] =
+    Unmarshaller.strict[String, EntityName] { value =>
+      Try { EntityName(value) } match {
+        case Success(e) => e
+        case Failure(t) => throw new IllegalArgumentException(Messages.badEntityName(value))
+      }
+    }
+
+  /** Custom unmarshaller for query parameters "name" into valid namespace. */
+  private implicit val stringToNamespace: Unmarshaller[String, EntityPath] =
+    Unmarshaller.strict[String, EntityPath] { value =>
+      Try { EntityPath(value) } match {
+        case Success(e) => e
+        case Failure(t) => throw new IllegalArgumentException(Messages.badNamespace(value))
+      }
+    }
+
+  /** Custom unmarshaller for query parameters "since" and "upto" into a valid Instant. */
+  private implicit val stringToInstantDeserializer: Unmarshaller[String, Instant] =
+    Unmarshaller.strict[String, Instant] { value =>
+      Try { Instant.ofEpochMilli(value.toLong) } match {
+        case Success(e) => e
+        case Failure(t) => throw new IllegalArgumentException(Messages.badEpoch(value))
+      }
+    }
 }

--- a/core/controller/src/main/scala/whisk/core/controller/ApiUtils.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/ApiUtils.scala
@@ -55,50 +55,50 @@ import whisk.http.Messages._
 
 /** An exception to throw inside a Predicate future. */
 protected[core] case class RejectRequest(code: StatusCode, message: Option[ErrorResponse]) extends Throwable {
-    override def toString = s"RejectRequest($code)" + message.map(" " + _.error).getOrElse("")
+  override def toString = s"RejectRequest($code)" + message.map(" " + _.error).getOrElse("")
 }
 
 protected[core] object RejectRequest {
-    /** Creates rejection with default message for status code. */
-    protected[core] def apply(code: StatusCode)(implicit transid: TransactionId): RejectRequest = {
-        RejectRequest(code, Some(ErrorResponse.response(code)(transid)))
-    }
 
-    /** Creates rejection with custom message for status code. */
-    protected[core] def apply(code: StatusCode, m: String)(implicit transid: TransactionId): RejectRequest = {
-        RejectRequest(code, Some(ErrorResponse(m, transid)))
-    }
+  /** Creates rejection with default message for status code. */
+  protected[core] def apply(code: StatusCode)(implicit transid: TransactionId): RejectRequest = {
+    RejectRequest(code, Some(ErrorResponse.response(code)(transid)))
+  }
 
-    /** Creates rejection with custom message for status code derived from reason for throwable. */
-    protected[core] def apply(code: StatusCode, t: Throwable)(implicit transid: TransactionId): RejectRequest = {
-        val reason = t.getMessage
-        RejectRequest(code, if (reason != null) reason else "Rejected")
-    }
+  /** Creates rejection with custom message for status code. */
+  protected[core] def apply(code: StatusCode, m: String)(implicit transid: TransactionId): RejectRequest = {
+    RejectRequest(code, Some(ErrorResponse(m, transid)))
+  }
+
+  /** Creates rejection with custom message for status code derived from reason for throwable. */
+  protected[core] def apply(code: StatusCode, t: Throwable)(implicit transid: TransactionId): RejectRequest = {
+    val reason = t.getMessage
+    RejectRequest(code, if (reason != null) reason else "Rejected")
+  }
 }
 
 protected[controller] object FilterEntityList {
-    import WhiskEntity.sharedFieldName
+  import WhiskEntity.sharedFieldName
 
-    /**
-     * Filters from a list of entities serialized to JsObjects only those
-     * that have the shared field ("publish") equal to true and excludes
-     * all others.
-     */
-    protected[controller] def filter(
-        resources: List[JsValue],
-        excludePrivate: Boolean,
-        additionalFilter: JsObject => Boolean = (_ => true)) = {
-        if (excludePrivate) {
-            resources filter {
-                case obj: JsObject =>
-                    obj.getFields(sharedFieldName) match {
-                        case Seq(JsBoolean(true)) => true && additionalFilter(obj) // a shared entity
-                        case _                    => false
-                    }
-                case _ => false // only expecting JsObject instances
-            }
-        } else resources
-    }
+  /**
+   * Filters from a list of entities serialized to JsObjects only those
+   * that have the shared field ("publish") equal to true and excludes
+   * all others.
+   */
+  protected[controller] def filter(resources: List[JsValue],
+                                   excludePrivate: Boolean,
+                                   additionalFilter: JsObject => Boolean = (_ => true)) = {
+    if (excludePrivate) {
+      resources filter {
+        case obj: JsObject =>
+          obj.getFields(sharedFieldName) match {
+            case Seq(JsBoolean(true)) => true && additionalFilter(obj) // a shared entity
+            case _                    => false
+          }
+        case _ => false // only expecting JsObject instances
+      }
+    } else resources
+  }
 }
 
 /**
@@ -106,276 +106,273 @@ protected[controller] object FilterEntityList {
  * on an operation and terminate the HTTP request.
  */
 package object PostProcess {
-    type PostProcessEntity[A] = A => RequestContext => Future[RouteResult]
+  type PostProcessEntity[A] = A => RequestContext => Future[RouteResult]
 }
 
 /** A trait for REST APIs that read entities from a datastore */
 trait ReadOps extends Directives {
 
-    /** An execution context for futures */
-    protected implicit val executionContext: ExecutionContext
+  /** An execution context for futures */
+  protected implicit val executionContext: ExecutionContext
 
-    protected implicit val logging: Logging
+  protected implicit val logging: Logging
 
-    /** JSON response formatter. */
-    import RestApiCommons.jsonDefaultResponsePrinter
+  /** JSON response formatter. */
+  import RestApiCommons.jsonDefaultResponsePrinter
 
-    /**
-     * Get all entities of type A from datastore that match key. Terminates HTTP request.
-     *
-     * @param factory the factory that can fetch entities of type A from datastore
-     * @param datastore the client to the database
-     * @param key the key to use to match records in the view, optional, if not defined, use namespace
-     * @param view the view to query
-     * @param filter a function List[A] => List[A] that filters the results
-     *
-     * Responses are one of (Code, Message)
-     * - 200 entity A [] as JSON []
-     * - 500 Internal Server Error
-     */
-    protected def listEntities(list: Future[List[JsValue]])(implicit transid: TransactionId) = {
-        onComplete(list) {
-            case Success(entities) =>
-                logging.info(this, s"[LIST] entity success")
-                complete(OK, entities)
-            case Failure(t: Throwable) =>
-                logging.error(this, s"[LIST] entity failed: ${t.getMessage}")
-                terminate(InternalServerError)
-        }
+  /**
+   * Get all entities of type A from datastore that match key. Terminates HTTP request.
+   *
+   * @param factory the factory that can fetch entities of type A from datastore
+   * @param datastore the client to the database
+   * @param key the key to use to match records in the view, optional, if not defined, use namespace
+   * @param view the view to query
+   * @param filter a function List[A] => List[A] that filters the results
+   *
+   * Responses are one of (Code, Message)
+   * - 200 entity A [] as JSON []
+   * - 500 Internal Server Error
+   */
+  protected def listEntities(list: Future[List[JsValue]])(implicit transid: TransactionId) = {
+    onComplete(list) {
+      case Success(entities) =>
+        logging.info(this, s"[LIST] entity success")
+        complete(OK, entities)
+      case Failure(t: Throwable) =>
+        logging.error(this, s"[LIST] entity failed: ${t.getMessage}")
+        terminate(InternalServerError)
     }
+  }
 
-    /**
-     * Gets an entity of type A from datastore. Terminates HTTP request.
-     *
-     * @param factory the factory that can fetch entity of type A from datastore
-     * @param datastore the client to the database
-     * @param docid the document id to get
-     * @param postProcess an optional continuation to post process the result of the
-     * get and terminate the HTTP request directly
-     *
-     * Responses are one of (Code, Message)
-     * - 200 entity A as JSON
-     * - 404 Not Found
-     * - 500 Internal Server Error
-     */
-    protected def getEntity[A, Au >: A](
-        factory: DocumentFactory[A],
-        datastore: ArtifactStore[Au],
-        docid: DocId,
-        postProcess: Option[PostProcessEntity[A]] = None)(
-            implicit transid: TransactionId,
-            format: RootJsonFormat[A],
-            ma: Manifest[A]) = {
-        onComplete(factory.get(datastore, docid)) {
-            case Success(entity) =>
-                logging.info(this, s"[GET] entity success")
-                postProcess map { _(entity) } getOrElse complete(OK, entity)
-            case Failure(t: NoDocumentException) =>
-                logging.info(this, s"[GET] entity does not exist")
-                terminate(NotFound)
-            case Failure(t: DocumentTypeMismatchException) =>
-                logging.info(this, s"[GET] entity conformance check failed: ${t.getMessage}")
-                terminate(Conflict, conformanceMessage)
-            case Failure(t: ArtifactStoreException) =>
-                logging.info(this, s"[GET] entity unreadable")
-                terminate(InternalServerError, t.getMessage)
-            case Failure(t: Throwable) =>
-                logging.error(this, s"[GET] entity failed: ${t.getMessage}")
-                terminate(InternalServerError)
-        }
+  /**
+   * Gets an entity of type A from datastore. Terminates HTTP request.
+   *
+   * @param factory the factory that can fetch entity of type A from datastore
+   * @param datastore the client to the database
+   * @param docid the document id to get
+   * @param postProcess an optional continuation to post process the result of the
+   * get and terminate the HTTP request directly
+   *
+   * Responses are one of (Code, Message)
+   * - 200 entity A as JSON
+   * - 404 Not Found
+   * - 500 Internal Server Error
+   */
+  protected def getEntity[A, Au >: A](factory: DocumentFactory[A],
+                                      datastore: ArtifactStore[Au],
+                                      docid: DocId,
+                                      postProcess: Option[PostProcessEntity[A]] = None)(implicit transid: TransactionId,
+                                                                                        format: RootJsonFormat[A],
+                                                                                        ma: Manifest[A]) = {
+    onComplete(factory.get(datastore, docid)) {
+      case Success(entity) =>
+        logging.info(this, s"[GET] entity success")
+        postProcess map { _(entity) } getOrElse complete(OK, entity)
+      case Failure(t: NoDocumentException) =>
+        logging.info(this, s"[GET] entity does not exist")
+        terminate(NotFound)
+      case Failure(t: DocumentTypeMismatchException) =>
+        logging.info(this, s"[GET] entity conformance check failed: ${t.getMessage}")
+        terminate(Conflict, conformanceMessage)
+      case Failure(t: ArtifactStoreException) =>
+        logging.info(this, s"[GET] entity unreadable")
+        terminate(InternalServerError, t.getMessage)
+      case Failure(t: Throwable) =>
+        logging.error(this, s"[GET] entity failed: ${t.getMessage}")
+        terminate(InternalServerError)
     }
+  }
 
-    /**
-     * Gets an entity of type A from datastore and project fields for response. Terminates HTTP request.
-     *
-     * @param factory the factory that can fetch entity of type A from datastore
-     * @param datastore the client to the database
-     * @param docid the document id to get
-     * @param project a function A => JSON which projects fields form A
-     *
-     * Responses are one of (Code, Message)
-     * - 200 project(A) as JSON
-     * - 404 Not Found
-     * - 500 Internal Server Error
-     */
-    protected def getEntityAndProject[A, Au >: A](
-        factory: DocumentFactory[A],
-        datastore: ArtifactStore[Au],
-        docid: DocId,
-        project: A => JsObject)(
-            implicit transid: TransactionId,
-            format: RootJsonFormat[A],
-            ma: Manifest[A]) = {
-        onComplete(factory.get(datastore, docid)) {
-            case Success(entity) =>
-                logging.info(this, s"[PROJECT] entity success")
-                complete(OK, project(entity))
-            case Failure(t: NoDocumentException) =>
-                logging.info(this, s"[PROJECT] entity does not exist")
-                terminate(NotFound)
-            case Failure(t: DocumentTypeMismatchException) =>
-                logging.info(this, s"[PROJECT] entity conformance check failed: ${t.getMessage}")
-                terminate(Conflict, conformanceMessage)
-            case Failure(t: ArtifactStoreException) =>
-                logging.info(this, s"[PROJECT] entity unreadable")
-                terminate(InternalServerError, t.getMessage)
-            case Failure(t: Throwable) =>
-                logging.error(this, s"[PROJECT] entity failed: ${t.getMessage}")
-                terminate(InternalServerError)
-        }
+  /**
+   * Gets an entity of type A from datastore and project fields for response. Terminates HTTP request.
+   *
+   * @param factory the factory that can fetch entity of type A from datastore
+   * @param datastore the client to the database
+   * @param docid the document id to get
+   * @param project a function A => JSON which projects fields form A
+   *
+   * Responses are one of (Code, Message)
+   * - 200 project(A) as JSON
+   * - 404 Not Found
+   * - 500 Internal Server Error
+   */
+  protected def getEntityAndProject[A, Au >: A](
+    factory: DocumentFactory[A],
+    datastore: ArtifactStore[Au],
+    docid: DocId,
+    project: A => JsObject)(implicit transid: TransactionId, format: RootJsonFormat[A], ma: Manifest[A]) = {
+    onComplete(factory.get(datastore, docid)) {
+      case Success(entity) =>
+        logging.info(this, s"[PROJECT] entity success")
+        complete(OK, project(entity))
+      case Failure(t: NoDocumentException) =>
+        logging.info(this, s"[PROJECT] entity does not exist")
+        terminate(NotFound)
+      case Failure(t: DocumentTypeMismatchException) =>
+        logging.info(this, s"[PROJECT] entity conformance check failed: ${t.getMessage}")
+        terminate(Conflict, conformanceMessage)
+      case Failure(t: ArtifactStoreException) =>
+        logging.info(this, s"[PROJECT] entity unreadable")
+        terminate(InternalServerError, t.getMessage)
+      case Failure(t: Throwable) =>
+        logging.error(this, s"[PROJECT] entity failed: ${t.getMessage}")
+        terminate(InternalServerError)
     }
+  }
 }
 
 /** A trait for REST APIs that write entities to a datastore */
 trait WriteOps extends Directives {
 
-    /** An execution context for futures */
-    protected implicit val executionContext: ExecutionContext
+  /** An execution context for futures */
+  protected implicit val executionContext: ExecutionContext
 
-    protected implicit val logging: Logging
+  protected implicit val logging: Logging
 
-    /** JSON response formatter. */
-    import RestApiCommons.jsonDefaultResponsePrinter
+  /** JSON response formatter. */
+  import RestApiCommons.jsonDefaultResponsePrinter
 
-    /**
-     * A predicate future that completes with true iff the entity should be
-     * stored in the datastore. Future should fail otherwise with RejectPut.
-     */
-    protected type PutPredicate = Future[Boolean]
+  /**
+   * A predicate future that completes with true iff the entity should be
+   * stored in the datastore. Future should fail otherwise with RejectPut.
+   */
+  protected type PutPredicate = Future[Boolean]
 
-    /**
-     * Creates or updates an entity of type A in the datastore. First, fetch the entity
-     * by id from the datastore (this is required to get the document revision for an update).
-     * If the entity does not exist, create it. If it does exist, and 'overwrite' is enabled,
-     * update the entity.
-     *
-     * @param factory the factory that can fetch entity of type A from datastore
-     * @param datastore the client to the database
-     * @param docid the document id to put
-     * @param overwrite updates an existing entity iff overwrite == true
-     * @param update a function (A) => Future[A] that updates the existing entity with PUT content
-     * @param create a function () => Future[A] that creates a new entity from PUT content
-     * @param treatExistsAsConflict if true and document exists but overwrite is not enabled, respond
-     * with Conflict else return OK and the existing document
-     *
-     * Responses are one of (Code, Message)
-     * - 200 entity A as JSON
-     * - 400 Bad Request
-     * - 409 Conflict
-     * - 500 Internal Server Error
-     */
-    protected def putEntity[A, Au >: A](
-        factory: DocumentFactory[A],
-        datastore: ArtifactStore[Au],
-        docid: DocId,
-        overwrite: Boolean,
-        update: A => Future[A],
-        create: () => Future[A],
-        treatExistsAsConflict: Boolean = true,
-        postProcess: Option[PostProcessEntity[A]] = None)(
-            implicit transid: TransactionId,
-            format: RootJsonFormat[A],
-            notifier: Option[CacheChangeNotification],
-            ma: Manifest[A]) = {
-        // marker to return an existing doc with status OK rather than conflict if overwrite is false
-        case class IdentityPut(self: A) extends Throwable
+  /**
+   * Creates or updates an entity of type A in the datastore. First, fetch the entity
+   * by id from the datastore (this is required to get the document revision for an update).
+   * If the entity does not exist, create it. If it does exist, and 'overwrite' is enabled,
+   * update the entity.
+   *
+   * @param factory the factory that can fetch entity of type A from datastore
+   * @param datastore the client to the database
+   * @param docid the document id to put
+   * @param overwrite updates an existing entity iff overwrite == true
+   * @param update a function (A) => Future[A] that updates the existing entity with PUT content
+   * @param create a function () => Future[A] that creates a new entity from PUT content
+   * @param treatExistsAsConflict if true and document exists but overwrite is not enabled, respond
+   * with Conflict else return OK and the existing document
+   *
+   * Responses are one of (Code, Message)
+   * - 200 entity A as JSON
+   * - 400 Bad Request
+   * - 409 Conflict
+   * - 500 Internal Server Error
+   */
+  protected def putEntity[A, Au >: A](factory: DocumentFactory[A],
+                                      datastore: ArtifactStore[Au],
+                                      docid: DocId,
+                                      overwrite: Boolean,
+                                      update: A => Future[A],
+                                      create: () => Future[A],
+                                      treatExistsAsConflict: Boolean = true,
+                                      postProcess: Option[PostProcessEntity[A]] = None)(
+    implicit transid: TransactionId,
+    format: RootJsonFormat[A],
+    notifier: Option[CacheChangeNotification],
+    ma: Manifest[A]) = {
+    // marker to return an existing doc with status OK rather than conflict if overwrite is false
+    case class IdentityPut(self: A) extends Throwable
 
-        onComplete(factory.get(datastore, docid) flatMap { doc =>
-            if (overwrite) {
-                logging.info(this, s"[PUT] entity exists, will try to update '$doc'")
-                update(doc)
-            } else if (treatExistsAsConflict) {
-                logging.info(this, s"[PUT] entity exists, but overwrite is not enabled, aborting")
-                Future failed RejectRequest(Conflict, "resource already exists")
-            } else {
-                Future failed IdentityPut(doc)
-            }
-        } recoverWith {
-            case _: NoDocumentException =>
-                logging.info(this, s"[PUT] entity does not exist, will try to create it")
-                create()
-        } flatMap { a =>
-            logging.info(this, s"[PUT] entity created/updated, writing back to datastore")
-            factory.put(datastore, a) map { _ => a }
-        }) {
-            case Success(entity) =>
-                logging.info(this, s"[PUT] entity success")
-                postProcess map { _(entity) } getOrElse complete(OK, entity)
-            case Failure(IdentityPut(a)) =>
-                logging.info(this, s"[PUT] entity exists, not overwritten")
-                complete(OK, a)
-            case Failure(t: DocumentConflictException) =>
-                logging.info(this, s"[PUT] entity conflict: ${t.getMessage}")
-                terminate(Conflict, conflictMessage)
-            case Failure(RejectRequest(code, message)) =>
-                logging.info(this, s"[PUT] entity rejected with code $code: $message")
-                terminate(code, message)
-            case Failure(t: DocumentTypeMismatchException) =>
-                logging.info(this, s"[PUT] entity conformance check failed: ${t.getMessage}")
-                terminate(Conflict, conformanceMessage)
-            case Failure(t: ArtifactStoreException) =>
-                logging.info(this, s"[PUT] entity unreadable")
-                terminate(InternalServerError, t.getMessage)
-            case Failure(t: Throwable) =>
-                logging.error(this, s"[PUT] entity failed: ${t.getMessage}")
-                terminate(InternalServerError)
-        }
+    onComplete(factory.get(datastore, docid) flatMap { doc =>
+      if (overwrite) {
+        logging.info(this, s"[PUT] entity exists, will try to update '$doc'")
+        update(doc)
+      } else if (treatExistsAsConflict) {
+        logging.info(this, s"[PUT] entity exists, but overwrite is not enabled, aborting")
+        Future failed RejectRequest(Conflict, "resource already exists")
+      } else {
+        Future failed IdentityPut(doc)
+      }
+    } recoverWith {
+      case _: NoDocumentException =>
+        logging.info(this, s"[PUT] entity does not exist, will try to create it")
+        create()
+    } flatMap { a =>
+      logging.info(this, s"[PUT] entity created/updated, writing back to datastore")
+      factory.put(datastore, a) map { _ =>
+        a
+      }
+    }) {
+      case Success(entity) =>
+        logging.info(this, s"[PUT] entity success")
+        postProcess map { _(entity) } getOrElse complete(OK, entity)
+      case Failure(IdentityPut(a)) =>
+        logging.info(this, s"[PUT] entity exists, not overwritten")
+        complete(OK, a)
+      case Failure(t: DocumentConflictException) =>
+        logging.info(this, s"[PUT] entity conflict: ${t.getMessage}")
+        terminate(Conflict, conflictMessage)
+      case Failure(RejectRequest(code, message)) =>
+        logging.info(this, s"[PUT] entity rejected with code $code: $message")
+        terminate(code, message)
+      case Failure(t: DocumentTypeMismatchException) =>
+        logging.info(this, s"[PUT] entity conformance check failed: ${t.getMessage}")
+        terminate(Conflict, conformanceMessage)
+      case Failure(t: ArtifactStoreException) =>
+        logging.info(this, s"[PUT] entity unreadable")
+        terminate(InternalServerError, t.getMessage)
+      case Failure(t: Throwable) =>
+        logging.error(this, s"[PUT] entity failed: ${t.getMessage}")
+        terminate(InternalServerError)
     }
+  }
 
-    /**
-     * Deletes an entity of type A from datastore.
-     * To delete an entity, first fetch the record to identify its revision and then delete it.
-     * Terminates HTTP request.
-     *
-     * @param factory the factory that can fetch entity of type A from datastore
-     * @param datastore the client to the database
-     * @param docid the document id to delete
-     * @param confirm a function (A => Future[Unit]) that confirms the entity is safe to delete (must fail future to abort)
-     * or fails the future with an appropriate message
-     *
-     * Responses are one of (Code, Message)
-     * - 200 entity A as JSON
-     * - 404 Not Found
-     * - 409 Conflict
-     * - 500 Internal Server Error
-     */
-    protected def deleteEntity[A <: WhiskDocument, Au >: A](
-        factory: DocumentFactory[A],
-        datastore: ArtifactStore[Au],
-        docid: DocId,
-        confirm: A => Future[Unit],
-        postProcess: Option[PostProcessEntity[A]] = None)(
-            implicit transid: TransactionId,
-            format: RootJsonFormat[A],
-            notifier: Option[CacheChangeNotification],
-            ma: Manifest[A]) = {
-        onComplete(factory.get(datastore, docid) flatMap {
-            entity =>
-                confirm(entity) flatMap {
-                    case _ => factory.del(datastore, entity.docinfo) map { _ => entity }
-                }
-        }) {
-            case Success(entity) =>
-                logging.info(this, s"[DEL] entity success")
-                postProcess map { _(entity) } getOrElse complete(OK, entity)
-            case Failure(t: NoDocumentException) =>
-                logging.info(this, s"[DEL] entity does not exist")
-                terminate(NotFound)
-            case Failure(t: DocumentConflictException) =>
-                logging.info(this, s"[DEL] entity conflict: ${t.getMessage}")
-                terminate(Conflict, conflictMessage)
-            case Failure(RejectRequest(code, message)) =>
-                logging.info(this, s"[DEL] entity rejected with code $code: $message")
-                terminate(code, message)
-            case Failure(t: DocumentTypeMismatchException) =>
-                logging.info(this, s"[DEL] entity conformance check failed: ${t.getMessage}")
-                terminate(Conflict, conformanceMessage)
-            case Failure(t: ArtifactStoreException) =>
-                logging.info(this, s"[DEL] entity unreadable")
-                terminate(InternalServerError, t.getMessage)
-            case Failure(t: Throwable) =>
-                logging.error(this, s"[DEL] entity failed: ${t.getMessage}")
-                terminate(InternalServerError)
-        }
+  /**
+   * Deletes an entity of type A from datastore.
+   * To delete an entity, first fetch the record to identify its revision and then delete it.
+   * Terminates HTTP request.
+   *
+   * @param factory the factory that can fetch entity of type A from datastore
+   * @param datastore the client to the database
+   * @param docid the document id to delete
+   * @param confirm a function (A => Future[Unit]) that confirms the entity is safe to delete (must fail future to abort)
+   * or fails the future with an appropriate message
+   *
+   * Responses are one of (Code, Message)
+   * - 200 entity A as JSON
+   * - 404 Not Found
+   * - 409 Conflict
+   * - 500 Internal Server Error
+   */
+  protected def deleteEntity[A <: WhiskDocument, Au >: A](factory: DocumentFactory[A],
+                                                          datastore: ArtifactStore[Au],
+                                                          docid: DocId,
+                                                          confirm: A => Future[Unit],
+                                                          postProcess: Option[PostProcessEntity[A]] = None)(
+    implicit transid: TransactionId,
+    format: RootJsonFormat[A],
+    notifier: Option[CacheChangeNotification],
+    ma: Manifest[A]) = {
+    onComplete(factory.get(datastore, docid) flatMap { entity =>
+      confirm(entity) flatMap {
+        case _ =>
+          factory.del(datastore, entity.docinfo) map { _ =>
+            entity
+          }
+      }
+    }) {
+      case Success(entity) =>
+        logging.info(this, s"[DEL] entity success")
+        postProcess map { _(entity) } getOrElse complete(OK, entity)
+      case Failure(t: NoDocumentException) =>
+        logging.info(this, s"[DEL] entity does not exist")
+        terminate(NotFound)
+      case Failure(t: DocumentConflictException) =>
+        logging.info(this, s"[DEL] entity conflict: ${t.getMessage}")
+        terminate(Conflict, conflictMessage)
+      case Failure(RejectRequest(code, message)) =>
+        logging.info(this, s"[DEL] entity rejected with code $code: $message")
+        terminate(code, message)
+      case Failure(t: DocumentTypeMismatchException) =>
+        logging.info(this, s"[DEL] entity conformance check failed: ${t.getMessage}")
+        terminate(Conflict, conformanceMessage)
+      case Failure(t: ArtifactStoreException) =>
+        logging.info(this, s"[DEL] entity unreadable")
+        terminate(InternalServerError, t.getMessage)
+      case Failure(t: Throwable) =>
+        logging.error(this, s"[DEL] entity failed: ${t.getMessage}")
+        terminate(InternalServerError)
     }
+  }
 }

--- a/core/controller/src/main/scala/whisk/core/controller/Authenticate.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Authenticate.scala
@@ -36,47 +36,49 @@ import whisk.core.entity.Secret
 import whisk.core.entity.UUID
 
 object Authenticate {
-    /** Required properties for this component */
-    def requiredProperties = WhiskAuthStore.requiredProperties
+
+  /** Required properties for this component */
+  def requiredProperties = WhiskAuthStore.requiredProperties
 }
 
 /** A trait to validate basic auth credentials */
 trait Authenticate {
-    protected implicit val executionContext: ExecutionContext
-    protected implicit val logging: Logging
+  protected implicit val executionContext: ExecutionContext
+  protected implicit val logging: Logging
 
-    /** Database service to lookup credentials */
-    protected val authStore: AuthStore
+  /** Database service to lookup credentials */
+  protected val authStore: AuthStore
 
-    /**
-     * Validates credentials against the authentication database; may be used in
-     * authentication directive.
-     */
-    def validateCredentials(credentials: Option[BasicHttpCredentials])(implicit transid: TransactionId): Future[Option[Identity]] = {
-        credentials flatMap { pw =>
-            Try {
-                // authkey deserialization is wrapped in a try to guard against malformed values
-                val authkey = AuthKey(UUID(pw.username), Secret(pw.password))
-                logging.info(this, s"authenticate: ${authkey.uuid}")
-                val future = Identity.get(authStore, authkey) map { result =>
-                    if (authkey == result.authkey) {
-                        logging.info(this, s"authentication valid")
-                        Some(result)
-                    } else {
-                        logging.info(this, s"authentication not valid")
-                        None
-                    }
-                } recover {
-                    case _: NoDocumentException | _: IllegalArgumentException =>
-                        logging.info(this, s"authentication not valid")
-                        None
-                }
-                future onFailure { case t => logging.error(this, s"authentication error: $t") }
-                future
-            }.toOption
-        } getOrElse {
-            credentials.foreach(_ => logging.info(this, s"credentials are malformed"))
-            Future.successful(None)
+  /**
+   * Validates credentials against the authentication database; may be used in
+   * authentication directive.
+   */
+  def validateCredentials(credentials: Option[BasicHttpCredentials])(
+    implicit transid: TransactionId): Future[Option[Identity]] = {
+    credentials flatMap { pw =>
+      Try {
+        // authkey deserialization is wrapped in a try to guard against malformed values
+        val authkey = AuthKey(UUID(pw.username), Secret(pw.password))
+        logging.info(this, s"authenticate: ${authkey.uuid}")
+        val future = Identity.get(authStore, authkey) map { result =>
+          if (authkey == result.authkey) {
+            logging.info(this, s"authentication valid")
+            Some(result)
+          } else {
+            logging.info(this, s"authentication not valid")
+            None
+          }
+        } recover {
+          case _: NoDocumentException | _: IllegalArgumentException =>
+            logging.info(this, s"authentication not valid")
+            None
         }
+        future onFailure { case t => logging.error(this, s"authentication error: $t") }
+        future
+      }.toOption
+    } getOrElse {
+      credentials.foreach(_ => logging.info(this, s"credentials are malformed"))
+      Future.successful(None)
     }
+  }
 }

--- a/core/controller/src/main/scala/whisk/core/controller/AuthenticatedRoute.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/AuthenticatedRoute.scala
@@ -33,24 +33,25 @@ import whisk.core.entity.Identity
 /** A common trait for secured routes */
 trait AuthenticatedRoute {
 
-    /** An execution context for futures */
-    protected implicit val executionContext: ExecutionContext
+  /** An execution context for futures */
+  protected implicit val executionContext: ExecutionContext
 
-    /** Creates HTTP BasicAuth handler */
-    def basicAuth[A](verify: Option[BasicHttpCredentials] => Future[Option[A]]) = {
-        authenticateOrRejectWithChallenge[BasicHttpCredentials, A] { creds =>
-            verify(creds).map {
-                case Some(t) => AuthenticationResult.success(t)
-                case None    => AuthenticationResult.failWithChallenge(HttpChallenges.basic("OpenWhisk secure realm"))
-            }
-        }
+  /** Creates HTTP BasicAuth handler */
+  def basicAuth[A](verify: Option[BasicHttpCredentials] => Future[Option[A]]) = {
+    authenticateOrRejectWithChallenge[BasicHttpCredentials, A] { creds =>
+      verify(creds).map {
+        case Some(t) => AuthenticationResult.success(t)
+        case None    => AuthenticationResult.failWithChallenge(HttpChallenges.basic("OpenWhisk secure realm"))
+      }
     }
+  }
 
-    /** Validates credentials against database of subjects */
-    protected def validateCredentials(credentials: Option[BasicHttpCredentials])(implicit transid: TransactionId): Future[Option[Identity]]
+  /** Validates credentials against database of subjects */
+  protected def validateCredentials(credentials: Option[BasicHttpCredentials])(
+    implicit transid: TransactionId): Future[Option[Identity]]
 }
 
 /** A trait for authenticated routes. */
 trait AuthenticatedRouteProvider {
-    def routes(user: Identity)(implicit transid: TransactionId): Route
+  def routes(user: Identity)(implicit transid: TransactionId): Route
 }

--- a/core/controller/src/main/scala/whisk/core/controller/Backend.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Backend.scala
@@ -26,15 +26,16 @@ import whisk.core.loadBalancer.LoadBalancer
  * A trait which defines a few services which a whisk microservice may rely on.
  */
 trait WhiskServices {
-    /** Whisk configuration object. */
-    protected val whiskConfig: WhiskConfig
 
-    /** An entitlement service to check access rights. */
-    protected val entitlementProvider: EntitlementProvider
+  /** Whisk configuration object. */
+  protected val whiskConfig: WhiskConfig
 
-    /** A generator for new activation ids. */
-    protected val activationIdFactory: ActivationIdGenerator
+  /** An entitlement service to check access rights. */
+  protected val entitlementProvider: EntitlementProvider
 
-    /** A load balancing service that launches invocations. */
-    protected val loadBalancer: LoadBalancer
+  /** A generator for new activation ids. */
+  protected val activationIdFactory: ActivationIdGenerator
+
+  /** A load balancing service that launches invocations. */
+  protected val loadBalancer: LoadBalancer
 }

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -19,7 +19,7 @@ package whisk.core.controller
 
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
 
 import akka.actor._
 import akka.actor.ActorSystem
@@ -68,74 +68,76 @@ import whisk.http.BasicRasService
  * @param verbosity logging verbosity
  * @param executionContext Scala runtime support for concurrent operations
  */
-class Controller(
-    override val instance: InstanceId,
-    runtimes: Runtimes,
-    implicit val whiskConfig: WhiskConfig,
-    implicit val actorSystem: ActorSystem,
-    implicit val materializer: ActorMaterializer,
-    implicit val logging: Logging)
+class Controller(override val instance: InstanceId,
+                 runtimes: Runtimes,
+                 implicit val whiskConfig: WhiskConfig,
+                 implicit val actorSystem: ActorSystem,
+                 implicit val materializer: ActorMaterializer,
+                 implicit val logging: Logging)
     extends BasicRasService {
 
-    override val numberOfInstances = whiskConfig.controllerInstances.toInt
+  override val numberOfInstances = whiskConfig.controllerInstances.toInt
 
-    TransactionId.controller.mark(this, LoggingMarkers.CONTROLLER_STARTUP(instance.toInt), s"starting controller instance ${instance.toInt}")
+  TransactionId.controller.mark(
+    this,
+    LoggingMarkers.CONTROLLER_STARTUP(instance.toInt),
+    s"starting controller instance ${instance.toInt}")
 
-    /**
-     * A Route in Akka is technically a function taking a RequestContext as a parameter.
-     *
-     * The "~" Akka DSL operator composes two independent Routes, building a routing tree structure.
-     * @see http://doc.akka.io/docs/akka-http/current/scala/http/routing-dsl/routes.html#composing-routes
-     */
-    override def routes(implicit transid: TransactionId): Route = {
-        super.routes ~ {
-            (pathEndOrSingleSlash & get) {
-                complete(info)
-            }
-        } ~ apiV1.routes ~ swagger.swaggerRoutes ~ internalInvokerHealth
+  /**
+   * A Route in Akka is technically a function taking a RequestContext as a parameter.
+   *
+   * The "~" Akka DSL operator composes two independent Routes, building a routing tree structure.
+   * @see http://doc.akka.io/docs/akka-http/current/scala/http/routing-dsl/routes.html#composing-routes
+   */
+  override def routes(implicit transid: TransactionId): Route = {
+    super.routes ~ {
+      (pathEndOrSingleSlash & get) {
+        complete(info)
+      }
+    } ~ apiV1.routes ~ swagger.swaggerRoutes ~ internalInvokerHealth
+  }
+
+  // initialize datastores
+  private implicit val authStore = WhiskAuthStore.datastore(whiskConfig)
+  private implicit val entityStore = WhiskEntityStore.datastore(whiskConfig)
+  private implicit val activationStore = WhiskActivationStore.datastore(whiskConfig)
+  private implicit val cacheChangeNotification = Some(new CacheChangeNotification {
+    val remoteCacheInvalidaton = new RemoteCacheInvalidation(whiskConfig, "controller", instance)
+    override def apply(k: CacheKey) = remoteCacheInvalidaton.notifyOtherInstancesAboutInvalidation(k)
+  })
+
+  // initialize backend services
+  private implicit val loadBalancer = new LoadBalancerService(whiskConfig, instance, entityStore)
+  private implicit val entitlementProvider = new LocalEntitlementProvider(whiskConfig, loadBalancer)
+  private implicit val activationIdFactory = new ActivationIdGenerator {}
+
+  // register collections
+  Collection.initialize(entityStore)
+
+  /** The REST APIs. */
+  implicit val controllerInstance = instance
+  private val apiV1 = new RestAPIVersion(whiskConfig, "api", "v1")
+  private val swagger = new SwaggerDocs(Uri.Path.Empty, "infoswagger.json")
+
+  /**
+   * Handles GET /invokers URI.
+   *
+   * @return JSON of invoker health
+   */
+  private val internalInvokerHealth = {
+    implicit val executionContext = actorSystem.dispatcher
+
+    (path("invokers") & get) {
+      complete {
+        loadBalancer.allInvokers.map(_.map {
+          case (instance, state) => s"invoker${instance.toInt}" -> state.asString
+        }.toMap.toJson.asJsObject)
+      }
     }
+  }
 
-    // initialize datastores
-    private implicit val authStore = WhiskAuthStore.datastore(whiskConfig)
-    private implicit val entityStore = WhiskEntityStore.datastore(whiskConfig)
-    private implicit val activationStore = WhiskActivationStore.datastore(whiskConfig)
-    private implicit val cacheChangeNotification = Some(new CacheChangeNotification {
-        val remoteCacheInvalidaton = new RemoteCacheInvalidation(whiskConfig, "controller", instance)
-        override def apply(k: CacheKey) = remoteCacheInvalidaton.notifyOtherInstancesAboutInvalidation(k)
-    })
-
-    // initialize backend services
-    private implicit val loadBalancer = new LoadBalancerService(whiskConfig, instance, entityStore)
-    private implicit val entitlementProvider = new LocalEntitlementProvider(whiskConfig, loadBalancer)
-    private implicit val activationIdFactory = new ActivationIdGenerator {}
-
-    // register collections
-    Collection.initialize(entityStore)
-
-    /** The REST APIs. */
-    implicit val controllerInstance = instance
-    private val apiV1 = new RestAPIVersion(whiskConfig, "api", "v1")
-    private val swagger = new SwaggerDocs(Uri.Path.Empty, "infoswagger.json")
-
-    /**
-     * Handles GET /invokers URI.
-     *
-     * @return JSON of invoker health
-     */
-    private val internalInvokerHealth = {
-        implicit val executionContext = actorSystem.dispatcher
-
-        (path("invokers") & get) {
-            complete {
-                loadBalancer.allInvokers.map(_.map {
-                    case (instance, state) => s"invoker${instance.toInt}" -> state.asString
-                }.toMap.toJson.asJsObject)
-            }
-        }
-    }
-
-    // controller top level info
-    private val info = Controller.info(whiskConfig, runtimes, List(apiV1.basepath()))
+  // controller top level info
+  private val info = Controller.info(whiskConfig, runtimes, List(apiV1.basepath()))
 }
 
 /**
@@ -143,58 +145,66 @@ class Controller(
  */
 object Controller {
 
-    // requiredProperties is a Map whose keys define properties that must be bound to
-    // a value, and whose values are default values.   A null value in the Map means there is
-    // no default value specified, so it must appear in the properties file
-    def requiredProperties = Map(WhiskConfig.controllerInstances -> null) ++
-        ExecManifest.requiredProperties ++
-        RestApiCommons.requiredProperties ++
-        LoadBalancerService.requiredProperties ++
-        EntitlementProvider.requiredProperties
+  // requiredProperties is a Map whose keys define properties that must be bound to
+  // a value, and whose values are default values.   A null value in the Map means there is
+  // no default value specified, so it must appear in the properties file
+  def requiredProperties =
+    Map(WhiskConfig.controllerInstances -> null) ++
+      ExecManifest.requiredProperties ++
+      RestApiCommons.requiredProperties ++
+      LoadBalancerService.requiredProperties ++
+      EntitlementProvider.requiredProperties
 
-    private def info(config: WhiskConfig, runtimes: Runtimes, apis: List[String]) = JsObject(
-        "description" -> "OpenWhisk".toJson,
-        "support" -> JsObject(
-            "github" -> "https://github.com/apache/incubator-openwhisk/issues".toJson,
-            "slack" -> "http://slack.openwhisk.org".toJson),
-        "api_paths" -> apis.toJson,
-        "limits" -> JsObject(
-            "actions_per_minute" -> config.actionInvokePerMinuteLimit.toInt.toJson,
-            "triggers_per_minute" -> config.triggerFirePerMinuteLimit.toInt.toJson,
-            "concurrent_actions" -> config.actionInvokeConcurrentLimit.toInt.toJson),
-        "runtimes" -> runtimes.toJson)
+  private def info(config: WhiskConfig, runtimes: Runtimes, apis: List[String]) =
+    JsObject(
+      "description" -> "OpenWhisk".toJson,
+      "support" -> JsObject(
+        "github" -> "https://github.com/apache/incubator-openwhisk/issues".toJson,
+        "slack" -> "http://slack.openwhisk.org".toJson),
+      "api_paths" -> apis.toJson,
+      "limits" -> JsObject(
+        "actions_per_minute" -> config.actionInvokePerMinuteLimit.toInt.toJson,
+        "triggers_per_minute" -> config.triggerFirePerMinuteLimit.toInt.toJson,
+        "concurrent_actions" -> config.actionInvokeConcurrentLimit.toInt.toJson),
+      "runtimes" -> runtimes.toJson)
 
-    def main(args: Array[String]): Unit = {
-        implicit val actorSystem = ActorSystem("controller-actor-system")
-        implicit val logger = new AkkaLogging(akka.event.Logging.getLogger(actorSystem, this))
+  def main(args: Array[String]): Unit = {
+    implicit val actorSystem = ActorSystem("controller-actor-system")
+    implicit val logger = new AkkaLogging(akka.event.Logging.getLogger(actorSystem, this))
 
-        // extract configuration data from the environment
-        val config = new WhiskConfig(requiredProperties)
-        val port = config.servicePort.toInt
+    // extract configuration data from the environment
+    val config = new WhiskConfig(requiredProperties)
+    val port = config.servicePort.toInt
 
-        // if deploying multiple instances (scale out), must pass the instance number as the
-        require(args.length >= 1, "controller instance required")
-        val instance = args(0).toInt
+    // if deploying multiple instances (scale out), must pass the instance number as the
+    require(args.length >= 1, "controller instance required")
+    val instance = args(0).toInt
 
-        def abort() = {
-            logger.error(this, "Bad configuration, cannot start.")
-            actorSystem.terminate()
-            Await.result(actorSystem.whenTerminated, 30.seconds)
-            sys.exit(1)
-        }
-
-        if (!config.isValid) {
-            abort()
-        }
-
-        ExecManifest.initialize(config) match {
-            case Success(_) =>
-                val controller = new Controller(InstanceId(instance), ExecManifest.runtimesManifest, config, actorSystem, ActorMaterializer.create(actorSystem), logger)
-                BasicHttpService.startService(controller.route, port)(actorSystem, controller.materializer)
-
-            case Failure(t) =>
-                logger.error(this, s"Invalid runtimes manifest: $t")
-                abort()
-        }
+    def abort() = {
+      logger.error(this, "Bad configuration, cannot start.")
+      actorSystem.terminate()
+      Await.result(actorSystem.whenTerminated, 30.seconds)
+      sys.exit(1)
     }
+
+    if (!config.isValid) {
+      abort()
+    }
+
+    ExecManifest.initialize(config) match {
+      case Success(_) =>
+        val controller = new Controller(
+          InstanceId(instance),
+          ExecManifest.runtimesManifest,
+          config,
+          actorSystem,
+          ActorMaterializer.create(actorSystem),
+          logger)
+        BasicHttpService.startService(controller.route, port)(actorSystem, controller.materializer)
+
+      case Failure(t) =>
+        logger.error(this, s"Invalid runtimes manifest: $t")
+        abort()
+    }
+  }
 }

--- a/core/controller/src/main/scala/whisk/core/controller/Entities.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Entities.scala
@@ -42,26 +42,27 @@ import whisk.http.Messages
 
 protected[controller] trait ValidateRequestSize extends Directives {
 
-    protected def validateSize(check: => Option[SizeError])(
-        implicit tid: TransactionId, jsonPrinter: JsonPrinter) = new Directive0 {
-        override def tapply(f: Unit => Route) = {
-            check map {
-                case e: SizeError => terminate(RequestEntityTooLarge, Messages.entityTooBig(e))
-            } getOrElse f(None)
-        }
+  protected def validateSize(check: => Option[SizeError])(implicit tid: TransactionId, jsonPrinter: JsonPrinter) =
+    new Directive0 {
+      override def tapply(f: Unit => Route) = {
+        check map {
+          case e: SizeError => terminate(RequestEntityTooLarge, Messages.entityTooBig(e))
+        } getOrElse f(None)
+      }
     }
 
-    /** Checks if request entity is within allowed length range. */
-    protected def isWhithinRange(length: Long) = {
-        if (length <= allowedActivationEntitySize) {
-            None
-        } else Some {
-            SizeError(fieldDescriptionForSizeError, length.B, allowedActivationEntitySize.B)
-        }
-    }
+  /** Checks if request entity is within allowed length range. */
+  protected def isWhithinRange(length: Long) = {
+    if (length <= allowedActivationEntitySize) {
+      None
+    } else
+      Some {
+        SizeError(fieldDescriptionForSizeError, length.B, allowedActivationEntitySize.B)
+      }
+  }
 
-    protected val allowedActivationEntitySize: Long = ActivationEntityLimit.MAX_ACTIVATION_ENTITY_LIMIT.toBytes
-    protected val fieldDescriptionForSizeError = "Request"
+  protected val allowedActivationEntitySize: Long = ActivationEntityLimit.MAX_ACTIVATION_ENTITY_LIMIT.toBytes
+  protected val fieldDescriptionForSizeError = "Request"
 }
 
 /** A trait implementing the basic operations on WhiskEntities in support of the various APIs. */
@@ -73,81 +74,87 @@ trait WhiskCollectionAPI
     with ReadOps
     with WriteOps {
 
-    /** The core collections require backend services to be injected in this trait. */
-    services: WhiskServices =>
+  /** The core collections require backend services to be injected in this trait. */
+  services: WhiskServices =>
 
-    /** Creates an entity, or updates an existing one, in namespace. Terminates HTTP request. */
-    protected def create(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId): RequestContext => Future[RouteResult]
+  /** Creates an entity, or updates an existing one, in namespace. Terminates HTTP request. */
+  protected def create(user: Identity, entityName: FullyQualifiedEntityName)(
+    implicit transid: TransactionId): RequestContext => Future[RouteResult]
 
-    /** Activates entity. Examples include invoking an action, firing a trigger, enabling/disabling a rule. */
-    protected def activate(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(implicit transid: TransactionId): RequestContext => Future[RouteResult]
+  /** Activates entity. Examples include invoking an action, firing a trigger, enabling/disabling a rule. */
+  protected def activate(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(
+    implicit transid: TransactionId): RequestContext => Future[RouteResult]
 
-    /** Removes entity from namespace. Terminates HTTP request. */
-    protected def remove(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId): RequestContext => Future[RouteResult]
+  /** Removes entity from namespace. Terminates HTTP request. */
+  protected def remove(user: Identity, entityName: FullyQualifiedEntityName)(
+    implicit transid: TransactionId): RequestContext => Future[RouteResult]
 
-    /** Gets entity from namespace. Terminates HTTP request. */
-    protected def fetch(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(implicit transid: TransactionId): RequestContext => Future[RouteResult]
+  /** Gets entity from namespace. Terminates HTTP request. */
+  protected def fetch(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(
+    implicit transid: TransactionId): RequestContext => Future[RouteResult]
 
-    /** Gets all entities from namespace. If necessary filter only entities that are shared. Terminates HTTP request. */
-    protected def list(user: Identity, path: EntityPath, excludePrivate: Boolean)(implicit transid: TransactionId): RequestContext => Future[RouteResult]
+  /** Gets all entities from namespace. If necessary filter only entities that are shared. Terminates HTTP request. */
+  protected def list(user: Identity, path: EntityPath, excludePrivate: Boolean)(
+    implicit transid: TransactionId): RequestContext => Future[RouteResult]
 
-    /** Indicates if listing entities in collection requires filtering out private entities. */
-    protected val listRequiresPrivateEntityFilter = false // currently supported on PACKAGES only
+  /** Indicates if listing entities in collection requires filtering out private entities. */
+  protected val listRequiresPrivateEntityFilter = false // currently supported on PACKAGES only
 
-    /** Dispatches resource to the proper handler depending on context. */
-    protected override def dispatchOp(user: Identity, op: Privilege, resource: Resource)(implicit transid: TransactionId) = {
-        resource.entity match {
-            case Some(EntityName(name)) => op match {
-                case READ => fetch(user, FullyQualifiedEntityName(resource.namespace, name), resource.env)
-                case PUT =>
-                    entity(as[LimitedWhiskEntityPut]) { e =>
-                        validateSize(e.isWithinSizeLimits)(transid, RestApiCommons.jsonDefaultResponsePrinter) {
-                            create(user, FullyQualifiedEntityName(resource.namespace, name))
-                        }
-                    }
-                case ACTIVATE =>
-                    extract(_.request.entity.contentLengthOption) { length =>
-                        validateSize(isWhithinRange(length.getOrElse(0)))(transid, RestApiCommons.jsonDefaultResponsePrinter) {
-                            activate(user, FullyQualifiedEntityName(resource.namespace, name), resource.env)
-                        }
-                    }
-
-                case DELETE => remove(user, FullyQualifiedEntityName(resource.namespace, name))
-                case _      => reject
+  /** Dispatches resource to the proper handler depending on context. */
+  protected override def dispatchOp(user: Identity, op: Privilege, resource: Resource)(
+    implicit transid: TransactionId) = {
+    resource.entity match {
+      case Some(EntityName(name)) =>
+        op match {
+          case READ => fetch(user, FullyQualifiedEntityName(resource.namespace, name), resource.env)
+          case PUT =>
+            entity(as[LimitedWhiskEntityPut]) { e =>
+              validateSize(e.isWithinSizeLimits)(transid, RestApiCommons.jsonDefaultResponsePrinter) {
+                create(user, FullyQualifiedEntityName(resource.namespace, name))
+              }
             }
-            case None => op match {
-                case READ =>
-                    // the entitlement service will authorize any subject to list PACKAGES
-                    // in any namespace regardless of ownership but the list operation CANNOT
-                    // produce all entities in the requested namespace UNLESS the subject is
-                    // entitled to them which for now means they own the namespace. If the
-                    // subject does not own the namespace, then exclude packages that are private
-                    val excludePrivate = listRequiresPrivateEntityFilter && resource.namespace.root != user.namespace
-                    logging.info(this, s"[LIST] exclude private entities: required == $excludePrivate")
-                    list(user, resource.namespace, excludePrivate)
-
-                case _ => reject
+          case ACTIVATE =>
+            extract(_.request.entity.contentLengthOption) { length =>
+              validateSize(isWhithinRange(length.getOrElse(0)))(transid, RestApiCommons.jsonDefaultResponsePrinter) {
+                activate(user, FullyQualifiedEntityName(resource.namespace, name), resource.env)
+              }
             }
+
+          case DELETE => remove(user, FullyQualifiedEntityName(resource.namespace, name))
+          case _      => reject
+        }
+      case None =>
+        op match {
+          case READ =>
+            // the entitlement service will authorize any subject to list PACKAGES
+            // in any namespace regardless of ownership but the list operation CANNOT
+            // produce all entities in the requested namespace UNLESS the subject is
+            // entitled to them which for now means they own the namespace. If the
+            // subject does not own the namespace, then exclude packages that are private
+            val excludePrivate = listRequiresPrivateEntityFilter && resource.namespace.root != user.namespace
+            logging.info(this, s"[LIST] exclude private entities: required == $excludePrivate")
+            list(user, resource.namespace, excludePrivate)
+
+          case _ => reject
         }
     }
+  }
 
-    /** Validates entity name from the matched path segment. */
-    protected val segmentDescriptionForSizeError = "Name segement"
+  /** Validates entity name from the matched path segment. */
+  protected val segmentDescriptionForSizeError = "Name segement"
 
-    protected override final def entityname(s: String) = {
-        validate(isEntity(s), {
-            if (s.length > EntityName.ENTITY_NAME_MAX_LENGTH) {
-                Messages.entityNameTooLong(
-                    SizeError(
-                        segmentDescriptionForSizeError,
-                        s.length.B,
-                        EntityName.ENTITY_NAME_MAX_LENGTH.B))
-            } else {
-                Messages.entityNameIllegal
-            }
-        }) & extract(_ => s)
-    }
+  protected override final def entityname(s: String) = {
+    validate(
+      isEntity(s), {
+        if (s.length > EntityName.ENTITY_NAME_MAX_LENGTH) {
+          Messages.entityNameTooLong(
+            SizeError(segmentDescriptionForSizeError, s.length.B, EntityName.ENTITY_NAME_MAX_LENGTH.B))
+        } else {
+          Messages.entityNameIllegal
+        }
+      }) & extract(_ => s)
+  }
 
-    /** Confirms that a path segment is a valid entity name. Used to reject invalid entity names. */
-    protected final def isEntity(n: String) = Try { EntityName(n) } isSuccess
+  /** Confirms that a path segment is a valid entity name. Used to reject invalid entity names. */
+  protected final def isEntity(n: String) = Try { EntityName(n) } isSuccess
 }

--- a/core/controller/src/main/scala/whisk/core/controller/Packages.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Packages.scala
@@ -40,283 +40,313 @@ import whisk.http.ErrorResponse.terminate
 import whisk.http.Messages
 
 trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
-    services: WhiskServices =>
+  services: WhiskServices =>
 
-    protected override val collection = Collection(Collection.PACKAGES)
+  protected override val collection = Collection(Collection.PACKAGES)
 
-    /** Database service to CRUD packages. */
-    protected val entityStore: EntityStore
+  /** Database service to CRUD packages. */
+  protected val entityStore: EntityStore
 
-    /** Notification service for cache invalidation. */
-    protected implicit val cacheChangeNotification: Some[CacheChangeNotification]
+  /** Notification service for cache invalidation. */
+  protected implicit val cacheChangeNotification: Some[CacheChangeNotification]
 
-    /** Route directives for API. The methods that are supported on packages. */
-    protected override lazy val entityOps = put | get | delete
+  /** Route directives for API. The methods that are supported on packages. */
+  protected override lazy val entityOps = put | get | delete
 
-    /** Must exclude any private packages when listing those in a namespace unless owned by subject. */
-    protected override val listRequiresPrivateEntityFilter = true
+  /** Must exclude any private packages when listing those in a namespace unless owned by subject. */
+  protected override val listRequiresPrivateEntityFilter = true
 
-    /** JSON response formatter. */
-    import RestApiCommons.jsonDefaultResponsePrinter
+  /** JSON response formatter. */
+  import RestApiCommons.jsonDefaultResponsePrinter
 
-    /**
-     * Creates or updates package/binding if it already exists. The PUT content is deserialized into a
-     * WhiskPackagePut which is a subset of WhiskPackage (it eschews the namespace and entity name since
-     * the former is derived from the authenticated user and the latter is derived from the URI). If the
-     * binding property is defined, creates or updates a package binding as long as resource is already a
-     * binding.
-     *
-     * The WhiskPackagePut is merged with the existing WhiskPackage in the datastore, overriding old values
-     * with new values that are defined. Any values not defined in the PUT content are replaced with old values.
-     *
-     * Responses are one of (Code, Message)
-     * - 200 WhiskPackage as JSON
-     * - 400 Bad Request
-     * - 409 Conflict
-     * - 500 Internal Server Error
-     */
-    override def create(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
-        parameter('overwrite ? false) { overwrite =>
-            entity(as[WhiskPackagePut]) { content =>
-                val request = content.resolve(entityName.namespace)
+  /**
+   * Creates or updates package/binding if it already exists. The PUT content is deserialized into a
+   * WhiskPackagePut which is a subset of WhiskPackage (it eschews the namespace and entity name since
+   * the former is derived from the authenticated user and the latter is derived from the URI). If the
+   * binding property is defined, creates or updates a package binding as long as resource is already a
+   * binding.
+   *
+   * The WhiskPackagePut is merged with the existing WhiskPackage in the datastore, overriding old values
+   * with new values that are defined. Any values not defined in the PUT content are replaced with old values.
+   *
+   * Responses are one of (Code, Message)
+   * - 200 WhiskPackage as JSON
+   * - 400 Bad Request
+   * - 409 Conflict
+   * - 500 Internal Server Error
+   */
+  override def create(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
+    parameter('overwrite ? false) { overwrite =>
+      entity(as[WhiskPackagePut]) { content =>
+        val request = content.resolve(entityName.namespace)
 
-                request.binding.map { b => logging.info(this, "checking if package is accessible") }
-                val referencedentities = referencedEntities(request)
-
-                onComplete(entitlementProvider.check(user, Privilege.READ, referencedentities)) {
-                    case Success(_) =>
-                        putEntity(WhiskPackage, entityStore, entityName.toDocId, overwrite,
-                            update(request) _, () => create(request, entityName))
-                    case Failure(f) =>
-                        rewriteEntitlementFailure(f)
-                }
-            }
+        request.binding.map { b =>
+          logging.info(this, "checking if package is accessible")
         }
-    }
+        val referencedentities = referencedEntities(request)
 
-    /**
-     * Activating a package is not supported. This method is not permitted and is not reachable.
-     *
-     * Responses are one of (Code, Message)
-     * - 405 Not Allowed
-     */
-    override def activate(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(implicit transid: TransactionId) = {
-        logging.error(this, "activate is not permitted on packages")
-        reject
-    }
-
-    /**
-     * Deletes package/binding. If a package, may only be deleted if there are no entities in the package.
-     *
-     * Responses are one of (Code, Message)
-     * - 200 WhiskPackage as JSON
-     * - 404 Not Found
-     * - 409 Conflict
-     * - 500 Internal Server Error
-     */
-    override def remove(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
-        deleteEntity(WhiskPackage, entityStore, entityName.toDocId, (wp: WhiskPackage) => {
-            wp.binding map {
-                // this is a binding, it is safe to remove
-                _ => Future.successful({})
-            } getOrElse {
-                // may only delete a package if all its ingredients are deleted already
-                WhiskAction.listCollectionInNamespace(entityStore, wp.namespace.addPath(wp.name), skip = 0, limit = 0) flatMap {
-                    case Left(list) if (list.size != 0) =>
-                        Future failed {
-                            RejectRequest(Conflict, s"Package not empty (contains ${list.size} ${if (list.size == 1) "entity" else "entities"})")
-                        }
-                    case _ => Future.successful({})
-                }
-            }
-        })
-    }
-
-    /**
-     * Gets package/binding.
-     * The package/binding name is prefixed with the namespace to create the primary index key.
-     *
-     * Responses are one of (Code, Message)
-     * - 200 WhiskPackage has JSON
-     * - 404 Not Found
-     * - 500 Internal Server Error
-     */
-    override def fetch(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(implicit transid: TransactionId) = {
-        getEntity(WhiskPackage, entityStore, entityName.toDocId, Some { mergePackageWithBinding() _ })
-    }
-
-    /**
-     * Gets all packages/bindings in namespace.
-     *
-     * Responses are one of (Code, Message)
-     * - 200 [] or [WhiskPackage as JSON]
-     * - 500 Internal Server Error
-     */
-    override def list(user: Identity, namespace: EntityPath, excludePrivate: Boolean)(implicit transid: TransactionId) = {
-        // for consistency, all the collections should support the same list API
-        // but because supporting docs on actions is difficult, the API does not
-        // offer an option to fetch entities with full docs yet; see comment in
-        // Actions API for more.
-        val docs = false
-
-        // disable listing all public (shared) packages in all namespaces until
-        // there exists a process in place to curate and rank these packages
-        val publicPackagesInAnyNamespace = false
-        parameter('skip ? 0, 'limit ? collection.listLimit, 'count ? false) {
-            (skip, limit, count) =>
-                if (publicPackagesInAnyNamespace && docs) {
-                    terminate(BadRequest, "Parameters 'public' and 'docs' may not both be true at the same time")
-                } else listEntities {
-                    if (!publicPackagesInAnyNamespace) {
-                        WhiskPackage.listCollectionInNamespace(entityStore, namespace, skip, limit, docs) map {
-                            list =>
-                                // any subject is entitled to list packages in any namespace
-                                // however, they shall only observe public packages if the packages
-                                // are not in one of the namespaces the subject is entitled to
-                                val packages = if (docs) {
-                                    list.right.get map { WhiskPackage.serdes.write(_) }
-                                } else list.left.get
-                                FilterEntityList.filter(packages, excludePrivate,
-                                    additionalFilter = { // additionally exclude bindings
-                                        case pkg: JsObject => Try {
-                                            pkg.fields(WhiskPackage.bindingFieldName) == JsBoolean(false)
-                                        } getOrElse false
-                                    })
-                        }
-                    } else {
-                        WhiskPackage.listCollectionInAnyNamespace(entityStore, skip, limit, docs = false, reduce = publicPackagesInAnyNamespace) map {
-                            _.left.get
-                        }
-                    }
-                }
+        onComplete(entitlementProvider.check(user, Privilege.READ, referencedentities)) {
+          case Success(_) =>
+            putEntity(
+              WhiskPackage,
+              entityStore,
+              entityName.toDocId,
+              overwrite,
+              update(request) _,
+              () => create(request, entityName))
+          case Failure(f) =>
+            rewriteEntitlementFailure(f)
         }
+      }
     }
+  }
 
-    /**
-     * Validates that a referenced binding exists.
-     */
-    private def checkBinding(binding: FullyQualifiedEntityName)(implicit transid: TransactionId): Future[Unit] = {
-        WhiskPackage.get(entityStore, binding.toDocId) recoverWith {
-            case t: NoDocumentException           => Future.failed(RejectRequest(BadRequest, Messages.bindingDoesNotExist))
-            case t: DocumentTypeMismatchException => Future.failed(RejectRequest(Conflict, Messages.requestedBindingIsNotValid))
-            case t                                => Future.failed(RejectRequest(BadRequest, t))
-        } flatMap {
-            // trying to create a new package binding that refers to another binding
-            case provider if provider.binding.nonEmpty => Future.failed(RejectRequest(BadRequest, Messages.bindingCannotReferenceBinding))
-            // or creating a package binding that refers to a package
-            case _                                     => Future.successful({})
-        }
-    }
+  /**
+   * Activating a package is not supported. This method is not permitted and is not reachable.
+   *
+   * Responses are one of (Code, Message)
+   * - 405 Not Allowed
+   */
+  override def activate(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(
+    implicit transid: TransactionId) = {
+    logging.error(this, "activate is not permitted on packages")
+    reject
+  }
 
-    /**
-     * Creates a WhiskPackage from PUT content, generating default values where necessary.
-     * If this is a binding, confirm the referenced package exists.
-     */
-    private def create(content: WhiskPackagePut, pkgName: FullyQualifiedEntityName)(implicit transid: TransactionId): Future[WhiskPackage] = {
-        val validateBinding = content.binding map {
-            b => checkBinding(b.fullyQualifiedName)
-        } getOrElse Future.successful({})
-
-        validateBinding map { _ =>
-            WhiskPackage(
-                pkgName.path,
-                pkgName.name,
-                content.binding,
-                content.parameters getOrElse Parameters(),
-                content.version getOrElse SemVer(),
-                content.publish getOrElse false,
-                // remove any binding annotation from PUT (always set by the controller)
-                (content.annotations getOrElse Parameters())
-                    - WhiskPackage.bindingFieldName
-                    ++ bindingAnnotation(content.binding))
-        }
-    }
-
-    /** Updates a WhiskPackage from PUT content, merging old package/binding where necessary. */
-    private def update(content: WhiskPackagePut)(wp: WhiskPackage)(implicit transid: TransactionId): Future[WhiskPackage] = {
-        val validateBinding = content.binding map { binding =>
-            wp.binding map {
-                // pre-existing entity is a binding, check that new binding is valid
-                b => checkBinding(b.fullyQualifiedName)
-            } getOrElse {
-                // pre-existing entity is a package, cannot make it a binding
-                Future.failed(RejectRequest(Conflict, Messages.packageCannotBecomeBinding))
-            }
-        } getOrElse Future.successful({})
-
-        validateBinding map { _ =>
-            WhiskPackage(
-                wp.namespace,
-                wp.name,
-                content.binding orElse wp.binding,
-                content.parameters getOrElse wp.parameters,
-                content.version getOrElse wp.version.upPatch,
-                content.publish getOrElse wp.publish,
-                // override any binding annotation from PUT (always set by the controller)
-                (content.annotations getOrElse wp.annotations)
-                    - WhiskPackage.bindingFieldName
-                    ++ bindingAnnotation(content.binding orElse wp.binding)).
-                revision[WhiskPackage](wp.docinfo.rev)
-        }
-    }
-
-    private def rewriteEntitlementFailure(failure: Throwable)(
-        implicit transid: TransactionId): RequestContext => Future[RouteResult] = {
-        logging.info(this, s"rewriting failure $failure")
-        failure match {
-            case RejectRequest(NotFound, _) => terminate(BadRequest, Messages.bindingDoesNotExist)
-            case RejectRequest(Conflict, _) => terminate(Conflict, Messages.requestedBindingIsNotValid)
-            case _                          => super.handleEntitlementFailure(failure)
-        }
-    }
-
-    /**
-     * Constructs a "binding" annotation. This is redundant with the binding
-     * information available in WhiskPackage but necessary for some clients which
-     * fetch package lists but cannot determine which package may be bound. An
-     * alternative is to include the binding in the package list "view" but this
-     * will require an API change. So using an annotation instead.
-     */
-    private def bindingAnnotation(binding: Option[Binding]): Parameters = {
-        binding map {
-            b => Parameters(WhiskPackage.bindingFieldName, Binding.serdes.write(b))
-        } getOrElse Parameters()
-    }
-
-    /**
-     * Constructs a WhiskPackage that is a merger of a package with its packing binding (if any).
-     * If this is a binding, fetch package for binding, merge parameters then emit.
-     * Otherwise this is a package, emit it.
-     */
-    private def mergePackageWithBinding(ref: Option[WhiskPackage] = None)(wp: WhiskPackage)(implicit transid: TransactionId): RequestContext => Future[RouteResult] = {
+  /**
+   * Deletes package/binding. If a package, may only be deleted if there are no entities in the package.
+   *
+   * Responses are one of (Code, Message)
+   * - 200 WhiskPackage as JSON
+   * - 404 Not Found
+   * - 409 Conflict
+   * - 500 Internal Server Error
+   */
+  override def remove(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
+    deleteEntity(
+      WhiskPackage,
+      entityStore,
+      entityName.toDocId,
+      (wp: WhiskPackage) => {
         wp.binding map {
-            case b: Binding =>
-                val docid = b.fullyQualifiedName.toDocId
-                logging.info(this, s"fetching package '$docid' for reference")
-                getEntity(WhiskPackage, entityStore, docid, Some {
-                    mergePackageWithBinding(Some { wp }) _
-                })
+          // this is a binding, it is safe to remove
+          _ =>
+            Future.successful({})
         } getOrElse {
-            val pkg = ref map { _ inherit wp.parameters } getOrElse wp
-            logging.info(this, s"fetching package actions in '${wp.fullPath}'")
-            val actions = WhiskAction.listCollectionInNamespace(entityStore, wp.fullPath, skip = 0, limit = 0) flatMap {
-                case Left(list) => Future.successful {
-                    pkg withPackageActions (list map { o => WhiskPackageAction.serdes.read(o) })
-                }
-                case t => Future.failed {
-                    logging.error(this, "unexpected result in package action lookup: $t")
-                    new IllegalStateException(s"unexpected result in package action lookup: $t")
-                }
-            }
+          // may only delete a package if all its ingredients are deleted already
+          WhiskAction
+            .listCollectionInNamespace(entityStore, wp.namespace.addPath(wp.name), skip = 0, limit = 0) flatMap {
+            case Left(list) if (list.size != 0) =>
+              Future failed {
+                RejectRequest(
+                  Conflict,
+                  s"Package not empty (contains ${list.size} ${if (list.size == 1) "entity" else "entities"})")
+              }
+            case _ => Future.successful({})
+          }
+        }
+      })
+  }
 
-            onComplete(actions) {
-                case Success(p) =>
-                    logging.info(this, s"[GET] entity success")
-                    complete(OK, p)
-                case Failure(t) =>
-                    logging.error(this, s"[GET] failed: ${t.getMessage}")
-                    terminate(InternalServerError)
+  /**
+   * Gets package/binding.
+   * The package/binding name is prefixed with the namespace to create the primary index key.
+   *
+   * Responses are one of (Code, Message)
+   * - 200 WhiskPackage has JSON
+   * - 404 Not Found
+   * - 500 Internal Server Error
+   */
+  override def fetch(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(
+    implicit transid: TransactionId) = {
+    getEntity(WhiskPackage, entityStore, entityName.toDocId, Some { mergePackageWithBinding() _ })
+  }
+
+  /**
+   * Gets all packages/bindings in namespace.
+   *
+   * Responses are one of (Code, Message)
+   * - 200 [] or [WhiskPackage as JSON]
+   * - 500 Internal Server Error
+   */
+  override def list(user: Identity, namespace: EntityPath, excludePrivate: Boolean)(implicit transid: TransactionId) = {
+    // for consistency, all the collections should support the same list API
+    // but because supporting docs on actions is difficult, the API does not
+    // offer an option to fetch entities with full docs yet; see comment in
+    // Actions API for more.
+    val docs = false
+
+    // disable listing all public (shared) packages in all namespaces until
+    // there exists a process in place to curate and rank these packages
+    val publicPackagesInAnyNamespace = false
+    parameter('skip ? 0, 'limit ? collection.listLimit, 'count ? false) { (skip, limit, count) =>
+      if (publicPackagesInAnyNamespace && docs) {
+        terminate(BadRequest, "Parameters 'public' and 'docs' may not both be true at the same time")
+      } else
+        listEntities {
+          if (!publicPackagesInAnyNamespace) {
+            WhiskPackage.listCollectionInNamespace(entityStore, namespace, skip, limit, docs) map { list =>
+              // any subject is entitled to list packages in any namespace
+              // however, they shall only observe public packages if the packages
+              // are not in one of the namespaces the subject is entitled to
+              val packages = if (docs) {
+                list.right.get map { WhiskPackage.serdes.write(_) }
+              } else list.left.get
+              FilterEntityList.filter(packages, excludePrivate, additionalFilter = { // additionally exclude bindings
+                case pkg: JsObject =>
+                  Try {
+                    pkg.fields(WhiskPackage.bindingFieldName) == JsBoolean(false)
+                  } getOrElse false
+              })
             }
+          } else {
+            WhiskPackage.listCollectionInAnyNamespace(
+              entityStore,
+              skip,
+              limit,
+              docs = false,
+              reduce = publicPackagesInAnyNamespace) map {
+              _.left.get
+            }
+          }
         }
     }
+  }
+
+  /**
+   * Validates that a referenced binding exists.
+   */
+  private def checkBinding(binding: FullyQualifiedEntityName)(implicit transid: TransactionId): Future[Unit] = {
+    WhiskPackage.get(entityStore, binding.toDocId) recoverWith {
+      case t: NoDocumentException => Future.failed(RejectRequest(BadRequest, Messages.bindingDoesNotExist))
+      case t: DocumentTypeMismatchException =>
+        Future.failed(RejectRequest(Conflict, Messages.requestedBindingIsNotValid))
+      case t => Future.failed(RejectRequest(BadRequest, t))
+    } flatMap {
+      // trying to create a new package binding that refers to another binding
+      case provider if provider.binding.nonEmpty =>
+        Future.failed(RejectRequest(BadRequest, Messages.bindingCannotReferenceBinding))
+      // or creating a package binding that refers to a package
+      case _ => Future.successful({})
+    }
+  }
+
+  /**
+   * Creates a WhiskPackage from PUT content, generating default values where necessary.
+   * If this is a binding, confirm the referenced package exists.
+   */
+  private def create(content: WhiskPackagePut, pkgName: FullyQualifiedEntityName)(
+    implicit transid: TransactionId): Future[WhiskPackage] = {
+    val validateBinding = content.binding map { b =>
+      checkBinding(b.fullyQualifiedName)
+    } getOrElse Future.successful({})
+
+    validateBinding map { _ =>
+      WhiskPackage(
+        pkgName.path,
+        pkgName.name,
+        content.binding,
+        content.parameters getOrElse Parameters(),
+        content.version getOrElse SemVer(),
+        content.publish getOrElse false,
+        // remove any binding annotation from PUT (always set by the controller)
+        (content.annotations getOrElse Parameters())
+          - WhiskPackage.bindingFieldName
+          ++ bindingAnnotation(content.binding))
+    }
+  }
+
+  /** Updates a WhiskPackage from PUT content, merging old package/binding where necessary. */
+  private def update(content: WhiskPackagePut)(wp: WhiskPackage)(
+    implicit transid: TransactionId): Future[WhiskPackage] = {
+    val validateBinding = content.binding map { binding =>
+      wp.binding map {
+        // pre-existing entity is a binding, check that new binding is valid
+        b =>
+          checkBinding(b.fullyQualifiedName)
+      } getOrElse {
+        // pre-existing entity is a package, cannot make it a binding
+        Future.failed(RejectRequest(Conflict, Messages.packageCannotBecomeBinding))
+      }
+    } getOrElse Future.successful({})
+
+    validateBinding map { _ =>
+      WhiskPackage(
+        wp.namespace,
+        wp.name,
+        content.binding orElse wp.binding,
+        content.parameters getOrElse wp.parameters,
+        content.version getOrElse wp.version.upPatch,
+        content.publish getOrElse wp.publish,
+        // override any binding annotation from PUT (always set by the controller)
+        (content.annotations getOrElse wp.annotations)
+          - WhiskPackage.bindingFieldName
+          ++ bindingAnnotation(content.binding orElse wp.binding)).revision[WhiskPackage](wp.docinfo.rev)
+    }
+  }
+
+  private def rewriteEntitlementFailure(failure: Throwable)(
+    implicit transid: TransactionId): RequestContext => Future[RouteResult] = {
+    logging.info(this, s"rewriting failure $failure")
+    failure match {
+      case RejectRequest(NotFound, _) => terminate(BadRequest, Messages.bindingDoesNotExist)
+      case RejectRequest(Conflict, _) => terminate(Conflict, Messages.requestedBindingIsNotValid)
+      case _                          => super.handleEntitlementFailure(failure)
+    }
+  }
+
+  /**
+   * Constructs a "binding" annotation. This is redundant with the binding
+   * information available in WhiskPackage but necessary for some clients which
+   * fetch package lists but cannot determine which package may be bound. An
+   * alternative is to include the binding in the package list "view" but this
+   * will require an API change. So using an annotation instead.
+   */
+  private def bindingAnnotation(binding: Option[Binding]): Parameters = {
+    binding map { b =>
+      Parameters(WhiskPackage.bindingFieldName, Binding.serdes.write(b))
+    } getOrElse Parameters()
+  }
+
+  /**
+   * Constructs a WhiskPackage that is a merger of a package with its packing binding (if any).
+   * If this is a binding, fetch package for binding, merge parameters then emit.
+   * Otherwise this is a package, emit it.
+   */
+  private def mergePackageWithBinding(ref: Option[WhiskPackage] = None)(wp: WhiskPackage)(
+    implicit transid: TransactionId): RequestContext => Future[RouteResult] = {
+    wp.binding map {
+      case b: Binding =>
+        val docid = b.fullyQualifiedName.toDocId
+        logging.info(this, s"fetching package '$docid' for reference")
+        getEntity(WhiskPackage, entityStore, docid, Some {
+          mergePackageWithBinding(Some { wp }) _
+        })
+    } getOrElse {
+      val pkg = ref map { _ inherit wp.parameters } getOrElse wp
+      logging.info(this, s"fetching package actions in '${wp.fullPath}'")
+      val actions = WhiskAction.listCollectionInNamespace(entityStore, wp.fullPath, skip = 0, limit = 0) flatMap {
+        case Left(list) =>
+          Future.successful {
+            pkg withPackageActions (list map { o =>
+              WhiskPackageAction.serdes.read(o)
+            })
+          }
+        case t =>
+          Future.failed {
+            logging.error(this, "unexpected result in package action lookup: $t")
+            new IllegalStateException(s"unexpected result in package action lookup: $t")
+          }
+      }
+
+      onComplete(actions) {
+        case Success(p) =>
+          logging.info(this, s"[GET] entity success")
+          complete(OK, p)
+        case Failure(t) =>
+          logging.error(this, s"[GET] failed: ${t.getMessage}")
+          terminate(InternalServerError)
+      }
+    }
+  }
 }

--- a/core/controller/src/main/scala/whisk/core/controller/Rules.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Rules.scala
@@ -42,354 +42,376 @@ import whisk.core.entitlement.ReferencedEntities
 
 /** A trait implementing the rules API */
 trait WhiskRulesApi extends WhiskCollectionAPI with ReferencedEntities {
-    services: WhiskServices =>
+  services: WhiskServices =>
 
-    protected override val collection = Collection(Collection.RULES)
+  protected override val collection = Collection(Collection.RULES)
 
-    /** An actor system for timed based futures. */
-    protected implicit val actorSystem: ActorSystem
+  /** An actor system for timed based futures. */
+  protected implicit val actorSystem: ActorSystem
 
-    /** Database service to CRUD rules. */
-    protected val entityStore: EntityStore
+  /** Database service to CRUD rules. */
+  protected val entityStore: EntityStore
 
-    /** JSON response formatter. */
-    import RestApiCommons.jsonDefaultResponsePrinter
+  /** JSON response formatter. */
+  import RestApiCommons.jsonDefaultResponsePrinter
 
-    /** Notification service for cache invalidation. */
-    protected implicit val cacheChangeNotification: Some[CacheChangeNotification]
+  /** Notification service for cache invalidation. */
+  protected implicit val cacheChangeNotification: Some[CacheChangeNotification]
 
-    /** Path to Rules REST API. */
-    protected val rulesPath = "rules"
+  /** Path to Rules REST API. */
+  protected val rulesPath = "rules"
 
-    /**
-     * Creates or updates rule if it already exists. The PUT content is deserialized into a WhiskRulePut
-     * which is a subset of WhiskRule (it eschews the namespace, entity name and status since the former
-     * are derived from the authenticated user and the URI and the status is managed automatically).
-     * The WhiskRulePut is merged with the existing WhiskRule in the datastore, overriding old values
-     * with new values that are defined. Any values not defined in the PUT content are replaced with
-     * old values.
-     *
-     * The rule will not update if the status of the entity in the datastore is not INACTIVE. It rejects
-     * such requests with Conflict.
-     *
-     * The create/update is also guarded by a predicate that confirm the trigger and action are valid.
-     * Otherwise rejects the request with Bad Request and an appropriate message. It is true that the
-     * trigger/action may be deleted after creation but at the very least confirming dependences here
-     * prevents use errors where a rule is created with an invalid trigger/action which then fails
-     * testing (fire a trigger and expect an action activation to occur).
-     *
-     * Responses are one of (Code, Message)
-     * - 200 WhiskRule as JSON
-     * - 400 Bad Request
-     * - 409 Conflict
-     * - 500 Internal Server Error
-     */
-    override def create(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
-        parameter('overwrite ? false) { overwrite =>
-            entity(as[WhiskRulePut]) { content =>
-                val request = content.resolve(entityName.namespace)
-                onComplete(entitlementProvider.check(user, Privilege.READ, referencedEntities(request))) {
-                    case Success(_) =>
-                        putEntity(WhiskRule, entityStore, entityName.toDocId, overwrite,
-                            update(request) _, () => { create(request, entityName) },
-                            postProcess = Some { rule: WhiskRule =>
-                                completeAsRuleResponse(rule, Status.ACTIVE)
-                            })
-                    case Failure(f) =>
-                        handleEntitlementFailure(f)
-                }
-            }
-        }
-    }
-
-    /**
-     * Toggles rule status from enabled -> disabled and vice versa. The action are not confirmed
-     * to still exist. This is deferred to trigger activation which will fail to post activations
-     * for non-existent actions.
-     *
-     * Responses are one of (Code, Message)
-     * - 200 OK rule in desired state
-     * - 202 Accepted rule state change accepted
-     * - 404 Not Found
-     * - 409 Conflict
-     * - 500 Internal Server Error
-     */
-    override def activate(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(implicit transid: TransactionId) = {
-        extractStatusRequest { requestedState =>
-            val docid = entityName.toDocId
-
-            getEntity(WhiskRule, entityStore, docid, Some {
-                rule: WhiskRule =>
-                    val ruleName = rule.fullyQualifiedName(false)
-
-                    val changeStatus = getTrigger(rule.trigger) map { trigger =>
-                        getStatus(trigger, ruleName)
-                    } flatMap { oldStatus =>
-                        if (requestedState != oldStatus) {
-                            logging.info(this, s"[POST] rule state change initiated: ${oldStatus} -> $requestedState")
-                            Future successful requestedState
-                        } else {
-                            logging.info(this, s"[POST] rule state will not be changed, the requested state is the same as the old state: ${oldStatus} -> $requestedState")
-                            Future failed { IgnoredRuleActivation(requestedState == oldStatus) }
-                        }
-                    } flatMap {
-                        case (newStatus) =>
-                            logging.info(this, s"[POST] attempting to set rule state to: ${newStatus}")
-                            WhiskTrigger.get(entityStore, rule.trigger.toDocId) flatMap { trigger =>
-                                val newTrigger = trigger.removeRule(ruleName)
-                                val triggerLink = ReducedRule(rule.action, newStatus)
-                                WhiskTrigger.put(entityStore, newTrigger.addRule(ruleName, triggerLink))
-                            }
-                    }
-
-                    onComplete(changeStatus) {
-                        case Success(response) =>
-                            complete(OK)
-                        case Failure(t) => t match {
-                            case _: DocumentConflictException =>
-                                logging.info(this, s"[POST] rule update conflict")
-                                terminate(Conflict, conflictMessage)
-                            case IgnoredRuleActivation(ok) =>
-                                logging.info(this, s"[POST] rule update ignored")
-                                if (ok) complete(OK) else terminate(Conflict)
-                            case _: NoDocumentException =>
-                                logging.info(this, s"[POST] the trigger attached to the rule doesn't exist")
-                                terminate(NotFound, "Only rules with existing triggers can be activated")
-                            case _: DeserializationException =>
-                                logging.error(this, s"[POST] rule update failed: ${t.getMessage}")
-                                terminate(InternalServerError, corruptedEntity)
-                            case _: Throwable =>
-                                logging.error(this, s"[POST] rule update failed: ${t.getMessage}")
-                                terminate(InternalServerError)
-                        }
-                    }
+  /**
+   * Creates or updates rule if it already exists. The PUT content is deserialized into a WhiskRulePut
+   * which is a subset of WhiskRule (it eschews the namespace, entity name and status since the former
+   * are derived from the authenticated user and the URI and the status is managed automatically).
+   * The WhiskRulePut is merged with the existing WhiskRule in the datastore, overriding old values
+   * with new values that are defined. Any values not defined in the PUT content are replaced with
+   * old values.
+   *
+   * The rule will not update if the status of the entity in the datastore is not INACTIVE. It rejects
+   * such requests with Conflict.
+   *
+   * The create/update is also guarded by a predicate that confirm the trigger and action are valid.
+   * Otherwise rejects the request with Bad Request and an appropriate message. It is true that the
+   * trigger/action may be deleted after creation but at the very least confirming dependences here
+   * prevents use errors where a rule is created with an invalid trigger/action which then fails
+   * testing (fire a trigger and expect an action activation to occur).
+   *
+   * Responses are one of (Code, Message)
+   * - 200 WhiskRule as JSON
+   * - 400 Bad Request
+   * - 409 Conflict
+   * - 500 Internal Server Error
+   */
+  override def create(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
+    parameter('overwrite ? false) { overwrite =>
+      entity(as[WhiskRulePut]) { content =>
+        val request = content.resolve(entityName.namespace)
+        onComplete(entitlementProvider.check(user, Privilege.READ, referencedEntities(request))) {
+          case Success(_) =>
+            putEntity(WhiskRule, entityStore, entityName.toDocId, overwrite, update(request) _, () => {
+              create(request, entityName)
+            }, postProcess = Some { rule: WhiskRule =>
+              completeAsRuleResponse(rule, Status.ACTIVE)
             })
+          case Failure(f) =>
+            handleEntitlementFailure(f)
         }
+      }
     }
+  }
 
-    /**
-     * Deletes rule iff rule is inactive.
-     *
-     * Responses are one of (Code, Message)
-     * - 200 WhiskRule as JSON
-     * - 404 Not Found
-     * - 409 Conflict
-     * - 500 Internal Server Error
-     */
-    override def remove(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
-        deleteEntity(WhiskRule, entityStore, entityName.toDocId, (r: WhiskRule) => {
-            val ruleName = FullyQualifiedEntityName(r.namespace, r.name)
-            getTrigger(r.trigger) map { trigger =>
-                (getStatus(trigger, ruleName), trigger)
-            } flatMap {
-                case (status, triggerOpt) =>
-                    triggerOpt map { trigger =>
-                        WhiskTrigger.put(entityStore, trigger.removeRule(ruleName)) map { _ => {} }
-                    } getOrElse Future.successful({})
-            }
-        }, postProcess = Some { rule: WhiskRule =>
-            completeAsRuleResponse(rule, Status.INACTIVE)
-        })
+  /**
+   * Toggles rule status from enabled -> disabled and vice versa. The action are not confirmed
+   * to still exist. This is deferred to trigger activation which will fail to post activations
+   * for non-existent actions.
+   *
+   * Responses are one of (Code, Message)
+   * - 200 OK rule in desired state
+   * - 202 Accepted rule state change accepted
+   * - 404 Not Found
+   * - 409 Conflict
+   * - 500 Internal Server Error
+   */
+  override def activate(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(
+    implicit transid: TransactionId) = {
+    extractStatusRequest { requestedState =>
+      val docid = entityName.toDocId
+
+      getEntity(WhiskRule, entityStore, docid, Some {
+        rule: WhiskRule =>
+          val ruleName = rule.fullyQualifiedName(false)
+
+          val changeStatus = getTrigger(rule.trigger) map { trigger =>
+            getStatus(trigger, ruleName)
+          } flatMap {
+            oldStatus =>
+              if (requestedState != oldStatus) {
+                logging.info(this, s"[POST] rule state change initiated: ${oldStatus} -> $requestedState")
+                Future successful requestedState
+              } else {
+                logging.info(
+                  this,
+                  s"[POST] rule state will not be changed, the requested state is the same as the old state: ${oldStatus} -> $requestedState")
+                Future failed { IgnoredRuleActivation(requestedState == oldStatus) }
+              }
+          } flatMap {
+            case (newStatus) =>
+              logging.info(this, s"[POST] attempting to set rule state to: ${newStatus}")
+              WhiskTrigger.get(entityStore, rule.trigger.toDocId) flatMap { trigger =>
+                val newTrigger = trigger.removeRule(ruleName)
+                val triggerLink = ReducedRule(rule.action, newStatus)
+                WhiskTrigger.put(entityStore, newTrigger.addRule(ruleName, triggerLink))
+              }
+          }
+
+          onComplete(changeStatus) {
+            case Success(response) =>
+              complete(OK)
+            case Failure(t) =>
+              t match {
+                case _: DocumentConflictException =>
+                  logging.info(this, s"[POST] rule update conflict")
+                  terminate(Conflict, conflictMessage)
+                case IgnoredRuleActivation(ok) =>
+                  logging.info(this, s"[POST] rule update ignored")
+                  if (ok) complete(OK) else terminate(Conflict)
+                case _: NoDocumentException =>
+                  logging.info(this, s"[POST] the trigger attached to the rule doesn't exist")
+                  terminate(NotFound, "Only rules with existing triggers can be activated")
+                case _: DeserializationException =>
+                  logging.error(this, s"[POST] rule update failed: ${t.getMessage}")
+                  terminate(InternalServerError, corruptedEntity)
+                case _: Throwable =>
+                  logging.error(this, s"[POST] rule update failed: ${t.getMessage}")
+                  terminate(InternalServerError)
+              }
+          }
+      })
     }
+  }
 
-    /**
-     * Gets rule. The rule name is prefixed with the namespace to create the primary index key.
-     *
-     * Responses are one of (Code, Message)
-     * - 200 WhiskRule has JSON
-     * - 404 Not Found
-     * - 500 Internal Server Error
-     */
-    override def fetch(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(implicit transid: TransactionId) = {
-        getEntity(WhiskRule, entityStore, entityName.toDocId, Some { rule: WhiskRule =>
-            val getRuleWithStatus = getTrigger(rule.trigger) map { trigger =>
-                getStatus(trigger, entityName)
-            } map { status =>
-                rule.withStatus(status)
-            }
-
-            onComplete(getRuleWithStatus) {
-                case Success(r) => complete(OK, r)
-                case Failure(t) => terminate(InternalServerError)
-            }
-        })
-    }
-
-    /**
-     * Gets all rules in namespace.
-     *
-     * Responses are one of (Code, Message)
-     * - 200 [] or [WhiskRule as JSON]
-     * - 500 Internal Server Error
-     */
-    override def list(user: Identity, namespace: EntityPath, excludePrivate: Boolean)(implicit transid: TransactionId) = {
-        // for consistency, all the collections should support the same list API
-        // but because supporting docs on actions is difficult, the API does not
-        // offer an option to fetch entities with full docs yet; see comment in
-        // Actions API for more.
-        val docs = false
-        parameter('skip ? 0, 'limit ? collection.listLimit, 'count ? false) {
-            (skip, limit, count) =>
-                listEntities {
-                    WhiskRule.listCollectionInNamespace(entityStore, namespace, skip, limit, docs) map {
-                        list =>
-                            val rules = if (docs) {
-                                list.right.get map { WhiskRule.serdes.write(_) }
-                            } else list.left.get
-                            FilterEntityList.filter(rules, excludePrivate)
-                    }
-                }
+  /**
+   * Deletes rule iff rule is inactive.
+   *
+   * Responses are one of (Code, Message)
+   * - 200 WhiskRule as JSON
+   * - 404 Not Found
+   * - 409 Conflict
+   * - 500 Internal Server Error
+   */
+  override def remove(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
+    deleteEntity(
+      WhiskRule,
+      entityStore,
+      entityName.toDocId,
+      (r: WhiskRule) => {
+        val ruleName = FullyQualifiedEntityName(r.namespace, r.name)
+        getTrigger(r.trigger) map { trigger =>
+          (getStatus(trigger, ruleName), trigger)
+        } flatMap {
+          case (status, triggerOpt) =>
+            triggerOpt map { trigger =>
+              WhiskTrigger.put(entityStore, trigger.removeRule(ruleName)) map { _ =>
+                {}
+              }
+            } getOrElse Future.successful({})
         }
-    }
+      },
+      postProcess = Some { rule: WhiskRule =>
+        completeAsRuleResponse(rule, Status.INACTIVE)
+      })
+  }
 
-    /** Creates a WhiskRule from PUT content, generating default values where necessary. */
-    private def create(content: WhiskRulePut, ruleName: FullyQualifiedEntityName)(implicit transid: TransactionId): Future[WhiskRule] = {
-        if (content.trigger.isDefined && content.action.isDefined) {
-            val triggerName = content.trigger.get
-            val actionName = content.action.get
-
-            checkTriggerAndActionExist(triggerName, actionName) recoverWith {
-                case t => Future.failed(RejectRequest(BadRequest, t))
-            } flatMap {
-                case (trigger, action) =>
-                    val rule = WhiskRule(
-                        ruleName.path,
-                        ruleName.name,
-                        content.trigger.get,
-                        content.action.get,
-                        content.version getOrElse SemVer(),
-                        content.publish getOrElse false,
-                        content.annotations getOrElse Parameters())
-
-                    val triggerLink = ReducedRule(actionName, Status.ACTIVE)
-                    logging.info(this, s"about to put ${trigger.addRule(ruleName, triggerLink)}")
-                    WhiskTrigger.put(entityStore, trigger.addRule(ruleName, triggerLink)) map { _ => rule }
-            }
-        } else Future.failed(RejectRequest(BadRequest, "rule requires a valid trigger and a valid action"))
-    }
-
-    /** Updates a WhiskTrigger from PUT content, merging old trigger where necessary. */
-    private def update(content: WhiskRulePut)(rule: WhiskRule)(implicit transid: TransactionId): Future[WhiskRule] = {
-        val ruleName = FullyQualifiedEntityName(rule.namespace, rule.name)
-        val oldTriggerName = rule.trigger
-
-        getTrigger(oldTriggerName) flatMap { oldTriggerOpt =>
-            val newTriggerEntity = content.trigger getOrElse rule.trigger
-            val newTriggerName = newTriggerEntity
-
-            val actionEntity = content.action getOrElse rule.action
-            val actionName = actionEntity
-
-            checkTriggerAndActionExist(newTriggerName, actionName) recoverWith {
-                case t => Future.failed(RejectRequest(BadRequest, t))
-            } flatMap {
-                case (newTrigger, newAction) =>
-                    val r = WhiskRule(
-                        rule.namespace,
-                        rule.name,
-                        newTriggerEntity,
-                        actionEntity,
-                        content.version getOrElse rule.version.upPatch,
-                        content.publish getOrElse rule.publish,
-                        content.annotations getOrElse rule.annotations).
-                        revision[WhiskRule](rule.docinfo.rev)
-
-                    // Deletes reference from the old trigger iff it is different from the new one
-                    val deleteOldLink = for {
-                        isDifferentTrigger <- content.trigger.filter(_ => newTriggerName != oldTriggerName)
-                        oldTrigger <- oldTriggerOpt
-                    } yield {
-                        WhiskTrigger.put(entityStore, oldTrigger.removeRule(ruleName))
-                    }
-
-                    val triggerLink = ReducedRule(actionName, Status.INACTIVE)
-                    val update = WhiskTrigger.put(entityStore, newTrigger.addRule(ruleName, triggerLink))
-                    Future.sequence(Seq(deleteOldLink.getOrElse(Future.successful(true)), update)).map(_ => r)
-            }
+  /**
+   * Gets rule. The rule name is prefixed with the namespace to create the primary index key.
+   *
+   * Responses are one of (Code, Message)
+   * - 200 WhiskRule has JSON
+   * - 404 Not Found
+   * - 500 Internal Server Error
+   */
+  override def fetch(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(
+    implicit transid: TransactionId) = {
+    getEntity(
+      WhiskRule,
+      entityStore,
+      entityName.toDocId,
+      Some { rule: WhiskRule =>
+        val getRuleWithStatus = getTrigger(rule.trigger) map { trigger =>
+          getStatus(trigger, entityName)
+        } map { status =>
+          rule.withStatus(status)
         }
-    }
 
-    /**
-     * Gets a WhiskTrigger defined by the given DocInfo. Gracefully falls back to None iff the trigger is not found.
-     *
-     * @param tid DocInfo defining the trigger to get
-     * @return a WhiskTrigger iff found, else None
-     */
-    private def getTrigger(t: FullyQualifiedEntityName)(implicit transid: TransactionId): Future[Option[WhiskTrigger]] = {
-        WhiskTrigger.get(entityStore, t.toDocId) map {
-            trigger => Some(trigger)
-        } recover {
-            case _: NoDocumentException | DeserializationException(_, _, _) => None
+        onComplete(getRuleWithStatus) {
+          case Success(r) => complete(OK, r)
+          case Failure(t) => terminate(InternalServerError)
         }
-    }
+      })
+  }
 
-    /**
-     * Extracts the Status for the rule out of a WhiskTrigger that may be there. Falls back to INACTIVE if the trigger
-     * could not be found or the rule being worked on has not yet been written into the trigger record.
-     *
-     * @param triggerOpt Option containing a WhiskTrigger
-     * @param ruleName Namespace the name of the rule being worked on
-     * @return Status of the rule
-     */
-    private def getStatus(triggerOpt: Option[WhiskTrigger], ruleName: FullyQualifiedEntityName)(implicit transid: TransactionId): Status = {
-        val statusFromTrigger = for {
-            trigger <- triggerOpt
-            rules <- trigger.rules
-            rule <- rules.get(ruleName)
-        } yield {
-            rule.status
+  /**
+   * Gets all rules in namespace.
+   *
+   * Responses are one of (Code, Message)
+   * - 200 [] or [WhiskRule as JSON]
+   * - 500 Internal Server Error
+   */
+  override def list(user: Identity, namespace: EntityPath, excludePrivate: Boolean)(implicit transid: TransactionId) = {
+    // for consistency, all the collections should support the same list API
+    // but because supporting docs on actions is difficult, the API does not
+    // offer an option to fetch entities with full docs yet; see comment in
+    // Actions API for more.
+    val docs = false
+    parameter('skip ? 0, 'limit ? collection.listLimit, 'count ? false) { (skip, limit, count) =>
+      listEntities {
+        WhiskRule.listCollectionInNamespace(entityStore, namespace, skip, limit, docs) map { list =>
+          val rules = if (docs) {
+            list.right.get map { WhiskRule.serdes.write(_) }
+          } else list.left.get
+          FilterEntityList.filter(rules, excludePrivate)
         }
-        statusFromTrigger getOrElse Status.INACTIVE
+      }
     }
+  }
 
-    /**
-     * Completes an HTTP request with a WhiskRule including the computed Status
-     *
-     * @param rule the rule to send
-     * @param status the status to include in the response
-     */
-    private def completeAsRuleResponse(rule: WhiskRule, status: Status = Status.INACTIVE): StandardRoute = {
-        complete(OK, rule.withStatus(status))
+  /** Creates a WhiskRule from PUT content, generating default values where necessary. */
+  private def create(content: WhiskRulePut, ruleName: FullyQualifiedEntityName)(
+    implicit transid: TransactionId): Future[WhiskRule] = {
+    if (content.trigger.isDefined && content.action.isDefined) {
+      val triggerName = content.trigger.get
+      val actionName = content.action.get
+
+      checkTriggerAndActionExist(triggerName, actionName) recoverWith {
+        case t => Future.failed(RejectRequest(BadRequest, t))
+      } flatMap {
+        case (trigger, action) =>
+          val rule = WhiskRule(
+            ruleName.path,
+            ruleName.name,
+            content.trigger.get,
+            content.action.get,
+            content.version getOrElse SemVer(),
+            content.publish getOrElse false,
+            content.annotations getOrElse Parameters())
+
+          val triggerLink = ReducedRule(actionName, Status.ACTIVE)
+          logging.info(this, s"about to put ${trigger.addRule(ruleName, triggerLink)}")
+          WhiskTrigger.put(entityStore, trigger.addRule(ruleName, triggerLink)) map { _ =>
+            rule
+          }
+      }
+    } else Future.failed(RejectRequest(BadRequest, "rule requires a valid trigger and a valid action"))
+  }
+
+  /** Updates a WhiskTrigger from PUT content, merging old trigger where necessary. */
+  private def update(content: WhiskRulePut)(rule: WhiskRule)(implicit transid: TransactionId): Future[WhiskRule] = {
+    val ruleName = FullyQualifiedEntityName(rule.namespace, rule.name)
+    val oldTriggerName = rule.trigger
+
+    getTrigger(oldTriggerName) flatMap { oldTriggerOpt =>
+      val newTriggerEntity = content.trigger getOrElse rule.trigger
+      val newTriggerName = newTriggerEntity
+
+      val actionEntity = content.action getOrElse rule.action
+      val actionName = actionEntity
+
+      checkTriggerAndActionExist(newTriggerName, actionName) recoverWith {
+        case t => Future.failed(RejectRequest(BadRequest, t))
+      } flatMap {
+        case (newTrigger, newAction) =>
+          val r = WhiskRule(
+            rule.namespace,
+            rule.name,
+            newTriggerEntity,
+            actionEntity,
+            content.version getOrElse rule.version.upPatch,
+            content.publish getOrElse rule.publish,
+            content.annotations getOrElse rule.annotations).revision[WhiskRule](rule.docinfo.rev)
+
+          // Deletes reference from the old trigger iff it is different from the new one
+          val deleteOldLink = for {
+            isDifferentTrigger <- content.trigger.filter(_ => newTriggerName != oldTriggerName)
+            oldTrigger <- oldTriggerOpt
+          } yield {
+            WhiskTrigger.put(entityStore, oldTrigger.removeRule(ruleName))
+          }
+
+          val triggerLink = ReducedRule(actionName, Status.INACTIVE)
+          val update = WhiskTrigger.put(entityStore, newTrigger.addRule(ruleName, triggerLink))
+          Future.sequence(Seq(deleteOldLink.getOrElse(Future.successful(true)), update)).map(_ => r)
+      }
     }
+  }
 
-    /**
-     * Checks if trigger and action are valid documents (that is, they exist) in the datastore.
-     *
-     * @param trigger the trigger id
-     * @param action the action id
-     * @return future that completes with references trigger and action if they exist
-     */
-    private def checkTriggerAndActionExist(trigger: FullyQualifiedEntityName, action: FullyQualifiedEntityName)(
-        implicit transid: TransactionId): Future[(WhiskTrigger, WhiskAction)] = {
-
-        for {
-            triggerExists <- WhiskTrigger.get(entityStore, trigger.toDocId) recoverWith {
-                case _: NoDocumentException => Future.failed {
-                    new NoDocumentException(s"trigger ${trigger.qualifiedNameWithLeadingSlash} does not exist")
-                }
-                case _: DeserializationException => Future.failed {
-                    new DeserializationException(s"trigger ${trigger.qualifiedNameWithLeadingSlash} is corrupted")
-                }
-            }
-
-            actionExists <- WhiskAction.resolveAction(entityStore, action) flatMap {
-                resolvedName => WhiskAction.get(entityStore, resolvedName.toDocId)
-            } recoverWith {
-                case _: NoDocumentException => Future.failed {
-                    new NoDocumentException(s"action ${action.qualifiedNameWithLeadingSlash} does not exist")
-                }
-                case _: DeserializationException => Future.failed {
-                    new DeserializationException(s"action ${action.qualifiedNameWithLeadingSlash} is corrupted")
-                }
-            }
-        } yield (triggerExists, actionExists)
+  /**
+   * Gets a WhiskTrigger defined by the given DocInfo. Gracefully falls back to None iff the trigger is not found.
+   *
+   * @param tid DocInfo defining the trigger to get
+   * @return a WhiskTrigger iff found, else None
+   */
+  private def getTrigger(t: FullyQualifiedEntityName)(implicit transid: TransactionId): Future[Option[WhiskTrigger]] = {
+    WhiskTrigger.get(entityStore, t.toDocId) map { trigger =>
+      Some(trigger)
+    } recover {
+      case _: NoDocumentException | DeserializationException(_, _, _) => None
     }
+  }
 
-    /** Extracts status request subject to allowed values. */
-    private def extractStatusRequest = {
-        implicit val statusSerdes = Status.serdesRestricted
-        entity(as[Status])
+  /**
+   * Extracts the Status for the rule out of a WhiskTrigger that may be there. Falls back to INACTIVE if the trigger
+   * could not be found or the rule being worked on has not yet been written into the trigger record.
+   *
+   * @param triggerOpt Option containing a WhiskTrigger
+   * @param ruleName Namespace the name of the rule being worked on
+   * @return Status of the rule
+   */
+  private def getStatus(triggerOpt: Option[WhiskTrigger], ruleName: FullyQualifiedEntityName)(
+    implicit transid: TransactionId): Status = {
+    val statusFromTrigger = for {
+      trigger <- triggerOpt
+      rules <- trigger.rules
+      rule <- rules.get(ruleName)
+    } yield {
+      rule.status
     }
+    statusFromTrigger getOrElse Status.INACTIVE
+  }
+
+  /**
+   * Completes an HTTP request with a WhiskRule including the computed Status
+   *
+   * @param rule the rule to send
+   * @param status the status to include in the response
+   */
+  private def completeAsRuleResponse(rule: WhiskRule, status: Status = Status.INACTIVE): StandardRoute = {
+    complete(OK, rule.withStatus(status))
+  }
+
+  /**
+   * Checks if trigger and action are valid documents (that is, they exist) in the datastore.
+   *
+   * @param trigger the trigger id
+   * @param action the action id
+   * @return future that completes with references trigger and action if they exist
+   */
+  private def checkTriggerAndActionExist(trigger: FullyQualifiedEntityName, action: FullyQualifiedEntityName)(
+    implicit transid: TransactionId): Future[(WhiskTrigger, WhiskAction)] = {
+
+    for {
+      triggerExists <- WhiskTrigger.get(entityStore, trigger.toDocId) recoverWith {
+        case _: NoDocumentException =>
+          Future.failed {
+            new NoDocumentException(s"trigger ${trigger.qualifiedNameWithLeadingSlash} does not exist")
+          }
+        case _: DeserializationException =>
+          Future.failed {
+            new DeserializationException(s"trigger ${trigger.qualifiedNameWithLeadingSlash} is corrupted")
+          }
+      }
+
+      actionExists <- WhiskAction.resolveAction(entityStore, action) flatMap { resolvedName =>
+        WhiskAction.get(entityStore, resolvedName.toDocId)
+      } recoverWith {
+        case _: NoDocumentException =>
+          Future.failed {
+            new NoDocumentException(s"action ${action.qualifiedNameWithLeadingSlash} does not exist")
+          }
+        case _: DeserializationException =>
+          Future.failed {
+            new DeserializationException(s"action ${action.qualifiedNameWithLeadingSlash} is corrupted")
+          }
+      }
+    } yield (triggerExists, actionExists)
+  }
+
+  /** Extracts status request subject to allowed values. */
+  private def extractStatusRequest = {
+    implicit val statusSerdes = Status.serdesRestricted
+    entity(as[Status])
+  }
 }
 
 private case class IgnoredRuleActivation(noop: Boolean) extends Throwable

--- a/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
@@ -21,7 +21,7 @@ import java.time.Clock
 import java.time.Instant
 
 import scala.concurrent.Future
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
@@ -64,279 +64,288 @@ import whisk.http.ErrorResponse.terminate
 
 /** A trait implementing the triggers API. */
 trait WhiskTriggersApi extends WhiskCollectionAPI {
-    services: WhiskServices =>
+  services: WhiskServices =>
 
-    protected override val collection = Collection(Collection.TRIGGERS)
+  protected override val collection = Collection(Collection.TRIGGERS)
 
-    /** An actor system for timed based futures. */
-    protected implicit val actorSystem: ActorSystem
+  /** An actor system for timed based futures. */
+  protected implicit val actorSystem: ActorSystem
 
-    /** Database service to CRUD triggers. */
-    protected val entityStore: EntityStore
+  /** Database service to CRUD triggers. */
+  protected val entityStore: EntityStore
 
-    /** Notification service for cache invalidation. */
-    protected implicit val cacheChangeNotification: Some[CacheChangeNotification]
+  /** Notification service for cache invalidation. */
+  protected implicit val cacheChangeNotification: Some[CacheChangeNotification]
 
-    /** Database service to get activations. */
-    protected val activationStore: ActivationStore
+  /** Database service to get activations. */
+  protected val activationStore: ActivationStore
 
-    /** JSON response formatter. */
-    import RestApiCommons.jsonDefaultResponsePrinter
+  /** JSON response formatter. */
+  import RestApiCommons.jsonDefaultResponsePrinter
 
-    /** Path to Triggers REST API. */
-    protected val triggersPath = "triggers"
+  /** Path to Triggers REST API. */
+  protected val triggersPath = "triggers"
 
-    protected implicit val materializer: ActorMaterializer
+  protected implicit val materializer: ActorMaterializer
 
-    import RestApiCommons.emptyEntityToJsObject
+  import RestApiCommons.emptyEntityToJsObject
 
-    /**
-     * Creates or updates trigger if it already exists. The PUT content is deserialized into a WhiskTriggerPut
-     * which is a subset of WhiskTrigger (it eschews the namespace and entity name since the former is derived
-     * from the authenticated user and the latter is derived from the URI). The WhiskTriggerPut is merged with
-     * the existing WhiskTrigger in the datastore, overriding old values with new values that are defined.
-     * Any values not defined in the PUT content are replaced with old values.
-     *
-     * Responses are one of (Code, Message)
-     * - 200 WhiskAction as JSON
-     * - 400 Bad Request
-     * - 409 Conflict
-     * - 500 Internal Server Error
-     */
-    override def create(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
-        parameter('overwrite ? false) { overwrite =>
-            entity(as[WhiskTriggerPut]) { content =>
-                putEntity(WhiskTrigger, entityStore, entityName.toDocId, overwrite,
-                    update(content) _,
-                    () => { create(content, entityName) },
-                    postProcess = Some { trigger =>
-                        completeAsTriggerResponse(trigger)
-                    })
-            }
-        }
-    }
-
-    /**
-     * Fires trigger if it exists. The POST content is deserialized into a Payload and posted
-     * to the loadbalancer.
-     *
-     * Responses are one of (Code, Message)
-     * - 200 ActivationId as JSON
-     * - 404 Not Found
-     * - 500 Internal Server Error
-     */
-    override def activate(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(implicit transid: TransactionId) = {
-        entity(as[Option[JsObject]]) {
-            payload =>
-                getEntity(WhiskTrigger, entityStore, entityName.toDocId, Some {
-                    trigger: WhiskTrigger =>
-                        val args = trigger.parameters.merge(payload)
-                        val triggerActivationId = activationIdFactory.make()
-                        logging.info(this, s"[POST] trigger activation id: ${triggerActivationId}")
-
-                        val triggerActivation = WhiskActivation(
-                            namespace = user.namespace.toPath, // all activations should end up in the one space regardless trigger.namespace,
-                            entityName.name,
-                            user.subject,
-                            triggerActivationId,
-                            Instant.now(Clock.systemUTC()),
-                            Instant.EPOCH,
-                            response = ActivationResponse.success(payload orElse Some(JsObject())),
-                            version = trigger.version,
-                            duration = None)
-                        logging.info(this, s"[POST] trigger activated, writing activation record to datastore: $triggerActivationId")
-                        val saveTriggerActivation = WhiskActivation.put(activationStore, triggerActivation) map {
-                            _ => triggerActivationId
-                        }
-
-                        val url = Uri(s"http://localhost:${whiskConfig.servicePort}")
-
-                        trigger.rules.map {
-                            _.filter {
-                                case (ruleName, rule) => rule.status == Status.ACTIVE
-                            } foreach {
-                                case (ruleName, rule) =>
-                                    val ruleActivation = WhiskActivation(
-                                        namespace = user.namespace.toPath, // all activations should end up in the one space regardless trigger.namespace,
-                                        ruleName.name,
-                                        user.subject,
-                                        activationIdFactory.make(),
-                                        Instant.now(Clock.systemUTC()),
-                                        Instant.EPOCH,
-                                        cause = Some(triggerActivationId),
-                                        response = ActivationResponse.success(),
-                                        version = trigger.version,
-                                        duration = None)
-                                    logging.info(this, s"[POST] rule ${ruleName} activated, writing activation record to datastore")
-                                    WhiskActivation.put(activationStore, ruleActivation)
-
-                                    val actionNamespace = rule.action.path.root.asString
-                                    val actionPath = {
-                                        rule.action.path.relativePath.map {
-                                            pkg => (Path.SingleSlash + pkg.namespace) / rule.action.name.asString
-                                        } getOrElse {
-                                            Path.SingleSlash + rule.action.name.asString
-                                        }
-                                    }.toString
-
-                                    val actionUrl = Path("/api/v1") / "namespaces" / actionNamespace / "actions"
-                                    val request = HttpRequest(
-                                        method = POST,
-                                        uri = url.withPath(actionUrl + actionPath),
-                                        headers = List(Authorization(BasicHttpCredentials(user.authkey.uuid.asString, user.authkey.key.asString))),
-                                        entity = HttpEntity(MediaTypes.`application/json`, args.getOrElse(JsObject()).compactPrint))
-
-                                    Http().singleRequest(request).map { response =>
-                                        response.status match {
-                                            case OK | Accepted => Unmarshal(response.entity).to[JsObject].map { a =>
-                                                logging.info(this, s"${rule.action} activated ${a.fields("activationId")}")
-                                            }
-                                            case NotFound =>
-                                                response.discardEntityBytes()
-                                                logging.info(this, s"${rule.action} failed, action not found")
-                                            case _ => Unmarshal(response.entity).to[String].map { error =>
-                                                logging.warn(this, s"${rule.action} failed due to $error")
-                                            }
-                                        }
-                                    }
-                            }
-                        }
-
-                        onComplete(saveTriggerActivation) {
-                            case Success(activationId) =>
-                                complete(OK, activationId.toJsObject)
-                            case Failure(t: Throwable) =>
-                                logging.error(this, s"[POST] storing trigger activation failed: ${t.getMessage}")
-                                terminate(InternalServerError)
-                        }
-                })
-        }
-    }
-
-    /**
-     * Deletes trigger.
-     *
-     * Responses are one of (Code, Message)
-     * - 200 WhiskTrigger as JSON
-     * - 404 Not Found
-     * - 409 Conflict
-     * - 500 Internal Server Error
-     */
-    override def remove(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
-        deleteEntity(WhiskTrigger, entityStore, entityName.toDocId, (t: WhiskTrigger) => Future.successful({}), postProcess = Some { trigger =>
-            completeAsTriggerResponse(trigger)
+  /**
+   * Creates or updates trigger if it already exists. The PUT content is deserialized into a WhiskTriggerPut
+   * which is a subset of WhiskTrigger (it eschews the namespace and entity name since the former is derived
+   * from the authenticated user and the latter is derived from the URI). The WhiskTriggerPut is merged with
+   * the existing WhiskTrigger in the datastore, overriding old values with new values that are defined.
+   * Any values not defined in the PUT content are replaced with old values.
+   *
+   * Responses are one of (Code, Message)
+   * - 200 WhiskAction as JSON
+   * - 400 Bad Request
+   * - 409 Conflict
+   * - 500 Internal Server Error
+   */
+  override def create(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
+    parameter('overwrite ? false) { overwrite =>
+      entity(as[WhiskTriggerPut]) { content =>
+        putEntity(WhiskTrigger, entityStore, entityName.toDocId, overwrite, update(content) _, () => {
+          create(content, entityName)
+        }, postProcess = Some { trigger =>
+          completeAsTriggerResponse(trigger)
         })
+      }
     }
+  }
 
-    /**
-     * Gets trigger. The trigger name is prefixed with the namespace to create the primary index key.
-     *
-     * Responses are one of (Code, Message)
-     * - 200 WhiskTrigger has JSON
-     * - 404 Not Found
-     * - 500 Internal Server Error
-     */
-    override def fetch(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(implicit transid: TransactionId) = {
-        getEntity(WhiskTrigger, entityStore, entityName.toDocId, Some { trigger =>
-            completeAsTriggerResponse(trigger)
-        })
-    }
+  /**
+   * Fires trigger if it exists. The POST content is deserialized into a Payload and posted
+   * to the loadbalancer.
+   *
+   * Responses are one of (Code, Message)
+   * - 200 ActivationId as JSON
+   * - 404 Not Found
+   * - 500 Internal Server Error
+   */
+  override def activate(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(
+    implicit transid: TransactionId) = {
+    entity(as[Option[JsObject]]) { payload =>
+      getEntity(WhiskTrigger, entityStore, entityName.toDocId, Some {
+        trigger: WhiskTrigger =>
+          val args = trigger.parameters.merge(payload)
+          val triggerActivationId = activationIdFactory.make()
+          logging.info(this, s"[POST] trigger activation id: ${triggerActivationId}")
 
-    /**
-     * Gets all triggers in namespace.
-     *
-     * Responses are one of (Code, Message)
-     * - 200 [] or [WhiskTrigger as JSON]
-     * - 500 Internal Server Error
-     */
-    override def list(user: Identity, namespace: EntityPath, excludePrivate: Boolean)(implicit transid: TransactionId) = {
-        // for consistency, all the collections should support the same list API
-        // but because supporting docs on actions is difficult, the API does not
-        // offer an option to fetch entities with full docs yet; see comment in
-        // Actions API for more.
-        val docs = false
-        parameter('skip ? 0, 'limit ? collection.listLimit, 'count ? false) {
-            (skip, limit, count) =>
-                listEntities {
-                    WhiskTrigger.listCollectionInNamespace(entityStore, namespace, skip, limit, docs) map {
-                        list =>
-                            val triggers = if (docs) {
-                                list.right.get map { WhiskTrigger.serdes.write(_) }
-                            } else list.left.get
-                            FilterEntityList.filter(triggers, excludePrivate)
+          val triggerActivation = WhiskActivation(
+            namespace = user.namespace.toPath, // all activations should end up in the one space regardless trigger.namespace,
+            entityName.name,
+            user.subject,
+            triggerActivationId,
+            Instant.now(Clock.systemUTC()),
+            Instant.EPOCH,
+            response = ActivationResponse.success(payload orElse Some(JsObject())),
+            version = trigger.version,
+            duration = None)
+          logging.info(this, s"[POST] trigger activated, writing activation record to datastore: $triggerActivationId")
+          val saveTriggerActivation = WhiskActivation.put(activationStore, triggerActivation) map { _ =>
+            triggerActivationId
+          }
+
+          val url = Uri(s"http://localhost:${whiskConfig.servicePort}")
+
+          trigger.rules.map {
+            _.filter {
+              case (ruleName, rule) => rule.status == Status.ACTIVE
+            } foreach {
+              case (ruleName, rule) =>
+                val ruleActivation = WhiskActivation(
+                  namespace = user.namespace.toPath, // all activations should end up in the one space regardless trigger.namespace,
+                  ruleName.name,
+                  user.subject,
+                  activationIdFactory.make(),
+                  Instant.now(Clock.systemUTC()),
+                  Instant.EPOCH,
+                  cause = Some(triggerActivationId),
+                  response = ActivationResponse.success(),
+                  version = trigger.version,
+                  duration = None)
+                logging.info(this, s"[POST] rule ${ruleName} activated, writing activation record to datastore")
+                WhiskActivation.put(activationStore, ruleActivation)
+
+                val actionNamespace = rule.action.path.root.asString
+                val actionPath = {
+                  rule.action.path.relativePath.map { pkg =>
+                    (Path.SingleSlash + pkg.namespace) / rule.action.name.asString
+                  } getOrElse {
+                    Path.SingleSlash + rule.action.name.asString
+                  }
+                }.toString
+
+                val actionUrl = Path("/api/v1") / "namespaces" / actionNamespace / "actions"
+                val request = HttpRequest(
+                  method = POST,
+                  uri = url.withPath(actionUrl + actionPath),
+                  headers =
+                    List(Authorization(BasicHttpCredentials(user.authkey.uuid.asString, user.authkey.key.asString))),
+                  entity = HttpEntity(MediaTypes.`application/json`, args.getOrElse(JsObject()).compactPrint))
+
+                Http().singleRequest(request).map {
+                  response =>
+                    response.status match {
+                      case OK | Accepted =>
+                        Unmarshal(response.entity).to[JsObject].map { a =>
+                          logging.info(this, s"${rule.action} activated ${a.fields("activationId")}")
+                        }
+                      case NotFound =>
+                        response.discardEntityBytes()
+                        logging.info(this, s"${rule.action} failed, action not found")
+                      case _ =>
+                        Unmarshal(response.entity).to[String].map { error =>
+                          logging.warn(this, s"${rule.action} failed due to $error")
+                        }
                     }
                 }
-        }
-    }
-
-    /** Creates a WhiskTrigger from PUT content, generating default values where necessary. */
-    private def create(content: WhiskTriggerPut, triggerName: FullyQualifiedEntityName)(implicit transid: TransactionId): Future[WhiskTrigger] = {
-        val newTrigger = WhiskTrigger(
-            triggerName.path,
-            triggerName.name,
-            content.parameters getOrElse Parameters(),
-            content.limits getOrElse TriggerLimits(),
-            content.version getOrElse SemVer(),
-            content.publish getOrElse false,
-            content.annotations getOrElse Parameters())
-        validateTriggerFeed(newTrigger)
-    }
-
-    /** Updates a WhiskTrigger from PUT content, merging old trigger where necessary. */
-    private def update(content: WhiskTriggerPut)(trigger: WhiskTrigger)(implicit transid: TransactionId): Future[WhiskTrigger] = {
-        val newTrigger = WhiskTrigger(
-            trigger.namespace,
-            trigger.name,
-            content.parameters getOrElse trigger.parameters,
-            content.limits getOrElse trigger.limits,
-            content.version getOrElse trigger.version.upPatch,
-            content.publish getOrElse trigger.publish,
-            content.annotations getOrElse trigger.annotations,
-            trigger.rules).
-            revision[WhiskTrigger](trigger.docinfo.rev)
-
-        // feed must be specified in create, and cannot be added as a trigger update
-        content.annotations flatMap { _.get(Parameters.Feed) } map { _ =>
-            Future failed {
-                RejectRequest(BadRequest, "A trigger feed is only permitted when the trigger is created")
             }
-        } getOrElse {
-            Future successful newTrigger
-        }
-    }
+          }
 
-    /**
-     * Validates a trigger feed annotation.
-     * A trigger feed must be a valid entity name, e.g., one of 'namespace/package/name'
-     * or 'namespace/name', or just 'name'.
-     *
-     * TODO: check if the feed actually exists. This is deferred because the macro
-     * operation of creating a trigger and initializing the feed is handled as one
-     * atomic operation in the CLI and the UI. At some point these may be promoted
-     * to a single atomic operation in the controller; at which point, validating
-     * the trigger feed should execute the action (verifies it is a valid name that
-     * the subject is entitled to) and iff that succeeds will the trigger be created
-     * or updated.
-     */
-    private def validateTriggerFeed(trigger: WhiskTrigger)(implicit transid: TransactionId) = {
-        trigger.annotations.get(Parameters.Feed) map {
-            case JsString(f) if (EntityPath.validate(f)) =>
-                Future successful trigger
-            case _ => Future failed {
-                RejectRequest(BadRequest, "Feed name is not valid")
-            }
-        } getOrElse {
-            Future successful trigger
-        }
+          onComplete(saveTriggerActivation) {
+            case Success(activationId) =>
+              complete(OK, activationId.toJsObject)
+            case Failure(t: Throwable) =>
+              logging.error(this, s"[POST] storing trigger activation failed: ${t.getMessage}")
+              terminate(InternalServerError)
+          }
+      })
     }
+  }
 
-    /**
-     * Completes an HTTP request with a WhiskRule including the computed Status
-     *
-     * @param rule the rule to send
-     * @param status the status to include in the response
-     */
-    private def completeAsTriggerResponse(trigger: WhiskTrigger): RequestContext => Future[RouteResult] = {
-        complete(OK, trigger.withoutRules)
+  /**
+   * Deletes trigger.
+   *
+   * Responses are one of (Code, Message)
+   * - 200 WhiskTrigger as JSON
+   * - 404 Not Found
+   * - 409 Conflict
+   * - 500 Internal Server Error
+   */
+  override def remove(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
+    deleteEntity(
+      WhiskTrigger,
+      entityStore,
+      entityName.toDocId,
+      (t: WhiskTrigger) => Future.successful({}),
+      postProcess = Some { trigger =>
+        completeAsTriggerResponse(trigger)
+      })
+  }
+
+  /**
+   * Gets trigger. The trigger name is prefixed with the namespace to create the primary index key.
+   *
+   * Responses are one of (Code, Message)
+   * - 200 WhiskTrigger has JSON
+   * - 404 Not Found
+   * - 500 Internal Server Error
+   */
+  override def fetch(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(
+    implicit transid: TransactionId) = {
+    getEntity(WhiskTrigger, entityStore, entityName.toDocId, Some { trigger =>
+      completeAsTriggerResponse(trigger)
+    })
+  }
+
+  /**
+   * Gets all triggers in namespace.
+   *
+   * Responses are one of (Code, Message)
+   * - 200 [] or [WhiskTrigger as JSON]
+   * - 500 Internal Server Error
+   */
+  override def list(user: Identity, namespace: EntityPath, excludePrivate: Boolean)(implicit transid: TransactionId) = {
+    // for consistency, all the collections should support the same list API
+    // but because supporting docs on actions is difficult, the API does not
+    // offer an option to fetch entities with full docs yet; see comment in
+    // Actions API for more.
+    val docs = false
+    parameter('skip ? 0, 'limit ? collection.listLimit, 'count ? false) { (skip, limit, count) =>
+      listEntities {
+        WhiskTrigger.listCollectionInNamespace(entityStore, namespace, skip, limit, docs) map { list =>
+          val triggers = if (docs) {
+            list.right.get map { WhiskTrigger.serdes.write(_) }
+          } else list.left.get
+          FilterEntityList.filter(triggers, excludePrivate)
+        }
+      }
     }
+  }
+
+  /** Creates a WhiskTrigger from PUT content, generating default values where necessary. */
+  private def create(content: WhiskTriggerPut, triggerName: FullyQualifiedEntityName)(
+    implicit transid: TransactionId): Future[WhiskTrigger] = {
+    val newTrigger = WhiskTrigger(
+      triggerName.path,
+      triggerName.name,
+      content.parameters getOrElse Parameters(),
+      content.limits getOrElse TriggerLimits(),
+      content.version getOrElse SemVer(),
+      content.publish getOrElse false,
+      content.annotations getOrElse Parameters())
+    validateTriggerFeed(newTrigger)
+  }
+
+  /** Updates a WhiskTrigger from PUT content, merging old trigger where necessary. */
+  private def update(content: WhiskTriggerPut)(trigger: WhiskTrigger)(
+    implicit transid: TransactionId): Future[WhiskTrigger] = {
+    val newTrigger = WhiskTrigger(
+      trigger.namespace,
+      trigger.name,
+      content.parameters getOrElse trigger.parameters,
+      content.limits getOrElse trigger.limits,
+      content.version getOrElse trigger.version.upPatch,
+      content.publish getOrElse trigger.publish,
+      content.annotations getOrElse trigger.annotations,
+      trigger.rules).revision[WhiskTrigger](trigger.docinfo.rev)
+
+    // feed must be specified in create, and cannot be added as a trigger update
+    content.annotations flatMap { _.get(Parameters.Feed) } map { _ =>
+      Future failed {
+        RejectRequest(BadRequest, "A trigger feed is only permitted when the trigger is created")
+      }
+    } getOrElse {
+      Future successful newTrigger
+    }
+  }
+
+  /**
+   * Validates a trigger feed annotation.
+   * A trigger feed must be a valid entity name, e.g., one of 'namespace/package/name'
+   * or 'namespace/name', or just 'name'.
+   *
+   * TODO: check if the feed actually exists. This is deferred because the macro
+   * operation of creating a trigger and initializing the feed is handled as one
+   * atomic operation in the CLI and the UI. At some point these may be promoted
+   * to a single atomic operation in the controller; at which point, validating
+   * the trigger feed should execute the action (verifies it is a valid name that
+   * the subject is entitled to) and iff that succeeds will the trigger be created
+   * or updated.
+   */
+  private def validateTriggerFeed(trigger: WhiskTrigger)(implicit transid: TransactionId) = {
+    trigger.annotations.get(Parameters.Feed) map {
+      case JsString(f) if (EntityPath.validate(f)) =>
+        Future successful trigger
+      case _ =>
+        Future failed {
+          RejectRequest(BadRequest, "Feed name is not valid")
+        }
+    } getOrElse {
+      Future successful trigger
+    }
+  }
+
+  /**
+   * Completes an HTTP request with a WhiskRule including the computed Status
+   *
+   * @param rule the rule to send
+   * @param status the status to include in the response
+   */
+  private def completeAsTriggerResponse(trigger: WhiskTrigger): RequestContext => Future[RouteResult] = {
+    complete(OK, trigger.withoutRules)
+  }
 }

--- a/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
@@ -20,7 +20,7 @@ package whisk.core.controller
 import java.util.Base64
 
 import scala.concurrent.Future
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 
 import akka.http.scaladsl.model.HttpEntity.Empty
 import akka.http.scaladsl.server.Directives
@@ -41,14 +41,14 @@ import akka.http.scaladsl.model.headers.`Content-Type`
 import akka.http.scaladsl.model.ContentType
 import akka.http.scaladsl.model.ContentTypes
 import akka.http.scaladsl.model.FormData
-import akka.http.scaladsl.model.HttpMethods.{ OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH }
+import akka.http.scaladsl.model.HttpMethods.{DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT}
 import akka.http.scaladsl.model.HttpCharsets
 
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
 import WhiskWebActionsApi.MediaExtension
-import RestApiCommons.{ jsonPrettyResponsePrinter => jsonPrettyPrinter }
+import RestApiCommons.{jsonPrettyResponsePrinter => jsonPrettyPrinter}
 
 import whisk.common.TransactionId
 import whisk.core.controller.actions.PostActionActivation
@@ -60,647 +60,650 @@ import whisk.http.Messages
 import whisk.utils.JsHelpers._
 
 protected[controller] sealed class WebApiDirectives(prefix: String = "__ow_") {
-    // enforce the presence of an extension (e.g., .http) in the URI path
-    val enforceExtension = false
+  // enforce the presence of an extension (e.g., .http) in the URI path
+  val enforceExtension = false
 
-    // the field name that represents the status code for an http action response
-    val statusCode = "statusCode"
+  // the field name that represents the status code for an http action response
+  val statusCode = "statusCode"
 
-    // parameters that are added to an action input to pass HTTP request context values
-    val method: String = fields("method")
-    val headers: String = fields("headers")
-    val path: String = fields("path")
-    val namespace: String = fields("user")
-    val query: String = fields("query")
-    val body: String = fields("body")
+  // parameters that are added to an action input to pass HTTP request context values
+  val method: String = fields("method")
+  val headers: String = fields("headers")
+  val path: String = fields("path")
+  val namespace: String = fields("user")
+  val query: String = fields("query")
+  val body: String = fields("body")
 
-    lazy val reservedProperties: Set[String] = Set(method, headers, path, namespace, query, body)
-    protected final def fields(f: String) = s"$prefix$f"
+  lazy val reservedProperties: Set[String] = Set(method, headers, path, namespace, query, body)
+  protected final def fields(f: String) = s"$prefix$f"
 }
 
-private case class Context(
-    propertyMap: WebApiDirectives,
-    method: HttpMethod,
-    headers: Seq[HttpHeader],
-    path: String,
-    query: Query,
-    body: Option[JsValue] = None) {
+private case class Context(propertyMap: WebApiDirectives,
+                           method: HttpMethod,
+                           headers: Seq[HttpHeader],
+                           path: String,
+                           query: Query,
+                           body: Option[JsValue] = None) {
 
-    val queryAsMap = query.toMap
+  val queryAsMap = query.toMap
 
-    // returns true iff the attached query and body parameters contain a property
-    // that conflicts with the given reserved parameters
-    def overrides(reservedParams: Set[String]): Set[String] = {
-        val queryParams = queryAsMap.keySet
-        val bodyParams = body.map {
-            case JsObject(fields) => fields.keySet
-            case _                => Set.empty
-        }.getOrElse(Set.empty)
+  // returns true iff the attached query and body parameters contain a property
+  // that conflicts with the given reserved parameters
+  def overrides(reservedParams: Set[String]): Set[String] = {
+    val queryParams = queryAsMap.keySet
+    val bodyParams = body
+      .map {
+        case JsObject(fields) => fields.keySet
+        case _                => Set.empty
+      }
+      .getOrElse(Set.empty)
 
-        (queryParams ++ bodyParams) intersect reservedParams
+    (queryParams ++ bodyParams) intersect reservedParams
+  }
+
+  // attach the body to the Context
+  def withBody(b: Option[JsValue]) = Context(propertyMap, method, headers, path, query, b)
+
+  def metadata(user: Option[Identity]): Map[String, JsValue] = {
+    Map(
+      propertyMap.method -> method.value.toLowerCase.toJson,
+      propertyMap.headers -> headers.map(h => h.lowercaseName -> h.value).toMap.toJson,
+      propertyMap.path -> path.toJson) ++
+      user.map(u => propertyMap.namespace -> u.namespace.asString.toJson)
+  }
+
+  def toActionArgument(user: Option[Identity], boxQueryAndBody: Boolean): Map[String, JsValue] = {
+    val queryParams = if (boxQueryAndBody) {
+      Map(propertyMap.query -> JsString(query.toString))
+    } else {
+      queryAsMap.map(kv => kv._1 -> JsString(kv._2))
     }
 
-    // attach the body to the Context
-    def withBody(b: Option[JsValue]) = Context(propertyMap, method, headers, path, query, b)
-
-    def metadata(user: Option[Identity]): Map[String, JsValue] = {
-        Map(propertyMap.method -> method.value.toLowerCase.toJson,
-            propertyMap.headers -> headers.map(h => h.lowercaseName -> h.value).toMap.toJson,
-            propertyMap.path -> path.toJson) ++
-            user.map(u => propertyMap.namespace -> u.namespace.asString.toJson)
+    // if the body is a json object, merge with query parameters
+    // otherwise, this is an opaque body that will be nested under
+    // __ow_body in the parameters sent to the action as an argument
+    val bodyParams = body match {
+      case Some(JsObject(fields)) if !boxQueryAndBody => fields
+      case Some(v)                                    => Map(propertyMap.body -> v)
+      case None if !boxQueryAndBody                   => Map.empty
+      case _                                          => Map(propertyMap.body -> JsObject())
     }
 
-    def toActionArgument(user: Option[Identity], boxQueryAndBody: Boolean): Map[String, JsValue] = {
-        val queryParams = if (boxQueryAndBody) {
-            Map(propertyMap.query -> JsString(query.toString))
-        } else {
-            queryAsMap.map(kv => kv._1 -> JsString(kv._2))
-        }
-
-        // if the body is a json object, merge with query parameters
-        // otherwise, this is an opaque body that will be nested under
-        // __ow_body in the parameters sent to the action as an argument
-        val bodyParams = body match {
-            case Some(JsObject(fields)) if !boxQueryAndBody => fields
-            case Some(v) => Map(propertyMap.body -> v)
-            case None if !boxQueryAndBody => Map.empty
-            case _ => Map(propertyMap.body -> JsObject())
-        }
-
-        // precedence order is: query params -> body (last wins)
-        metadata(user) ++ queryParams ++ bodyParams
-    }
+    // precedence order is: query params -> body (last wins)
+    metadata(user) ++ queryParams ++ bodyParams
+  }
 }
 
 protected[core] object WhiskWebActionsApi extends Directives {
 
-    private val mediaTranscoders = {
-        // extensions are expected to contain only [a-z]
-        Seq(MediaExtension(".http", None, false, resultAsHttp _),
-            MediaExtension(".json", None, true, resultAsJson _),
-            MediaExtension(".html", Some(List("html")), true, resultAsHtml _),
-            MediaExtension(".svg", Some(List("svg")), true, resultAsSvg _),
-            MediaExtension(".text", Some(List("text")), true, resultAsText _))
+  private val mediaTranscoders = {
+    // extensions are expected to contain only [a-z]
+    Seq(
+      MediaExtension(".http", None, false, resultAsHttp _),
+      MediaExtension(".json", None, true, resultAsJson _),
+      MediaExtension(".html", Some(List("html")), true, resultAsHtml _),
+      MediaExtension(".svg", Some(List("svg")), true, resultAsSvg _),
+      MediaExtension(".text", Some(List("text")), true, resultAsText _))
+  }
+
+  private val defaultMediaTranscoder: MediaExtension = mediaTranscoders.find(_.extension == ".http").get
+
+  val allowedExtensions: Set[String] = mediaTranscoders.map(_.extension).toSet
+
+  /**
+   * Splits string into a base name plus optional extension.
+   * If name ends with ".xxxx" which matches a known extension, accept it as the extension.
+   * Otherwise, the extension is ".http" by definition unless enforcing the presence of an extension.
+   */
+  def mediaTranscoderForName(name: String, enforceExtension: Boolean): (String, Option[MediaExtension]) = {
+    mediaTranscoders
+      .find(mt => name.endsWith(mt.extension))
+      .map { mt =>
+        val base = name.dropRight(mt.extensionLength)
+        (base, Some(mt))
+      }
+      .getOrElse {
+        (name, if (enforceExtension) None else Some(defaultMediaTranscoder))
+      }
+  }
+
+  /**
+   * Supported extensions, their default projection and transcoder to complete a request.
+   *
+   * @param extension the supported media types for action response
+   * @param defaultProject the default media extensions for action projection
+   * @param transcoder the HTTP decoder and terminator for the extension
+   */
+  protected case class MediaExtension(extension: String,
+                                      defaultProjection: Option[List[String]],
+                                      projectionAllowed: Boolean,
+                                      transcoder: (JsValue, TransactionId, WebApiDirectives) => Route) {
+    val extensionLength = extension.length
+  }
+
+  private def resultAsHtml(result: JsValue, transid: TransactionId, rp: WebApiDirectives) = result match {
+    case JsString(html) => complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, html))
+    case _              => terminate(BadRequest, Messages.invalidMedia(`text/html`))(transid, jsonPrettyPrinter)
+  }
+
+  private def resultAsSvg(result: JsValue, transid: TransactionId, rp: WebApiDirectives) = result match {
+    case JsString(svg) => complete(HttpEntity(`image/svg+xml`, svg.getBytes))
+    case _             => terminate(BadRequest, Messages.invalidMedia(`image/svg+xml`))(transid, jsonPrettyPrinter)
+  }
+
+  private def resultAsText(result: JsValue, transid: TransactionId, rp: WebApiDirectives) = {
+    result match {
+      case r: JsObject  => complete(OK, r.prettyPrint)
+      case r: JsArray   => complete(OK, r.prettyPrint)
+      case JsString(s)  => complete(OK, s)
+      case JsBoolean(b) => complete(OK, b.toString)
+      case JsNumber(n)  => complete(OK, n.toString)
+      case JsNull       => complete(OK, JsNull.toString)
     }
+  }
 
-    private val defaultMediaTranscoder: MediaExtension = mediaTranscoders.find(_.extension == ".http").get
+  private def resultAsJson(result: JsValue, transid: TransactionId, rp: WebApiDirectives) = {
+    result match {
+      case r: JsObject => complete(OK, r)
+      case r: JsArray  => complete(OK, r)
+      case _           => terminate(BadRequest, Messages.invalidMedia(`application/json`))(transid, jsonPrettyPrinter)
+    }
+  }
 
-    val allowedExtensions: Set[String] = mediaTranscoders.map(_.extension).toSet
+  private def resultAsHttp(result: JsValue, transid: TransactionId, rp: WebApiDirectives) = {
+    Try {
+      val JsObject(fields) = result
+      val headers = fields.get("headers").map {
+        case JsObject(hs) =>
+          hs.flatMap {
+            case (k, v) => headersFromJson(k, v)
+          }.toList
 
-    /**
-     * Splits string into a base name plus optional extension.
-     * If name ends with ".xxxx" which matches a known extension, accept it as the extension.
-     * Otherwise, the extension is ".http" by definition unless enforcing the presence of an extension.
-     */
-    def mediaTranscoderForName(name: String, enforceExtension: Boolean): (String, Option[MediaExtension]) = {
-        mediaTranscoders.find(mt => name.endsWith(mt.extension)).map { mt =>
-            val base = name.dropRight(mt.extensionLength)
-            (base, Some(mt))
-        }.getOrElse {
-            (name, if (enforceExtension) None else Some(defaultMediaTranscoder))
+        case _ => throw new Throwable("Invalid header")
+      } getOrElse List()
+
+      val code = fields.get(rp.statusCode).map {
+        case JsNumber(c) =>
+          // the following throws an exception if the code is
+          // not a whole number or a valid code
+          StatusCode.int2StatusCode(c.toIntExact)
+
+        case _ => throw new Throwable("Illegal code")
+      } getOrElse (OK)
+
+      fields.get("body") map {
+        case JsString(str) => interpretHttpResponse(code, headers, str, transid)
+        case js            => interpretHttpResponseAsJson(code, headers, js, transid)
+      } getOrElse {
+        respondWithHeaders(removeContentTypeHeader(headers)) {
+          // note that if header defined a content-type, it will be ignored
+          // since the type must be compatible with the data response
+          complete(code, HttpEntity.Empty)
         }
+      }
+    } getOrElse {
+      // either the result was not a JsObject or there was an exception validting the
+      // response as an http result
+      terminate(BadRequest, Messages.invalidMedia(`message/http`))(transid, jsonPrettyPrinter)
     }
+  }
 
-    /**
-     * Supported extensions, their default projection and transcoder to complete a request.
-     *
-     * @param extension the supported media types for action response
-     * @param defaultProject the default media extensions for action projection
-     * @param transcoder the HTTP decoder and terminator for the extension
-     */
-    protected case class MediaExtension(
-        extension: String,
-        defaultProjection: Option[List[String]],
-        projectionAllowed: Boolean,
-        transcoder: (JsValue, TransactionId, WebApiDirectives) => Route) {
-        val extensionLength = extension.length
-    }
+  private def headersFromJson(k: String, v: JsValue): Seq[RawHeader] = v match {
+    case JsString(v)  => Seq(RawHeader(k, v))
+    case JsBoolean(v) => Seq(RawHeader(k, v.toString))
+    case JsNumber(v)  => Seq(RawHeader(k, v.toString))
+    case JsArray(v)   => v.flatMap(inner => headersFromJson(k, inner))
+    case _            => throw new Throwable("Invalid header")
+  }
 
-    private def resultAsHtml(result: JsValue, transid: TransactionId, rp: WebApiDirectives) = result match {
-        case JsString(html) => complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, html))
-        case _              => terminate(BadRequest, Messages.invalidMedia(`text/html`))(transid, jsonPrettyPrinter)
-    }
-
-    private def resultAsSvg(result: JsValue, transid: TransactionId, rp: WebApiDirectives) = result match {
-        case JsString(svg) => complete(HttpEntity(`image/svg+xml`, svg.getBytes))
-        case _             => terminate(BadRequest, Messages.invalidMedia(`image/svg+xml`))(transid, jsonPrettyPrinter)
-    }
-
-    private def resultAsText(result: JsValue, transid: TransactionId, rp: WebApiDirectives) = {
-        result match {
-            case r: JsObject  => complete(OK, r.prettyPrint)
-            case r: JsArray   => complete(OK, r.prettyPrint)
-            case JsString(s)  => complete(OK, s)
-            case JsBoolean(b) => complete(OK, b.toString)
-            case JsNumber(n)  => complete(OK, n.toString)
-            case JsNull       => complete(OK, JsNull.toString)
-        }
-    }
-
-    private def resultAsJson(result: JsValue, transid: TransactionId, rp: WebApiDirectives) = {
-        result match {
-            case r: JsObject => complete(OK, r)
-            case r: JsArray  => complete(OK, r)
-            case _           => terminate(BadRequest, Messages.invalidMedia(`application/json`))(transid, jsonPrettyPrinter)
-        }
-    }
-
-    private def resultAsHttp(result: JsValue, transid: TransactionId, rp: WebApiDirectives) = {
-        Try {
-            val JsObject(fields) = result
-            val headers = fields.get("headers").map {
-                case JsObject(hs) => hs.flatMap {
-                    case (k, v) => headersFromJson(k, v)
-                }.toList
-
-                case _ => throw new Throwable("Invalid header")
-            } getOrElse List()
-
-            val code = fields.get(rp.statusCode).map {
-                case JsNumber(c) =>
-                    // the following throws an exception if the code is
-                    // not a whole number or a valid code
-                    StatusCode.int2StatusCode(c.toIntExact)
-
-                case _ => throw new Throwable("Illegal code")
-            } getOrElse (OK)
-
-            fields.get("body") map {
-                case JsString(str) => interpretHttpResponse(code, headers, str, transid)
-                case js            => interpretHttpResponseAsJson(code, headers, js, transid)
-            } getOrElse {
-                respondWithHeaders(removeContentTypeHeader(headers)) {
-                    // note that if header defined a content-type, it will be ignored
-                    // since the type must be compatible with the data response
-                    complete(code, HttpEntity.Empty)
-                }
+  /**
+   * Finds the content-type in the header list and maps it to a known media type. If it is not
+   * recognized, construct a failure with appropriate message.
+   */
+  private def findContentTypeInHeader(headers: List[RawHeader],
+                                      transid: TransactionId,
+                                      defaultType: MediaType): Try[MediaType] = {
+    headers.find(_.lowercaseName == `Content-Type`.lowercaseName) match {
+      case Some(header) =>
+        MediaType.parse(header.value) match {
+          case Right(mediaType: MediaType) =>
+            // lookup the media type specified in the content header to see if it is a recognized type
+            MediaTypes.getForKey(mediaType.mainType -> mediaType.subType).map(Success(_)).getOrElse {
+              // this is a content-type that is not recognized, reject it
+              Failure(RejectRequest(BadRequest, Messages.httpUnknownContentType)(transid))
             }
-        } getOrElse {
-            // either the result was not a JsObject or there was an exception validting the
-            // response as an http result
-            terminate(BadRequest, Messages.invalidMedia(`message/http`))(transid, jsonPrettyPrinter)
+          case _ => Failure(RejectRequest(BadRequest, Messages.httpUnknownContentType)(transid))
         }
+      case None => Success(defaultType)
     }
+  }
 
-    private def headersFromJson(k: String, v: JsValue): Seq[RawHeader] = v match {
-        case JsString(v)  => Seq(RawHeader(k, v))
-        case JsBoolean(v) => Seq(RawHeader(k, v.toString))
-        case JsNumber(v)  => Seq(RawHeader(k, v.toString))
-        case JsArray(v)   => v.flatMap(inner => headersFromJson(k, inner))
-        case _            => throw new Throwable("Invalid header")
-    }
-
-    /**
-     * Finds the content-type in the header list and maps it to a known media type. If it is not
-     * recognized, construct a failure with appropriate message.
-     */
-    private def findContentTypeInHeader(headers: List[RawHeader], transid: TransactionId, defaultType: MediaType): Try[MediaType] = {
-        headers.find(_.lowercaseName == `Content-Type`.lowercaseName) match {
-            case Some(header) =>
-                MediaType.parse(header.value) match {
-                    case Right(mediaType: MediaType) =>
-                        // lookup the media type specified in the content header to see if it is a recognized type
-                        MediaTypes.getForKey(mediaType.mainType -> mediaType.subType).map(Success(_)).getOrElse {
-                            // this is a content-type that is not recognized, reject it
-                            Failure(RejectRequest(BadRequest, Messages.httpUnknownContentType)(transid))
-                        }
-                    case _ => Failure(RejectRequest(BadRequest, Messages.httpUnknownContentType)(transid))
-                }
-            case None => Success(defaultType)
+  private def interpretHttpResponseAsJson(code: StatusCode,
+                                          headers: List[RawHeader],
+                                          js: JsValue,
+                                          transid: TransactionId) = {
+    findContentTypeInHeader(headers, transid, `application/json`) match {
+      case Success(mediaType) if (mediaType == `application/json`) =>
+        respondWithHeaders(removeContentTypeHeader(headers)) {
+          complete(code, js)
         }
+
+      case _ =>
+        terminate(BadRequest, Messages.httpContentTypeError)(transid, jsonPrettyPrinter)
     }
+  }
 
-    private def interpretHttpResponseAsJson(code: StatusCode, headers: List[RawHeader], js: JsValue, transid: TransactionId) = {
-        findContentTypeInHeader(headers, transid, `application/json`) match {
-            case Success(mediaType) if (mediaType == `application/json`) =>
-                respondWithHeaders(removeContentTypeHeader(headers)) {
-                    complete(code, js)
-                }
+  private def interpretHttpResponse(code: StatusCode, headers: List[RawHeader], str: String, transid: TransactionId) = {
+    findContentTypeInHeader(headers, transid, `text/html`).flatMap { mediaType =>
+      val ct = ContentType(mediaType, () => HttpCharsets.`UTF-8`)
+      ct match {
+        case _: ContentType.Binary | ContentType(`application/json`, _) =>
+          // base64 encoded json response supported for legacy reasons
+          Try(Base64.getDecoder().decode(str)).map(HttpEntity(ct, _))
 
-            case _ =>
-                terminate(BadRequest, Messages.httpContentTypeError)(transid, jsonPrettyPrinter)
+        case nonbinary: ContentType.NonBinary => Success(HttpEntity(nonbinary, str))
+      }
+    } match {
+      case Success(entity) =>
+        respondWithHeaders(removeContentTypeHeader(headers)) {
+          complete(code, entity)
         }
+
+      case Failure(RejectRequest(code, message)) =>
+        terminate(code, message)(transid, jsonPrettyPrinter)
+
+      case _ =>
+        terminate(BadRequest, Messages.httpContentTypeError)(transid, jsonPrettyPrinter)
     }
+  }
 
-    private def interpretHttpResponse(code: StatusCode, headers: List[RawHeader], str: String, transid: TransactionId) = {
-        findContentTypeInHeader(headers, transid, `text/html`).flatMap { mediaType =>
-            val ct = ContentType(mediaType, () => HttpCharsets.`UTF-8`)
-            ct match {
-                case _: ContentType.Binary | ContentType(`application/json`, _) =>
-                    // base64 encoded json response supported for legacy reasons
-                    Try(Base64.getDecoder().decode(str)).map(HttpEntity(ct, _))
-
-                case nonbinary: ContentType.NonBinary => Success(HttpEntity(nonbinary, str))
-            }
-        } match {
-            case Success(entity) =>
-                respondWithHeaders(removeContentTypeHeader(headers)) {
-                    complete(code, entity)
-                }
-
-            case Failure(RejectRequest(code, message)) =>
-                terminate(code, message)(transid, jsonPrettyPrinter)
-
-            case _ =>
-                terminate(BadRequest, Messages.httpContentTypeError)(transid, jsonPrettyPrinter)
-        }
-    }
-
-    private def removeContentTypeHeader(headers: List[RawHeader]) =
-        headers.filter(_.lowercaseName != `Content-Type`.lowercaseName)
+  private def removeContentTypeHeader(headers: List[RawHeader]) =
+    headers.filter(_.lowercaseName != `Content-Type`.lowercaseName)
 }
 
-trait WhiskWebActionsApi
-    extends Directives
-    with ValidateRequestSize
-    with PostActionActivation {
-    services: WhiskServices =>
+trait WhiskWebActionsApi extends Directives with ValidateRequestSize with PostActionActivation {
+  services: WhiskServices =>
 
-    /** API path invocation path for posting activations directly through the host. */
-    protected val webInvokePathSegments: Seq[String]
+  /** API path invocation path for posting activations directly through the host. */
+  protected val webInvokePathSegments: Seq[String]
 
-    /** Mapping of HTTP request fields to action parameter names. */
-    protected val webApiDirectives: WebApiDirectives
+  /** Mapping of HTTP request fields to action parameter names. */
+  protected val webApiDirectives: WebApiDirectives
 
-    /** Store for identities. */
-    protected val authStore: AuthStore
+  /** Store for identities. */
+  protected val authStore: AuthStore
 
-    /** The prefix for web invokes e.g., /web. */
-    private lazy val webRoutePrefix = {
-        pathPrefix(webInvokePathSegments.map(_segmentStringToPathMatcher(_)).reduceLeft(_ / _))
+  /** The prefix for web invokes e.g., /web. */
+  private lazy val webRoutePrefix = {
+    pathPrefix(webInvokePathSegments.map(_segmentStringToPathMatcher(_)).reduceLeft(_ / _))
+  }
+
+  /** Allowed verbs. */
+  private lazy val allowedOperations = get | delete | post | put | head | options | patch
+
+  private lazy val validNameSegment = pathPrefix(EntityName.REGEX.r)
+  private lazy val packagePrefix = pathPrefix("default".r | EntityName.REGEX.r)
+
+  private val defaultCorsResponse = List(
+    `Access-Control-Allow-Origin`.*,
+    `Access-Control-Allow-Methods`(OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH),
+    `Access-Control-Allow-Headers`(`Authorization`.name, `Content-Type`.name))
+
+  /** Extracts the HTTP method, headers, query params and unmatched (remaining) path. */
+  private val requestMethodParamsAndPath = {
+    extract { ctx =>
+      val method = ctx.request.method
+      val query = ctx.request.uri.query()
+      val path = ctx.unmatchedPath.toString
+      val headers = ctx.request.headers
+      Context(webApiDirectives, method, headers, path, query)
     }
+  }
 
-    /** Allowed verbs. */
-    private lazy val allowedOperations = get | delete | post | put | head | options | patch
+  def routes(user: Identity)(implicit transid: TransactionId): Route = routes(Some(user))
+  def routes()(implicit transid: TransactionId): Route = routes(None)
 
-    private lazy val validNameSegment = pathPrefix(EntityName.REGEX.r)
-    private lazy val packagePrefix = pathPrefix("default".r | EntityName.REGEX.r)
+  private val maxWaitForWebActionResult = Some(WhiskActionsApi.maxWaitForBlockingActivation)
 
-    private val defaultCorsResponse = List(
-        `Access-Control-Allow-Origin`.*,
-        `Access-Control-Allow-Methods`(OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH),
-        `Access-Control-Allow-Headers`(`Authorization`.name, `Content-Type`.name))
-
-    /** Extracts the HTTP method, headers, query params and unmatched (remaining) path. */
-    private val requestMethodParamsAndPath = {
-        extract { ctx =>
-            val method = ctx.request.method
-            val query = ctx.request.uri.query()
-            val path = ctx.unmatchedPath.toString
-            val headers = ctx.request.headers
-            Context(webApiDirectives, method, headers, path, query)
+  /**
+   * Adds route to web based activations. Actions invoked this way are anonymous in that the
+   * caller is not authenticated. The intended action must be named in the path as a fully qualified
+   * name as in /web/some-namespace/some-package/some-action. The package is optional
+   * in that the action may be in the default package, in which case, the string "default" must be used.
+   * If the action doesn't exist (or the namespace is not valid) NotFound is generated. Following the
+   * action name, an "extension" is required to specify the desired content type for the response. This
+   * extension is one of supported media types. An example is ".json" for a JSON response or ".html" for
+   * an text/html response.
+   *
+   * Optionally, the result form the action may be projected based on a named property. As in
+   * /web/some-namespace/some-package/some-action/some-property. If the property
+   * does not exist in the result then a NotFound error is generated. A path of properties may
+   * be supplied to project nested properties.
+   *
+   * Actions may be exposed to this web proxy by adding an annotation ("export" -> true).
+   */
+  def routes(user: Option[Identity])(implicit transid: TransactionId): Route = {
+    (allowedOperations & webRoutePrefix) {
+      validNameSegment { namespace =>
+        packagePrefix { pkg =>
+          validNameSegment { seg =>
+            handleMatch(namespace, pkg, seg, user)
+          }
         }
+      }
+    }
+  }
+
+  /**
+   * Gets package from datastore.
+   * This method is factored out to allow mock testing.
+   */
+  protected def getPackage(pkgName: FullyQualifiedEntityName)(implicit transid: TransactionId): Future[WhiskPackage] = {
+    WhiskPackage.get(entityStore, pkgName.toDocId)
+  }
+
+  /**
+   * Gets action from datastore.
+   * This method is factored out to allow mock testing.
+   */
+  protected def getAction(actionName: FullyQualifiedEntityName)(
+    implicit transid: TransactionId): Future[WhiskAction] = {
+    WhiskAction.get(entityStore, actionName.toDocId)
+  }
+
+  /**
+   * Gets identity from datastore.
+   * This method is factored out to allow mock testing.
+   */
+  protected def getIdentity(namespace: EntityName)(implicit transid: TransactionId): Future[Identity] = {
+    Identity.get(authStore, namespace)
+  }
+
+  private def handleMatch(namespaceSegment: String,
+                          pkgSegment: String,
+                          actionNameWithExtension: String,
+                          onBehalfOf: Option[Identity])(implicit transid: TransactionId) = {
+
+    def fullyQualifiedActionName(actionName: String) = {
+      val namespace = EntityName(namespaceSegment)
+      val pkgName = if (pkgSegment == "default") None else Some(EntityName(pkgSegment))
+      namespace.addPath(pkgName).addPath(EntityName(actionName)).toFullyQualifiedEntityName
     }
 
-    def routes(user: Identity)(implicit transid: TransactionId): Route = routes(Some(user))
-    def routes()(implicit transid: TransactionId): Route = routes(None)
-
-    private val maxWaitForWebActionResult = Some(WhiskActionsApi.maxWaitForBlockingActivation)
-
-    /**
-     * Adds route to web based activations. Actions invoked this way are anonymous in that the
-     * caller is not authenticated. The intended action must be named in the path as a fully qualified
-     * name as in /web/some-namespace/some-package/some-action. The package is optional
-     * in that the action may be in the default package, in which case, the string "default" must be used.
-     * If the action doesn't exist (or the namespace is not valid) NotFound is generated. Following the
-     * action name, an "extension" is required to specify the desired content type for the response. This
-     * extension is one of supported media types. An example is ".json" for a JSON response or ".html" for
-     * an text/html response.
-     *
-     * Optionally, the result form the action may be projected based on a named property. As in
-     * /web/some-namespace/some-package/some-action/some-property. If the property
-     * does not exist in the result then a NotFound error is generated. A path of properties may
-     * be supplied to project nested properties.
-     *
-     * Actions may be exposed to this web proxy by adding an annotation ("export" -> true).
-     */
-    def routes(user: Option[Identity])(implicit transid: TransactionId): Route = {
-        (allowedOperations & webRoutePrefix) {
-            validNameSegment { namespace =>
-                packagePrefix { pkg =>
-                    validNameSegment { seg =>
-                        handleMatch(namespace, pkg, seg, user)
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * Gets package from datastore.
-     * This method is factored out to allow mock testing.
-     */
-    protected def getPackage(pkgName: FullyQualifiedEntityName)(
-        implicit transid: TransactionId): Future[WhiskPackage] = {
-        WhiskPackage.get(entityStore, pkgName.toDocId)
-    }
-
-    /**
-     * Gets action from datastore.
-     * This method is factored out to allow mock testing.
-     */
-    protected def getAction(actionName: FullyQualifiedEntityName)(
-        implicit transid: TransactionId): Future[WhiskAction] = {
-        WhiskAction.get(entityStore, actionName.toDocId)
-    }
-
-    /**
-     * Gets identity from datastore.
-     * This method is factored out to allow mock testing.
-     */
-    protected def getIdentity(namespace: EntityName)(
-        implicit transid: TransactionId): Future[Identity] = {
-        Identity.get(authStore, namespace)
-    }
-
-    private def handleMatch(namespaceSegment: String, pkgSegment: String, actionNameWithExtension: String, onBehalfOf: Option[Identity])(
-        implicit transid: TransactionId) = {
-
-        def fullyQualifiedActionName(actionName: String) = {
-            val namespace = EntityName(namespaceSegment)
-            val pkgName = if (pkgSegment == "default") None else Some(EntityName(pkgSegment))
-            namespace.addPath(pkgName).addPath(EntityName(actionName)).toFullyQualifiedEntityName
-        }
-
-        provide(WhiskWebActionsApi.mediaTranscoderForName(actionNameWithExtension, webApiDirectives.enforceExtension)) {
-            case (actionName, Some(extension)) =>
-                // extract request context, checks for overrides of reserved properties, and constructs action arguments
-                // as the context body which may be the incoming request when the content type is JSON or formdata, or
-                // the raw body as __ow_body (and query parameters as __ow_query) otherwise
-                extract(_.request.entity) { e =>
-                    validateSize(isWhithinRange(e.contentLengthOption.getOrElse(0)))(transid, jsonPrettyPrinter) {
-                        requestMethodParamsAndPath { context =>
-                            provide(fullyQualifiedActionName(actionName)) { fullActionName =>
-                                onComplete(verifyWebAction(fullActionName, onBehalfOf.isDefined)) {
-                                    case Success((actionOwnerIdentity, action)) =>
-                                        if (!action.annotations.asBool("web-custom-options").exists(identity)) {
-                                            respondWithHeaders(defaultCorsResponse) {
-                                                if (context.method == OPTIONS) {
-                                                    complete(OK, HttpEntity.Empty)
-                                                } else {
-                                                    extractEntityAndProcessRequest(actionOwnerIdentity, action, extension, onBehalfOf, context, e)
-                                                }
-                                            }
-                                        } else {
-                                            extractEntityAndProcessRequest(actionOwnerIdentity, action, extension, onBehalfOf, context, e)
-                                        }
-
-                                    case Failure(t: RejectRequest) =>
-                                        terminate(t.code, t.message)
-
-                                    case Failure(t) =>
-                                        logging.error(this, s"exception in handleMatch: $t")
-                                        terminate(InternalServerError)
-                                }
-                            }
+    provide(WhiskWebActionsApi.mediaTranscoderForName(actionNameWithExtension, webApiDirectives.enforceExtension)) {
+      case (actionName, Some(extension)) =>
+        // extract request context, checks for overrides of reserved properties, and constructs action arguments
+        // as the context body which may be the incoming request when the content type is JSON or formdata, or
+        // the raw body as __ow_body (and query parameters as __ow_query) otherwise
+        extract(_.request.entity) { e =>
+          validateSize(isWhithinRange(e.contentLengthOption.getOrElse(0)))(transid, jsonPrettyPrinter) {
+            requestMethodParamsAndPath { context =>
+              provide(fullyQualifiedActionName(actionName)) { fullActionName =>
+                onComplete(verifyWebAction(fullActionName, onBehalfOf.isDefined)) {
+                  case Success((actionOwnerIdentity, action)) =>
+                    if (!action.annotations.asBool("web-custom-options").exists(identity)) {
+                      respondWithHeaders(defaultCorsResponse) {
+                        if (context.method == OPTIONS) {
+                          complete(OK, HttpEntity.Empty)
+                        } else {
+                          extractEntityAndProcessRequest(actionOwnerIdentity, action, extension, onBehalfOf, context, e)
                         }
-                    }
-                }
-
-            case (_, None) => terminate(NotAcceptable, Messages.contentTypeExtensionNotSupported(WhiskWebActionsApi.allowedExtensions))
-        }
-    }
-
-    /**
-     * Checks that subject has right to post an activation and fetch the action
-     * followed by the package and merge parameters. The action is fetched first since
-     * it will not succeed for references relative to a binding, and the export bit is
-     * confirmed before fetching the package and merging parameters.
-     *
-     * @return Future that completes with the action and action-owner-identity on success otherwise
-     *         a failed future with a request rejection error which may be one of the following:
-     *         not entitled (throttled), package/action not found, action not web enabled,
-     *         or request overrides final parameters
-     */
-    private def verifyWebAction(actionName: FullyQualifiedEntityName, authenticated: Boolean)(
-        implicit transid: TransactionId) = {
-        for {
-            // lookup the identity for the action namespace
-            actionOwnerIdentity <- identityLookup(actionName.path.root) flatMap {
-                i => entitlementProvider.checkThrottles(i) map (_ => i)
-            }
-
-            // lookup the action - since actions are stored relative to package name
-            // the lookup will fail if the package name for the action refers to a binding instead
-            // also merge package and action parameters at the same time
-            // precedence order for parameters:
-            // package.params -> action.params -> query.params -> request.entity (body) -> augment arguments (namespace, path)
-            action <- confirmExportedAction(actionLookup(actionName), authenticated) flatMap { a =>
-                if (a.namespace.defaultPackage) {
-                    Future.successful(a)
-                } else {
-                    pkgLookup(a.namespace.toFullyQualifiedEntityName) map {
-                        pkg => (a.inherit(pkg.parameters))
-                    }
-                }
-            }
-        } yield (actionOwnerIdentity, action)
-    }
-
-    private def extractEntityAndProcessRequest(
-        actionOwnerIdentity: Identity,
-        action: WhiskAction,
-        extension: MediaExtension,
-        onBehalfOf: Option[Identity],
-        context: Context,
-        httpEntity: HttpEntity)(
-            implicit transid: TransactionId) = {
-
-        def process(body: Option[JsValue], isRawHttpAction: Boolean) = {
-            processRequest(actionOwnerIdentity, action, extension, onBehalfOf, context.withBody(body), isRawHttpAction)
-        }
-
-        provide(action.annotations.asBool("raw-http").exists(identity)) { isRawHttpAction =>
-            httpEntity match {
-                case Empty =>
-                    process(None, isRawHttpAction)
-
-                case HttpEntity.Strict(ContentTypes.`application/json`, _) if !isRawHttpAction =>
-                    entity(as[JsObject]) { body =>
-                        process(Some(body), isRawHttpAction)
-                    }
-
-                case HttpEntity.Strict(ContentType(MediaTypes.`application/x-www-form-urlencoded`, _), _) if !isRawHttpAction =>
-                    entity(as[FormData]) { form =>
-                        val body = form.fields.toMap.toJson.asJsObject
-                        process(Some(body), isRawHttpAction)
-                    }
-
-                case HttpEntity.Strict(contentType, data) =>
-                    // application/json is not a binary type in Akka, but is binary in Spray
-                    if (contentType.mediaType.binary || contentType.mediaType == `application/json`) {
-                        Try(JsString(Base64.getEncoder.encodeToString(data.toArray))) match {
-                            case Success(bytes) => process(Some(bytes), isRawHttpAction)
-                            case Failure(t)     => terminate(BadRequest, Messages.unsupportedContentType(contentType.mediaType))
-                        }
+                      }
                     } else {
-                        val str = JsString(data.utf8String)
-                        process(Some(str), isRawHttpAction)
+                      extractEntityAndProcessRequest(actionOwnerIdentity, action, extension, onBehalfOf, context, e)
                     }
 
-                case _ => terminate(BadRequest, Messages.unsupportedContentType)
-            }
-        }
-    }
+                  case Failure(t: RejectRequest) =>
+                    terminate(t.code, t.message)
 
-    private def processRequest(
-        actionOwnerIdentity: Identity,
-        action: WhiskAction,
-        responseType: MediaExtension,
-        onBehalfOf: Option[Identity],
-        context: Context,
-        isRawHttpAction: Boolean)(
-            implicit transid: TransactionId) = {
-
-        def queuedActivation = {
-            // checks (1) if any of the query or body parameters override final action parameters
-            // computes overrides if any relative to the reserved __ow_* properties, and (2) if
-            // action is a raw http handler
-            //
-            // NOTE: it is assumed the action parameters do not intersect with the reserved properties
-            // since these are system properties, the action should not define them, and if it does,
-            // they will be overwritten
-            if (isRawHttpAction || context.overrides(webApiDirectives.reservedProperties ++ action.immutableParameters).isEmpty) {
-                val content = context.toActionArgument(onBehalfOf, isRawHttpAction)
-                invokeAction(actionOwnerIdentity, action, Some(JsObject(content)), maxWaitForWebActionResult, cause = None)
-            } else {
-                Future.failed(RejectRequest(BadRequest, Messages.parametersNotAllowed))
-            }
-        }
-
-        completeRequest(queuedActivation, projectResultField(context, responseType), responseType)
-    }
-
-    private def completeRequest(
-        queuedActivation: Future[Either[ActivationId, WhiskActivation]],
-        projectResultField: => List[String],
-        responseType: MediaExtension)(
-            implicit transid: TransactionId) = {
-        onComplete(queuedActivation) {
-            case Success(Right(activation)) =>
-                val result = activation.resultAsJson
-
-                if (activation.response.isSuccess || activation.response.isApplicationError) {
-                    val resultPath = if (activation.response.isSuccess) {
-                        projectResultField
-                    } else {
-                        // the activation produced an error response: therefore ignore
-                        // the requested projection and unwrap the error instead
-                        // and attempt to handle it per the desired response type (extension)
-                        List(ActivationResponse.ERROR_FIELD)
-                    }
-
-                    val result = getFieldPath(activation.resultAsJson, resultPath)
-                    result match {
-                        case Some(projection) =>
-                            val marshaler = Future(responseType.transcoder(projection, transid, webApiDirectives))
-                            onComplete(marshaler) {
-                                case Success(done) => done // all transcoders terminate the connection
-                                case Failure(t)    => terminate(InternalServerError)
-                            }
-                        case _ => terminate(NotFound, Messages.propertyNotFound)
-                    }
-                } else {
-                    terminate(BadRequest, Messages.errorProcessingRequest)
+                  case Failure(t) =>
+                    logging.error(this, s"exception in handleMatch: $t")
+                    terminate(InternalServerError)
                 }
-
-            case Success(Left(activationId)) =>
-                // blocking invoke which got queued instead
-                // this should not happen, instead it should be a blocking invoke timeout
-                logging.info(this, "activation waiting period expired")
-                terminate(Accepted, Messages.responseNotReady)
-
-            case Failure(t: RejectRequest) => terminate(t.code, t.message)
-
-            case Failure(t) =>
-                logging.error(this, s"exception in completeRequest: $t")
-                terminate(InternalServerError)
-        }
-    }
-
-    /**
-     * Gets package from datastore and confirms it is not a binding.
-     */
-    private def pkgLookup(pkg: FullyQualifiedEntityName)(
-        implicit transid: TransactionId): Future[WhiskPackage] = {
-        getPackage(pkg).filter {
-            _.binding.isEmpty
-        } recoverWith {
-            case _: ArtifactStoreException | DeserializationException(_, _, _) =>
-                // if the package lookup fails or the package doesn't conform to expected invariants,
-                // fail the request with BadRequest so as not to leak information about the existence
-                // of packages that are otherwise private
-                logging.info(this, s"package which does not exist")
-                Future.failed(RejectRequest(NotFound))
-            case _: NoSuchElementException =>
-                logging.warn(this, s"'$pkg' is a binding")
-                Future.failed(RejectRequest(NotFound))
-        }
-    }
-
-    /**
-     * Gets the action if it exists and fail future with RejectRequest if it does not.
-     *
-     * @return future action document or NotFound rejection
-     */
-    private def actionLookup(actionName: FullyQualifiedEntityName)(
-        implicit transid: TransactionId): Future[WhiskAction] = {
-        getAction(actionName) recoverWith {
-            case _: ArtifactStoreException | DeserializationException(_, _, _) =>
-                Future.failed(RejectRequest(NotFound))
-        }
-    }
-
-    /**
-     * Gets the identity for the namespace.
-     */
-    private def identityLookup(namespace: EntityName)(
-        implicit transid: TransactionId): Future[Identity] = {
-        getIdentity(namespace) recoverWith {
-            case _: ArtifactStoreException | DeserializationException(_, _, _) =>
-                Future.failed(RejectRequest(NotFound))
-            case t =>
-                // leak nothing no matter what, failure is already logged so skip here
-                Future.failed(RejectRequest(NotFound))
-        }
-    }
-
-    /**
-     * Checks if an action is exported (i.e., carries the required annotation).
-     */
-    private def confirmExportedAction(actionLookup: Future[WhiskAction], authenticated: Boolean)(
-        implicit transid: TransactionId): Future[WhiskAction] = {
-        actionLookup flatMap { action =>
-            val requiresAuthenticatedUser = action.annotations.asBool("require-whisk-auth").exists(identity)
-            val isExported = action.annotations.asBool("web-export").exists(identity)
-
-            if ((isExported && requiresAuthenticatedUser && authenticated) ||
-                (isExported && !requiresAuthenticatedUser)) {
-                logging.info(this, s"${action.fullyQualifiedName(true)} is exported")
-                Future.successful(action)
-            } else if (!isExported) {
-                logging.info(this, s"${action.fullyQualifiedName(true)} not exported")
-                Future.failed(RejectRequest(NotFound))
-            } else {
-                logging.info(this, s"${action.fullyQualifiedName(true)} requires authentication")
-                Future.failed(RejectRequest(Unauthorized))
+              }
             }
+          }
         }
+
+      case (_, None) =>
+        terminate(NotAcceptable, Messages.contentTypeExtensionNotSupported(WhiskWebActionsApi.allowedExtensions))
+    }
+  }
+
+  /**
+   * Checks that subject has right to post an activation and fetch the action
+   * followed by the package and merge parameters. The action is fetched first since
+   * it will not succeed for references relative to a binding, and the export bit is
+   * confirmed before fetching the package and merging parameters.
+   *
+   * @return Future that completes with the action and action-owner-identity on success otherwise
+   *         a failed future with a request rejection error which may be one of the following:
+   *         not entitled (throttled), package/action not found, action not web enabled,
+   *         or request overrides final parameters
+   */
+  private def verifyWebAction(actionName: FullyQualifiedEntityName, authenticated: Boolean)(
+    implicit transid: TransactionId) = {
+    for {
+      // lookup the identity for the action namespace
+      actionOwnerIdentity <- identityLookup(actionName.path.root) flatMap { i =>
+        entitlementProvider.checkThrottles(i) map (_ => i)
+      }
+
+      // lookup the action - since actions are stored relative to package name
+      // the lookup will fail if the package name for the action refers to a binding instead
+      // also merge package and action parameters at the same time
+      // precedence order for parameters:
+      // package.params -> action.params -> query.params -> request.entity (body) -> augment arguments (namespace, path)
+      action <- confirmExportedAction(actionLookup(actionName), authenticated) flatMap { a =>
+        if (a.namespace.defaultPackage) {
+          Future.successful(a)
+        } else {
+          pkgLookup(a.namespace.toFullyQualifiedEntityName) map { pkg =>
+            (a.inherit(pkg.parameters))
+          }
+        }
+      }
+    } yield (actionOwnerIdentity, action)
+  }
+
+  private def extractEntityAndProcessRequest(actionOwnerIdentity: Identity,
+                                             action: WhiskAction,
+                                             extension: MediaExtension,
+                                             onBehalfOf: Option[Identity],
+                                             context: Context,
+                                             httpEntity: HttpEntity)(implicit transid: TransactionId) = {
+
+    def process(body: Option[JsValue], isRawHttpAction: Boolean) = {
+      processRequest(actionOwnerIdentity, action, extension, onBehalfOf, context.withBody(body), isRawHttpAction)
     }
 
-    /**
-     * Determines the result projection path, if any.
-     *
-     * @return optional list of projections
-     */
-    private def projectResultField(context: Context, responseType: MediaExtension): List[String] = {
-        val projection = if (responseType.projectionAllowed) {
-            Option(context.path)
-                .filter(_.nonEmpty)
-                .map(_.split("/").filter(_.nonEmpty).toList)
-                .orElse(responseType.defaultProjection)
-        } else responseType.defaultProjection
+    provide(action.annotations.asBool("raw-http").exists(identity)) { isRawHttpAction =>
+      httpEntity match {
+        case Empty =>
+          process(None, isRawHttpAction)
 
-        projection.getOrElse(List())
+        case HttpEntity.Strict(ContentTypes.`application/json`, _) if !isRawHttpAction =>
+          entity(as[JsObject]) { body =>
+            process(Some(body), isRawHttpAction)
+          }
+
+        case HttpEntity.Strict(ContentType(MediaTypes.`application/x-www-form-urlencoded`, _), _) if !isRawHttpAction =>
+          entity(as[FormData]) { form =>
+            val body = form.fields.toMap.toJson.asJsObject
+            process(Some(body), isRawHttpAction)
+          }
+
+        case HttpEntity.Strict(contentType, data) =>
+          // application/json is not a binary type in Akka, but is binary in Spray
+          if (contentType.mediaType.binary || contentType.mediaType == `application/json`) {
+            Try(JsString(Base64.getEncoder.encodeToString(data.toArray))) match {
+              case Success(bytes) => process(Some(bytes), isRawHttpAction)
+              case Failure(t)     => terminate(BadRequest, Messages.unsupportedContentType(contentType.mediaType))
+            }
+          } else {
+            val str = JsString(data.utf8String)
+            process(Some(str), isRawHttpAction)
+          }
+
+        case _ => terminate(BadRequest, Messages.unsupportedContentType)
+      }
     }
+  }
+
+  private def processRequest(actionOwnerIdentity: Identity,
+                             action: WhiskAction,
+                             responseType: MediaExtension,
+                             onBehalfOf: Option[Identity],
+                             context: Context,
+                             isRawHttpAction: Boolean)(implicit transid: TransactionId) = {
+
+    def queuedActivation = {
+      // checks (1) if any of the query or body parameters override final action parameters
+      // computes overrides if any relative to the reserved __ow_* properties, and (2) if
+      // action is a raw http handler
+      //
+      // NOTE: it is assumed the action parameters do not intersect with the reserved properties
+      // since these are system properties, the action should not define them, and if it does,
+      // they will be overwritten
+      if (isRawHttpAction || context
+            .overrides(webApiDirectives.reservedProperties ++ action.immutableParameters)
+            .isEmpty) {
+        val content = context.toActionArgument(onBehalfOf, isRawHttpAction)
+        invokeAction(actionOwnerIdentity, action, Some(JsObject(content)), maxWaitForWebActionResult, cause = None)
+      } else {
+        Future.failed(RejectRequest(BadRequest, Messages.parametersNotAllowed))
+      }
+    }
+
+    completeRequest(queuedActivation, projectResultField(context, responseType), responseType)
+  }
+
+  private def completeRequest(queuedActivation: Future[Either[ActivationId, WhiskActivation]],
+                              projectResultField: => List[String],
+                              responseType: MediaExtension)(implicit transid: TransactionId) = {
+    onComplete(queuedActivation) {
+      case Success(Right(activation)) =>
+        val result = activation.resultAsJson
+
+        if (activation.response.isSuccess || activation.response.isApplicationError) {
+          val resultPath = if (activation.response.isSuccess) {
+            projectResultField
+          } else {
+            // the activation produced an error response: therefore ignore
+            // the requested projection and unwrap the error instead
+            // and attempt to handle it per the desired response type (extension)
+            List(ActivationResponse.ERROR_FIELD)
+          }
+
+          val result = getFieldPath(activation.resultAsJson, resultPath)
+          result match {
+            case Some(projection) =>
+              val marshaler = Future(responseType.transcoder(projection, transid, webApiDirectives))
+              onComplete(marshaler) {
+                case Success(done) => done // all transcoders terminate the connection
+                case Failure(t)    => terminate(InternalServerError)
+              }
+            case _ => terminate(NotFound, Messages.propertyNotFound)
+          }
+        } else {
+          terminate(BadRequest, Messages.errorProcessingRequest)
+        }
+
+      case Success(Left(activationId)) =>
+        // blocking invoke which got queued instead
+        // this should not happen, instead it should be a blocking invoke timeout
+        logging.info(this, "activation waiting period expired")
+        terminate(Accepted, Messages.responseNotReady)
+
+      case Failure(t: RejectRequest) => terminate(t.code, t.message)
+
+      case Failure(t) =>
+        logging.error(this, s"exception in completeRequest: $t")
+        terminate(InternalServerError)
+    }
+  }
+
+  /**
+   * Gets package from datastore and confirms it is not a binding.
+   */
+  private def pkgLookup(pkg: FullyQualifiedEntityName)(implicit transid: TransactionId): Future[WhiskPackage] = {
+    getPackage(pkg).filter {
+      _.binding.isEmpty
+    } recoverWith {
+      case _: ArtifactStoreException | DeserializationException(_, _, _) =>
+        // if the package lookup fails or the package doesn't conform to expected invariants,
+        // fail the request with BadRequest so as not to leak information about the existence
+        // of packages that are otherwise private
+        logging.info(this, s"package which does not exist")
+        Future.failed(RejectRequest(NotFound))
+      case _: NoSuchElementException =>
+        logging.warn(this, s"'$pkg' is a binding")
+        Future.failed(RejectRequest(NotFound))
+    }
+  }
+
+  /**
+   * Gets the action if it exists and fail future with RejectRequest if it does not.
+   *
+   * @return future action document or NotFound rejection
+   */
+  private def actionLookup(actionName: FullyQualifiedEntityName)(
+    implicit transid: TransactionId): Future[WhiskAction] = {
+    getAction(actionName) recoverWith {
+      case _: ArtifactStoreException | DeserializationException(_, _, _) =>
+        Future.failed(RejectRequest(NotFound))
+    }
+  }
+
+  /**
+   * Gets the identity for the namespace.
+   */
+  private def identityLookup(namespace: EntityName)(implicit transid: TransactionId): Future[Identity] = {
+    getIdentity(namespace) recoverWith {
+      case _: ArtifactStoreException | DeserializationException(_, _, _) =>
+        Future.failed(RejectRequest(NotFound))
+      case t =>
+        // leak nothing no matter what, failure is already logged so skip here
+        Future.failed(RejectRequest(NotFound))
+    }
+  }
+
+  /**
+   * Checks if an action is exported (i.e., carries the required annotation).
+   */
+  private def confirmExportedAction(actionLookup: Future[WhiskAction], authenticated: Boolean)(
+    implicit transid: TransactionId): Future[WhiskAction] = {
+    actionLookup flatMap { action =>
+      val requiresAuthenticatedUser = action.annotations.asBool("require-whisk-auth").exists(identity)
+      val isExported = action.annotations.asBool("web-export").exists(identity)
+
+      if ((isExported && requiresAuthenticatedUser && authenticated) ||
+          (isExported && !requiresAuthenticatedUser)) {
+        logging.info(this, s"${action.fullyQualifiedName(true)} is exported")
+        Future.successful(action)
+      } else if (!isExported) {
+        logging.info(this, s"${action.fullyQualifiedName(true)} not exported")
+        Future.failed(RejectRequest(NotFound))
+      } else {
+        logging.info(this, s"${action.fullyQualifiedName(true)} requires authentication")
+        Future.failed(RejectRequest(Unauthorized))
+      }
+    }
+  }
+
+  /**
+   * Determines the result projection path, if any.
+   *
+   * @return optional list of projections
+   */
+  private def projectResultField(context: Context, responseType: MediaExtension): List[String] = {
+    val projection = if (responseType.projectionAllowed) {
+      Option(context.path)
+        .filter(_.nonEmpty)
+        .map(_.split("/").filter(_.nonEmpty).toList)
+        .orElse(responseType.defaultProjection)
+    } else responseType.defaultProjection
+
+    projection.getOrElse(List())
+  }
 }

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
@@ -43,271 +43,272 @@ import whisk.core.entity.types.EntityStore
 import whisk.utils.ExecutionContextFactory.FutureExtensions
 
 protected[actions] trait PrimitiveActions {
-    /** The core collections require backend services to be injected in this trait. */
-    services: WhiskServices =>
+  /** The core collections require backend services to be injected in this trait. */
+  services: WhiskServices =>
 
-    /** An actor system for timed based futures. */
-    protected implicit val actorSystem: ActorSystem
+  /** An actor system for timed based futures. */
+  protected implicit val actorSystem: ActorSystem
 
-    /** An execution context for futures. */
-    protected implicit val executionContext: ExecutionContext
+  /** An execution context for futures. */
+  protected implicit val executionContext: ExecutionContext
 
-    protected implicit val logging: Logging
+  protected implicit val logging: Logging
 
-    /**
-     *  The index of the active ack topic, this controller is listening for.
-     *  Typically this is also the instance number of the controller
-     */
-    protected val activeAckTopicIndex: InstanceId
+  /**
+   *  The index of the active ack topic, this controller is listening for.
+   *  Typically this is also the instance number of the controller
+   */
+  protected val activeAckTopicIndex: InstanceId
 
-    /** Database service to CRUD actions. */
-    protected val entityStore: EntityStore
+  /** Database service to CRUD actions. */
+  protected val entityStore: EntityStore
 
-    /** Database service to get activations. */
-    protected val activationStore: ActivationStore
+  /** Database service to get activations. */
+  protected val activationStore: ActivationStore
 
-    /**
-     * Posts request to the loadbalancer. If the loadbalancer accepts the requests with an activation id,
-     * then wait for the result of the activation if necessary.
-     *
-     * NOTE:
-     * For activations of actions, cause is populated only for actions that were invoked as a result of a sequence activation.
-     * For actions that are enclosed in a sequence and are activated as a result of the sequence activation, the cause
-     * contains the activation id of the immediately enclosing sequence.
-     * e.g.,: s -> a, x, c    and   x -> c  (x and s are sequences, a, b, c atomic actions)
-     * cause for a, x, c is the activation id of s
-     * cause for c is the activation id of x
-     * cause for s is not defined
-     *
-     * @param user the identity invoking the action
-     * @param action the action to invoke
-     * @param payload the dynamic arguments for the activation
-     * @param waitForResponse if not empty, wait upto specified duration for a response (this is used for blocking activations)
-     * @param cause the activation id that is responsible for this invoke/activation
-     * @param transid a transaction id for logging
-     * @return a promise that completes with one of the following successful cases:
-     *            Right(WhiskActivation) if waiting for a response and response is ready within allowed duration,
-     *            Left(ActivationId) if not waiting for a response, or allowed duration has elapsed without a result ready
-     *         or these custom failures:
-     *            RequestEntityTooLarge if the message is too large to to post to the message bus
-     */
-    protected[actions] def invokeSingleAction(
-        user: Identity,
-        action: ExecutableWhiskAction,
-        payload: Option[JsObject],
-        waitForResponse: Option[FiniteDuration],
-        cause: Option[ActivationId])(
-            implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
+  /**
+   * Posts request to the loadbalancer. If the loadbalancer accepts the requests with an activation id,
+   * then wait for the result of the activation if necessary.
+   *
+   * NOTE:
+   * For activations of actions, cause is populated only for actions that were invoked as a result of a sequence activation.
+   * For actions that are enclosed in a sequence and are activated as a result of the sequence activation, the cause
+   * contains the activation id of the immediately enclosing sequence.
+   * e.g.,: s -> a, x, c    and   x -> c  (x and s are sequences, a, b, c atomic actions)
+   * cause for a, x, c is the activation id of s
+   * cause for c is the activation id of x
+   * cause for s is not defined
+   *
+   * @param user the identity invoking the action
+   * @param action the action to invoke
+   * @param payload the dynamic arguments for the activation
+   * @param waitForResponse if not empty, wait upto specified duration for a response (this is used for blocking activations)
+   * @param cause the activation id that is responsible for this invoke/activation
+   * @param transid a transaction id for logging
+   * @return a promise that completes with one of the following successful cases:
+   *            Right(WhiskActivation) if waiting for a response and response is ready within allowed duration,
+   *            Left(ActivationId) if not waiting for a response, or allowed duration has elapsed without a result ready
+   *         or these custom failures:
+   *            RequestEntityTooLarge if the message is too large to to post to the message bus
+   */
+  protected[actions] def invokeSingleAction(
+    user: Identity,
+    action: ExecutableWhiskAction,
+    payload: Option[JsObject],
+    waitForResponse: Option[FiniteDuration],
+    cause: Option[ActivationId])(implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
 
-        // merge package parameters with action (action parameters supersede), then merge in payload
-        val args = action.parameters merge payload
-        val message = ActivationMessage(
-            transid,
-            FullyQualifiedEntityName(action.namespace, action.name, Some(action.version)),
-            action.rev,
-            user,
-            activationIdFactory.make(), // activation id created here
-            activationNamespace = user.namespace.toPath,
-            activeAckTopicIndex,
-            waitForResponse.isDefined,
-            args,
-            cause = cause)
+    // merge package parameters with action (action parameters supersede), then merge in payload
+    val args = action.parameters merge payload
+    val message = ActivationMessage(
+      transid,
+      FullyQualifiedEntityName(action.namespace, action.name, Some(action.version)),
+      action.rev,
+      user,
+      activationIdFactory.make(), // activation id created here
+      activationNamespace = user.namespace.toPath,
+      activeAckTopicIndex,
+      waitForResponse.isDefined,
+      args,
+      cause = cause)
 
-        val startActivation = transid.started(this, waitForResponse.map(_ => LoggingMarkers.CONTROLLER_ACTIVATION_BLOCKING).getOrElse(LoggingMarkers.CONTROLLER_ACTIVATION))
-        val startLoadbalancer = transid.started(this, LoggingMarkers.CONTROLLER_LOADBALANCER, s"action activation id: ${message.activationId}")
-        val postedFuture = loadBalancer.publish(action, message)
+    val startActivation = transid.started(
+      this,
+      waitForResponse
+        .map(_ => LoggingMarkers.CONTROLLER_ACTIVATION_BLOCKING)
+        .getOrElse(LoggingMarkers.CONTROLLER_ACTIVATION))
+    val startLoadbalancer =
+      transid.started(this, LoggingMarkers.CONTROLLER_LOADBALANCER, s"action activation id: ${message.activationId}")
+    val postedFuture = loadBalancer.publish(action, message)
 
-        postedFuture.flatMap { activeAckResponse =>
-            // successfully posted activation request to the message bus
-            transid.finished(this, startLoadbalancer)
+    postedFuture.flatMap { activeAckResponse =>
+      // successfully posted activation request to the message bus
+      transid.finished(this, startLoadbalancer)
 
-            // is caller waiting for the result of the activation?
-            waitForResponse.map { timeout =>
-                // yes, then wait for the activation response from the message bus
-                // (known as the active response or active ack)
-                waitForActivationResponse(user, message.activationId, timeout, activeAckResponse)
-                    .andThen { case _ => transid.finished(this, startActivation) }
-            }.getOrElse {
-                // no, return the activation id
-                transid.finished(this, startActivation)
-                Future.successful(Left(message.activationId))
-            }
+      // is caller waiting for the result of the activation?
+      waitForResponse
+        .map { timeout =>
+          // yes, then wait for the activation response from the message bus
+          // (known as the active response or active ack)
+          waitForActivationResponse(user, message.activationId, timeout, activeAckResponse)
+            .andThen { case _ => transid.finished(this, startActivation) }
+        }
+        .getOrElse {
+          // no, return the activation id
+          transid.finished(this, startActivation)
+          Future.successful(Left(message.activationId))
         }
     }
+  }
 
-    /**
-     * Waits for a response from the message bus (e.g., Kafka) containing the result of the activation. This is the fast path
-     * used for blocking calls where only the result of the activation is needed. This path is called active acknowledgement
-     * or active ack.
-     *
-     * While waiting for the active ack, periodically poll the datastore in case there is a failure in the fast path delivery
-     * which could happen if the connection from an invoker to the message bus is disrupted, or if the publishing of the response
-     * fails because the message is too large.
-     */
-    private def waitForActivationResponse(
-        user: Identity,
-        activationId: ActivationId,
-        totalWaitTime: FiniteDuration,
-        activeAckResponse: Future[Either[ActivationId, WhiskActivation]])(
-            implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
-        // this is the promise which active ack or db polling will try to complete via:
-        // 1. active ack response, or
-        // 2. failing active ack (due to active ack timeout), fall over to db polling
-        // 3. timeout on db polling => converts activation to non-blocking (returns activation id only)
-        // 4. internal error message
-        val docid = DocId(WhiskEntity.qualifiedName(user.namespace.toPath, activationId))
-        val (promise, finisher) = ActivationFinisher.props({
-            () => WhiskActivation.get(activationStore, docid)
-        })
+  /**
+   * Waits for a response from the message bus (e.g., Kafka) containing the result of the activation. This is the fast path
+   * used for blocking calls where only the result of the activation is needed. This path is called active acknowledgement
+   * or active ack.
+   *
+   * While waiting for the active ack, periodically poll the datastore in case there is a failure in the fast path delivery
+   * which could happen if the connection from an invoker to the message bus is disrupted, or if the publishing of the response
+   * fails because the message is too large.
+   */
+  private def waitForActivationResponse(user: Identity,
+                                        activationId: ActivationId,
+                                        totalWaitTime: FiniteDuration,
+                                        activeAckResponse: Future[Either[ActivationId, WhiskActivation]])(
+    implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
+    // this is the promise which active ack or db polling will try to complete via:
+    // 1. active ack response, or
+    // 2. failing active ack (due to active ack timeout), fall over to db polling
+    // 3. timeout on db polling => converts activation to non-blocking (returns activation id only)
+    // 4. internal error message
+    val docid = DocId(WhiskEntity.qualifiedName(user.namespace.toPath, activationId))
+    val (promise, finisher) = ActivationFinisher.props({ () =>
+      WhiskActivation.get(activationStore, docid)
+    })
 
-        logging.info(this, s"action activation will block for result upto $totalWaitTime")
+    logging.info(this, s"action activation will block for result upto $totalWaitTime")
 
-        activeAckResponse map {
-            case result @ Right(_) =>
-                // activation complete, result is available
-                finisher ! ActivationFinisher.Finish(result)
+    activeAckResponse map {
+      case result @ Right(_) =>
+        // activation complete, result is available
+        finisher ! ActivationFinisher.Finish(result)
 
-            case _ =>
-                // active ack received but it does not carry the response,
-                // no result available except by polling the db
-                logging.warn(this, "pre-emptively polling db because active ack is missing result")
-                finisher ! Scheduler.WorkOnceNow
-        }
-
-        // return the promise which is either fulfilled by active ack, polling from the database,
-        // or the timeout alternative when the allowed duration expires (i.e., the action took
-        // longer than the permitted, per totalWaitTime).
-        promise.withAlternativeAfterTimeout(totalWaitTime, {
-            Future.successful(Left(activationId)).andThen {
-                // result no longer interesting; terminate the finisher/shut down db polling if necessary
-                case _ => actorSystem.stop(finisher)
-            }
-        })
+      case _ =>
+        // active ack received but it does not carry the response,
+        // no result available except by polling the db
+        logging.warn(this, "pre-emptively polling db because active ack is missing result")
+        finisher ! Scheduler.WorkOnceNow
     }
+
+    // return the promise which is either fulfilled by active ack, polling from the database,
+    // or the timeout alternative when the allowed duration expires (i.e., the action took
+    // longer than the permitted, per totalWaitTime).
+    promise.withAlternativeAfterTimeout(
+      totalWaitTime, {
+        Future.successful(Left(activationId)).andThen {
+          // result no longer interesting; terminate the finisher/shut down db polling if necessary
+          case _ => actorSystem.stop(finisher)
+        }
+      })
+  }
 }
 
 /** Companion to the ActivationFinisher. */
 protected[actions] object ActivationFinisher {
-    case class Finish(activation: Right[ActivationId, WhiskActivation])
+  case class Finish(activation: Right[ActivationId, WhiskActivation])
 
-    private type ActivationLookup = () => Future[WhiskActivation]
+  private type ActivationLookup = () => Future[WhiskActivation]
 
-    /** Periodically polls the db to cover missing active acks. */
-    private val datastorePollPeriodForActivation = 15.seconds
+  /** Periodically polls the db to cover missing active acks. */
+  private val datastorePollPeriodForActivation = 15.seconds
 
-    /**
-     * In case of a partial active ack where it is know an activation completed
-     * but the result could not be sent over the bus, use this periodicity to poll
-     * for a result.
-     */
-    private val datastorePreemptivePolling = Seq(1.second, 3.seconds, 5.seconds, 7.seconds)
+  /**
+   * In case of a partial active ack where it is know an activation completed
+   * but the result could not be sent over the bus, use this periodicity to poll
+   * for a result.
+   */
+  private val datastorePreemptivePolling = Seq(1.second, 3.seconds, 5.seconds, 7.seconds)
 
-    def props(activationLookup: ActivationLookup)(
-        implicit transid: TransactionId,
-        actorSystem: ActorSystem,
-        executionContext: ExecutionContext,
-        logging: Logging): (Future[Either[ActivationId, WhiskActivation]], ActorRef) = {
+  def props(activationLookup: ActivationLookup)(
+    implicit transid: TransactionId,
+    actorSystem: ActorSystem,
+    executionContext: ExecutionContext,
+    logging: Logging): (Future[Either[ActivationId, WhiskActivation]], ActorRef) = {
 
-        val (p, _, f) = props(activationLookup, datastorePollPeriodForActivation, datastorePreemptivePolling)
-        (p.future, f) // hides the polling actor
-    }
+    val (p, _, f) = props(activationLookup, datastorePollPeriodForActivation, datastorePreemptivePolling)
+    (p.future, f) // hides the polling actor
+  }
 
-    /**
-     * Creates the finishing actor.
-     * This is factored for testing.
-     */
-    protected[actions] def props(
-        activationLookup: ActivationLookup,
-        slowPoll: FiniteDuration,
-        fastPolls: Seq[FiniteDuration])(
-            implicit transid: TransactionId,
-            actorSystem: ActorSystem,
-            executionContext: ExecutionContext,
-            logging: Logging): (Promise[Either[ActivationId, WhiskActivation]], ActorRef, ActorRef) = {
+  /**
+   * Creates the finishing actor.
+   * This is factored for testing.
+   */
+  protected[actions] def props(activationLookup: ActivationLookup,
+                               slowPoll: FiniteDuration,
+                               fastPolls: Seq[FiniteDuration])(
+    implicit transid: TransactionId,
+    actorSystem: ActorSystem,
+    executionContext: ExecutionContext,
+    logging: Logging): (Promise[Either[ActivationId, WhiskActivation]], ActorRef, ActorRef) = {
 
-        // this is strictly completed by the finishing actor
-        val promise = Promise[Either[ActivationId, WhiskActivation]]
-        val dbpoller = poller(slowPoll, promise, activationLookup)
-        val finisher = Props(new ActivationFinisher(dbpoller, fastPolls, promise))
+    // this is strictly completed by the finishing actor
+    val promise = Promise[Either[ActivationId, WhiskActivation]]
+    val dbpoller = poller(slowPoll, promise, activationLookup)
+    val finisher = Props(new ActivationFinisher(dbpoller, fastPolls, promise))
 
-        (promise, dbpoller, actorSystem.actorOf(finisher))
-    }
+    (promise, dbpoller, actorSystem.actorOf(finisher))
+  }
 
-    /**
-     * An actor to complete a blocking activation request. It encapsulates a promise
-     * to be completed when the result is ready. This may happen in one of two ways.
-     * An active ack message is relayed to this actor to complete the promise when
-     * the active ack is received. Or in case of a partial/missing active ack, an
-     * explicitly scheduled datastore poll of the activation record, if found, will
-     * complete the transaction. When the promise is fulfilled, the actor self destructs.
-     */
-    private class ActivationFinisher(
-        poller: ActorRef, // the activation poller
-        fastPollPeriods: Seq[FiniteDuration],
-        promise: Promise[Either[ActivationId, WhiskActivation]])(
-            implicit transid: TransactionId,
-            actorSystem: ActorSystem,
-            executionContext: ExecutionContext,
-            logging: Logging) extends Actor {
+  /**
+   * An actor to complete a blocking activation request. It encapsulates a promise
+   * to be completed when the result is ready. This may happen in one of two ways.
+   * An active ack message is relayed to this actor to complete the promise when
+   * the active ack is received. Or in case of a partial/missing active ack, an
+   * explicitly scheduled datastore poll of the activation record, if found, will
+   * complete the transaction. When the promise is fulfilled, the actor self destructs.
+   */
+  private class ActivationFinisher(poller: ActorRef, // the activation poller
+                                   fastPollPeriods: Seq[FiniteDuration],
+                                   promise: Promise[Either[ActivationId, WhiskActivation]])(
+    implicit transid: TransactionId,
+    actorSystem: ActorSystem,
+    executionContext: ExecutionContext,
+    logging: Logging)
+      extends Actor {
 
-        // when the future completes, self-destruct
-        promise.future.andThen { case _ => shutdown() }
+    // when the future completes, self-destruct
+    promise.future.andThen { case _ => shutdown() }
 
-        val preemptiveMsgs: Buffer[Cancellable] = Buffer.empty
+    val preemptiveMsgs: Buffer[Cancellable] = Buffer.empty
 
-        def receive = {
-            case ActivationFinisher.Finish(activation) =>
-                promise.trySuccess(activation)
+    def receive = {
+      case ActivationFinisher.Finish(activation) =>
+        promise.trySuccess(activation)
 
-            case msg @ Scheduler.WorkOnceNow =>
-                // try up to three times when pre-emptying the schedule
-                fastPollPeriods.foreach {
-                    s => preemptiveMsgs += context.system.scheduler.scheduleOnce(s, poller, msg)
-                }
-        }
-
-        def shutdown(): Unit = {
-            preemptiveMsgs.foreach(_.cancel())
-            preemptiveMsgs.clear()
-            context.stop(poller)
-            context.stop(self)
-        }
-
-        override def postStop() = {
-            logging.info(this, "finisher shutdown")
-            preemptiveMsgs.foreach(_.cancel())
-            preemptiveMsgs.clear()
-            context.stop(poller)
+      case msg @ Scheduler.WorkOnceNow =>
+        // try up to three times when pre-emptying the schedule
+        fastPollPeriods.foreach { s =>
+          preemptiveMsgs += context.system.scheduler.scheduleOnce(s, poller, msg)
         }
     }
 
-    /**
-     * This creates the inner datastore poller for the completed activation.
-     * It is a factory method to facilitate testing.
-     */
-    private def poller(
-        slowPollPeriod: FiniteDuration,
-        promise: Promise[Either[ActivationId, WhiskActivation]],
-        activationLookup: ActivationLookup)(
-            implicit transid: TransactionId,
-            actorSystem: ActorSystem,
-            executionContext: ExecutionContext,
-            logging: Logging): ActorRef = {
-        Scheduler.scheduleWaitAtMost(
-            slowPollPeriod,
-            initialDelay = slowPollPeriod,
-            name = "dbpoll")(() => {
-                if (!promise.isCompleted) {
-                    activationLookup() map {
-                        // complete the future, which in turn will poison pill this scheduler
-                        activation => promise.trySuccess(Right(activation.withoutLogs)) // logs excluded on blocking calls
-                    } andThen {
-                        case Failure(e: NoDocumentException) => // do nothing, scheduler will reschedule another poll
-                        case Failure(t: Throwable) => // something went wrong, abort
-                            logging.error(this, s"failed while waiting on result: ${t.getMessage}")
-                            promise.tryFailure(t) // complete the future, which in turn will poison pill this scheduler
-                    }
-                } else Future.successful({}) // the scheduler will be halted because the promise is now resolved
-            })
+    def shutdown(): Unit = {
+      preemptiveMsgs.foreach(_.cancel())
+      preemptiveMsgs.clear()
+      context.stop(poller)
+      context.stop(self)
     }
+
+    override def postStop() = {
+      logging.info(this, "finisher shutdown")
+      preemptiveMsgs.foreach(_.cancel())
+      preemptiveMsgs.clear()
+      context.stop(poller)
+    }
+  }
+
+  /**
+   * This creates the inner datastore poller for the completed activation.
+   * It is a factory method to facilitate testing.
+   */
+  private def poller(slowPollPeriod: FiniteDuration,
+                     promise: Promise[Either[ActivationId, WhiskActivation]],
+                     activationLookup: ActivationLookup)(implicit transid: TransactionId,
+                                                         actorSystem: ActorSystem,
+                                                         executionContext: ExecutionContext,
+                                                         logging: Logging): ActorRef = {
+    Scheduler.scheduleWaitAtMost(slowPollPeriod, initialDelay = slowPollPeriod, name = "dbpoll")(() => {
+      if (!promise.isCompleted) {
+        activationLookup() map {
+          // complete the future, which in turn will poison pill this scheduler
+          activation =>
+            promise.trySuccess(Right(activation.withoutLogs)) // logs excluded on blocking calls
+        } andThen {
+          case Failure(e: NoDocumentException) => // do nothing, scheduler will reschedule another poll
+          case Failure(t: Throwable) => // something went wrong, abort
+            logging.error(this, s"failed while waiting on result: ${t.getMessage}")
+            promise.tryFailure(t) // complete the future, which in turn will poison pill this scheduler
+        }
+      } else Future.successful({}) // the scheduler will be halted because the promise is now resolved
+    })
+  }
 }

--- a/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
@@ -43,317 +43,342 @@ import whisk.http.Messages._
 import whisk.utils.ExecutionContextFactory.FutureExtensions
 
 protected[actions] trait SequenceActions {
-    /** The core collections require backend services to be injected in this trait. */
-    services: WhiskServices =>
+  /** The core collections require backend services to be injected in this trait. */
+  services: WhiskServices =>
 
-    /** An actor system for timed based futures. */
-    protected implicit val actorSystem: ActorSystem
+  /** An actor system for timed based futures. */
+  protected implicit val actorSystem: ActorSystem
 
-    /** An execution context for futures. */
-    protected implicit val executionContext: ExecutionContext
+  /** An execution context for futures. */
+  protected implicit val executionContext: ExecutionContext
 
-    protected implicit val logging: Logging
+  protected implicit val logging: Logging
 
-    /** Database service to CRUD actions. */
-    protected val entityStore: EntityStore
+  /** Database service to CRUD actions. */
+  protected val entityStore: EntityStore
 
-    /** Database service to get activations. */
-    protected val activationStore: ActivationStore
+  /** Database service to get activations. */
+  protected val activationStore: ActivationStore
 
-    /** A method that knows how to invoke a single primitive action. */
-    protected[actions] def invokeAction(
-        user: Identity,
-        action: WhiskAction,
-        payload: Option[JsObject],
-        waitForResponse: Option[FiniteDuration],
-        cause: Option[ActivationId])(
-            implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]]
+  /** A method that knows how to invoke a single primitive action. */
+  protected[actions] def invokeAction(
+    user: Identity,
+    action: WhiskAction,
+    payload: Option[JsObject],
+    waitForResponse: Option[FiniteDuration],
+    cause: Option[ActivationId])(implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]]
 
-    /**
-     * Executes a sequence by invoking in a blocking fashion each of its components.
-     *
-     * @param user the user invoking the action
-     * @param action the sequence action to be invoked
-     * @param payload the dynamic arguments for the activation
-     * @param blocking true iff this is a blocking invoke
-     * @param topmost true iff this is the topmost sequence invoked directly through the api (not indirectly through a sequence)
-     * @param components the actions in the sequence
-     * @param cause the id of the activation that caused this sequence (defined only for inner sequences and None for topmost sequences)
-     * @param atomicActionsCount the dynamic atomic action count observed so far since the start of invocation of the topmost sequence(0 if topmost)
-     * @param transid a transaction id for logging
-     * @return a future of type (ActivationId, Some(WhiskActivation), atomicActionsCount) if blocking; else (ActivationId, None, 0)
-     */
-    protected[actions] def invokeSequence(
-        user: Identity,
-        action: WhiskAction,
-        components: Vector[FullyQualifiedEntityName],
-        payload: Option[JsObject],
-        waitForOutermostResponse: Option[FiniteDuration],
-        cause: Option[ActivationId],
-        topmost: Boolean,
-        atomicActionsCount: Int)(
-            implicit transid: TransactionId): Future[(Either[ActivationId, WhiskActivation], Int)] = {
-        require(action.exec.kind == Exec.SEQUENCE, "this method requires an action sequence")
+  /**
+   * Executes a sequence by invoking in a blocking fashion each of its components.
+   *
+   * @param user the user invoking the action
+   * @param action the sequence action to be invoked
+   * @param payload the dynamic arguments for the activation
+   * @param blocking true iff this is a blocking invoke
+   * @param topmost true iff this is the topmost sequence invoked directly through the api (not indirectly through a sequence)
+   * @param components the actions in the sequence
+   * @param cause the id of the activation that caused this sequence (defined only for inner sequences and None for topmost sequences)
+   * @param atomicActionsCount the dynamic atomic action count observed so far since the start of invocation of the topmost sequence(0 if topmost)
+   * @param transid a transaction id for logging
+   * @return a future of type (ActivationId, Some(WhiskActivation), atomicActionsCount) if blocking; else (ActivationId, None, 0)
+   */
+  protected[actions] def invokeSequence(
+    user: Identity,
+    action: WhiskAction,
+    components: Vector[FullyQualifiedEntityName],
+    payload: Option[JsObject],
+    waitForOutermostResponse: Option[FiniteDuration],
+    cause: Option[ActivationId],
+    topmost: Boolean,
+    atomicActionsCount: Int)(implicit transid: TransactionId): Future[(Either[ActivationId, WhiskActivation], Int)] = {
+    require(action.exec.kind == Exec.SEQUENCE, "this method requires an action sequence")
 
-        // create new activation id that corresponds to the sequence
-        val seqActivationId = activationIdFactory.make()
-        logging.info(this, s"invoking sequence $action topmost $topmost activationid '$seqActivationId'")
+    // create new activation id that corresponds to the sequence
+    val seqActivationId = activationIdFactory.make()
+    logging.info(this, s"invoking sequence $action topmost $topmost activationid '$seqActivationId'")
 
-        val start = Instant.now(Clock.systemUTC())
-        val futureSeqResult: Future[(Either[ActivationId, WhiskActivation], Int)] = {
-            // even though the result of completeSequenceActivation is Right[WhiskActivation],
-            // use a more general type for futureSeqResult in case a blocking invoke takes
-            // longer than expected and we must return Left[ActivationId] instead
-            completeSequenceActivation(
-                seqActivationId,
-                // the cause for the component activations is the current sequence
-                invokeSequenceComponents(user, action, seqActivationId, payload, components, cause = Some(seqActivationId), atomicActionsCount),
-                user, action, topmost, start, cause)
+    val start = Instant.now(Clock.systemUTC())
+    val futureSeqResult: Future[(Either[ActivationId, WhiskActivation], Int)] = {
+      // even though the result of completeSequenceActivation is Right[WhiskActivation],
+      // use a more general type for futureSeqResult in case a blocking invoke takes
+      // longer than expected and we must return Left[ActivationId] instead
+      completeSequenceActivation(
+        seqActivationId,
+        // the cause for the component activations is the current sequence
+        invokeSequenceComponents(
+          user,
+          action,
+          seqActivationId,
+          payload,
+          components,
+          cause = Some(seqActivationId),
+          atomicActionsCount),
+        user,
+        action,
+        topmost,
+        start,
+        cause)
+    }
+
+    if (topmost) { // need to deal with blocking and closing connection
+      waitForOutermostResponse
+        .map { timeout =>
+          logging.info(this, s"invoke sequence blocking topmost!")
+          futureSeqResult.withAlternativeAfterTimeout(
+            timeout,
+            Future.successful(Left(seqActivationId), atomicActionsCount))
         }
+        .getOrElse {
+          // non-blocking sequence execution, return activation id
+          Future.successful(Left(seqActivationId), 0)
+        }
+    } else {
+      // not topmost, no need to worry about terminating incoming request
+      // and this is a blocking activation therefore by definition
+      // Note: the future for the sequence result recovers from all throwable failures
+      futureSeqResult
+    }
+  }
 
-        if (topmost) { // need to deal with blocking and closing connection
-            waitForOutermostResponse.map { timeout =>
-                logging.info(this, s"invoke sequence blocking topmost!")
-                futureSeqResult.withAlternativeAfterTimeout(timeout, Future.successful(Left(seqActivationId), atomicActionsCount))
-            }.getOrElse {
-                // non-blocking sequence execution, return activation id
-                Future.successful(Left(seqActivationId), 0)
+  /**
+   * Creates an activation for the sequence and writes it back to the datastore.
+   */
+  private def completeSequenceActivation(seqActivationId: ActivationId,
+                                         futureSeqResult: Future[SequenceAccounting],
+                                         user: Identity,
+                                         action: WhiskAction,
+                                         topmost: Boolean,
+                                         start: Instant,
+                                         cause: Option[ActivationId])(
+    implicit transid: TransactionId): Future[(Right[ActivationId, WhiskActivation], Int)] = {
+    // not topmost, no need to worry about terminating incoming request
+    // Note: the future for the sequence result recovers from all throwable failures
+    futureSeqResult
+      .map { accounting =>
+        // sequence terminated, the result of the sequence is the result of the last completed activation
+        val end = Instant.now(Clock.systemUTC())
+        val seqActivation =
+          makeSequenceActivation(user, action, seqActivationId, accounting, topmost, cause, start, end)
+        (Right(seqActivation), accounting.atomicActionCnt)
+      }
+      .andThen {
+        case Success((Right(seqActivation), _)) => storeSequenceActivation(seqActivation)
+
+        // This should never happen; in this case, there is no activation record created or stored:
+        // should there be?
+        case Failure(t) => logging.error(this, s"Sequence activation failed: ${t.getMessage}")
+      }
+  }
+
+  /**
+   * Stores sequence activation to database.
+   */
+  private def storeSequenceActivation(activation: WhiskActivation)(implicit transid: TransactionId): Unit = {
+    logging.info(this, s"recording activation '${activation.activationId}'")
+    WhiskActivation.put(activationStore, activation)(transid, notifier = None) onComplete {
+      case Success(id) => logging.info(this, s"recorded activation")
+      case Failure(t) =>
+        logging.error(
+          this,
+          s"failed to record activation ${activation.activationId} with error ${t.getLocalizedMessage}")
+    }
+  }
+
+  /**
+   * Creates an activation for a sequence.
+   */
+  private def makeSequenceActivation(user: Identity,
+                                     action: WhiskAction,
+                                     activationId: ActivationId,
+                                     accounting: SequenceAccounting,
+                                     topmost: Boolean,
+                                     cause: Option[ActivationId],
+                                     start: Instant,
+                                     end: Instant): WhiskActivation = {
+
+    // compute max memory
+    val sequenceLimits = accounting.maxMemory map { maxMemoryAcrossActionsInSequence =>
+      Parameters(
+        "limits",
+        ActionLimits(action.limits.timeout, MemoryLimit(maxMemoryAcrossActionsInSequence MB), action.limits.logs).toJson)
+    } getOrElse (Parameters())
+
+    // set causedBy if not topmost sequence
+    val causedBy = if (!topmost) {
+      Parameters("causedBy", JsString("sequence"))
+    } else {
+      Parameters()
+    }
+
+    // create the whisk activation
+    WhiskActivation(
+      namespace = user.namespace.toPath,
+      name = action.name,
+      user.subject,
+      activationId = activationId,
+      start = start,
+      end = end,
+      cause = if (topmost) None else cause, // propagate the cause for inner sequences, but undefined for topmost
+      response = accounting.previousResponse.getAndSet(null), // getAndSet(null) drops reference to the activation result
+      logs = accounting.finalLogs,
+      version = action.version,
+      publish = false,
+      annotations = Parameters("topmost", JsBoolean(topmost)) ++
+        Parameters("path", action.fullyQualifiedName(false).toString) ++
+        Parameters("kind", "sequence") ++
+        causedBy ++
+        sequenceLimits,
+      duration = Some(accounting.duration))
+  }
+
+  /**
+   * Invokes the components of a sequence in a blocking fashion.
+   * Returns a vector of successful futures containing the results of the invocation of all components in the sequence.
+   * Unexpected behavior is modeled through an Either with activation(right) or activation response in case of error (left).
+   *
+   * Keeps track of the dynamic atomic action count.
+   * @param user the user invoking the sequence
+   * @param seqAction the sequence invoked
+   * @param seqActivationId the id of the sequence
+   * @param inputPayload the payload passed to the first component in the sequence
+   * @param components the components in the sequence
+   * @param cause the activation id of the sequence that lead to invoking this sequence or None if this sequence is topmost
+   * @param atomicActionCnt the dynamic atomic action count observed so far since the start of the execution of the topmost sequence
+   * @return a future which resolves with the accounting for a sequence, including the last result, duration, and activation ids
+   */
+  private def invokeSequenceComponents(
+    user: Identity,
+    seqAction: WhiskAction,
+    seqActivationId: ActivationId,
+    inputPayload: Option[JsObject],
+    components: Vector[FullyQualifiedEntityName],
+    cause: Option[ActivationId],
+    atomicActionCnt: Int)(implicit transid: TransactionId): Future[SequenceAccounting] = {
+
+    // For each action in the sequence, fetch any of its associated parameters (including package or binding).
+    // We do this for all of the actions in the sequence even though it may be short circuited. This is to
+    // hide the latency of the fetches from the datastore and the parameter merging that has to occur. It
+    // may be desirable in the future to selectively speculate over a smaller number of components rather than
+    // the entire sequence.
+    //
+    // This action/parameter resolution is done in futures; the execution starts as soon as the first component
+    // is resolved.
+    val resolvedFutureActions = resolveDefaultNamespace(components, user) map { c =>
+      WhiskAction.resolveActionAndMergeParameters(entityStore, c)
+    }
+
+    // this holds the initial value of the accounting structure, including the input boxed as an ActivationResponse
+    val initialAccounting = Future.successful {
+      SequenceAccounting(atomicActionCnt, ActivationResponse.payloadPlaceholder(inputPayload))
+    }
+
+    // execute the actions in sequential blocking fashion
+    resolvedFutureActions
+      .foldLeft(initialAccounting) { (accountingFuture, futureAction) =>
+        accountingFuture.flatMap { accounting =>
+          if (accounting.atomicActionCnt < actionSequenceLimit) {
+            invokeNextAction(user, futureAction, accounting, cause).flatMap { accounting =>
+              if (!accounting.shortcircuit) {
+                Future.successful(accounting)
+              } else {
+                // this is to short circuit the fold
+                Future.failed(FailedSequenceActivation(accounting)) // terminates the fold
+              }
             }
-        } else {
-            // not topmost, no need to worry about terminating incoming request
-            // and this is a blocking activation therefore by definition
-            // Note: the future for the sequence result recovers from all throwable failures
-            futureSeqResult
+          } else {
+            val updatedAccount = accounting.fail(ActivationResponse.applicationError(sequenceIsTooLong), None)
+            Future.failed(FailedSequenceActivation(updatedAccount)) // terminates the fold
+          }
+        }
+      }
+      .recoverWith {
+        // turn the failed accounting back to success; this is the only possible failure
+        // since all throwables are recovered with a failed accounting instance and this is
+        // in turned boxed to FailedSequenceActivation
+        case FailedSequenceActivation(accounting) => Future.successful(accounting)
+      }
+  }
+
+  /**
+   * Invokes one component from a sequence action. Unless an unexpected whisk failure happens, the future returned is always successful.
+   * The return is a tuple of
+   *       1. either an activation (right) or an activation response (left) in case the activation could not be retrieved
+   *       2. the dynamic count of atomic actions observed so far since the start of the topmost sequence on behalf which this action is executing
+   *
+   * The method distinguishes between invoking a sequence or an atomic action.
+   * @param user the user executing the sequence
+   * @param futureAction the future which fetches the action to be invoked from the db
+   * @param accounting the state of the sequence activation, contains the dynamic activation count, logs and payload for the next action
+   * @param cause the activation id of the first sequence containing this activations
+   * @return a future which resolves with updated accounting for a sequence, including the last result, duration, and activation ids
+   */
+  private def invokeNextAction(
+    user: Identity,
+    futureAction: Future[WhiskAction],
+    accounting: SequenceAccounting,
+    cause: Option[ActivationId])(implicit transid: TransactionId): Future[SequenceAccounting] = {
+    futureAction.flatMap { action =>
+      // the previous response becomes input for the next action in the sequence;
+      // the accounting no longer needs to hold a reference to it once the action is
+      // invoked, so previousResponse.getAndSet(null) drops the reference at this point
+      // which prevents dragging the previous response for the lifetime of the next activation
+      val inputPayload = accounting.previousResponse.getAndSet(null).result.map(_.asJsObject)
+
+      // invoke the action by calling the right method depending on whether it's an atomic action or a sequence
+      val futureWhiskActivationTuple = action.toExecutableWhiskAction match {
+        case None =>
+          val SequenceExec(components) = action.exec
+          logging.info(this, s"sequence invoking an enclosed sequence $action")
+          // call invokeSequence to invoke the inner sequence; this is a blocking activation by definition
+          invokeSequence(
+            user,
+            action,
+            components,
+            inputPayload,
+            None,
+            cause,
+            topmost = false,
+            accounting.atomicActionCnt)
+        case Some(executable) =>
+          // this is an invoke for an atomic action
+          logging.info(this, s"sequence invoking an enclosed atomic action $action")
+          val timeout = action.limits.timeout.duration + 1.minute
+          invokeAction(user, action, inputPayload, waitForResponse = Some(timeout), cause) map {
+            case res => (res, accounting.atomicActionCnt + 1)
+          }
+      }
+
+      futureWhiskActivationTuple
+        .map {
+          case (Right(activation), atomicActionCountSoFar) =>
+            accounting.maybe(activation, atomicActionCountSoFar, actionSequenceLimit)
+
+          case (Left(activationId), atomicActionCountSoFar) =>
+            // the result could not be retrieved in time either from active ack or from db
+            logging.error(this, s"component activation timedout for $activationId")
+            val activationResponse = ActivationResponse.whiskError(sequenceRetrieveActivationTimeout(activationId))
+            accounting.fail(activationResponse, Some(activationId))
+
+        }
+        .recover {
+          // check any failure here and generate an activation response to encapsulate
+          // the failure mode; consider this failure a whisk error
+          case t: Throwable =>
+            logging.error(this, s"component activation failed: $t")
+            accounting.fail(ActivationResponse.whiskError(sequenceActivationFailure), None)
         }
     }
+  }
 
-    /**
-     * Creates an activation for the sequence and writes it back to the datastore.
-     */
-    private def completeSequenceActivation(
-        seqActivationId: ActivationId,
-        futureSeqResult: Future[SequenceAccounting],
-        user: Identity,
-        action: WhiskAction,
-        topmost: Boolean,
-        start: Instant,
-        cause: Option[ActivationId])(
-            implicit transid: TransactionId): Future[(Right[ActivationId, WhiskActivation], Int)] = {
-        // not topmost, no need to worry about terminating incoming request
-        // Note: the future for the sequence result recovers from all throwable failures
-        futureSeqResult.map { accounting =>
-            // sequence terminated, the result of the sequence is the result of the last completed activation
-            val end = Instant.now(Clock.systemUTC())
-            val seqActivation = makeSequenceActivation(user, action, seqActivationId, accounting, topmost, cause, start, end)
-            (Right(seqActivation), accounting.atomicActionCnt)
-        }.andThen {
-            case Success((Right(seqActivation), _)) => storeSequenceActivation(seqActivation)
+  /** Replaces default namespaces in a vector of components from a sequence with appropriate namespace. */
+  private def resolveDefaultNamespace(components: Vector[FullyQualifiedEntityName],
+                                      user: Identity): Vector[FullyQualifiedEntityName] = {
+    // resolve any namespaces that may appears as "_" (the default namespace)
+    components.map(c => FullyQualifiedEntityName(c.path.resolveNamespace(user.namespace), c.name))
+  }
 
-            // This should never happen; in this case, there is no activation record created or stored:
-            // should there be?
-            case Failure(t)                         => logging.error(this, s"Sequence activation failed: ${t.getMessage}")
-        }
-    }
-
-    /**
-     * Stores sequence activation to database.
-     */
-    private def storeSequenceActivation(activation: WhiskActivation)(implicit transid: TransactionId): Unit = {
-        logging.info(this, s"recording activation '${activation.activationId}'")
-        WhiskActivation.put(activationStore, activation)(transid, notifier = None) onComplete {
-            case Success(id) => logging.info(this, s"recorded activation")
-            case Failure(t)  => logging.error(this, s"failed to record activation ${activation.activationId} with error ${t.getLocalizedMessage}")
-        }
-    }
-
-    /**
-     * Creates an activation for a sequence.
-     */
-    private def makeSequenceActivation(
-        user: Identity,
-        action: WhiskAction,
-        activationId: ActivationId,
-        accounting: SequenceAccounting,
-        topmost: Boolean,
-        cause: Option[ActivationId],
-        start: Instant,
-        end: Instant): WhiskActivation = {
-
-        // compute max memory
-        val sequenceLimits = accounting.maxMemory map {
-            maxMemoryAcrossActionsInSequence =>
-                Parameters("limits", ActionLimits(
-                    action.limits.timeout,
-                    MemoryLimit(maxMemoryAcrossActionsInSequence MB),
-                    action.limits.logs).toJson)
-        } getOrElse (Parameters())
-
-        // set causedBy if not topmost sequence
-        val causedBy = if (!topmost) {
-            Parameters("causedBy", JsString("sequence"))
-        } else {
-            Parameters()
-        }
-
-        // create the whisk activation
-        WhiskActivation(
-            namespace = user.namespace.toPath,
-            name = action.name,
-            user.subject,
-            activationId = activationId,
-            start = start,
-            end = end,
-            cause = if (topmost) None else cause, // propagate the cause for inner sequences, but undefined for topmost
-            response = accounting.previousResponse.getAndSet(null), // getAndSet(null) drops reference to the activation result
-            logs = accounting.finalLogs,
-            version = action.version,
-            publish = false,
-            annotations = Parameters("topmost", JsBoolean(topmost)) ++
-                Parameters("path", action.fullyQualifiedName(false).toString) ++
-                Parameters("kind", "sequence") ++
-                causedBy ++
-                sequenceLimits,
-            duration = Some(accounting.duration))
-    }
-
-    /**
-     * Invokes the components of a sequence in a blocking fashion.
-     * Returns a vector of successful futures containing the results of the invocation of all components in the sequence.
-     * Unexpected behavior is modeled through an Either with activation(right) or activation response in case of error (left).
-     *
-     * Keeps track of the dynamic atomic action count.
-     * @param user the user invoking the sequence
-     * @param seqAction the sequence invoked
-     * @param seqActivationId the id of the sequence
-     * @param inputPayload the payload passed to the first component in the sequence
-     * @param components the components in the sequence
-     * @param cause the activation id of the sequence that lead to invoking this sequence or None if this sequence is topmost
-     * @param atomicActionCnt the dynamic atomic action count observed so far since the start of the execution of the topmost sequence
-     * @return a future which resolves with the accounting for a sequence, including the last result, duration, and activation ids
-     */
-    private def invokeSequenceComponents(
-        user: Identity,
-        seqAction: WhiskAction,
-        seqActivationId: ActivationId,
-        inputPayload: Option[JsObject],
-        components: Vector[FullyQualifiedEntityName],
-        cause: Option[ActivationId],
-        atomicActionCnt: Int)(
-            implicit transid: TransactionId): Future[SequenceAccounting] = {
-
-        // For each action in the sequence, fetch any of its associated parameters (including package or binding).
-        // We do this for all of the actions in the sequence even though it may be short circuited. This is to
-        // hide the latency of the fetches from the datastore and the parameter merging that has to occur. It
-        // may be desirable in the future to selectively speculate over a smaller number of components rather than
-        // the entire sequence.
-        //
-        // This action/parameter resolution is done in futures; the execution starts as soon as the first component
-        // is resolved.
-        val resolvedFutureActions = resolveDefaultNamespace(components, user) map {
-            c => WhiskAction.resolveActionAndMergeParameters(entityStore, c)
-        }
-
-        // this holds the initial value of the accounting structure, including the input boxed as an ActivationResponse
-        val initialAccounting = Future.successful {
-            SequenceAccounting(atomicActionCnt, ActivationResponse.payloadPlaceholder(inputPayload))
-        }
-
-        // execute the actions in sequential blocking fashion
-        resolvedFutureActions.foldLeft(initialAccounting) {
-            (accountingFuture, futureAction) =>
-                accountingFuture.flatMap { accounting =>
-                    if (accounting.atomicActionCnt < actionSequenceLimit) {
-                        invokeNextAction(user, futureAction, accounting, cause).flatMap { accounting =>
-                            if (!accounting.shortcircuit) {
-                                Future.successful(accounting)
-                            } else {
-                                // this is to short circuit the fold
-                                Future.failed(FailedSequenceActivation(accounting)) // terminates the fold
-                            }
-                        }
-                    } else {
-                        val updatedAccount = accounting.fail(ActivationResponse.applicationError(sequenceIsTooLong), None)
-                        Future.failed(FailedSequenceActivation(updatedAccount)) // terminates the fold
-                    }
-                }
-        }.recoverWith {
-            // turn the failed accounting back to success; this is the only possible failure
-            // since all throwables are recovered with a failed accounting instance and this is
-            // in turned boxed to FailedSequenceActivation
-            case FailedSequenceActivation(accounting) => Future.successful(accounting)
-        }
-    }
-
-    /**
-     * Invokes one component from a sequence action. Unless an unexpected whisk failure happens, the future returned is always successful.
-     * The return is a tuple of
-     *       1. either an activation (right) or an activation response (left) in case the activation could not be retrieved
-     *       2. the dynamic count of atomic actions observed so far since the start of the topmost sequence on behalf which this action is executing
-     *
-     * The method distinguishes between invoking a sequence or an atomic action.
-     * @param user the user executing the sequence
-     * @param futureAction the future which fetches the action to be invoked from the db
-     * @param accounting the state of the sequence activation, contains the dynamic activation count, logs and payload for the next action
-     * @param cause the activation id of the first sequence containing this activations
-     * @return a future which resolves with updated accounting for a sequence, including the last result, duration, and activation ids
-     */
-    private def invokeNextAction(
-        user: Identity,
-        futureAction: Future[WhiskAction],
-        accounting: SequenceAccounting,
-        cause: Option[ActivationId])(
-            implicit transid: TransactionId): Future[SequenceAccounting] = {
-        futureAction.flatMap { action =>
-            // the previous response becomes input for the next action in the sequence;
-            // the accounting no longer needs to hold a reference to it once the action is
-            // invoked, so previousResponse.getAndSet(null) drops the reference at this point
-            // which prevents dragging the previous response for the lifetime of the next activation
-            val inputPayload = accounting.previousResponse.getAndSet(null).result.map(_.asJsObject)
-
-            // invoke the action by calling the right method depending on whether it's an atomic action or a sequence
-            val futureWhiskActivationTuple = action.toExecutableWhiskAction match {
-                case None =>
-                    val SequenceExec(components) = action.exec
-                    logging.info(this, s"sequence invoking an enclosed sequence $action")
-                    // call invokeSequence to invoke the inner sequence; this is a blocking activation by definition
-                    invokeSequence(user, action, components, inputPayload, None, cause, topmost = false, accounting.atomicActionCnt)
-                case Some(executable) =>
-                    // this is an invoke for an atomic action
-                    logging.info(this, s"sequence invoking an enclosed atomic action $action")
-                    val timeout = action.limits.timeout.duration + 1.minute
-                    invokeAction(user, action, inputPayload, waitForResponse = Some(timeout), cause) map {
-                        case res => (res, accounting.atomicActionCnt + 1)
-                    }
-            }
-
-            futureWhiskActivationTuple.map {
-                case (Right(activation), atomicActionCountSoFar) =>
-                    accounting.maybe(activation, atomicActionCountSoFar, actionSequenceLimit)
-
-                case (Left(activationId), atomicActionCountSoFar) =>
-                    // the result could not be retrieved in time either from active ack or from db
-                    logging.error(this, s"component activation timedout for $activationId")
-                    val activationResponse = ActivationResponse.whiskError(sequenceRetrieveActivationTimeout(activationId))
-                    accounting.fail(activationResponse, Some(activationId))
-
-            }.recover {
-                // check any failure here and generate an activation response to encapsulate
-                // the failure mode; consider this failure a whisk error
-                case t: Throwable =>
-                    logging.error(this, s"component activation failed: $t")
-                    accounting.fail(ActivationResponse.whiskError(sequenceActivationFailure), None)
-            }
-        }
-    }
-
-    /** Replaces default namespaces in a vector of components from a sequence with appropriate namespace. */
-    private def resolveDefaultNamespace(components: Vector[FullyQualifiedEntityName], user: Identity): Vector[FullyQualifiedEntityName] = {
-        // resolve any namespaces that may appears as "_" (the default namespace)
-        components.map(c => FullyQualifiedEntityName(c.path.resolveNamespace(user.namespace), c.name))
-    }
-
-    /** Max atomic action count allowed for sequences */
-    private lazy val actionSequenceLimit = whiskConfig.actionSequenceLimit.toInt
+  /** Max atomic action count allowed for sequences */
+  private lazy val actionSequenceLimit = whiskConfig.actionSequenceLimit.toInt
 }
 
 /**
@@ -369,72 +394,71 @@ protected[actions] trait SequenceActions {
  *        components (needed to annotate the sequence with GB-s)
  * @param shortcircuit when true, stops the execution of the next component in the sequence
  */
-protected[actions] case class SequenceAccounting(
-    atomicActionCnt: Int,
-    previousResponse: AtomicReference[ActivationResponse],
-    logs: mutable.Buffer[ActivationId],
-    duration: Long = 0,
-    maxMemory: Option[Int] = None,
-    shortcircuit: Boolean = false) {
+protected[actions] case class SequenceAccounting(atomicActionCnt: Int,
+                                                 previousResponse: AtomicReference[ActivationResponse],
+                                                 logs: mutable.Buffer[ActivationId],
+                                                 duration: Long = 0,
+                                                 maxMemory: Option[Int] = None,
+                                                 shortcircuit: Boolean = false) {
 
-    /** @return the ActivationLogs data structure for this sequence invocation */
-    def finalLogs = ActivationLogs(logs.map(id => id.asString).toVector)
+  /** @return the ActivationLogs data structure for this sequence invocation */
+  def finalLogs = ActivationLogs(logs.map(id => id.asString).toVector)
 
-    /** The previous activation was successful. */
-    private def success(activation: WhiskActivation, newCnt: Int, shortcircuit: Boolean = false) = {
-        previousResponse.set(null)
-        SequenceAccounting(
-            prev = this,
-            newCnt = newCnt,
-            shortcircuit = shortcircuit,
-            incrDuration = activation.duration,
-            newResponse = activation.response,
-            newActivationId = activation.activationId,
-            newMemoryLimit = activation.annotations.get("limits") map {
-                limitsAnnotation => // we have a limits annotation
-                    limitsAnnotation.asJsObject.getFields("memory") match {
-                        case Seq(JsNumber(memory)) => Some(memory.toInt) // we have a numerical "memory" field in the "limits" annotation
-                    }
-            } getOrElse { None })
-    }
-
-    /** The previous activation failed (this is used when there is no activation record or an internal error. */
-    def fail(failureResponse: ActivationResponse, activationId: Option[ActivationId]) = {
-        require(!failureResponse.isSuccess)
-        logs.appendAll(activationId)
-        copy(previousResponse = new AtomicReference(failureResponse), shortcircuit = true)
-    }
-
-    /** Determines whether the previous activation succeeded or failed. */
-    def maybe(activation: WhiskActivation, newCnt: Int, maxSequenceCnt: Int) = {
-        // check conditions on payload that may lead to interrupting the execution of the sequence
-        //     short-circuit the execution of the sequence iff the payload contains an error field
-        //     and is the result of an action return, not the initial payload
-        val outputPayload = activation.response.result.map(_.asJsObject)
-        val payloadContent = outputPayload getOrElse JsObject.empty
-        val errorField = payloadContent.fields.get(ActivationResponse.ERROR_FIELD)
-        val withinSeqLimit = newCnt <= maxSequenceCnt
-
-        if (withinSeqLimit && errorField.isEmpty) {
-            // all good with this action invocation
-            success(activation, newCnt)
-        } else {
-            val nextActivation = if (!withinSeqLimit) {
-                // no error in the activation but the dynamic count of actions exceeds the threshold
-                // this is here as defensive code; the activation should not occur if its takes the
-                // count above its limit
-                val newResponse = ActivationResponse.applicationError(sequenceIsTooLong)
-                activation.copy(response = newResponse)
-            } else {
-                assert(errorField.isDefined)
-                activation
-            }
-
-            // there is an error field in the activation response. here, we treat this like success,
-            // in the sense of tallying up the accounting fields, but terminate the sequence early
-            success(nextActivation, newCnt, shortcircuit = true)
+  /** The previous activation was successful. */
+  private def success(activation: WhiskActivation, newCnt: Int, shortcircuit: Boolean = false) = {
+    previousResponse.set(null)
+    SequenceAccounting(
+      prev = this,
+      newCnt = newCnt,
+      shortcircuit = shortcircuit,
+      incrDuration = activation.duration,
+      newResponse = activation.response,
+      newActivationId = activation.activationId,
+      newMemoryLimit = activation.annotations.get("limits") map { limitsAnnotation => // we have a limits annotation
+        limitsAnnotation.asJsObject.getFields("memory") match {
+          case Seq(JsNumber(memory)) =>
+            Some(memory.toInt) // we have a numerical "memory" field in the "limits" annotation
         }
+      } getOrElse { None })
+  }
+
+  /** The previous activation failed (this is used when there is no activation record or an internal error. */
+  def fail(failureResponse: ActivationResponse, activationId: Option[ActivationId]) = {
+    require(!failureResponse.isSuccess)
+    logs.appendAll(activationId)
+    copy(previousResponse = new AtomicReference(failureResponse), shortcircuit = true)
+  }
+
+  /** Determines whether the previous activation succeeded or failed. */
+  def maybe(activation: WhiskActivation, newCnt: Int, maxSequenceCnt: Int) = {
+    // check conditions on payload that may lead to interrupting the execution of the sequence
+    //     short-circuit the execution of the sequence iff the payload contains an error field
+    //     and is the result of an action return, not the initial payload
+    val outputPayload = activation.response.result.map(_.asJsObject)
+    val payloadContent = outputPayload getOrElse JsObject.empty
+    val errorField = payloadContent.fields.get(ActivationResponse.ERROR_FIELD)
+    val withinSeqLimit = newCnt <= maxSequenceCnt
+
+    if (withinSeqLimit && errorField.isEmpty) {
+      // all good with this action invocation
+      success(activation, newCnt)
+    } else {
+      val nextActivation = if (!withinSeqLimit) {
+        // no error in the activation but the dynamic count of actions exceeds the threshold
+        // this is here as defensive code; the activation should not occur if its takes the
+        // count above its limit
+        val newResponse = ActivationResponse.applicationError(sequenceIsTooLong)
+        activation.copy(response = newResponse)
+      } else {
+        assert(errorField.isDefined)
+        activation
+      }
+
+      // there is an error field in the activation response. here, we treat this like success,
+      // in the sense of tallying up the accounting fields, but terminate the sequence early
+      success(nextActivation, newCnt, shortcircuit = true)
     }
+  }
 }
 
 /**
@@ -445,39 +469,38 @@ protected[actions] case class SequenceAccounting(
  */
 protected[actions] object SequenceAccounting {
 
-    def maxMemory(prevMemoryLimit: Option[Int], newMemoryLimit: Option[Int]): Option[Int] = {
-        (prevMemoryLimit ++ newMemoryLimit).reduceOption(Math.max)
-    }
+  def maxMemory(prevMemoryLimit: Option[Int], newMemoryLimit: Option[Int]): Option[Int] = {
+    (prevMemoryLimit ++ newMemoryLimit).reduceOption(Math.max)
+  }
 
-    // constructor for successful invocations, or error'ing ones (where shortcircuit = true)
-    def apply(
-        prev: SequenceAccounting,
-        newCnt: Int,
-        incrDuration: Option[Long],
-        newResponse: ActivationResponse,
-        newActivationId: ActivationId,
-        newMemoryLimit: Option[Int],
-        shortcircuit: Boolean): SequenceAccounting = {
+  // constructor for successful invocations, or error'ing ones (where shortcircuit = true)
+  def apply(prev: SequenceAccounting,
+            newCnt: Int,
+            incrDuration: Option[Long],
+            newResponse: ActivationResponse,
+            newActivationId: ActivationId,
+            newMemoryLimit: Option[Int],
+            shortcircuit: Boolean): SequenceAccounting = {
 
-        // compute the new max memory
-        val newMaxMemory = maxMemory(prev.maxMemory, newMemoryLimit)
+    // compute the new max memory
+    val newMaxMemory = maxMemory(prev.maxMemory, newMemoryLimit)
 
-        // append log entry
-        prev.logs += newActivationId
+    // append log entry
+    prev.logs += newActivationId
 
-        SequenceAccounting(
-            atomicActionCnt = newCnt,
-            previousResponse = new AtomicReference(newResponse),
-            logs = prev.logs,
-            duration = incrDuration map { prev.duration + _ } getOrElse { prev.duration },
-            maxMemory = newMaxMemory,
-            shortcircuit = shortcircuit)
-    }
+    SequenceAccounting(
+      atomicActionCnt = newCnt,
+      previousResponse = new AtomicReference(newResponse),
+      logs = prev.logs,
+      duration = incrDuration map { prev.duration + _ } getOrElse { prev.duration },
+      maxMemory = newMaxMemory,
+      shortcircuit = shortcircuit)
+  }
 
-    // constructor for initial payload
-    def apply(atomicActionCnt: Int, initialPayload: ActivationResponse): SequenceAccounting = {
-        SequenceAccounting(atomicActionCnt, new AtomicReference(initialPayload), mutable.Buffer.empty)
-    }
+  // constructor for initial payload
+  def apply(atomicActionCnt: Int, initialPayload: ActivationResponse): SequenceAccounting = {
+    SequenceAccounting(atomicActionCnt, new AtomicReference(initialPayload), mutable.Buffer.empty)
+  }
 }
 
 protected[actions] case class FailedSequenceActivation(accounting: SequenceAccounting) extends Throwable

--- a/core/controller/src/main/scala/whisk/core/entitlement/ActionCollection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/ActionCollection.scala
@@ -28,29 +28,33 @@ import whisk.core.entity.types.EntityStore
 
 class ActionCollection(entityStore: EntityStore) extends Collection(Collection.ACTIONS) {
 
-    protected override val allowedEntityRights = Privilege.ALL
+  protected override val allowedEntityRights = Privilege.ALL
 
-    /**
-     * Computes implicit rights on an action (sequence, in package, or primitive).
-     */
-    protected[core] override def implicitRights(user: Identity, namespaces: Set[String], right: Privilege, resource: Resource)(
-        implicit ep: EntitlementProvider, ec: ExecutionContext, transid: TransactionId) = {
-        val isOwner = namespaces.contains(resource.namespace.root.asString)
-        resource.entity map {
-            name =>
-                right match {
-                    // if action is in a package, check that the user is entitled to package [binding]
-                    case (Privilege.READ | Privilege.ACTIVATE) if !resource.namespace.defaultPackage =>
-                        val packageNamespace = resource.namespace.root.toPath
-                        val packageName = Some(resource.namespace.last.name)
-                        val packageResource = Resource(packageNamespace, Collection(Collection.PACKAGES), packageName)
-                        ep.check(user, Privilege.READ, packageResource) map { _ => true }
-                    case _ => Future.successful(isOwner && allowedEntityRights.contains(right))
-                }
-        } getOrElse {
-            // only a READ on the action collection is permitted if this is the owner of the collection
-            Future.successful(isOwner && right == Privilege.READ)
-        }
+  /**
+   * Computes implicit rights on an action (sequence, in package, or primitive).
+   */
+  protected[core] override def implicitRights(
+    user: Identity,
+    namespaces: Set[String],
+    right: Privilege,
+    resource: Resource)(implicit ep: EntitlementProvider, ec: ExecutionContext, transid: TransactionId) = {
+    val isOwner = namespaces.contains(resource.namespace.root.asString)
+    resource.entity map { name =>
+      right match {
+        // if action is in a package, check that the user is entitled to package [binding]
+        case (Privilege.READ | Privilege.ACTIVATE) if !resource.namespace.defaultPackage =>
+          val packageNamespace = resource.namespace.root.toPath
+          val packageName = Some(resource.namespace.last.name)
+          val packageResource = Resource(packageNamespace, Collection(Collection.PACKAGES), packageName)
+          ep.check(user, Privilege.READ, packageResource) map { _ =>
+            true
+          }
+        case _ => Future.successful(isOwner && allowedEntityRights.contains(right))
+      }
+    } getOrElse {
+      // only a READ on the action collection is permitted if this is the owner of the collection
+      Future.successful(isOwner && right == Privilege.READ)
     }
+  }
 
 }

--- a/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
@@ -32,26 +32,30 @@ import whisk.core.loadBalancer.LoadBalancer
  * @param defaultConcurrencyLimit the default max allowed concurrent operations
  * @param systemOverloadLimit the limit when the system is considered overloaded
  */
-class ActivationThrottler(loadBalancer: LoadBalancer, defaultConcurrencyLimit: Int, systemOverloadLimit: Int)(implicit logging: Logging) {
+class ActivationThrottler(loadBalancer: LoadBalancer, defaultConcurrencyLimit: Int, systemOverloadLimit: Int)(
+  implicit logging: Logging) {
 
-    logging.info(this, s"concurrencyLimit = $defaultConcurrencyLimit, systemOverloadLimit = $systemOverloadLimit")(TransactionId.controller)
+  logging.info(this, s"concurrencyLimit = $defaultConcurrencyLimit, systemOverloadLimit = $systemOverloadLimit")(
+    TransactionId.controller)
 
-    /**
-     * Checks whether the operation should be allowed to proceed.
-     */
-    def check(user: Identity)(implicit tid: TransactionId): Boolean = {
-        val concurrentActivations = loadBalancer.activeActivationsFor(user.uuid)
-        val concurrencyLimit = user.limits.concurrentInvocations.getOrElse(defaultConcurrencyLimit)
-        logging.info(this, s"namespace = ${user.uuid.asString}, concurrent activations = $concurrentActivations, below limit = $concurrencyLimit")
-        concurrentActivations < concurrencyLimit
-    }
+  /**
+   * Checks whether the operation should be allowed to proceed.
+   */
+  def check(user: Identity)(implicit tid: TransactionId): Boolean = {
+    val concurrentActivations = loadBalancer.activeActivationsFor(user.uuid)
+    val concurrencyLimit = user.limits.concurrentInvocations.getOrElse(defaultConcurrencyLimit)
+    logging.info(
+      this,
+      s"namespace = ${user.uuid.asString}, concurrent activations = $concurrentActivations, below limit = $concurrencyLimit")
+    concurrentActivations < concurrencyLimit
+  }
 
-    /**
-     * Checks whether the system is in a generally overloaded state.
-     */
-    def isOverloaded()(implicit tid: TransactionId): Boolean = {
-        val concurrentActivations = loadBalancer.totalActiveActivations
-        logging.info(this, s"concurrent activations in system = $concurrentActivations, below limit = $systemOverloadLimit")
-        concurrentActivations > systemOverloadLimit
-    }
+  /**
+   * Checks whether the system is in a generally overloaded state.
+   */
+  def isOverloaded()(implicit tid: TransactionId): Boolean = {
+    val concurrentActivations = loadBalancer.totalActiveActivations
+    logging.info(this, s"concurrent activations in system = $concurrentActivations, below limit = $systemOverloadLimit")
+    concurrentActivations > systemOverloadLimit
+  }
 }

--- a/core/controller/src/main/scala/whisk/core/entitlement/Collection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Collection.scala
@@ -47,95 +47,106 @@ import whisk.core.entity.types.EntityStore
  * @param activate the privilege for an activate (may be ACTIVATE or REJECT for example)
  * @param listLimit the default limit on number of entities returned from a collection on a list operation
  */
-protected[core] case class Collection protected (
-    val path: String,
-    val listLimit: Int = 30) {
-    override def toString = path
+protected[core] case class Collection protected (val path: String, val listLimit: Int = 30) {
+  override def toString = path
 
-    /** Determines the right to request for the resources and context. */
-    protected[core] def determineRight(op: HttpMethod, resource: Option[String])(
-        implicit transid: TransactionId): Privilege = {
-        op match {
-            case GET    => Privilege.READ
-            case PUT    => resource map { _ => Privilege.PUT } getOrElse Privilege.REJECT
-            case POST   => resource map { _ => activateAllowed } getOrElse Privilege.REJECT
-            case DELETE => resource map { _ => Privilege.DELETE } getOrElse Privilege.REJECT
-            case _      => Privilege.REJECT
-        }
+  /** Determines the right to request for the resources and context. */
+  protected[core] def determineRight(op: HttpMethod, resource: Option[String])(
+    implicit transid: TransactionId): Privilege = {
+    op match {
+      case GET => Privilege.READ
+      case PUT =>
+        resource map { _ =>
+          Privilege.PUT
+        } getOrElse Privilege.REJECT
+      case POST =>
+        resource map { _ =>
+          activateAllowed
+        } getOrElse Privilege.REJECT
+      case DELETE =>
+        resource map { _ =>
+          Privilege.DELETE
+        } getOrElse Privilege.REJECT
+      case _ => Privilege.REJECT
     }
+  }
 
-    protected val allowedCollectionRights = Set(Privilege.READ)
-    protected val allowedEntityRights = {
-        Set(Privilege.READ, Privilege.PUT, Privilege.ACTIVATE, Privilege.DELETE)
+  protected val allowedCollectionRights = Set(Privilege.READ)
+  protected val allowedEntityRights = {
+    Set(Privilege.READ, Privilege.PUT, Privilege.ACTIVATE, Privilege.DELETE)
+  }
+
+  private lazy val activateAllowed = {
+    if (allowedEntityRights.contains(Privilege.ACTIVATE)) {
+      Privilege.ACTIVATE
+    } else Privilege.REJECT
+  }
+
+  /**
+   * Infers implicit rights on a resource in the collection before checking explicit
+   * rights in the entitlement matrix. The subject has CRUD and activate rights
+   * to any resource in in any of their namespaces as long as the right (the implied operation)
+   * is permitted on the resource.
+   */
+  protected[core] def implicitRights(user: Identity, namespaces: Set[String], right: Privilege, resource: Resource)(
+    implicit ep: EntitlementProvider,
+    ec: ExecutionContext,
+    transid: TransactionId): Future[Boolean] = Future.successful {
+    // if the resource root namespace is in any of the allowed namespaces
+    // then this is an owner of the resource
+    val self = namespaces.contains(resource.namespace.root.asString)
+
+    resource.entity map { _ =>
+      self && allowedEntityRights.contains(right)
+    } getOrElse {
+      self && allowedCollectionRights.contains(right)
     }
-
-    private lazy val activateAllowed = {
-        if (allowedEntityRights.contains(Privilege.ACTIVATE)) {
-            Privilege.ACTIVATE
-        } else Privilege.REJECT
-    }
-
-    /**
-     * Infers implicit rights on a resource in the collection before checking explicit
-     * rights in the entitlement matrix. The subject has CRUD and activate rights
-     * to any resource in in any of their namespaces as long as the right (the implied operation)
-     * is permitted on the resource.
-     */
-    protected[core] def implicitRights(user: Identity, namespaces: Set[String], right: Privilege, resource: Resource)(
-        implicit ep: EntitlementProvider, ec: ExecutionContext, transid: TransactionId): Future[Boolean] = Future.successful {
-        // if the resource root namespace is in any of the allowed namespaces
-        // then this is an owner of the resource
-        val self = namespaces.contains(resource.namespace.root.asString)
-
-        resource.entity map {
-            _ => self && allowedEntityRights.contains(right)
-        } getOrElse {
-            self && allowedCollectionRights.contains(right)
-        }
-    }
+  }
 }
 
 /** An enumeration of known collections. */
 protected[core] object Collection {
 
-    protected[core] def requiredProperties = WhiskEntityStore.requiredProperties
+  protected[core] def requiredProperties = WhiskEntityStore.requiredProperties
 
-    protected[core] val ACTIONS = WhiskAction.collectionName
-    protected[core] val TRIGGERS = WhiskTrigger.collectionName
-    protected[core] val RULES = WhiskRule.collectionName
-    protected[core] val PACKAGES = WhiskPackage.collectionName
-    protected[core] val ACTIVATIONS = WhiskActivation.collectionName
-    protected[core] val NAMESPACES = "namespaces"
+  protected[core] val ACTIONS = WhiskAction.collectionName
+  protected[core] val TRIGGERS = WhiskTrigger.collectionName
+  protected[core] val RULES = WhiskRule.collectionName
+  protected[core] val PACKAGES = WhiskPackage.collectionName
+  protected[core] val ACTIVATIONS = WhiskActivation.collectionName
+  protected[core] val NAMESPACES = "namespaces"
 
-    private val collections = scala.collection.mutable.Map[String, Collection]()
-    private def register(c: Collection) = collections += c.path -> c
+  private val collections = scala.collection.mutable.Map[String, Collection]()
+  private def register(c: Collection) = collections += c.path -> c
 
-    protected[core] def apply(name: String) = collections.get(name).get
+  protected[core] def apply(name: String) = collections.get(name).get
 
-    protected[core] def initialize(entityStore: EntityStore)(implicit logging: Logging) = {
-        register(new ActionCollection(entityStore))
-        register(new Collection(TRIGGERS))
-        register(new Collection(RULES))
-        register(new PackageCollection(entityStore))
+  protected[core] def initialize(entityStore: EntityStore)(implicit logging: Logging) = {
+    register(new ActionCollection(entityStore))
+    register(new Collection(TRIGGERS))
+    register(new Collection(RULES))
+    register(new PackageCollection(entityStore))
 
-        register(new Collection(ACTIVATIONS) {
-            protected[core] override def determineRight(op: HttpMethod, resource: Option[String])(
-                implicit transid: TransactionId) = {
-                if (op == GET) Privilege.READ else Privilege.REJECT
-            }
+    register(new Collection(ACTIVATIONS) {
+      protected[core] override def determineRight(op: HttpMethod,
+                                                  resource: Option[String])(implicit transid: TransactionId) = {
+        if (op == GET) Privilege.READ else Privilege.REJECT
+      }
 
-            protected override val allowedEntityRights = Set(Privilege.READ)
-        })
+      protected override val allowedEntityRights = Set(Privilege.READ)
+    })
 
-        register(new Collection(NAMESPACES) {
-            protected[core] override def determineRight(op: HttpMethod, resource: Option[String])(
-                implicit transid: TransactionId) = {
-                resource map { _ => Privilege.REJECT } getOrElse {
-                    if (op == GET) Privilege.READ else Privilege.REJECT
-                }
-            }
+    register(new Collection(NAMESPACES) {
+      protected[core] override def determineRight(op: HttpMethod,
+                                                  resource: Option[String])(implicit transid: TransactionId) = {
+        resource map { _ =>
+          Privilege.REJECT
+        } getOrElse {
+          if (op == GET) Privilege.READ else Privilege.REJECT
+        }
+      }
 
-            protected override val allowedEntityRights = Set(Privilege.READ)
-        })
-    }
+      protected override val allowedEntityRights = Set(Privilege.READ)
+    })
+  }
 }

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -38,7 +38,7 @@ import whisk.core.loadBalancer.LoadBalancer
 import whisk.http.Messages._
 
 package object types {
-    type Entitlements = TrieMap[(Subject, String), Set[Privilege]]
+  type Entitlements = TrieMap[(Subject, String), Set[Privilege]]
 }
 
 /**
@@ -50,23 +50,22 @@ package object types {
  * @param entity an optional entity name that identifies a specific item in the collection
  * @param env an optional environment to bind to the resource during an activation
  */
-protected[core] case class Resource(
-    namespace: EntityPath,
-    collection: Collection,
-    entity: Option[String],
-    env: Option[Parameters] = None) {
-    def parent = collection.path + EntityPath.PATHSEP + namespace
-    def id = parent + (entity map { EntityPath.PATHSEP + _ } getOrElse (""))
-    override def toString = id
+protected[core] case class Resource(namespace: EntityPath,
+                                    collection: Collection,
+                                    entity: Option[String],
+                                    env: Option[Parameters] = None) {
+  def parent = collection.path + EntityPath.PATHSEP + namespace
+  def id = parent + (entity map { EntityPath.PATHSEP + _ } getOrElse (""))
+  override def toString = id
 }
 
 protected[core] object EntitlementProvider {
 
-    val requiredProperties = Map(
-        WhiskConfig.actionInvokePerMinuteLimit -> null,
-        WhiskConfig.actionInvokeConcurrentLimit -> null,
-        WhiskConfig.triggerFirePerMinuteLimit -> null,
-        WhiskConfig.actionInvokeSystemOverloadLimit -> null)
+  val requiredProperties = Map(
+    WhiskConfig.actionInvokePerMinuteLimit -> null,
+    WhiskConfig.actionInvokeConcurrentLimit -> null,
+    WhiskConfig.triggerFirePerMinuteLimit -> null,
+    WhiskConfig.actionInvokeSystemOverloadLimit -> null)
 }
 
 /**
@@ -74,217 +73,229 @@ protected[core] object EntitlementProvider {
  * This is where enforcement of activation quotas takes place, in additional to basic authorization.
  */
 protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBalancer: LoadBalancer)(
-    implicit actorSystem: ActorSystem, logging: Logging) {
+  implicit actorSystem: ActorSystem,
+  logging: Logging) {
 
-    private implicit val executionContext = actorSystem.dispatcher
+  private implicit val executionContext = actorSystem.dispatcher
 
-    private val invokeRateThrottler = new RateThrottler("actions per minute", config.actionInvokePerMinuteLimit.toInt, _.limits.invocationsPerMinute)
-    private val triggerRateThrottler = new RateThrottler("triggers per minute", config.triggerFirePerMinuteLimit.toInt, _.limits.firesPerMinute)
-    private val concurrentInvokeThrottler = new ActivationThrottler(loadBalancer, config.actionInvokeConcurrentLimit.toInt, config.actionInvokeSystemOverloadLimit.toInt)
+  private val invokeRateThrottler =
+    new RateThrottler("actions per minute", config.actionInvokePerMinuteLimit.toInt, _.limits.invocationsPerMinute)
+  private val triggerRateThrottler =
+    new RateThrottler("triggers per minute", config.triggerFirePerMinuteLimit.toInt, _.limits.firesPerMinute)
+  private val concurrentInvokeThrottler = new ActivationThrottler(
+    loadBalancer,
+    config.actionInvokeConcurrentLimit.toInt,
+    config.actionInvokeSystemOverloadLimit.toInt)
 
-    /**
-     * Grants a subject the right to access a resources.
-     *
-     * @param subject the subject to grant right to
-     * @param right the privilege to grant the subject
-     * @param resource the resource to grant the subject access to
-     * @return a promise that completes with true iff the subject is granted the right to access the requested resource
-     */
-    protected[core] def grant(subject: Subject, right: Privilege, resource: Resource)(implicit transid: TransactionId): Future[Boolean]
+  /**
+   * Grants a subject the right to access a resources.
+   *
+   * @param subject the subject to grant right to
+   * @param right the privilege to grant the subject
+   * @param resource the resource to grant the subject access to
+   * @return a promise that completes with true iff the subject is granted the right to access the requested resource
+   */
+  protected[core] def grant(subject: Subject, right: Privilege, resource: Resource)(
+    implicit transid: TransactionId): Future[Boolean]
 
-    /**
-     * Revokes a subject the right to access a resources.
-     *
-     * @param subject the subject to revoke right to
-     * @param right the privilege to revoke the subject
-     * @param resource the resource to revoke the subject access to
-     * @return a promise that completes with true iff the subject is revoked the right to access the requested resource
-     */
-    protected[core] def revoke(subject: Subject, right: Privilege, resource: Resource)(implicit transid: TransactionId): Future[Boolean]
+  /**
+   * Revokes a subject the right to access a resources.
+   *
+   * @param subject the subject to revoke right to
+   * @param right the privilege to revoke the subject
+   * @param resource the resource to revoke the subject access to
+   * @return a promise that completes with true iff the subject is revoked the right to access the requested resource
+   */
+  protected[core] def revoke(subject: Subject, right: Privilege, resource: Resource)(
+    implicit transid: TransactionId): Future[Boolean]
 
-    /**
-     * Checks if a subject is entitled to a resource because it was granted the right explicitly.
-     *
-     * @param subject the subject to check rights for
-     * @param right the privilege the subject is requesting
-     * @param resource the resource the subject requests access to
-     * @return a promise that completes with true iff the subject is permitted to access the request resource
-     */
-    protected def entitled(subject: Subject, right: Privilege, resource: Resource)(implicit transid: TransactionId): Future[Boolean]
+  /**
+   * Checks if a subject is entitled to a resource because it was granted the right explicitly.
+   *
+   * @param subject the subject to check rights for
+   * @param right the privilege the subject is requesting
+   * @param resource the resource the subject requests access to
+   * @return a promise that completes with true iff the subject is permitted to access the request resource
+   */
+  protected def entitled(subject: Subject, right: Privilege, resource: Resource)(
+    implicit transid: TransactionId): Future[Boolean]
 
-    /**
-     * Checks action activation rate throttles for an identity.
-     *
-     * @param user the identity to check rate throttles for
-     * @return a promise that completes with success iff the user is within their activation quota
-     */
-    protected[core] def checkThrottles(user: Identity)(
-        implicit transid: TransactionId): Future[Unit] = {
+  /**
+   * Checks action activation rate throttles for an identity.
+   *
+   * @param user the identity to check rate throttles for
+   * @return a promise that completes with success iff the user is within their activation quota
+   */
+  protected[core] def checkThrottles(user: Identity)(implicit transid: TransactionId): Future[Unit] = {
 
-        logging.info(this, s"checking user '${user.subject}' has not exceeded activation quota")
+    logging.info(this, s"checking user '${user.subject}' has not exceeded activation quota")
 
-        checkSystemOverload(ACTIVATE) orElse {
-            checkThrottleOverload(!invokeRateThrottler.check(user), tooManyRequests)
+    checkSystemOverload(ACTIVATE) orElse {
+      checkThrottleOverload(!invokeRateThrottler.check(user), tooManyRequests)
+    } orElse {
+      checkThrottleOverload(!concurrentInvokeThrottler.check(user), tooManyConcurrentRequests)
+    } map {
+      Future.failed(_)
+    } getOrElse Future.successful({})
+  }
+
+  /**
+   * Checks if a subject has the right to access a specific resource. The entitlement may be implicit,
+   * that is, inferred based on namespaces that a subject belongs to and the namespace of the
+   * resource for example, or explicit. The implicit check is computed here. The explicit check
+   * is delegated to the service implementing this interface.
+   *
+   * NOTE: do not use this method to check a package binding because this method does not allow
+   * for a continuation to check that both the binding and the references package are both either
+   * implicitly or explicitly granted. Instead, resolve the package binding first and use the alternate
+   * method which authorizes a set of resources.
+   *
+   * @param user the subject to check rights for
+   * @param right the privilege the subject is requesting (applies to the entire set of resources)
+   * @param resource the resource the subject requests access to
+   * @return a promise that completes with success iff the subject is permitted to access the requested resource
+   */
+  protected[core] def check(user: Identity, right: Privilege, resource: Resource)(
+    implicit transid: TransactionId): Future[Unit] = check(user, right, Set(resource))
+
+  /**
+   * Checks if a subject has the right to access a set of resources. The entitlement may be implicit,
+   * that is, inferred based on namespaces that a subject belongs to and the namespace of the
+   * resource for example, or explicit. The implicit check is computed here. The explicit check
+   * is delegated to the service implementing this interface.
+   *
+   * @param user the subject identity to check rights for
+   * @param right the privilege the subject is requesting (applies to the entire set of resources)
+   * @param resources the set of resources the subject requests access to
+   * @return a promise that completes with success iff the subject is permitted to access all of the requested resources
+   */
+  protected[core] def check(user: Identity, right: Privilege, resources: Set[Resource])(
+    implicit transid: TransactionId): Future[Unit] = {
+    val subject = user.subject
+
+    val entitlementCheck: Future[Boolean] = if (user.rights.contains(right)) {
+      if (resources.nonEmpty) {
+        logging.info(this, s"checking user '$subject' has privilege '$right' for '${resources.mkString(",")}'")
+        checkSystemOverload(right) orElse {
+          checkUserThrottle(user, right, resources)
         } orElse {
-            checkThrottleOverload(!concurrentInvokeThrottler.check(user), tooManyConcurrentRequests)
+          checkConcurrentUserThrottle(user, right, resources)
         } map {
-            Future.failed(_)
-        } getOrElse Future.successful({})
+          Future.failed(_)
+        } getOrElse checkPrivilege(user, right, resources)
+      } else Future.successful(true)
+    } else if (right != REJECT) {
+      logging.info(
+        this,
+        s"supplied authkey for user '$subject' does not have privilege '$right' for '${resources.mkString(",")}'")
+      Future.failed(RejectRequest(Forbidden))
+    } else {
+      Future.successful(false)
     }
 
-    /**
-     * Checks if a subject has the right to access a specific resource. The entitlement may be implicit,
-     * that is, inferred based on namespaces that a subject belongs to and the namespace of the
-     * resource for example, or explicit. The implicit check is computed here. The explicit check
-     * is delegated to the service implementing this interface.
-     *
-     * NOTE: do not use this method to check a package binding because this method does not allow
-     * for a continuation to check that both the binding and the references package are both either
-     * implicitly or explicitly granted. Instead, resolve the package binding first and use the alternate
-     * method which authorizes a set of resources.
-     *
-     * @param user the subject to check rights for
-     * @param right the privilege the subject is requesting (applies to the entire set of resources)
-     * @param resource the resource the subject requests access to
-     * @return a promise that completes with success iff the subject is permitted to access the requested resource
-     */
-    protected[core] def check(user: Identity, right: Privilege, resource: Resource)(
-        implicit transid: TransactionId): Future[Unit] = check(user, right, Set(resource))
+    entitlementCheck andThen {
+      case Success(r) if resources.nonEmpty =>
+        logging.info(this, if (r) "authorized" else "not authorized")
+      case Failure(r: RejectRequest) =>
+        logging.info(this, s"not authorized: $r")
+      case Failure(t) =>
+        logging.error(this, s"failed while checking entitlement: ${t.getMessage}")
+    } flatMap { isAuthorized =>
+      if (isAuthorized) Future.successful({})
+      else Future.failed(RejectRequest(Forbidden))
+    }
+  }
 
-    /**
-     * Checks if a subject has the right to access a set of resources. The entitlement may be implicit,
-     * that is, inferred based on namespaces that a subject belongs to and the namespace of the
-     * resource for example, or explicit. The implicit check is computed here. The explicit check
-     * is delegated to the service implementing this interface.
-     *
-     * @param user the subject identity to check rights for
-     * @param right the privilege the subject is requesting (applies to the entire set of resources)
-     * @param resources the set of resources the subject requests access to
-     * @return a promise that completes with success iff the subject is permitted to access all of the requested resources
-     */
-    protected[core] def check(user: Identity, right: Privilege, resources: Set[Resource])(
-        implicit transid: TransactionId): Future[Unit] = {
-        val subject = user.subject
+  /**
+   * NOTE: explicit grants do not work with package bindings because this method does not allow
+   * for a continuation to check that both the binding and the references package are both either
+   * implicitly or explicitly granted. Instead, the given resource set should include both the binding
+   * and the referenced package.
+   */
+  protected def checkPrivilege(user: Identity, right: Privilege, resources: Set[Resource])(
+    implicit transid: TransactionId): Future[Boolean] = {
+    // check the default namespace first, bypassing additional checks if permitted
+    val defaultNamespaces = Set(user.namespace.asString)
+    implicit val es = this
 
-        val entitlementCheck: Future[Boolean] = if (user.rights.contains(right)) {
-            if (resources.nonEmpty) {
-                logging.info(this, s"checking user '$subject' has privilege '$right' for '${resources.mkString(",")}'")
-                checkSystemOverload(right) orElse {
-                    checkUserThrottle(user, right, resources)
-                } orElse {
-                    checkConcurrentUserThrottle(user, right, resources)
-                } map {
-                    Future.failed(_)
-                } getOrElse checkPrivilege(user, right, resources)
-            } else Future.successful(true)
-        } else if (right != REJECT) {
-            logging.info(this, s"supplied authkey for user '$subject' does not have privilege '$right' for '${resources.mkString(",")}'")
-            Future.failed(RejectRequest(Forbidden))
-        } else {
-            Future.successful(false)
+    Future
+      .sequence {
+        resources.map { resource =>
+          resource.collection.implicitRights(user, defaultNamespaces, right, resource) flatMap {
+            case true => Future.successful(true)
+            case false =>
+              logging.info(this, "checking explicit grants")
+              entitled(user.subject, right, resource)
+          }
         }
+      }
+      .map { _.forall(identity) }
+  }
 
-        entitlementCheck andThen {
-            case Success(r) if resources.nonEmpty =>
-                logging.info(this, if (r) "authorized" else "not authorized")
-            case Failure(r: RejectRequest) =>
-                logging.info(this, s"not authorized: $r")
-            case Failure(t) =>
-                logging.error(this, s"failed while checking entitlement: ${t.getMessage}")
-        } flatMap { isAuthorized =>
-            if (isAuthorized) Future.successful({})
-            else Future.failed(RejectRequest(Forbidden))
-        }
+  /**
+   * Limits activations if the system is overloaded.
+   *
+   * @param right the privilege, if ACTIVATE then check quota else return None
+   * @return None if system is not overloaded else a rejection
+   */
+  protected def checkSystemOverload(right: Privilege)(implicit transid: TransactionId): Option[RejectRequest] = {
+    val systemOverload = right == ACTIVATE && concurrentInvokeThrottler.isOverloaded
+    if (systemOverload) {
+      logging.error(this, "system is overloaded")
+      Some(RejectRequest(TooManyRequests, systemOverloaded))
+    } else None
+  }
+
+  /**
+   * Limits activations if subject exceeds their own limits.
+   * If the requested right is an activation, the set of resources must contain an activation of an action or filter to be throttled.
+   * While it is possible for the set of resources to contain more than one action or trigger, the plurality is ignored and treated
+   * as one activation since these should originate from a single macro resources (e.g., a sequence).
+   *
+   * @param user the subject identity to check rights for
+   * @param right the privilege, if ACTIVATE then check quota else return None
+   * @param resource the set of resources must contain at least one resource that can be activated else return None
+   * @return None if subject is not throttled else a rejection
+   */
+  private def checkUserThrottle(user: Identity, right: Privilege, resources: Set[Resource])(
+    implicit transid: TransactionId): Option[RejectRequest] = {
+    def userThrottled = {
+      val isInvocation = resources.exists(_.collection.path == Collection.ACTIONS)
+      val isTrigger = resources.exists(_.collection.path == Collection.TRIGGERS)
+      (isInvocation && !invokeRateThrottler.check(user)) || (isTrigger && !triggerRateThrottler.check(user))
     }
 
-    /**
-     * NOTE: explicit grants do not work with package bindings because this method does not allow
-     * for a continuation to check that both the binding and the references package are both either
-     * implicitly or explicitly granted. Instead, the given resource set should include both the binding
-     * and the referenced package.
-     */
-    protected def checkPrivilege(user: Identity, right: Privilege, resources: Set[Resource])(
-        implicit transid: TransactionId): Future[Boolean] = {
-        // check the default namespace first, bypassing additional checks if permitted
-        val defaultNamespaces = Set(user.namespace.asString)
-        implicit val es = this
+    checkThrottleOverload(right == ACTIVATE && userThrottled, tooManyRequests)
+  }
 
-        Future.sequence {
-            resources.map { resource =>
-                resource.collection.implicitRights(user, defaultNamespaces, right, resource) flatMap {
-                    case true => Future.successful(true)
-                    case false =>
-                        logging.info(this, "checking explicit grants")
-                        entitled(user.subject, right, resource)
-                }
-            }
-        }.map { _.forall(identity) }
+  /**
+   * Limits activations if subject exceeds limit of concurrent invocations.
+   * If the requested right is an activation, the set of resources must contain an activation of an action to be throttled.
+   * While it is possible for the set of resources to contain more than one action, the plurality is ignored and treated
+   * as one activation since these should originate from a single macro resources (e.g., a sequence).
+   *
+   * @param user the subject identity to check rights for
+   * @param right the privilege, if ACTIVATE then check quota else return None
+   * @param resource the set of resources must contain at least one resource that can be activated else return None
+   * @return None if subject is not throttled else a rejection
+   */
+  private def checkConcurrentUserThrottle(user: Identity, right: Privilege, resources: Set[Resource])(
+    implicit transid: TransactionId): Option[RejectRequest] = {
+    def userThrottled = {
+      val isInvocation = resources.exists(_.collection.path == Collection.ACTIONS)
+      (isInvocation && !concurrentInvokeThrottler.check(user))
     }
 
-    /**
-     * Limits activations if the system is overloaded.
-     *
-     * @param right the privilege, if ACTIVATE then check quota else return None
-     * @return None if system is not overloaded else a rejection
-     */
-    protected def checkSystemOverload(right: Privilege)(implicit transid: TransactionId): Option[RejectRequest] = {
-        val systemOverload = right == ACTIVATE && concurrentInvokeThrottler.isOverloaded
-        if (systemOverload) {
-            logging.error(this, "system is overloaded")
-            Some(RejectRequest(TooManyRequests, systemOverloaded))
-        } else None
-    }
+    checkThrottleOverload(right == ACTIVATE && userThrottled, tooManyConcurrentRequests)
+  }
 
-    /**
-     * Limits activations if subject exceeds their own limits.
-     * If the requested right is an activation, the set of resources must contain an activation of an action or filter to be throttled.
-     * While it is possible for the set of resources to contain more than one action or trigger, the plurality is ignored and treated
-     * as one activation since these should originate from a single macro resources (e.g., a sequence).
-     *
-     * @param user the subject identity to check rights for
-     * @param right the privilege, if ACTIVATE then check quota else return None
-     * @param resource the set of resources must contain at least one resource that can be activated else return None
-     * @return None if subject is not throttled else a rejection
-     */
-    private def checkUserThrottle(user: Identity, right: Privilege, resources: Set[Resource])(
-        implicit transid: TransactionId): Option[RejectRequest] = {
-        def userThrottled = {
-            val isInvocation = resources.exists(_.collection.path == Collection.ACTIONS)
-            val isTrigger = resources.exists(_.collection.path == Collection.TRIGGERS)
-            (isInvocation && !invokeRateThrottler.check(user)) || (isTrigger && !triggerRateThrottler.check(user))
-        }
-
-        checkThrottleOverload(right == ACTIVATE && userThrottled, tooManyRequests)
-    }
-
-    /**
-     * Limits activations if subject exceeds limit of concurrent invocations.
-     * If the requested right is an activation, the set of resources must contain an activation of an action to be throttled.
-     * While it is possible for the set of resources to contain more than one action, the plurality is ignored and treated
-     * as one activation since these should originate from a single macro resources (e.g., a sequence).
-     *
-     * @param user the subject identity to check rights for
-     * @param right the privilege, if ACTIVATE then check quota else return None
-     * @param resource the set of resources must contain at least one resource that can be activated else return None
-     * @return None if subject is not throttled else a rejection
-     */
-    private def checkConcurrentUserThrottle(user: Identity, right: Privilege, resources: Set[Resource])(
-        implicit transid: TransactionId): Option[RejectRequest] = {
-        def userThrottled = {
-            val isInvocation = resources.exists(_.collection.path == Collection.ACTIONS)
-            (isInvocation && !concurrentInvokeThrottler.check(user))
-        }
-
-        checkThrottleOverload(right == ACTIVATE && userThrottled, tooManyConcurrentRequests)
-    }
-
-    /** Helper. */
-    private def checkThrottleOverload(hasTooMany: Boolean, message: String)(
-        implicit transid: TransactionId): Option[RejectRequest] = {
-        if (hasTooMany) {
-            Some(RejectRequest(TooManyRequests, message))
-        } else None
-    }
+  /** Helper. */
+  private def checkThrottleOverload(hasTooMany: Boolean, message: String)(
+    implicit transid: TransactionId): Option[RejectRequest] = {
+    if (hasTooMany) {
+      Some(RejectRequest(TooManyRequests, message))
+    } else None
+  }
 }
 
 /**
@@ -293,32 +304,36 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
  */
 trait ReferencedEntities {
 
-    /**
-     * Gathers referenced resources for types knows to refer to others.
-     * This is usually done on a PUT request, hence the types are not one of the
-     * canonical datastore types. Hence this method accepts Any reference but is
-     * only defined for WhiskPackagePut, WhiskRulePut, and SequenceExec.
-     *
-     * It is plausible to lift these disambiguation below to a new trait which is
-     * implemented by these types - however this will require exposing the Resource
-     * type outside of the controller which is not yet desirable (although this could
-     * cause further consolidation of the WhiskEntity and Resource types).
-     *
-     * @return Set of Resource instances if there are referenced entities.
-     */
-    def referencedEntities(reference: Any): Set[Resource] = {
-        reference match {
-            case WhiskPackagePut(Some(binding), _, _, _, _) =>
-                Set(Resource(binding.namespace.toPath, Collection(Collection.PACKAGES), Some(binding.name.asString)))
-            case r: WhiskRulePut =>
-                val triggerResource = r.trigger.map { t => Resource(t.path, Collection(Collection.TRIGGERS), Some(t.name.asString)) }
-                val actionResource = r.action map { a => Resource(a.path, Collection(Collection.ACTIONS), Some(a.name.asString)) }
-                Set(triggerResource, actionResource).flatten
-            case e: SequenceExec =>
-                e.components.map {
-                    c => Resource(c.path, Collection(Collection.ACTIONS), Some(c.name.asString))
-                }.toSet
-            case _ => Set()
+  /**
+   * Gathers referenced resources for types knows to refer to others.
+   * This is usually done on a PUT request, hence the types are not one of the
+   * canonical datastore types. Hence this method accepts Any reference but is
+   * only defined for WhiskPackagePut, WhiskRulePut, and SequenceExec.
+   *
+   * It is plausible to lift these disambiguation below to a new trait which is
+   * implemented by these types - however this will require exposing the Resource
+   * type outside of the controller which is not yet desirable (although this could
+   * cause further consolidation of the WhiskEntity and Resource types).
+   *
+   * @return Set of Resource instances if there are referenced entities.
+   */
+  def referencedEntities(reference: Any): Set[Resource] = {
+    reference match {
+      case WhiskPackagePut(Some(binding), _, _, _, _) =>
+        Set(Resource(binding.namespace.toPath, Collection(Collection.PACKAGES), Some(binding.name.asString)))
+      case r: WhiskRulePut =>
+        val triggerResource = r.trigger.map { t =>
+          Resource(t.path, Collection(Collection.TRIGGERS), Some(t.name.asString))
         }
+        val actionResource = r.action map { a =>
+          Resource(a.path, Collection(Collection.ACTIONS), Some(a.name.asString))
+        }
+        Set(triggerResource, actionResource).flatten
+      case e: SequenceExec =>
+        e.components.map { c =>
+          Resource(c.path, Collection(Collection.ACTIONS), Some(c.name.asString))
+        }.toSet
+      case _ => Set()
     }
+  }
 }

--- a/core/controller/src/main/scala/whisk/core/entitlement/LocalEntitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/LocalEntitlement.scala
@@ -30,45 +30,47 @@ import whisk.core.entity.Subject
 import whisk.core.loadBalancer.LoadBalancer
 
 private object LocalEntitlementProvider {
-    /** Poor mans entitlement matrix. Must persist to datastore eventually. */
-    private val matrix = TrieMap[(Subject, String), Set[Privilege]]()
+
+  /** Poor mans entitlement matrix. Must persist to datastore eventually. */
+  private val matrix = TrieMap[(Subject, String), Set[Privilege]]()
 }
 
-protected[core] class LocalEntitlementProvider(
-    private val config: WhiskConfig,
-    private val loadBalancer: LoadBalancer)(
-        implicit actorSystem: ActorSystem,
-        logging: Logging)
+protected[core] class LocalEntitlementProvider(private val config: WhiskConfig, private val loadBalancer: LoadBalancer)(
+  implicit actorSystem: ActorSystem,
+  logging: Logging)
     extends EntitlementProvider(config, loadBalancer) {
 
-    private implicit val executionContext = actorSystem.dispatcher
+  private implicit val executionContext = actorSystem.dispatcher
 
-    private val matrix = LocalEntitlementProvider.matrix
+  private val matrix = LocalEntitlementProvider.matrix
 
-    /** Grants subject right to resource by adding them to the entitlement matrix. */
-    protected[core] override def grant(subject: Subject, right: Privilege, resource: Resource)(implicit transid: TransactionId) = Future {
-        synchronized {
-            val key = (subject, resource.id)
-            matrix.put(key, matrix.get(key) map { _ + right } getOrElse Set(right))
-            logging.info(this, s"granted user '$subject' privilege '$right' for '$resource'")
-            true
-        }
+  /** Grants subject right to resource by adding them to the entitlement matrix. */
+  protected[core] override def grant(subject: Subject, right: Privilege, resource: Resource)(
+    implicit transid: TransactionId) = Future {
+    synchronized {
+      val key = (subject, resource.id)
+      matrix.put(key, matrix.get(key) map { _ + right } getOrElse Set(right))
+      logging.info(this, s"granted user '$subject' privilege '$right' for '$resource'")
+      true
     }
+  }
 
-    /** Revokes subject right to resource by removing them from the entitlement matrix. */
-    protected[core] override def revoke(subject: Subject, right: Privilege, resource: Resource)(implicit transid: TransactionId) = Future {
-        synchronized {
-            val key = (subject, resource.id)
-            val newrights = matrix.get(key) map { _ - right } map { matrix.put(key, _) }
-            logging.info(this, s"revoked user '$subject' privilege '$right' for '$resource'")
-            true
-        }
+  /** Revokes subject right to resource by removing them from the entitlement matrix. */
+  protected[core] override def revoke(subject: Subject, right: Privilege, resource: Resource)(
+    implicit transid: TransactionId) = Future {
+    synchronized {
+      val key = (subject, resource.id)
+      val newrights = matrix.get(key) map { _ - right } map { matrix.put(key, _) }
+      logging.info(this, s"revoked user '$subject' privilege '$right' for '$resource'")
+      true
     }
+  }
 
-    /** Checks if subject has explicit grant for a resource. */
-    protected override def entitled(subject: Subject, right: Privilege, resource: Resource)(implicit transid: TransactionId) = Future.successful {
-        lazy val one = matrix.get((subject, resource.id)) map { _ contains right } getOrElse false
-        lazy val any = matrix.get((subject, resource.parent)) map { _ contains right } getOrElse false
-        one || any
-    }
+  /** Checks if subject has explicit grant for a resource. */
+  protected override def entitled(subject: Subject, right: Privilege, resource: Resource)(
+    implicit transid: TransactionId) = Future.successful {
+    lazy val one = matrix.get((subject, resource.id)) map { _ contains right } getOrElse false
+    lazy val any = matrix.get((subject, resource.parent)) map { _ contains right } getOrElse false
+    one || any
+  }
 }

--- a/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
@@ -34,101 +34,105 @@ import whisk.http.Messages
 
 class PackageCollection(entityStore: EntityStore)(implicit logging: Logging) extends Collection(Collection.PACKAGES) {
 
-    protected override val allowedEntityRights = {
-        Set(Privilege.READ, Privilege.PUT, Privilege.DELETE)
-    }
+  protected override val allowedEntityRights = {
+    Set(Privilege.READ, Privilege.PUT, Privilege.DELETE)
+  }
 
-    /**
-     * Computes implicit rights on a package/binding.
-     *
-     * Must fetch the resource (a package or binding) to determine if it is in allowed namespaces.
-     * There are two cases:
-     *
-     * 1. the resource is a package: then either it is in allowed namespaces or it is public.
-     * 2. the resource is a binding: then it must be in allowed namespaces and (1) must hold for
-     *    the referenced package.
-     *
-     * A published package makes all its assets public regardless of their shared bit.
-     * All assets that are not in an explicit package are private because the default package is private.
-     */
-    protected[core] override def implicitRights(user: Identity, namespaces: Set[String], right: Privilege, resource: Resource)(
-        implicit ep: EntitlementProvider, ec: ExecutionContext, transid: TransactionId): Future[Boolean] = {
-        resource.entity map {
-            pkgname =>
-                val isOwner = namespaces.contains(resource.namespace.root.asString)
-                right match {
-                    case Privilege.READ =>
-                        // must determine if this is a public or owned package
-                        // or, for a binding, that it references a public or owned package
-                        val docid = FullyQualifiedEntityName(resource.namespace.root.toPath, EntityName(pkgname)).toDocId
-                        checkPackageReadPermission(namespaces, isOwner, docid)
-                    case _ => Future.successful(isOwner && allowedEntityRights.contains(right))
-                }
-        } getOrElse {
-            // only a READ on the package collection is permitted;
-            // NOTE: currently, the implementation allows any subject to
-            // list packages in any namespace, and defers the filtering of
-            // public packages to non-owning subjects to the API handlers
-            // for packages
-            Future.successful(right == Privilege.READ)
+  /**
+   * Computes implicit rights on a package/binding.
+   *
+   * Must fetch the resource (a package or binding) to determine if it is in allowed namespaces.
+   * There are two cases:
+   *
+   * 1. the resource is a package: then either it is in allowed namespaces or it is public.
+   * 2. the resource is a binding: then it must be in allowed namespaces and (1) must hold for
+   *    the referenced package.
+   *
+   * A published package makes all its assets public regardless of their shared bit.
+   * All assets that are not in an explicit package are private because the default package is private.
+   */
+  protected[core] override def implicitRights(user: Identity,
+                                              namespaces: Set[String],
+                                              right: Privilege,
+                                              resource: Resource)(implicit ep: EntitlementProvider,
+                                                                  ec: ExecutionContext,
+                                                                  transid: TransactionId): Future[Boolean] = {
+    resource.entity map { pkgname =>
+      val isOwner = namespaces.contains(resource.namespace.root.asString)
+      right match {
+        case Privilege.READ =>
+          // must determine if this is a public or owned package
+          // or, for a binding, that it references a public or owned package
+          val docid = FullyQualifiedEntityName(resource.namespace.root.toPath, EntityName(pkgname)).toDocId
+          checkPackageReadPermission(namespaces, isOwner, docid)
+        case _ => Future.successful(isOwner && allowedEntityRights.contains(right))
+      }
+    } getOrElse {
+      // only a READ on the package collection is permitted;
+      // NOTE: currently, the implementation allows any subject to
+      // list packages in any namespace, and defers the filtering of
+      // public packages to non-owning subjects to the API handlers
+      // for packages
+      Future.successful(right == Privilege.READ)
+    }
+  }
+
+  /**
+   * @param namespaces the set of namespaces the subject is entitled to
+   * @param isOwner indicates if the resource is owned by the subject requesting authorization
+   * @param docid the package (or binding) document id
+   */
+  private def checkPackageReadPermission(namespaces: Set[String], isOwner: Boolean, doc: DocId)(
+    implicit ec: ExecutionContext,
+    transid: TransactionId): Future[Boolean] = {
+
+    val right = Privilege.READ
+
+    WhiskPackage.get(entityStore, doc) flatMap {
+      case wp if wp.binding.isEmpty =>
+        val allowed = wp.publish || isOwner
+        logging.info(this, s"entitlement check on package, '$right' allowed?: $allowed")
+        Future.successful(allowed)
+      case wp =>
+        if (isOwner) {
+          val binding = wp.binding.get
+          val pkgOwner = namespaces.contains(binding.namespace.asString)
+          val pkgDocid = binding.docid
+          logging.info(this, s"checking subject has privilege '$right' for bound package '$pkgDocid'")
+          checkPackageReadPermission(namespaces, pkgOwner, pkgDocid)
+        } else {
+          logging.info(this, s"entitlement check on package binding, '$right' allowed?: false")
+          Future.successful(false)
+        }
+    } recoverWith {
+      case t: NoDocumentException =>
+        logging.info(this, s"the package does not exist (owner? $isOwner)")
+        // if owner, reject with not found, otherwise fail the future to reject with
+        // unauthorized (this prevents information leaks about packages in other namespaces)
+        if (isOwner) {
+          Future.failed(RejectRequest(NotFound))
+        } else {
+          Future.successful(false)
+        }
+      case t: DocumentTypeMismatchException =>
+        logging.info(this, s"the requested binding is not a package (owner? $isOwner)")
+        // if owner, reject with not found, otherwise fail the future to reject with
+        // unauthorized (this prevents information leaks about packages in other namespaces)
+        if (isOwner) {
+          Future.failed(RejectRequest(Conflict, Messages.conformanceMessage))
+        } else {
+          Future.successful(false)
+        }
+      case t: RejectRequest =>
+        logging.error(this, s"entitlement check on package failed: $t")
+        Future.failed(t)
+      case t =>
+        logging.error(this, s"entitlement check on package failed: ${t.getMessage}")
+        if (isOwner) {
+          Future.failed(RejectRequest(InternalServerError, Messages.corruptedEntity))
+        } else {
+          Future.successful(false)
         }
     }
-
-    /**
-     * @param namespaces the set of namespaces the subject is entitled to
-     * @param isOwner indicates if the resource is owned by the subject requesting authorization
-     * @param docid the package (or binding) document id
-     */
-    private def checkPackageReadPermission(namespaces: Set[String], isOwner: Boolean, doc: DocId)(
-        implicit ec: ExecutionContext, transid: TransactionId): Future[Boolean] = {
-
-        val right = Privilege.READ
-
-        WhiskPackage.get(entityStore, doc) flatMap {
-            case wp if wp.binding.isEmpty =>
-                val allowed = wp.publish || isOwner
-                logging.info(this, s"entitlement check on package, '$right' allowed?: $allowed")
-                Future.successful(allowed)
-            case wp =>
-                if (isOwner) {
-                    val binding = wp.binding.get
-                    val pkgOwner = namespaces.contains(binding.namespace.asString)
-                    val pkgDocid = binding.docid
-                    logging.info(this, s"checking subject has privilege '$right' for bound package '$pkgDocid'")
-                    checkPackageReadPermission(namespaces, pkgOwner, pkgDocid)
-                } else {
-                    logging.info(this, s"entitlement check on package binding, '$right' allowed?: false")
-                    Future.successful(false)
-                }
-        } recoverWith {
-            case t: NoDocumentException =>
-                logging.info(this, s"the package does not exist (owner? $isOwner)")
-                // if owner, reject with not found, otherwise fail the future to reject with
-                // unauthorized (this prevents information leaks about packages in other namespaces)
-                if (isOwner) {
-                    Future.failed(RejectRequest(NotFound))
-                } else {
-                    Future.successful(false)
-                }
-            case t: DocumentTypeMismatchException =>
-                logging.info(this, s"the requested binding is not a package (owner? $isOwner)")
-                // if owner, reject with not found, otherwise fail the future to reject with
-                // unauthorized (this prevents information leaks about packages in other namespaces)
-                if (isOwner) {
-                    Future.failed(RejectRequest(Conflict, Messages.conformanceMessage))
-                } else {
-                    Future.successful(false)
-                }
-            case t: RejectRequest =>
-                logging.error(this, s"entitlement check on package failed: $t")
-                Future.failed(t)
-            case t =>
-                logging.error(this, s"entitlement check on package failed: ${t.getMessage}")
-                if (isOwner) {
-                    Future.failed(RejectRequest(InternalServerError, Messages.corruptedEntity))
-                } else {
-                    Future.successful(false)
-                }
-        }
-    }
+  }
 }

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
@@ -75,109 +75,115 @@ final case class InvokerInfo(buffer: RingBuffer[Boolean])
  * Note: An Invoker that never sends an initial Ping will not be considered
  * by the InvokerPool and thus might not be caught by monitoring.
  */
-class InvokerPool(
-    childFactory: (ActorRefFactory, InstanceId) => ActorRef,
-    sendActivationToInvoker: (ActivationMessage, InstanceId) => Future[RecordMetadata],
-    pingConsumer: MessageConsumer) extends Actor {
+class InvokerPool(childFactory: (ActorRefFactory, InstanceId) => ActorRef,
+                  sendActivationToInvoker: (ActivationMessage, InstanceId) => Future[RecordMetadata],
+                  pingConsumer: MessageConsumer)
+    extends Actor {
 
-    implicit val transid = TransactionId.invokerHealth
-    implicit val logging = new AkkaLogging(context.system.log)
-    implicit val timeout = Timeout(5.seconds)
-    implicit val ec = context.dispatcher
+  implicit val transid = TransactionId.invokerHealth
+  implicit val logging = new AkkaLogging(context.system.log)
+  implicit val timeout = Timeout(5.seconds)
+  implicit val ec = context.dispatcher
 
-    // State of the actor. It's important not to close over these
-    // references directly, so they don't escape the Actor.
-    val instanceToRef = mutable.Map[InstanceId, ActorRef]()
-    val refToInstance = mutable.Map[ActorRef, InstanceId]()
-    var status = IndexedSeq[(InstanceId, InvokerState)]()
+  // State of the actor. It's important not to close over these
+  // references directly, so they don't escape the Actor.
+  val instanceToRef = mutable.Map[InstanceId, ActorRef]()
+  val refToInstance = mutable.Map[ActorRef, InstanceId]()
+  var status = IndexedSeq[(InstanceId, InvokerState)]()
 
-    def receive = {
-        case p: PingMessage =>
-            val invoker = instanceToRef.getOrElseUpdate(p.instance, {
-                logging.info(this, s"registered a new invoker: invoker${p.instance.toInt}")(TransactionId.invokerHealth)
+  def receive = {
+    case p: PingMessage =>
+      val invoker = instanceToRef.getOrElseUpdate(p.instance, {
+        logging.info(this, s"registered a new invoker: invoker${p.instance.toInt}")(TransactionId.invokerHealth)
 
-                status = padToIndexed(status, p.instance.toInt + 1, i => (InstanceId(i), Offline))
+        status = padToIndexed(status, p.instance.toInt + 1, i => (InstanceId(i), Offline))
 
-                val ref = childFactory(context, p.instance)
-                ref ! SubscribeTransitionCallBack(self) // register for state change events
+        val ref = childFactory(context, p.instance)
+        ref ! SubscribeTransitionCallBack(self) // register for state change events
 
-                refToInstance.update(ref, p.instance)
-                ref
-            })
-            invoker.forward(p)
+        refToInstance.update(ref, p.instance)
+        ref
+      })
+      invoker.forward(p)
 
-        case GetStatus => sender() ! status
+    case GetStatus => sender() ! status
 
-        case msg: InvocationFinishedMessage => {
-            // Forward message to invoker, if InvokerActor exists
-            instanceToRef.get(msg.invokerInstance).map(_.forward(msg))
-        }
-
-        case CurrentState(invoker, currentState: InvokerState) =>
-            refToInstance.get(invoker).foreach { instance =>
-                status = status.updated(instance.toInt, (instance, currentState))
-            }
-            logStatus()
-
-        case Transition(invoker, oldState: InvokerState, newState: InvokerState) =>
-            refToInstance.get(invoker).foreach {
-                instance => status = status.updated(instance.toInt, (instance, newState))
-            }
-            logStatus()
-
-        // this is only used for the internal test action which enabled an invoker to become healthy again
-        case msg: ActivationRequest => sendActivationToInvoker(msg.msg, msg.invoker).pipeTo(sender)
+    case msg: InvocationFinishedMessage => {
+      // Forward message to invoker, if InvokerActor exists
+      instanceToRef.get(msg.invokerInstance).map(_.forward(msg))
     }
 
-    def logStatus() = {
-        val pretty = status.map { case (instance, state) => s"${instance.toInt} -> $state" }
-        logging.info(this, s"invoker status changed to ${pretty.mkString(", ")}")
+    case CurrentState(invoker, currentState: InvokerState) =>
+      refToInstance.get(invoker).foreach { instance =>
+        status = status.updated(instance.toInt, (instance, currentState))
+      }
+      logStatus()
+
+    case Transition(invoker, oldState: InvokerState, newState: InvokerState) =>
+      refToInstance.get(invoker).foreach { instance =>
+        status = status.updated(instance.toInt, (instance, newState))
+      }
+      logStatus()
+
+    // this is only used for the internal test action which enabled an invoker to become healthy again
+    case msg: ActivationRequest => sendActivationToInvoker(msg.msg, msg.invoker).pipeTo(sender)
+  }
+
+  def logStatus() = {
+    val pretty = status.map { case (instance, state) => s"${instance.toInt} -> $state" }
+    logging.info(this, s"invoker status changed to ${pretty.mkString(", ")}")
+  }
+
+  /** Receive Ping messages from invokers. */
+  val pingPollDuration = 1.second
+  val invokerPingFeed = context.system.actorOf(Props {
+    new MessageFeed(
+      "ping",
+      logging,
+      pingConsumer,
+      pingConsumer.maxPeek,
+      pingPollDuration,
+      processInvokerPing,
+      logHandoff = false)
+  })
+
+  def processInvokerPing(bytes: Array[Byte]): Future[Unit] = Future {
+    val raw = new String(bytes, StandardCharsets.UTF_8)
+    PingMessage.parse(raw) match {
+      case Success(p: PingMessage) =>
+        self ! p
+        invokerPingFeed ! MessageFeed.Processed
+
+      case Failure(t) =>
+        invokerPingFeed ! MessageFeed.Processed
+        logging.error(this, s"failed processing message: $raw with $t")
     }
+  }
 
-    /** Receive Ping messages from invokers. */
-    val pingPollDuration = 1.second
-    val invokerPingFeed = context.system.actorOf(Props {
-        new MessageFeed("ping", logging, pingConsumer, pingConsumer.maxPeek, pingPollDuration, processInvokerPing, logHandoff = false)
-    })
-
-    def processInvokerPing(bytes: Array[Byte]): Future[Unit] = Future {
-        val raw = new String(bytes, StandardCharsets.UTF_8)
-        PingMessage.parse(raw) match {
-            case Success(p: PingMessage) =>
-                self ! p
-                invokerPingFeed ! MessageFeed.Processed
-
-            case Failure(t) =>
-                invokerPingFeed ! MessageFeed.Processed
-                logging.error(this, s"failed processing message: $raw with $t")
-        }
-    }
-
-    /** Pads a list to a given length using the given function to compute entries */
-    def padToIndexed[A](list: IndexedSeq[A], n: Int, f: (Int) => A) = list ++ (list.size until n).map(f)
+  /** Pads a list to a given length using the given function to compute entries */
+  def padToIndexed[A](list: IndexedSeq[A], n: Int, f: (Int) => A) = list ++ (list.size until n).map(f)
 }
 
 object InvokerPool {
-    def props(
-        f: (ActorRefFactory, InstanceId) => ActorRef,
-        p: (ActivationMessage, InstanceId) => Future[RecordMetadata],
-        pc: MessageConsumer) = {
-        Props(new InvokerPool(f, p, pc))
-    }
+  def props(f: (ActorRefFactory, InstanceId) => ActorRef,
+            p: (ActivationMessage, InstanceId) => Future[RecordMetadata],
+            pc: MessageConsumer) = {
+    Props(new InvokerPool(f, p, pc))
+  }
 
-    /** A stub identity for invoking the test action. This does not need to be a valid identity. */
-    val healthActionIdentity = {
-        val whiskSystem = "whisk.system"
-        Identity(Subject(whiskSystem), EntityName(whiskSystem), AuthKey(UUID(), Secret()), Set[Privilege]())
-    }
+  /** A stub identity for invoking the test action. This does not need to be a valid identity. */
+  val healthActionIdentity = {
+    val whiskSystem = "whisk.system"
+    Identity(Subject(whiskSystem), EntityName(whiskSystem), AuthKey(UUID(), Secret()), Set[Privilege]())
+  }
 
-    /** An action to use for monitoring invoker health. */
-    def healthAction(i: InstanceId) = ExecManifest.runtimesManifest.resolveDefaultRuntime("nodejs:6").map { manifest =>
-        new WhiskAction(
-            namespace = healthActionIdentity.namespace.toPath,
-            name = EntityName(s"invokerHealthTestAction${i.toInt}"),
-            exec = new CodeExecAsString(manifest, """function main(params) { return params; }""", None))
-    }
+  /** An action to use for monitoring invoker health. */
+  def healthAction(i: InstanceId) = ExecManifest.runtimesManifest.resolveDefaultRuntime("nodejs:6").map { manifest =>
+    new WhiskAction(
+      namespace = healthActionIdentity.namespace.toPath,
+      name = EntityName(s"invokerHealthTestAction${i.toInt}"),
+      exec = new CodeExecAsString(manifest, """function main(params) { return params; }""", None))
+  }
 }
 
 /**
@@ -187,149 +193,160 @@ object InvokerPool {
  * states "Healthy" and "Offline".
  */
 class InvokerActor(invokerInstance: InstanceId, controllerInstance: InstanceId) extends FSM[InvokerState, InvokerInfo] {
-    implicit val transid = TransactionId.invokerHealth
-    implicit val logging = new AkkaLogging(context.system.log)
-    val name = s"invoker${invokerInstance.toInt}"
+  implicit val transid = TransactionId.invokerHealth
+  implicit val logging = new AkkaLogging(context.system.log)
+  val name = s"invoker${invokerInstance.toInt}"
 
-    val healthyTimeout = 10.seconds
+  val healthyTimeout = 10.seconds
 
-    // This is done at this point to not intermingle with the state-machine
-    // especially their timeouts.
-    def customReceive: Receive = {
-        case _: RecordMetadata => // The response of putting testactions to the MessageProducer. We don't have to do anything with them.
+  // This is done at this point to not intermingle with the state-machine
+  // especially their timeouts.
+  def customReceive: Receive = {
+    case _: RecordMetadata => // The response of putting testactions to the MessageProducer. We don't have to do anything with them.
+  }
+  override def receive = customReceive.orElse(super.receive)
+
+  /**
+   *  Always start UnHealthy. Then the invoker receives some test activations and becomes Healthy.
+   */
+  startWith(UnHealthy, InvokerInfo(new RingBuffer[Boolean](InvokerActor.bufferSize)))
+
+  /**
+   * An Offline invoker represents an existing but broken
+   * invoker. This means, that it does not send pings anymore.
+   */
+  when(Offline) {
+    case Event(_: PingMessage, _) => goto(UnHealthy)
+  }
+
+  /**
+   * An UnHealthy invoker represents an invoker that was not able to handle actions successfully.
+   */
+  when(UnHealthy, stateTimeout = healthyTimeout) {
+    case Event(_: PingMessage, _) => stay
+    case Event(StateTimeout, _)   => goto(Offline)
+    case Event(Tick, info) => {
+      invokeTestAction()
+      stay
     }
-    override def receive = customReceive.orElse(super.receive)
+  }
 
-    /**
-     *  Always start UnHealthy. Then the invoker receives some test activations and becomes Healthy.
-     */
-    startWith(UnHealthy, InvokerInfo(new RingBuffer[Boolean](InvokerActor.bufferSize)))
+  /**
+   * A Healthy invoker is characterized by continuously getting
+   * pings. It will go offline if that state is not confirmed
+   * for 20 seconds.
+   */
+  when(Healthy, stateTimeout = healthyTimeout) {
+    case Event(_: PingMessage, _) => stay
+    case Event(StateTimeout, _)   => goto(Offline)
+  }
 
-    /**
-     * An Offline invoker represents an existing but broken
-     * invoker. This means, that it does not send pings anymore.
-     */
-    when(Offline) {
-        case Event(_: PingMessage, _) => goto(UnHealthy)
+  /**
+   * Handle the completion of an Activation in every state.
+   */
+  whenUnhandled {
+    case Event(cm: InvocationFinishedMessage, info) => handleCompletionMessage(cm.successful, info.buffer)
+  }
+
+  /** Logging on Transition change */
+  onTransition {
+    case _ -> Offline =>
+      transid.mark(
+        this,
+        LoggingMarkers.LOADBALANCER_INVOKER_OFFLINE,
+        s"$name is offline",
+        akka.event.Logging.WarningLevel)
+    case _ -> UnHealthy =>
+      transid.mark(
+        this,
+        LoggingMarkers.LOADBALANCER_INVOKER_UNHEALTHY,
+        s"$name is unhealthy",
+        akka.event.Logging.WarningLevel)
+    case _ -> Healthy => logging.info(this, s"$name is healthy")
+  }
+
+  /** Scheduler to send test activations when the invoker is unhealthy. */
+  onTransition {
+    case _ -> UnHealthy => {
+      invokeTestAction()
+      setTimer(InvokerActor.timerName, Tick, 1.minute, true)
     }
+    case UnHealthy -> _ => cancelTimer(InvokerActor.timerName)
+  }
 
-    /**
-     * An UnHealthy invoker represents an invoker that was not able to handle actions successfully.
-     */
-    when(UnHealthy, stateTimeout = healthyTimeout) {
-        case Event(_: PingMessage, _) => stay
-        case Event(StateTimeout, _)   => goto(Offline)
-        case Event(Tick, info) => {
-            invokeTestAction()
-            stay
-        }
-    }
+  initialize()
 
-    /**
-     * A Healthy invoker is characterized by continuously getting
-     * pings. It will go offline if that state is not confirmed
-     * for 20 seconds.
-     */
-    when(Healthy, stateTimeout = healthyTimeout) {
-        case Event(_: PingMessage, _) => stay
-        case Event(StateTimeout, _)   => goto(Offline)
-    }
+  /**
+   * Handling for active acks. This method saves the result (successful or unsuccessful)
+   * into an RingBuffer and checks, if the InvokerActor has to be changed to UnHealthy.
+   *
+   * @param wasActivationSuccessful: result of Activation
+   * @param buffer to be used
+   */
+  private def handleCompletionMessage(wasActivationSuccessful: Boolean, buffer: RingBuffer[Boolean]) = {
+    buffer.add(wasActivationSuccessful)
 
-    /**
-     * Handle the completion of an Activation in every state.
-     */
-    whenUnhandled {
-        case Event(cm: InvocationFinishedMessage, info) => handleCompletionMessage(cm.successful, info.buffer)
-    }
-
-    /** Logging on Transition change */
-    onTransition {
-        case _ -> Offline   => transid.mark(this, LoggingMarkers.LOADBALANCER_INVOKER_OFFLINE, s"$name is offline", akka.event.Logging.WarningLevel)
-        case _ -> UnHealthy => transid.mark(this, LoggingMarkers.LOADBALANCER_INVOKER_UNHEALTHY, s"$name is unhealthy", akka.event.Logging.WarningLevel)
-        case _ -> Healthy   => logging.info(this, s"$name is healthy")
-    }
-
-    /** Scheduler to send test activations when the invoker is unhealthy. */
-    onTransition {
-        case _ -> UnHealthy => {
-            invokeTestAction()
-            setTimer(InvokerActor.timerName, Tick, 1.minute, true)
-        }
-        case UnHealthy -> _ => cancelTimer(InvokerActor.timerName)
-    }
-
-    initialize()
-
-    /**
-     * Handling for active acks. This method saves the result (successful or unsuccessful)
-     * into an RingBuffer and checks, if the InvokerActor has to be changed to UnHealthy.
-     *
-     * @param wasActivationSuccessful: result of Activation
-     * @param buffer to be used
-     */
-    private def handleCompletionMessage(wasActivationSuccessful: Boolean, buffer: RingBuffer[Boolean]) = {
-        buffer.add(wasActivationSuccessful)
-
-        // If the current state is UnHealthy, then the active ack is the result of a test action.
-        // If this is successful it seems like the Invoker is Healthy again. So we execute immediately
-        // a new test action to remove the errors out of the RingBuffer as fast as possible.
-        if (wasActivationSuccessful && stateName == UnHealthy) {
-            invokeTestAction()
-        }
-
-        // Stay in online if the activations was successful.
-        // Stay in offline, if an activeAck reaches the controller.
-        if ((stateName == Healthy && wasActivationSuccessful) || stateName == Offline) {
-            stay
-        } else {
-            // Goto UnHealthy if there are more errors than accepted in buffer, else goto Healthy
-            if (buffer.toList.count(_ == true) >= InvokerActor.bufferSize - InvokerActor.bufferErrorTolerance) {
-                gotoIfNotThere(Healthy)
-            } else {
-                gotoIfNotThere(UnHealthy)
-            }
-        }
+    // If the current state is UnHealthy, then the active ack is the result of a test action.
+    // If this is successful it seems like the Invoker is Healthy again. So we execute immediately
+    // a new test action to remove the errors out of the RingBuffer as fast as possible.
+    if (wasActivationSuccessful && stateName == UnHealthy) {
+      invokeTestAction()
     }
 
-    /**
-     * Creates an activation request with the given action and sends it to the InvokerPool.
-     * The InvokerPool redirects it to the invoker which is represented by this InvokerActor.
-     */
-    private def invokeTestAction() = {
-        InvokerPool.healthAction(controllerInstance).map { action =>
-            val activationMessage = ActivationMessage(
-                // Use the sid of the InvokerSupervisor as tid
-                transid = transid,
-                action = action.fullyQualifiedName(true),
-                // Use empty DocRevision to force the invoker to pull the action from db all the time
-                revision = DocRevision.empty,
-                user = InvokerPool.healthActionIdentity,
-                // Create a new Activation ID for this activation
-                activationId = new ActivationIdGenerator {}.make(),
-                activationNamespace = action.namespace,
-                rootControllerIndex = controllerInstance,
-                blocking = false,
-                content = None)
-
-            context.parent ! ActivationRequest(activationMessage, invokerInstance)
-        }
+    // Stay in online if the activations was successful.
+    // Stay in offline, if an activeAck reaches the controller.
+    if ((stateName == Healthy && wasActivationSuccessful) || stateName == Offline) {
+      stay
+    } else {
+      // Goto UnHealthy if there are more errors than accepted in buffer, else goto Healthy
+      if (buffer.toList.count(_ == true) >= InvokerActor.bufferSize - InvokerActor.bufferErrorTolerance) {
+        gotoIfNotThere(Healthy)
+      } else {
+        gotoIfNotThere(UnHealthy)
+      }
     }
+  }
 
-    /**
-     * Only change the state if the currentState is not the newState.
-     *
-     * @param newState of the InvokerActor
-     */
-    private def gotoIfNotThere(newState: InvokerState) = {
-        if (stateName == newState) stay() else goto(newState)
+  /**
+   * Creates an activation request with the given action and sends it to the InvokerPool.
+   * The InvokerPool redirects it to the invoker which is represented by this InvokerActor.
+   */
+  private def invokeTestAction() = {
+    InvokerPool.healthAction(controllerInstance).map { action =>
+      val activationMessage = ActivationMessage(
+        // Use the sid of the InvokerSupervisor as tid
+        transid = transid,
+        action = action.fullyQualifiedName(true),
+        // Use empty DocRevision to force the invoker to pull the action from db all the time
+        revision = DocRevision.empty,
+        user = InvokerPool.healthActionIdentity,
+        // Create a new Activation ID for this activation
+        activationId = new ActivationIdGenerator {}.make(),
+        activationNamespace = action.namespace,
+        rootControllerIndex = controllerInstance,
+        blocking = false,
+        content = None)
+
+      context.parent ! ActivationRequest(activationMessage, invokerInstance)
     }
+  }
+
+  /**
+   * Only change the state if the currentState is not the newState.
+   *
+   * @param newState of the InvokerActor
+   */
+  private def gotoIfNotThere(newState: InvokerState) = {
+    if (stateName == newState) stay() else goto(newState)
+  }
 }
 
 object InvokerActor {
-    def props(invokerInstance: InstanceId, controllerInstance: InstanceId) = Props(new InvokerActor(invokerInstance, controllerInstance))
+  def props(invokerInstance: InstanceId, controllerInstance: InstanceId) =
+    Props(new InvokerActor(invokerInstance, controllerInstance))
 
-    val bufferSize = 10
-    val bufferErrorTolerance = 3
+  val bufferSize = 10
+  val bufferErrorTolerance = 3
 
-    val timerName = "testActionTimer"
+  val timerName = "testActionTimer"
 }

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerData.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerData.scala
@@ -22,11 +22,14 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.Promise
 
-import whisk.core.entity.{ ActivationId, UUID, WhiskActivation }
+import whisk.core.entity.{ActivationId, UUID, WhiskActivation}
 import whisk.core.entity.InstanceId
 
 /** Encapsulates data relevant for a single activation */
-case class ActivationEntry(id: ActivationId, namespaceId: UUID, invokerName: InstanceId, promise: Promise[Either[ActivationId, WhiskActivation]])
+case class ActivationEntry(id: ActivationId,
+                           namespaceId: UUID,
+                           invokerName: InstanceId,
+                           promise: Promise[Either[ActivationId, WhiskActivation]])
 
 /**
  * Encapsulates data used for loadbalancer and active-ack bookkeeping.
@@ -36,86 +39,86 @@ case class ActivationEntry(id: ActivationId, namespaceId: UUID, invokerName: Ins
  */
 class LoadBalancerData() {
 
-    private val activationByInvoker = TrieMap[InstanceId, AtomicInteger]()
-    private val activationByNamespaceId = TrieMap[UUID, AtomicInteger]()
-    private val activationsById = TrieMap[ActivationId, ActivationEntry]()
-    private val totalActivations = new AtomicInteger(0)
+  private val activationByInvoker = TrieMap[InstanceId, AtomicInteger]()
+  private val activationByNamespaceId = TrieMap[UUID, AtomicInteger]()
+  private val activationsById = TrieMap[ActivationId, ActivationEntry]()
+  private val totalActivations = new AtomicInteger(0)
 
-    /** Get the number of activations across all namespaces. */
-    def totalActivationCount = totalActivations.get
+  /** Get the number of activations across all namespaces. */
+  def totalActivationCount = totalActivations.get
 
-    /**
-     * Get the number of activations for a specific namespace.
-     *
-     * @param namespace The namespace to get the activation count for
-     * @return a map (namespace -> number of activations in the system)
-     */
-    def activationCountOn(namespace: UUID) = {
-        activationByNamespaceId.get(namespace).map(_.get).getOrElse(0)
+  /**
+   * Get the number of activations for a specific namespace.
+   *
+   * @param namespace The namespace to get the activation count for
+   * @return a map (namespace -> number of activations in the system)
+   */
+  def activationCountOn(namespace: UUID) = {
+    activationByNamespaceId.get(namespace).map(_.get).getOrElse(0)
+  }
+
+  /**
+   * Get the number of activations for a specific invoker.
+   *
+   * @param invoker The invoker to get the activation count for
+   * @return a map (invoker -> number of activations queued for the invoker)
+   */
+  def activationCountOn(invoker: InstanceId): Int = {
+    activationByInvoker.get(invoker).map(_.get).getOrElse(0)
+  }
+
+  /**
+   * Get an activation entry for a given activation id.
+   *
+   * @param activationId activation id to get data for
+   * @return the respective activation or None if it doesn't exist
+   */
+  def activationById(activationId: ActivationId): Option[ActivationEntry] = {
+    activationsById.get(activationId)
+  }
+
+  /**
+   * Adds an activation entry.
+   *
+   * @param id identifier to deduplicate the entry
+   * @param update block calculating the entry to add.
+   *               Note: This is evaluated iff the entry
+   *               didn't exist before.
+   * @return the entry calculated by the block or iff it did
+   *         exist before the entry from the state
+   */
+  def putActivation(id: ActivationId, update: => ActivationEntry): ActivationEntry = {
+    activationsById.getOrElseUpdate(id, {
+      val entry = update
+      totalActivations.incrementAndGet()
+      activationByNamespaceId.getOrElseUpdate(entry.namespaceId, new AtomicInteger(0)).incrementAndGet()
+      activationByInvoker.getOrElseUpdate(entry.invokerName, new AtomicInteger(0)).incrementAndGet()
+      entry
+    })
+  }
+
+  /**
+   * Removes the given entry.
+   *
+   * @param entry the entry to remove
+   * @return The deleted entry or None if nothing got deleted
+   */
+  def removeActivation(entry: ActivationEntry): Option[ActivationEntry] = {
+    activationsById.remove(entry.id).map { x =>
+      totalActivations.decrementAndGet()
+      activationByNamespaceId.getOrElseUpdate(entry.namespaceId, new AtomicInteger(0)).decrementAndGet()
+      activationByInvoker.getOrElseUpdate(entry.invokerName, new AtomicInteger(0)).decrementAndGet()
+      x
     }
+  }
 
-    /**
-     * Get the number of activations for a specific invoker.
-     *
-     * @param invoker The invoker to get the activation count for
-     * @return a map (invoker -> number of activations queued for the invoker)
-     */
-    def activationCountOn(invoker: InstanceId): Int = {
-        activationByInvoker.get(invoker).map(_.get).getOrElse(0)
-    }
-
-    /**
-     * Get an activation entry for a given activation id.
-     *
-     * @param activationId activation id to get data for
-     * @return the respective activation or None if it doesn't exist
-     */
-    def activationById(activationId: ActivationId): Option[ActivationEntry] = {
-        activationsById.get(activationId)
-    }
-
-    /**
-     * Adds an activation entry.
-     *
-     * @param id identifier to deduplicate the entry
-     * @param update block calculating the entry to add.
-     *               Note: This is evaluated iff the entry
-     *               didn't exist before.
-     * @return the entry calculated by the block or iff it did
-     *         exist before the entry from the state
-     */
-    def putActivation(id: ActivationId, update: => ActivationEntry): ActivationEntry = {
-        activationsById.getOrElseUpdate(id, {
-            val entry = update
-            totalActivations.incrementAndGet()
-            activationByNamespaceId.getOrElseUpdate(entry.namespaceId, new AtomicInteger(0)).incrementAndGet()
-            activationByInvoker.getOrElseUpdate(entry.invokerName, new AtomicInteger(0)).incrementAndGet()
-            entry
-        })
-    }
-
-    /**
-     * Removes the given entry.
-     *
-     * @param entry the entry to remove
-     * @return The deleted entry or None if nothing got deleted
-     */
-    def removeActivation(entry: ActivationEntry): Option[ActivationEntry] = {
-        activationsById.remove(entry.id).map { x =>
-            totalActivations.decrementAndGet()
-            activationByNamespaceId.getOrElseUpdate(entry.namespaceId, new AtomicInteger(0)).decrementAndGet()
-            activationByInvoker.getOrElseUpdate(entry.invokerName, new AtomicInteger(0)).decrementAndGet()
-            x
-        }
-    }
-
-    /**
-     * Removes the activation identified by the given activation id.
-     *
-     * @param aid activation id to remove
-     * @return The deleted entry or None if nothing got deleted
-     */
-    def removeActivation(aid: ActivationId): Option[ActivationEntry] = {
-        activationsById.get(aid).flatMap(removeActivation)
-    }
+  /**
+   * Removes the activation identified by the given activation id.
+   *
+   * @param aid activation id to remove
+   * @return The deleted entry or None if nothing got deleted
+   */
+  def removeActivation(aid: ActivationId): Option[ActivationEntry] = {
+    activationsById.get(aid).flatMap(removeActivation)
+  }
 }

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -41,12 +41,12 @@ import whisk.common.LoggingMarkers
 import whisk.common.TransactionId
 import whisk.core.WhiskConfig
 import whisk.core.WhiskConfig._
-import whisk.core.connector.{ ActivationMessage, CompletionMessage }
+import whisk.core.connector.{ActivationMessage, CompletionMessage}
 import whisk.core.connector.MessageFeed
 import whisk.core.connector.MessageProducer
 import whisk.core.connector.MessagingProvider
 import whisk.core.database.NoDocumentException
-import whisk.core.entity.{ ActivationId, WhiskActivation }
+import whisk.core.entity.{ActivationId, WhiskActivation}
 import whisk.core.entity.EntityName
 import whisk.core.entity.ExecutableWhiskAction
 import whisk.core.entity.Identity
@@ -58,287 +58,318 @@ import whisk.spi.SpiLoader
 
 trait LoadBalancer {
 
-    val activeAckTimeoutGrace = 1.minute
+  val activeAckTimeoutGrace = 1.minute
 
-    /** Gets the number of in-flight activations for a specific user. */
-    def activeActivationsFor(namspace: UUID): Int
+  /** Gets the number of in-flight activations for a specific user. */
+  def activeActivationsFor(namspace: UUID): Int
 
-    /** Gets the number of in-flight activations in the system. */
-    def totalActiveActivations: Int
+  /** Gets the number of in-flight activations in the system. */
+  def totalActiveActivations: Int
 
-    /**
-     * Publishes activation message on internal bus for an invoker to pick up.
-     *
-     * @param action the action to invoke
-     * @param msg the activation message to publish on an invoker topic
-     * @param transid the transaction id for the request
-     * @return result a nested Future the outer indicating completion of publishing and
-     *         the inner the completion of the action (i.e., the result)
-     *         if it is ready before timeout (Right) otherwise the activation id (Left).
-     *         The future is guaranteed to complete within the declared action time limit
-     *         plus a grace period (see activeAckTimeoutGrace).
-     */
-    def publish(action: ExecutableWhiskAction, msg: ActivationMessage)(implicit transid: TransactionId): Future[Future[Either[ActivationId, WhiskActivation]]]
+  /**
+   * Publishes activation message on internal bus for an invoker to pick up.
+   *
+   * @param action the action to invoke
+   * @param msg the activation message to publish on an invoker topic
+   * @param transid the transaction id for the request
+   * @return result a nested Future the outer indicating completion of publishing and
+   *         the inner the completion of the action (i.e., the result)
+   *         if it is ready before timeout (Right) otherwise the activation id (Left).
+   *         The future is guaranteed to complete within the declared action time limit
+   *         plus a grace period (see activeAckTimeoutGrace).
+   */
+  def publish(action: ExecutableWhiskAction, msg: ActivationMessage)(
+    implicit transid: TransactionId): Future[Future[Either[ActivationId, WhiskActivation]]]
 
 }
 
-class LoadBalancerService(
-    config: WhiskConfig,
-    instance: InstanceId,
-    entityStore: EntityStore)(
-        implicit val actorSystem: ActorSystem,
-        logging: Logging)
+class LoadBalancerService(config: WhiskConfig, instance: InstanceId, entityStore: EntityStore)(
+  implicit val actorSystem: ActorSystem,
+  logging: Logging)
     extends LoadBalancer {
 
-    /** The execution context for futures */
-    implicit val executionContext: ExecutionContext = actorSystem.dispatcher
+  /** The execution context for futures */
+  implicit val executionContext: ExecutionContext = actorSystem.dispatcher
 
-    /** How many invokers are dedicated to blackbox images.  We range bound to something sensical regardless of configuration. */
-    private val blackboxFraction: Double = Math.max(0.0, Math.min(1.0, config.controllerBlackboxFraction))
-    logging.info(this, s"blackboxFraction = $blackboxFraction")(TransactionId.loadbalancer)
+  /** How many invokers are dedicated to blackbox images.  We range bound to something sensical regardless of configuration. */
+  private val blackboxFraction: Double = Math.max(0.0, Math.min(1.0, config.controllerBlackboxFraction))
+  logging.info(this, s"blackboxFraction = $blackboxFraction")(TransactionId.loadbalancer)
 
-    private val loadBalancerData = new LoadBalancerData()
+  private val loadBalancerData = new LoadBalancerData()
 
-    override def activeActivationsFor(namespace: UUID) = loadBalancerData.activationCountOn(namespace)
+  override def activeActivationsFor(namespace: UUID) = loadBalancerData.activationCountOn(namespace)
 
-    override def totalActiveActivations = loadBalancerData.totalActivationCount
+  override def totalActiveActivations = loadBalancerData.totalActivationCount
 
-    override def publish(action: ExecutableWhiskAction, msg: ActivationMessage)(
-        implicit transid: TransactionId): Future[Future[Either[ActivationId, WhiskActivation]]] = {
-        chooseInvoker(msg.user, action).flatMap { invokerName =>
-            val entry = setupActivation(action, msg.activationId, msg.user.uuid, invokerName, transid)
-            sendActivationToInvoker(messageProducer, msg, invokerName).map { _ =>
-                entry.promise.future
-            }
+  override def publish(action: ExecutableWhiskAction, msg: ActivationMessage)(
+    implicit transid: TransactionId): Future[Future[Either[ActivationId, WhiskActivation]]] = {
+    chooseInvoker(msg.user, action).flatMap { invokerName =>
+      val entry = setupActivation(action, msg.activationId, msg.user.uuid, invokerName, transid)
+      sendActivationToInvoker(messageProducer, msg, invokerName).map { _ =>
+        entry.promise.future
+      }
+    }
+  }
+
+  /** An indexed sequence of all invokers in the current system */
+  def allInvokers: Future[IndexedSeq[(InstanceId, InvokerState)]] =
+    invokerPool
+      .ask(GetStatus)(Timeout(5.seconds))
+      .mapTo[IndexedSeq[(InstanceId, InvokerState)]]
+
+  /**
+   * Tries to fill in the result slot (i.e., complete the promise) when a completion message arrives.
+   * The promise is removed form the map when the result arrives or upon timeout.
+   *
+   * @param msg is the kafka message payload as Json
+   */
+  private def processCompletion(response: Either[ActivationId, WhiskActivation],
+                                tid: TransactionId,
+                                forced: Boolean): Unit = {
+    val aid = response.fold(l => l, r => r.activationId)
+    loadBalancerData.removeActivation(aid) match {
+      case Some(entry) =>
+        logging.info(this, s"${if (!forced) "received" else "forced"} active ack for '$aid'")(tid)
+        if (!forced) {
+          entry.promise.trySuccess(response)
+        } else {
+          entry.promise.tryFailure(new Throwable("no active ack received"))
         }
+      case None =>
+        // the entry was already removed
+        logging.debug(this, s"received active ack for '$aid' which has no entry")(tid)
     }
+  }
 
-    /** An indexed sequence of all invokers in the current system */
-    def allInvokers: Future[IndexedSeq[(InstanceId, InvokerState)]] = invokerPool
-        .ask(GetStatus)(Timeout(5.seconds))
-        .mapTo[IndexedSeq[(InstanceId, InvokerState)]]
+  /**
+   * Creates an activation entry and insert into various maps.
+   */
+  private def setupActivation(action: ExecutableWhiskAction,
+                              activationId: ActivationId,
+                              namespaceId: UUID,
+                              invokerName: InstanceId,
+                              transid: TransactionId): ActivationEntry = {
+    val timeout = action.limits.timeout.duration + activeAckTimeoutGrace
+    // Install a timeout handler for the catastrophic case where an active ack is not received at all
+    // (because say an invoker is down completely, or the connection to the message bus is disrupted) or when
+    // the active ack is significantly delayed (possibly dues to long queues but the subject should not be penalized);
+    // in this case, if the activation handler is still registered, remove it and update the books.
+    loadBalancerData.putActivation(activationId, {
+      actorSystem.scheduler.scheduleOnce(timeout) {
+        processCompletion(Left(activationId), transid, forced = true)
+      }
 
-    /**
-     * Tries to fill in the result slot (i.e., complete the promise) when a completion message arrives.
-     * The promise is removed form the map when the result arrives or upon timeout.
-     *
-     * @param msg is the kafka message payload as Json
-     */
-    private def processCompletion(response: Either[ActivationId, WhiskActivation], tid: TransactionId, forced: Boolean): Unit = {
-        val aid = response.fold(l => l, r => r.activationId)
-        loadBalancerData.removeActivation(aid) match {
-            case Some(entry) =>
-                logging.info(this, s"${if (!forced) "received" else "forced"} active ack for '$aid'")(tid)
-                if (!forced) {
-                    entry.promise.trySuccess(response)
-                } else {
-                    entry.promise.tryFailure(new Throwable("no active ack received"))
-                }
-            case None =>
-                // the entry was already removed
-                logging.debug(this, s"received active ack for '$aid' which has no entry")(tid)
-        }
-    }
-
-    /**
-     * Creates an activation entry and insert into various maps.
-     */
-    private def setupActivation(action: ExecutableWhiskAction, activationId: ActivationId, namespaceId: UUID, invokerName: InstanceId, transid: TransactionId): ActivationEntry = {
-        val timeout = action.limits.timeout.duration + activeAckTimeoutGrace
-        // Install a timeout handler for the catastrophic case where an active ack is not received at all
-        // (because say an invoker is down completely, or the connection to the message bus is disrupted) or when
-        // the active ack is significantly delayed (possibly dues to long queues but the subject should not be penalized);
-        // in this case, if the activation handler is still registered, remove it and update the books.
-        loadBalancerData.putActivation(activationId, {
-            actorSystem.scheduler.scheduleOnce(timeout) {
-                processCompletion(Left(activationId), transid, forced = true)
-            }
-
-            ActivationEntry(activationId, namespaceId, invokerName, Promise[Either[ActivationId, WhiskActivation]]())
-        })
-    }
-
-    /**
-     * Creates or updates a health test action by updating the entity store.
-     * This method is intended for use on startup.
-     * @return Future that completes successfully iff the action is added to the database
-     */
-    private def createTestActionForInvokerHealth(db: EntityStore, action: WhiskAction): Future[Unit] = {
-        implicit val tid = TransactionId.loadbalancer
-        WhiskAction.get(db, action.docid).flatMap { oldAction =>
-            WhiskAction.put(db, action.revision(oldAction.rev))(tid, notifier = None)
-        }.recover {
-            case _: NoDocumentException => WhiskAction.put(db, action)(tid, notifier = None)
-        }.map(_ => {}).andThen {
-            case Success(_) => logging.info(this, "test action for invoker health now exists")
-            case Failure(e) => logging.error(this, s"error creating test action for invoker health: $e")
-        }
-    }
-
-    /** Gets a producer which can publish messages to the kafka bus. */
-    private val messagingProvider = SpiLoader.get[MessagingProvider]
-    private val messageProducer = messagingProvider.getProducer(config, executionContext)
-
-    private def sendActivationToInvoker(producer: MessageProducer, msg: ActivationMessage, invoker: InstanceId): Future[RecordMetadata] = {
-        implicit val transid = msg.transid
-
-        val topic = s"invoker${invoker.toInt}"
-        val start = transid.started(this, LoggingMarkers.CONTROLLER_KAFKA, s"posting topic '$topic' with activation id '${msg.activationId}'")
-
-        producer.send(topic, msg).andThen {
-            case Success(status) => transid.finished(this, start, s"posted to ${status.topic()}[${status.partition()}][${status.offset()}]")
-            case Failure(e)      => transid.failed(this, start, s"error on posting to topic $topic")
-        }
-    }
-
-    private val invokerPool = {
-        // Do not create the invokerPool if it is not possible to create the health test action to recover the invokers.
-        InvokerPool.healthAction(instance).map {
-            // Await the creation of the test action; on failure, this will abort the constructor which should
-            // in turn abort the startup of the controller.
-            a => Await.result(createTestActionForInvokerHealth(entityStore, a), 1.minute)
-        }.orElse {
-            throw new IllegalStateException("cannot create test action for invoker health because runtime manifest is not valid")
-        }
-
-        val maxPingsPerPoll = 128
-        val pingConsumer = messagingProvider.getConsumer(config, s"health${instance.toInt}", "health", maxPeek = maxPingsPerPoll)
-        val invokerFactory = (f: ActorRefFactory, invokerInstance: InstanceId) => f.actorOf(InvokerActor.props(invokerInstance, instance))
-
-        actorSystem.actorOf(InvokerPool.props(
-            invokerFactory,
-            (m, i) => sendActivationToInvoker(messageProducer, m, i), pingConsumer))
-    }
-
-    /**
-     * Subscribes to active acks (completion messages from the invokers), and
-     * registers a handler for received active acks from invokers.
-     */
-    val maxActiveAcksPerPoll = 128
-    val activeAckPollDuration = 1.second
-    private val activeAckConsumer = messagingProvider.getConsumer(config, "completions", s"completed${instance.toInt}", maxPeek = maxActiveAcksPerPoll)
-    val activationFeed = actorSystem.actorOf(Props {
-        new MessageFeed("activeack", logging,
-            activeAckConsumer, maxActiveAcksPerPoll, activeAckPollDuration, processActiveAck)
+      ActivationEntry(activationId, namespaceId, invokerName, Promise[Either[ActivationId, WhiskActivation]]())
     })
+  }
 
-    def processActiveAck(bytes: Array[Byte]): Future[Unit] = Future {
-        val raw = new String(bytes, StandardCharsets.UTF_8)
-        CompletionMessage.parse(raw) match {
-            case Success(m: CompletionMessage) =>
-                processCompletion(m.response, m.transid, false)
-                // treat left as success (as it is the result a the message exceeding the bus limit)
-                val isSuccess = m.response.fold(l => true, r => !r.response.isWhiskError)
-                activationFeed ! MessageFeed.Processed
-                invokerPool ! InvocationFinishedMessage(m.invoker, isSuccess)
+  /**
+   * Creates or updates a health test action by updating the entity store.
+   * This method is intended for use on startup.
+   * @return Future that completes successfully iff the action is added to the database
+   */
+  private def createTestActionForInvokerHealth(db: EntityStore, action: WhiskAction): Future[Unit] = {
+    implicit val tid = TransactionId.loadbalancer
+    WhiskAction
+      .get(db, action.docid)
+      .flatMap { oldAction =>
+        WhiskAction.put(db, action.revision(oldAction.rev))(tid, notifier = None)
+      }
+      .recover {
+        case _: NoDocumentException => WhiskAction.put(db, action)(tid, notifier = None)
+      }
+      .map(_ => {})
+      .andThen {
+        case Success(_) => logging.info(this, "test action for invoker health now exists")
+        case Failure(e) => logging.error(this, s"error creating test action for invoker health: $e")
+      }
+  }
 
-            case Failure(t) =>
-                activationFeed ! MessageFeed.Processed
-                logging.error(this, s"failed processing message: $raw with $t")
-        }
+  /** Gets a producer which can publish messages to the kafka bus. */
+  private val messagingProvider = SpiLoader.get[MessagingProvider]
+  private val messageProducer = messagingProvider.getProducer(config, executionContext)
+
+  private def sendActivationToInvoker(producer: MessageProducer,
+                                      msg: ActivationMessage,
+                                      invoker: InstanceId): Future[RecordMetadata] = {
+    implicit val transid = msg.transid
+
+    val topic = s"invoker${invoker.toInt}"
+    val start = transid.started(
+      this,
+      LoggingMarkers.CONTROLLER_KAFKA,
+      s"posting topic '$topic' with activation id '${msg.activationId}'")
+
+    producer.send(topic, msg).andThen {
+      case Success(status) =>
+        transid.finished(this, start, s"posted to ${status.topic()}[${status.partition()}][${status.offset()}]")
+      case Failure(e) => transid.failed(this, start, s"error on posting to topic $topic")
     }
+  }
 
-    /** Compute the number of blackbox-dedicated invokers by applying a rounded down fraction of all invokers (but at least 1). */
-    private def numBlackbox(totalInvokers: Int) = Math.max(1, (totalInvokers.toDouble * blackboxFraction).toInt)
+  private val invokerPool = {
+    // Do not create the invokerPool if it is not possible to create the health test action to recover the invokers.
+    InvokerPool
+      .healthAction(instance)
+      .map {
+        // Await the creation of the test action; on failure, this will abort the constructor which should
+        // in turn abort the startup of the controller.
+        a =>
+          Await.result(createTestActionForInvokerHealth(entityStore, a), 1.minute)
+      }
+      .orElse {
+        throw new IllegalStateException(
+          "cannot create test action for invoker health because runtime manifest is not valid")
+      }
 
-    /** Return invokers (almost) dedicated to running blackbox actions. */
-    private def blackboxInvokers(invokers: IndexedSeq[(InstanceId, InvokerState)]): IndexedSeq[(InstanceId, InvokerState)] = {
-        val blackboxes = numBlackbox(invokers.size)
-        invokers.takeRight(blackboxes)
+    val maxPingsPerPoll = 128
+    val pingConsumer =
+      messagingProvider.getConsumer(config, s"health${instance.toInt}", "health", maxPeek = maxPingsPerPoll)
+    val invokerFactory = (f: ActorRefFactory, invokerInstance: InstanceId) =>
+      f.actorOf(InvokerActor.props(invokerInstance, instance))
+
+    actorSystem.actorOf(
+      InvokerPool.props(invokerFactory, (m, i) => sendActivationToInvoker(messageProducer, m, i), pingConsumer))
+  }
+
+  /**
+   * Subscribes to active acks (completion messages from the invokers), and
+   * registers a handler for received active acks from invokers.
+   */
+  val maxActiveAcksPerPoll = 128
+  val activeAckPollDuration = 1.second
+  private val activeAckConsumer =
+    messagingProvider.getConsumer(config, "completions", s"completed${instance.toInt}", maxPeek = maxActiveAcksPerPoll)
+  val activationFeed = actorSystem.actorOf(Props {
+    new MessageFeed(
+      "activeack",
+      logging,
+      activeAckConsumer,
+      maxActiveAcksPerPoll,
+      activeAckPollDuration,
+      processActiveAck)
+  })
+
+  def processActiveAck(bytes: Array[Byte]): Future[Unit] = Future {
+    val raw = new String(bytes, StandardCharsets.UTF_8)
+    CompletionMessage.parse(raw) match {
+      case Success(m: CompletionMessage) =>
+        processCompletion(m.response, m.transid, false)
+        // treat left as success (as it is the result a the message exceeding the bus limit)
+        val isSuccess = m.response.fold(l => true, r => !r.response.isWhiskError)
+        activationFeed ! MessageFeed.Processed
+        invokerPool ! InvocationFinishedMessage(m.invoker, isSuccess)
+
+      case Failure(t) =>
+        activationFeed ! MessageFeed.Processed
+        logging.error(this, s"failed processing message: $raw with $t")
     }
+  }
 
-    /**
-     * Return (at least one) invokers for running non black-box actions.
-     * This set can overlap with the blackbox set if there is only one invoker.
-     */
-    private def managedInvokers(invokers: IndexedSeq[(InstanceId, InvokerState)]): IndexedSeq[(InstanceId, InvokerState)] = {
-        val managed = Math.max(1, invokers.length - numBlackbox(invokers.length))
-        invokers.take(managed)
+  /** Compute the number of blackbox-dedicated invokers by applying a rounded down fraction of all invokers (but at least 1). */
+  private def numBlackbox(totalInvokers: Int) = Math.max(1, (totalInvokers.toDouble * blackboxFraction).toInt)
+
+  /** Return invokers (almost) dedicated to running blackbox actions. */
+  private def blackboxInvokers(
+    invokers: IndexedSeq[(InstanceId, InvokerState)]): IndexedSeq[(InstanceId, InvokerState)] = {
+    val blackboxes = numBlackbox(invokers.size)
+    invokers.takeRight(blackboxes)
+  }
+
+  /**
+   * Return (at least one) invokers for running non black-box actions.
+   * This set can overlap with the blackbox set if there is only one invoker.
+   */
+  private def managedInvokers(
+    invokers: IndexedSeq[(InstanceId, InvokerState)]): IndexedSeq[(InstanceId, InvokerState)] = {
+    val managed = Math.max(1, invokers.length - numBlackbox(invokers.length))
+    invokers.take(managed)
+  }
+
+  /** Determine which invoker this activation should go to. Due to dynamic conditions, it may return no invoker. */
+  private def chooseInvoker(user: Identity, action: ExecutableWhiskAction): Future[InstanceId] = {
+    val hash = generateHash(user.namespace, action)
+
+    allInvokers.flatMap { invokers =>
+      val invokersToUse = if (action.exec.pull) blackboxInvokers(invokers) else managedInvokers(invokers)
+      val invokersWithUsage = invokersToUse.view.map {
+        // Using a view defers the comparably expensive lookup to actual access of the element
+        case (instance, state) => (instance, state, loadBalancerData.activationCountOn(instance))
+      }
+
+      LoadBalancerService.schedule(invokersWithUsage, config.loadbalancerInvokerBusyThreshold, hash) match {
+        case Some(invoker) => Future.successful(invoker)
+        case None =>
+          logging.error(this, s"all invokers down")(TransactionId.invokerHealth)
+          Future.failed(new LoadBalancerException("no invokers available"))
+      }
     }
+  }
 
-    /** Determine which invoker this activation should go to. Due to dynamic conditions, it may return no invoker. */
-    private def chooseInvoker(user: Identity, action: ExecutableWhiskAction): Future[InstanceId] = {
-        val hash = generateHash(user.namespace, action)
-
-        allInvokers.flatMap { invokers =>
-            val invokersToUse = if (action.exec.pull) blackboxInvokers(invokers) else managedInvokers(invokers)
-            val invokersWithUsage = invokersToUse.view.map {
-                // Using a view defers the comparably expensive lookup to actual access of the element
-                case (instance, state) => (instance, state, loadBalancerData.activationCountOn(instance))
-            }
-
-            LoadBalancerService.schedule(invokersWithUsage, config.loadbalancerInvokerBusyThreshold, hash) match {
-                case Some(invoker) => Future.successful(invoker)
-                case None =>
-                    logging.error(this, s"all invokers down")(TransactionId.invokerHealth)
-                    Future.failed(new LoadBalancerException("no invokers available"))
-            }
-        }
-    }
-
-    /** Generates a hash based on the string representation of namespace and action */
-    private def generateHash(namespace: EntityName, action: ExecutableWhiskAction): Int = {
-        (namespace.asString.hashCode() ^ action.fullyQualifiedName(false).asString.hashCode()).abs
-    }
+  /** Generates a hash based on the string representation of namespace and action */
+  private def generateHash(namespace: EntityName, action: ExecutableWhiskAction): Int = {
+    (namespace.asString.hashCode() ^ action.fullyQualifiedName(false).asString.hashCode()).abs
+  }
 }
 
 object LoadBalancerService {
-    def requiredProperties = kafkaHost ++ Map(loadbalancerInvokerBusyThreshold -> null)
+  def requiredProperties = kafkaHost ++ Map(loadbalancerInvokerBusyThreshold -> null)
 
-    /** Memoizes the result of `f` for later use. */
-    def memoize[I, O](f: I => O): I => O = new scala.collection.mutable.HashMap[I, O]() {
-        override def apply(key: I) = getOrElseUpdate(key, f(key))
-    }
+  /** Memoizes the result of `f` for later use. */
+  def memoize[I, O](f: I => O): I => O = new scala.collection.mutable.HashMap[I, O]() {
+    override def apply(key: I) = getOrElseUpdate(key, f(key))
+  }
 
-    /** Euclidean algorithm to determine the greatest-common-divisor */
-    @tailrec
-    def gcd(a: Int, b: Int): Int = if (b == 0) a else gcd(b, a % b)
+  /** Euclidean algorithm to determine the greatest-common-divisor */
+  @tailrec
+  def gcd(a: Int, b: Int): Int = if (b == 0) a else gcd(b, a % b)
 
-    /** Returns pairwise coprime numbers until x. Result is memoized. */
-    val pairwiseCoprimeNumbersUntil: Int => IndexedSeq[Int] = LoadBalancerService.memoize {
-        case x =>
-            (1 to x).foldLeft(IndexedSeq.empty[Int])((primes, cur) => {
-                if (gcd(cur, x) == 1 && primes.forall(i => gcd(i, cur) == 1)) {
-                    primes :+ cur
-                } else primes
-            })
-    }
+  /** Returns pairwise coprime numbers until x. Result is memoized. */
+  val pairwiseCoprimeNumbersUntil: Int => IndexedSeq[Int] = LoadBalancerService.memoize {
+    case x =>
+      (1 to x).foldLeft(IndexedSeq.empty[Int])((primes, cur) => {
+        if (gcd(cur, x) == 1 && primes.forall(i => gcd(i, cur) == 1)) {
+          primes :+ cur
+        } else primes
+      })
+  }
 
-    /**
-     * Scans through all invokers and searches for an invoker, that has a queue length
-     * below the defined threshold. The threshold is subject to a 3 times back off. Iff
-     * no "underloaded" invoker was found it will default to the first invoker in the
-     * step-defined progression that is healthy.
-     *
-     * @param invokers a list of available invokers to search in, including their state and usage
-     * @param invokerBusyThreshold defines when an invoker is considered overloaded
-     * @param hash stable identifier of the entity to be scheduled
-     * @return an invoker to schedule to or None of no invoker is available
-     */
-    def schedule(
-        invokers: Seq[(InstanceId, InvokerState, Int)],
-        invokerBusyThreshold: Int,
-        hash: Int): Option[InstanceId] = {
+  /**
+   * Scans through all invokers and searches for an invoker, that has a queue length
+   * below the defined threshold. The threshold is subject to a 3 times back off. Iff
+   * no "underloaded" invoker was found it will default to the first invoker in the
+   * step-defined progression that is healthy.
+   *
+   * @param invokers a list of available invokers to search in, including their state and usage
+   * @param invokerBusyThreshold defines when an invoker is considered overloaded
+   * @param hash stable identifier of the entity to be scheduled
+   * @return an invoker to schedule to or None of no invoker is available
+   */
+  def schedule(invokers: Seq[(InstanceId, InvokerState, Int)],
+               invokerBusyThreshold: Int,
+               hash: Int): Option[InstanceId] = {
 
-        val numInvokers = invokers.size
-        if (numInvokers > 0) {
-            val homeInvoker = hash % numInvokers
-            val stepSizes = LoadBalancerService.pairwiseCoprimeNumbersUntil(numInvokers)
-            val step = stepSizes(hash % stepSizes.size)
+    val numInvokers = invokers.size
+    if (numInvokers > 0) {
+      val homeInvoker = hash % numInvokers
+      val stepSizes = LoadBalancerService.pairwiseCoprimeNumbersUntil(numInvokers)
+      val step = stepSizes(hash % stepSizes.size)
 
-            val invokerProgression = Stream.from(0)
-                .take(numInvokers)
-                .map(i => (homeInvoker + i * step) % numInvokers)
-                .map(invokers)
-                .filter(_._2 == Healthy)
+      val invokerProgression = Stream
+        .from(0)
+        .take(numInvokers)
+        .map(i => (homeInvoker + i * step) % numInvokers)
+        .map(invokers)
+        .filter(_._2 == Healthy)
 
-            invokerProgression.find(_._3 < invokerBusyThreshold)
-                .orElse(invokerProgression.find(_._3 < invokerBusyThreshold * 2))
-                .orElse(invokerProgression.find(_._3 < invokerBusyThreshold * 3))
-                .orElse(invokerProgression.headOption)
-                .map(_._1)
-        } else None
-    }
+      invokerProgression
+        .find(_._3 < invokerBusyThreshold)
+        .orElse(invokerProgression.find(_._3 < invokerBusyThreshold * 2))
+        .orElse(invokerProgression.find(_._3 < invokerBusyThreshold * 3))
+        .orElse(invokerProgression.headOption)
+        .map(_._1)
+    } else None
+  }
 
 }
 

--- a/core/invoker/build.gradle
+++ b/core/invoker/build.gradle
@@ -1,9 +1,6 @@
 apply plugin: 'scala'
 apply plugin: 'application'
 apply plugin: 'eclipse'
-apply plugin: 'scalafmt'
-
-scalafmt.configFilePath = gradle.scalafmt.config
 
 ext.dockerImageName = 'invoker'
 apply from: '../../gradle/docker.gradle'

--- a/core/invoker/build.gradle
+++ b/core/invoker/build.gradle
@@ -1,6 +1,18 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath "cz.alenkacz:gradle-scalafmt:${gradle.scalafmt.version}"
+    }
+}
+
 apply plugin: 'scala'
 apply plugin: 'application'
 apply plugin: 'eclipse'
+apply plugin: 'scalafmt'
+
+scalafmt.configFilePath = gradle.scalafmt.config
 
 ext.dockerImageName = 'invoker'
 apply from: '../../gradle/docker.gradle'

--- a/core/invoker/build.gradle
+++ b/core/invoker/build.gradle
@@ -1,12 +1,3 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath "cz.alenkacz:gradle-scalafmt:${gradle.scalafmt.version}"
-    }
-}
-
 apply plugin: 'scala'
 apply plugin: 'application'
 apply plugin: 'eclipse'

--- a/core/invoker/src/main/scala/whisk/core/containerpool/Container.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/Container.scala
@@ -33,23 +33,25 @@ import scala.concurrent.duration._
  * OpenWhisk specific behavior, especially for initialize and run.
  */
 trait Container {
-    /** Stops the container from consuming CPU cycles. */
-    def suspend()(implicit transid: TransactionId): Future[Unit]
 
-    /** Dual of halt. */
-    def resume()(implicit transid: TransactionId): Future[Unit]
+  /** Stops the container from consuming CPU cycles. */
+  def suspend()(implicit transid: TransactionId): Future[Unit]
 
-    /** Completely destroys this instance of the container. */
-    def destroy()(implicit transid: TransactionId): Future[Unit]
+  /** Dual of halt. */
+  def resume()(implicit transid: TransactionId): Future[Unit]
 
-    /** Initializes code in the container. */
-    def initialize(initializer: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[Interval]
+  /** Completely destroys this instance of the container. */
+  def destroy()(implicit transid: TransactionId): Future[Unit]
 
-    /** Runs code in the container. */
-    def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[(Interval, ActivationResponse)]
+  /** Initializes code in the container. */
+  def initialize(initializer: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[Interval]
 
-    /** Obtains logs up to a given threshold from the container. Optionally waits for a sentinel to appear. */
-    def logs(limit: ByteSize, waitForSentinel: Boolean)(implicit transid: TransactionId): Future[Vector[String]]
+  /** Runs code in the container. */
+  def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration)(
+    implicit transid: TransactionId): Future[(Interval, ActivationResponse)]
+
+  /** Obtains logs up to a given threshold from the container. Optionally waits for a sentinel to appear. */
+  def logs(limit: ByteSize, waitForSentinel: Boolean)(implicit transid: TransactionId): Future[Vector[String]]
 }
 
 /** Indicates a general error with the container */
@@ -68,13 +70,14 @@ case class BlackboxStartupError(msg: String) extends ContainerStartupError(msg)
 case class InitializationError(interval: Interval, response: ActivationResponse) extends Exception(response.toString)
 
 case class Interval(start: Instant, end: Instant) {
-    def duration = Duration.create(end.toEpochMilli() - start.toEpochMilli(), MILLISECONDS)
+  def duration = Duration.create(end.toEpochMilli() - start.toEpochMilli(), MILLISECONDS)
 }
 
 object Interval {
-    /** An interval starting now with zero duration. */
-    def zero = {
-        val now = Instant.now
-        Interval(now, now)
-    }
+
+  /** An interval starting now with zero duration. */
+  def zero = {
+    val now = Instant.now
+    Interval(now, now)
+  }
 }

--- a/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
@@ -27,7 +27,7 @@ import scala.util.Failure
 import akka.actor.FSM
 import akka.actor.Props
 import akka.actor.Stash
-import akka.actor.Status.{ Failure => FailureMessage }
+import akka.actor.Status.{Failure => FailureMessage}
 import akka.pattern.pipe
 import spray.json._
 import spray.json.DefaultJsonProtocol._
@@ -55,7 +55,11 @@ case object Removing extends ContainerState
 sealed abstract class ContainerData(val lastUsed: Instant)
 case class NoData() extends ContainerData(Instant.EPOCH)
 case class PreWarmedData(container: Container, kind: String, memoryLimit: ByteSize) extends ContainerData(Instant.EPOCH)
-case class WarmedData(container: Container, invocationNamespace: EntityName, action: ExecutableWhiskAction, override val lastUsed: Instant) extends ContainerData(lastUsed)
+case class WarmedData(container: Container,
+                      invocationNamespace: EntityName,
+                      action: ExecutableWhiskAction,
+                      override val lastUsed: Instant)
+    extends ContainerData(lastUsed)
 
 // Events received by the actor
 case class Start(exec: CodeExec[_], memoryLimit: ByteSize)
@@ -87,332 +91,351 @@ case object ContainerRemoved
  * @param unusedTimeout time after which the container is automatically thrown away
  * @param pauseGrace time to wait for new work before pausing the container
  */
-class ContainerProxy(
-    factory: (TransactionId, String, ImageName, Boolean, ByteSize) => Future[Container],
-    sendActiveAck: (TransactionId, WhiskActivation, Boolean, InstanceId) => Future[Any],
-    storeActivation: (TransactionId, WhiskActivation) => Future[Any],
-    instance: InstanceId,
-    unusedTimeout: FiniteDuration,
-    pauseGrace: FiniteDuration) extends FSM[ContainerState, ContainerData] with Stash {
-    implicit val ec = context.system.dispatcher
-    val logging = new AkkaLogging(context.system.log)
+class ContainerProxy(factory: (TransactionId, String, ImageName, Boolean, ByteSize) => Future[Container],
+                     sendActiveAck: (TransactionId, WhiskActivation, Boolean, InstanceId) => Future[Any],
+                     storeActivation: (TransactionId, WhiskActivation) => Future[Any],
+                     instance: InstanceId,
+                     unusedTimeout: FiniteDuration,
+                     pauseGrace: FiniteDuration)
+    extends FSM[ContainerState, ContainerData]
+    with Stash {
+  implicit val ec = context.system.dispatcher
+  val logging = new AkkaLogging(context.system.log)
 
-    startWith(Uninitialized, NoData())
+  startWith(Uninitialized, NoData())
 
-    when(Uninitialized) {
-        // pre warm a container (creates a stem cell container)
-        case Event(job: Start, _) =>
-            factory(
-                TransactionId.invokerWarmup,
-                ContainerProxy.containerName(instance, "prewarm", job.exec.kind),
-                job.exec.image,
-                job.exec.pull,
-                job.memoryLimit)
-                .map(container => PreWarmedData(container, job.exec.kind, job.memoryLimit))
-                .pipeTo(self)
+  when(Uninitialized) {
+    // pre warm a container (creates a stem cell container)
+    case Event(job: Start, _) =>
+      factory(
+        TransactionId.invokerWarmup,
+        ContainerProxy.containerName(instance, "prewarm", job.exec.kind),
+        job.exec.image,
+        job.exec.pull,
+        job.memoryLimit)
+        .map(container => PreWarmedData(container, job.exec.kind, job.memoryLimit))
+        .pipeTo(self)
 
-            goto(Starting)
+      goto(Starting)
 
-        // cold start (no container to reuse or available stem cell container)
-        case Event(job: Run, _) =>
-            implicit val transid = job.msg.transid
+    // cold start (no container to reuse or available stem cell container)
+    case Event(job: Run, _) =>
+      implicit val transid = job.msg.transid
 
-            // create a new container
-            val container = factory(
-                job.msg.transid,
-                ContainerProxy.containerName(instance, job.msg.user.namespace.name, job.action.name.name),
-                job.action.exec.image,
-                job.action.exec.pull,
-                job.action.limits.memory.megabytes.MB)
+      // create a new container
+      val container = factory(
+        job.msg.transid,
+        ContainerProxy.containerName(instance, job.msg.user.namespace.name, job.action.name.name),
+        job.action.exec.image,
+        job.action.exec.pull,
+        job.action.limits.memory.megabytes.MB)
 
-            // container factory will either yield a new container ready to execute the action, or
-            // starting up the container failed; for the latter, it's either an internal error starting
-            // a container or a docker action that is not conforming to the required action API
-            container.andThen {
-                case Success(container) =>
-                    // the container is ready to accept an activation; register it as PreWarmed; this
-                    // normalizes the life cycle for containers and their cleanup when activations fail
-                    self ! PreWarmedData(container, job.action.exec.kind, job.action.limits.memory.megabytes.MB)
+      // container factory will either yield a new container ready to execute the action, or
+      // starting up the container failed; for the latter, it's either an internal error starting
+      // a container or a docker action that is not conforming to the required action API
+      container
+        .andThen {
+          case Success(container) =>
+            // the container is ready to accept an activation; register it as PreWarmed; this
+            // normalizes the life cycle for containers and their cleanup when activations fail
+            self ! PreWarmedData(container, job.action.exec.kind, job.action.limits.memory.megabytes.MB)
 
-                case Failure(t) =>
-                    // the container did not come up cleanly, so disambiguate the failure mode and then cleanup
-                    // the failure is either the system fault, or for docker actions, the application/developer fault
-                    val response = t match {
-                        case WhiskContainerStartupError(msg) => ActivationResponse.whiskError(msg)
-                        case BlackboxStartupError(msg)       => ActivationResponse.applicationError(msg)
-                        case _                               => ActivationResponse.whiskError(t.getMessage)
-                    }
-                    // construct an appropriate activation and record it in the datastore,
-                    // also update the feed and active ack; the container cleanup is queued
-                    // implicitly via a FailureMessage which will be processed later when the state
-                    // transitions to Running
-                    val activation = ContainerProxy.constructWhiskActivation(job, Interval.zero, response)
-                    sendActiveAck(transid, activation, job.msg.blocking, job.msg.rootControllerIndex)
-                    storeActivation(transid, activation)
-            }.flatMap {
-                container =>
-                    // now attempt to inject the user code and run the action
-                    initializeAndRun(container, job)
-                        .map(_ => WarmedData(container, job.msg.user.namespace, job.action, Instant.now))
-            }.pipeTo(self)
-
-            goto(Running)
-    }
-
-    when(Starting) {
-        // container was successfully obtained
-        case Event(data: PreWarmedData, _) =>
-            context.parent ! NeedWork(data)
-            goto(Started) using data
-
-        // container creation failed
-        case Event(_: FailureMessage, _) =>
-            context.parent ! ContainerRemoved
-            stop()
-
-        case _ => delay
-    }
-
-    when(Started) {
-        case Event(job: Run, data: PreWarmedData) =>
-            implicit val transid = job.msg.transid
-            initializeAndRun(data.container, job)
-                .map(_ => WarmedData(data.container, job.msg.user.namespace, job.action, Instant.now))
-                .pipeTo(self)
-
-            goto(Running)
-
-        case Event(Remove, data: PreWarmedData) => destroyContainer(data.container)
-    }
-
-    when(Running) {
-        // Intermediate state, we were able to start a container
-        // and we keep it in case we need to destroy it.
-        case Event(data: PreWarmedData, _) => stay using data
-
-        // Run was successful
-        case Event(data: WarmedData, _) =>
-            context.parent ! NeedWork(data)
-            goto(Ready) using data
-
-        // Failed after /init (the first run failed)
-        case Event(_: FailureMessage, data: PreWarmedData) => destroyContainer(data.container)
-
-        // Failed for a subsequent /run
-        case Event(_: FailureMessage, data: WarmedData)    => destroyContainer(data.container)
-
-        // Failed at getting a container for a cold-start run
-        case Event(_: FailureMessage, _) =>
-            context.parent ! ContainerRemoved
-            stop()
-
-        case _ => delay
-    }
-
-    when(Ready, stateTimeout = pauseGrace) {
-        case Event(job: Run, data: WarmedData) =>
-            implicit val transid = job.msg.transid
-            initializeAndRun(data.container, job)
-                .map(_ => WarmedData(data.container, job.msg.user.namespace, job.action, Instant.now))
-                .pipeTo(self)
-
-            goto(Running)
-
-        // pause grace timed out
-        case Event(StateTimeout, data: WarmedData) =>
-            data.container.suspend()(TransactionId.invokerNanny).map(_ => ContainerPaused).pipeTo(self)
-            goto(Pausing)
-
-        case Event(Remove, data: WarmedData) => destroyContainer(data.container)
-    }
-
-    when(Pausing) {
-        case Event(ContainerPaused, data: WarmedData) => goto(Paused)
-        case Event(_: FailureMessage, data: WarmedData) => destroyContainer(data.container)
-        case _ => delay
-    }
-
-    when(Paused, stateTimeout = unusedTimeout) {
-        case Event(job: Run, data: WarmedData) =>
-            implicit val transid = job.msg.transid
-            data.container.resume().andThen {
-                // Sending the message to self on a failure will cause the message
-                // to ultimately be sent back to the parent (which will retry it)
-                // when container removal is done.
-                case Failure(_) => self ! job
-            }.flatMap(_ => initializeAndRun(data.container, job))
-                .map(_ => WarmedData(data.container, job.msg.user.namespace, job.action, Instant.now))
-                .pipeTo(self)
-
-            goto(Running)
-
-        // timeout or removing
-        case Event(StateTimeout | Remove, data: WarmedData) => destroyContainer(data.container)
-    }
-
-    when(Removing) {
-        case Event(job: Run, _) =>
-            // Send the job back to the pool to be rescheduled
-            context.parent ! job
-            stay
-        case Event(ContainerRemoved, _)  => stop()
-        case Event(_: FailureMessage, _) => stop()
-    }
-
-    // Unstash all messages stashed while in intermediate state
-    onTransition {
-        case _ -> Started  => unstashAll()
-        case _ -> Ready    => unstashAll()
-        case _ -> Paused   => unstashAll()
-        case _ -> Removing => unstashAll()
-    }
-
-    initialize()
-
-    /** Delays all incoming messages until unstashAll() is called */
-    def delay = {
-        stash()
-        stay
-    }
-
-    /**
-     * Destroys the container after unpausing it if needed. Can be used
-     * as a state progression as it goes to Removing.
-     *
-     * @param container the container to destroy
-     */
-    def destroyContainer(container: Container) = {
-        context.parent ! ContainerRemoved
-
-        val unpause = stateName match {
-            case Paused => container.resume()(TransactionId.invokerNanny)
-            case _      => Future.successful(())
-        }
-
-        unpause
-            .flatMap(_ => container.destroy()(TransactionId.invokerNanny))
-            .map(_ => ContainerRemoved).pipeTo(self)
-
-        goto(Removing)
-    }
-
-    /**
-     * Runs the job, initialize first if necessary.
-     * Completes the job by:
-     * 1. sending an activate ack,
-     * 2. fetching the logs for the run,
-     * 3. indicating the resource is free to the parent pool,
-     * 4. recording the result to the data store
-     *
-     * @param container the container to run the job on
-     * @param job the job to run
-     * @return a future completing after logs have been collected and
-     *         added to the WhiskActivation
-     */
-    def initializeAndRun(container: Container, job: Run)(implicit tid: TransactionId): Future[WhiskActivation] = {
-        val actionTimeout = job.action.limits.timeout.duration
-
-        // Only initialize iff we haven't yet warmed the container
-        val initialize = stateData match {
-            case data: WarmedData => Future.successful(Interval.zero)
-            case _                => container.initialize(job.action.containerInitializer, actionTimeout)
-        }
-
-        val activation: Future[WhiskActivation] = initialize.flatMap { initInterval =>
-            val parameters = job.msg.content getOrElse JsObject()
-
-            val environment = JsObject(
-                "api_key" -> job.msg.user.authkey.compact.toJson,
-                "namespace" -> job.msg.user.namespace.toJson,
-                "action_name" -> job.msg.action.qualifiedNameWithLeadingSlash.toJson,
-                "activation_id" -> job.msg.activationId.toString.toJson,
-                // compute deadline on invoker side avoids discrepancies inside container
-                // but potentially under-estimates actual deadline
-                "deadline" -> (Instant.now.toEpochMilli + actionTimeout.toMillis).toString.toJson)
-
-            container.run(parameters, environment, actionTimeout)(job.msg.transid).map {
-                case (runInterval, response) =>
-                    val initRunInterval = Interval(runInterval.start.minusMillis(initInterval.duration.toMillis), runInterval.end)
-                    ContainerProxy.constructWhiskActivation(job, initRunInterval, response)
+          case Failure(t) =>
+            // the container did not come up cleanly, so disambiguate the failure mode and then cleanup
+            // the failure is either the system fault, or for docker actions, the application/developer fault
+            val response = t match {
+              case WhiskContainerStartupError(msg) => ActivationResponse.whiskError(msg)
+              case BlackboxStartupError(msg)       => ActivationResponse.applicationError(msg)
+              case _                               => ActivationResponse.whiskError(t.getMessage)
             }
-        }.recover {
-            case InitializationError(interval, response) =>
-                ContainerProxy.constructWhiskActivation(job, interval, response)
-            case t =>
-                // Actually, this should never happen - but we want to make sure to not miss a problem
-                logging.error(this, s"caught unexpected error while running activation: ${t}")
-                ContainerProxy.constructWhiskActivation(job, Interval.zero, ActivationResponse.whiskError(Messages.abnormalRun))
+            // construct an appropriate activation and record it in the datastore,
+            // also update the feed and active ack; the container cleanup is queued
+            // implicitly via a FailureMessage which will be processed later when the state
+            // transitions to Running
+            val activation = ContainerProxy.constructWhiskActivation(job, Interval.zero, response)
+            sendActiveAck(transid, activation, job.msg.blocking, job.msg.rootControllerIndex)
+            storeActivation(transid, activation)
         }
+        .flatMap { container =>
+          // now attempt to inject the user code and run the action
+          initializeAndRun(container, job)
+            .map(_ => WarmedData(container, job.msg.user.namespace, job.action, Instant.now))
+        }
+        .pipeTo(self)
 
-        // Sending active ack and storing the activation are concurrent side-effects
-        // and do not block further execution of the future. They are completely
-        // asynchronous.
-        activation.andThen {
-            // the activation future will always complete with Success
-            case Success(ack) => sendActiveAck(tid, ack, job.msg.blocking, job.msg.rootControllerIndex)
-        }.flatMap { activation =>
-            container.logs(job.action.limits.logs.asMegaBytes, job.action.exec.sentinelledLogs).map { logs =>
-                activation.withLogs(ActivationLogs(logs.toVector))
-            }
-        }.andThen {
-            case Success(activation) => storeActivation(tid, activation)
-        }.flatMap { activation =>
-            // Fail the future iff the activation was unsuccessful to facilitate
-            // better cleanup logic.
-            if (activation.response.isSuccess) Future.successful(activation)
-            else Future.failed(ActivationUnsuccessfulError(activation))
+      goto(Running)
+  }
+
+  when(Starting) {
+    // container was successfully obtained
+    case Event(data: PreWarmedData, _) =>
+      context.parent ! NeedWork(data)
+      goto(Started) using data
+
+    // container creation failed
+    case Event(_: FailureMessage, _) =>
+      context.parent ! ContainerRemoved
+      stop()
+
+    case _ => delay
+  }
+
+  when(Started) {
+    case Event(job: Run, data: PreWarmedData) =>
+      implicit val transid = job.msg.transid
+      initializeAndRun(data.container, job)
+        .map(_ => WarmedData(data.container, job.msg.user.namespace, job.action, Instant.now))
+        .pipeTo(self)
+
+      goto(Running)
+
+    case Event(Remove, data: PreWarmedData) => destroyContainer(data.container)
+  }
+
+  when(Running) {
+    // Intermediate state, we were able to start a container
+    // and we keep it in case we need to destroy it.
+    case Event(data: PreWarmedData, _) => stay using data
+
+    // Run was successful
+    case Event(data: WarmedData, _) =>
+      context.parent ! NeedWork(data)
+      goto(Ready) using data
+
+    // Failed after /init (the first run failed)
+    case Event(_: FailureMessage, data: PreWarmedData) => destroyContainer(data.container)
+
+    // Failed for a subsequent /run
+    case Event(_: FailureMessage, data: WarmedData) => destroyContainer(data.container)
+
+    // Failed at getting a container for a cold-start run
+    case Event(_: FailureMessage, _) =>
+      context.parent ! ContainerRemoved
+      stop()
+
+    case _ => delay
+  }
+
+  when(Ready, stateTimeout = pauseGrace) {
+    case Event(job: Run, data: WarmedData) =>
+      implicit val transid = job.msg.transid
+      initializeAndRun(data.container, job)
+        .map(_ => WarmedData(data.container, job.msg.user.namespace, job.action, Instant.now))
+        .pipeTo(self)
+
+      goto(Running)
+
+    // pause grace timed out
+    case Event(StateTimeout, data: WarmedData) =>
+      data.container.suspend()(TransactionId.invokerNanny).map(_ => ContainerPaused).pipeTo(self)
+      goto(Pausing)
+
+    case Event(Remove, data: WarmedData) => destroyContainer(data.container)
+  }
+
+  when(Pausing) {
+    case Event(ContainerPaused, data: WarmedData)   => goto(Paused)
+    case Event(_: FailureMessage, data: WarmedData) => destroyContainer(data.container)
+    case _                                          => delay
+  }
+
+  when(Paused, stateTimeout = unusedTimeout) {
+    case Event(job: Run, data: WarmedData) =>
+      implicit val transid = job.msg.transid
+      data.container
+        .resume()
+        .andThen {
+          // Sending the message to self on a failure will cause the message
+          // to ultimately be sent back to the parent (which will retry it)
+          // when container removal is done.
+          case Failure(_) => self ! job
         }
+        .flatMap(_ => initializeAndRun(data.container, job))
+        .map(_ => WarmedData(data.container, job.msg.user.namespace, job.action, Instant.now))
+        .pipeTo(self)
+
+      goto(Running)
+
+    // timeout or removing
+    case Event(StateTimeout | Remove, data: WarmedData) => destroyContainer(data.container)
+  }
+
+  when(Removing) {
+    case Event(job: Run, _) =>
+      // Send the job back to the pool to be rescheduled
+      context.parent ! job
+      stay
+    case Event(ContainerRemoved, _)  => stop()
+    case Event(_: FailureMessage, _) => stop()
+  }
+
+  // Unstash all messages stashed while in intermediate state
+  onTransition {
+    case _ -> Started  => unstashAll()
+    case _ -> Ready    => unstashAll()
+    case _ -> Paused   => unstashAll()
+    case _ -> Removing => unstashAll()
+  }
+
+  initialize()
+
+  /** Delays all incoming messages until unstashAll() is called */
+  def delay = {
+    stash()
+    stay
+  }
+
+  /**
+   * Destroys the container after unpausing it if needed. Can be used
+   * as a state progression as it goes to Removing.
+   *
+   * @param container the container to destroy
+   */
+  def destroyContainer(container: Container) = {
+    context.parent ! ContainerRemoved
+
+    val unpause = stateName match {
+      case Paused => container.resume()(TransactionId.invokerNanny)
+      case _      => Future.successful(())
     }
+
+    unpause
+      .flatMap(_ => container.destroy()(TransactionId.invokerNanny))
+      .map(_ => ContainerRemoved)
+      .pipeTo(self)
+
+    goto(Removing)
+  }
+
+  /**
+   * Runs the job, initialize first if necessary.
+   * Completes the job by:
+   * 1. sending an activate ack,
+   * 2. fetching the logs for the run,
+   * 3. indicating the resource is free to the parent pool,
+   * 4. recording the result to the data store
+   *
+   * @param container the container to run the job on
+   * @param job the job to run
+   * @return a future completing after logs have been collected and
+   *         added to the WhiskActivation
+   */
+  def initializeAndRun(container: Container, job: Run)(implicit tid: TransactionId): Future[WhiskActivation] = {
+    val actionTimeout = job.action.limits.timeout.duration
+
+    // Only initialize iff we haven't yet warmed the container
+    val initialize = stateData match {
+      case data: WarmedData => Future.successful(Interval.zero)
+      case _                => container.initialize(job.action.containerInitializer, actionTimeout)
+    }
+
+    val activation: Future[WhiskActivation] = initialize
+      .flatMap { initInterval =>
+        val parameters = job.msg.content getOrElse JsObject()
+
+        val environment = JsObject(
+          "api_key" -> job.msg.user.authkey.compact.toJson,
+          "namespace" -> job.msg.user.namespace.toJson,
+          "action_name" -> job.msg.action.qualifiedNameWithLeadingSlash.toJson,
+          "activation_id" -> job.msg.activationId.toString.toJson,
+          // compute deadline on invoker side avoids discrepancies inside container
+          // but potentially under-estimates actual deadline
+          "deadline" -> (Instant.now.toEpochMilli + actionTimeout.toMillis).toString.toJson)
+
+        container.run(parameters, environment, actionTimeout)(job.msg.transid).map {
+          case (runInterval, response) =>
+            val initRunInterval =
+              Interval(runInterval.start.minusMillis(initInterval.duration.toMillis), runInterval.end)
+            ContainerProxy.constructWhiskActivation(job, initRunInterval, response)
+        }
+      }
+      .recover {
+        case InitializationError(interval, response) =>
+          ContainerProxy.constructWhiskActivation(job, interval, response)
+        case t =>
+          // Actually, this should never happen - but we want to make sure to not miss a problem
+          logging.error(this, s"caught unexpected error while running activation: ${t}")
+          ContainerProxy.constructWhiskActivation(
+            job,
+            Interval.zero,
+            ActivationResponse.whiskError(Messages.abnormalRun))
+      }
+
+    // Sending active ack and storing the activation are concurrent side-effects
+    // and do not block further execution of the future. They are completely
+    // asynchronous.
+    activation
+      .andThen {
+        // the activation future will always complete with Success
+        case Success(ack) => sendActiveAck(tid, ack, job.msg.blocking, job.msg.rootControllerIndex)
+      }
+      .flatMap { activation =>
+        container.logs(job.action.limits.logs.asMegaBytes, job.action.exec.sentinelledLogs).map { logs =>
+          activation.withLogs(ActivationLogs(logs.toVector))
+        }
+      }
+      .andThen {
+        case Success(activation) => storeActivation(tid, activation)
+      }
+      .flatMap { activation =>
+        // Fail the future iff the activation was unsuccessful to facilitate
+        // better cleanup logic.
+        if (activation.response.isSuccess) Future.successful(activation)
+        else Future.failed(ActivationUnsuccessfulError(activation))
+      }
+  }
 }
 
 object ContainerProxy {
-    def props(factory: (TransactionId, String, ImageName, Boolean, ByteSize) => Future[Container],
-              ack: (TransactionId, WhiskActivation, Boolean, InstanceId) => Future[Any],
-              store: (TransactionId, WhiskActivation) => Future[Any],
-              instance: InstanceId,
-              unusedTimeout: FiniteDuration = 10.minutes,
-              pauseGrace: FiniteDuration = 50.milliseconds) = Props(new ContainerProxy(factory, ack, store, instance, unusedTimeout, pauseGrace))
+  def props(factory: (TransactionId, String, ImageName, Boolean, ByteSize) => Future[Container],
+            ack: (TransactionId, WhiskActivation, Boolean, InstanceId) => Future[Any],
+            store: (TransactionId, WhiskActivation) => Future[Any],
+            instance: InstanceId,
+            unusedTimeout: FiniteDuration = 10.minutes,
+            pauseGrace: FiniteDuration = 50.milliseconds) =
+    Props(new ContainerProxy(factory, ack, store, instance, unusedTimeout, pauseGrace))
 
-    // Needs to be thread-safe as it's used by multiple proxies concurrently.
-    private val containerCount = new Counter
+  // Needs to be thread-safe as it's used by multiple proxies concurrently.
+  private val containerCount = new Counter
 
-    /**
-     * Generates a unique container name.
-     *
-     * @param prefix the container name's prefix
-     * @param suffix the container name's suffix
-     * @return a unique container name
-     */
-    def containerName(instance: InstanceId, prefix: String, suffix: String) =
-        s"wsk${instance.toInt}_${containerCount.next()}_${prefix}_${suffix}".replaceAll("[^a-zA-Z0-9_]", "")
+  /**
+   * Generates a unique container name.
+   *
+   * @param prefix the container name's prefix
+   * @param suffix the container name's suffix
+   * @return a unique container name
+   */
+  def containerName(instance: InstanceId, prefix: String, suffix: String) =
+    s"wsk${instance.toInt}_${containerCount.next()}_${prefix}_${suffix}".replaceAll("[^a-zA-Z0-9_]", "")
 
-    /**
-     * Creates a WhiskActivation ready to be sent via active ack.
-     *
-     * @param job the job that was executed
-     * @param interval the time it took to execute the job
-     * @param response the response to return to the user
-     * @return a WhiskActivation to be sent to the user
-     */
-    def constructWhiskActivation(job: Run, interval: Interval, response: ActivationResponse) = {
-        val causedBy = if (job.msg.causedBySequence) Parameters("causedBy", "sequence".toJson) else Parameters()
-        WhiskActivation(
-            activationId = job.msg.activationId,
-            namespace = job.msg.activationNamespace,
-            subject = job.msg.user.subject,
-            cause = job.msg.cause,
-            name = job.action.name,
-            version = job.action.version,
-            start = interval.start,
-            end = interval.end,
-            duration = Some(interval.duration.toMillis),
-            response = response,
-            annotations = {
-                Parameters("limits", job.action.limits.toJson) ++
-                    Parameters("path", job.action.fullyQualifiedName(false).toString.toJson) ++ causedBy
-            })
-    }
+  /**
+   * Creates a WhiskActivation ready to be sent via active ack.
+   *
+   * @param job the job that was executed
+   * @param interval the time it took to execute the job
+   * @param response the response to return to the user
+   * @return a WhiskActivation to be sent to the user
+   */
+  def constructWhiskActivation(job: Run, interval: Interval, response: ActivationResponse) = {
+    val causedBy = if (job.msg.causedBySequence) Parameters("causedBy", "sequence".toJson) else Parameters()
+    WhiskActivation(
+      activationId = job.msg.activationId,
+      namespace = job.msg.activationNamespace,
+      subject = job.msg.user.subject,
+      cause = job.msg.cause,
+      name = job.action.name,
+      version = job.action.version,
+      start = interval.start,
+      end = interval.end,
+      duration = Some(interval.duration.toMillis),
+      response = response,
+      annotations = {
+        Parameters("limits", job.action.limits.toJson) ++
+          Parameters("path", job.action.fullyQualifiedName(false).toString.toJson) ++ causedBy
+      })
+  }
 }
 
 /** Indicates an activation with a non-successful response */
-case class ActivationUnsuccessfulError(activation: WhiskActivation) extends Exception(s"activation ${activation.activationId} failed")
+case class ActivationUnsuccessfulError(activation: WhiskActivation)
+    extends Exception(s"activation ${activation.activationId} failed")

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerActionLogDriver.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerActionLogDriver.scala
@@ -18,12 +18,12 @@
 package whisk.core.containerpool.docker
 
 import java.nio.charset.StandardCharsets
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 import spray.json._
 import spray.json.DefaultJsonProtocol
-import whisk.common.{ Logging, TransactionId }
+import whisk.common.{Logging, TransactionId}
 import whisk.core.entity._
-import whisk.core.entity.size.{ SizeInt, SizeString }
+import whisk.core.entity.size.{SizeInt, SizeString}
 import scala.collection.mutable.Buffer
 import whisk.http.Messages
 
@@ -31,89 +31,90 @@ import whisk.http.Messages
  * Represents a single log line as read from a docker log
  */
 protected[core] case class LogLine(time: String, stream: String, log: String) {
-    def toFormattedString = f"$time%-30s $stream: ${log.trim}"
-    def dropRight(maxBytes: ByteSize) = {
-        val bytes = log.getBytes(StandardCharsets.UTF_8).dropRight(maxBytes.toBytes.toInt)
-        LogLine(time, stream, new String(bytes, StandardCharsets.UTF_8))
-    }
+  def toFormattedString = f"$time%-30s $stream: ${log.trim}"
+  def dropRight(maxBytes: ByteSize) = {
+    val bytes = log.getBytes(StandardCharsets.UTF_8).dropRight(maxBytes.toBytes.toInt)
+    LogLine(time, stream, new String(bytes, StandardCharsets.UTF_8))
+  }
 }
 
 protected[core] object LogLine extends DefaultJsonProtocol {
-    implicit val serdes = jsonFormat3(LogLine.apply)
+  implicit val serdes = jsonFormat3(LogLine.apply)
 }
 
 protected[core] object DockerActionLogDriver {
-    // The action proxies inserts this line in the logs at the end of each activation for stdout/stderr
-    val LOG_ACTIVATION_SENTINEL = "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX"
+  // The action proxies inserts this line in the logs at the end of each activation for stdout/stderr
+  val LOG_ACTIVATION_SENTINEL = "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX"
 }
 
 protected[core] trait DockerActionLogDriver {
 
-    /**
-     * Given the JSON driver's raw output of a docker container, convert it into our own
-     * JSON format. If asked, check for sentinel markers (which are not included in the output).
-     *
-     * Only parses and returns so much logs to fit into the LogLimit passed.
-     *
-     * @param logMsgs raw String read from a JSON log-driver written file
-     * @param requireSentinel determines if the processor should wait for a sentinel to appear
-     * @param limit the limit to apply to the log size
-     *
-     * @return Tuple containing (isComplete, isTruncated, logs)
-     */
-    protected def processJsonDriverLogContents(logMsgs: String, requireSentinel: Boolean, limit: ByteSize)(
-        implicit transid: TransactionId, logging: Logging): (Boolean, Boolean, Vector[String]) = {
+  /**
+   * Given the JSON driver's raw output of a docker container, convert it into our own
+   * JSON format. If asked, check for sentinel markers (which are not included in the output).
+   *
+   * Only parses and returns so much logs to fit into the LogLimit passed.
+   *
+   * @param logMsgs raw String read from a JSON log-driver written file
+   * @param requireSentinel determines if the processor should wait for a sentinel to appear
+   * @param limit the limit to apply to the log size
+   *
+   * @return Tuple containing (isComplete, isTruncated, logs)
+   */
+  protected def processJsonDriverLogContents(logMsgs: String, requireSentinel: Boolean, limit: ByteSize)(
+    implicit transid: TransactionId,
+    logging: Logging): (Boolean, Boolean, Vector[String]) = {
 
-        var hasOut = false
-        var hasErr = false
-        var truncated = false
-        var bytesSoFar = 0.B
-        val logLines = Buffer[String]()
-        val lines = logMsgs.lines
+    var hasOut = false
+    var hasErr = false
+    var truncated = false
+    var bytesSoFar = 0.B
+    val logLines = Buffer[String]()
+    val lines = logMsgs.lines
 
-        // read whiles bytesSoFar <= limit when requireSentinel to try and grab sentinel if they exist to indicate completion
-        while (lines.hasNext && ((requireSentinel && bytesSoFar <= limit) || bytesSoFar < limit)) {
-            // if line does not parse, there's an error in the container log driver
-            Try(lines.next().parseJson.convertTo[LogLine]) match {
-                case Success(t) =>
-                    // if sentinels are expected, do not account for their size, otherwise, all bytes are accounted for
-                    if (requireSentinel && t.log.trim != DockerActionLogDriver.LOG_ACTIVATION_SENTINEL || !requireSentinel) {
-                        // ignore empty log lines
-                        if (t.log.nonEmpty) {
-                            bytesSoFar += t.log.sizeInBytes
-                            if (bytesSoFar <= limit) {
-                                logLines.append(t.toFormattedString)
-                            } else {
-                                // chop off the right most bytes that overflow
-                                val chopped = t.dropRight(bytesSoFar - limit)
-                                if (chopped.log.nonEmpty) {
-                                    logLines.append(chopped.toFormattedString)
-                                }
-                                truncated = true
-                            }
-                        }
-                    } else if (requireSentinel) {
-                        // there may be more than one sentinel in stdout/stderr (as logs may leak across activations
-                        // if for example there log limit was exceeded in one activation and the container was reused
-                        // to run the same action again (this is considered a feature - otherwise, must drain the logs
-                        // or destroy the container as if it errored)
-                        if (t.stream == "stdout") {
-                            hasOut = true
-                        } else if (t.stream == "stderr") {
-                            hasErr = true
-                        }
-                    }
-
-                case Failure(t) =>
-                    // Drop lines that did not parse to JSON objects.
-                    // However, should not happen since we are using the json log driver.
-                    logging.error(this, s"log line skipped/did not parse: $t")
+    // read whiles bytesSoFar <= limit when requireSentinel to try and grab sentinel if they exist to indicate completion
+    while (lines.hasNext && ((requireSentinel && bytesSoFar <= limit) || bytesSoFar < limit)) {
+      // if line does not parse, there's an error in the container log driver
+      Try(lines.next().parseJson.convertTo[LogLine]) match {
+        case Success(t) =>
+          // if sentinels are expected, do not account for their size, otherwise, all bytes are accounted for
+          if (requireSentinel && t.log.trim != DockerActionLogDriver.LOG_ACTIVATION_SENTINEL || !requireSentinel) {
+            // ignore empty log lines
+            if (t.log.nonEmpty) {
+              bytesSoFar += t.log.sizeInBytes
+              if (bytesSoFar <= limit) {
+                logLines.append(t.toFormattedString)
+              } else {
+                // chop off the right most bytes that overflow
+                val chopped = t.dropRight(bytesSoFar - limit)
+                if (chopped.log.nonEmpty) {
+                  logLines.append(chopped.toFormattedString)
+                }
+                truncated = true
+              }
             }
-        }
+          } else if (requireSentinel) {
+            // there may be more than one sentinel in stdout/stderr (as logs may leak across activations
+            // if for example there log limit was exceeded in one activation and the container was reused
+            // to run the same action again (this is considered a feature - otherwise, must drain the logs
+            // or destroy the container as if it errored)
+            if (t.stream == "stdout") {
+              hasOut = true
+            } else if (t.stream == "stderr") {
+              hasErr = true
+            }
+          }
 
-        if (lines.hasNext) truncated = true
-        if (truncated) logLines.append(Messages.truncateLogs(limit))
-
-        ((hasOut && hasErr) || !requireSentinel, truncated, logLines.toVector)
+        case Failure(t) =>
+          // Drop lines that did not parse to JSON objects.
+          // However, should not happen since we are using the json log driver.
+          logging.error(this, s"log line skipped/did not parse: $t")
+      }
     }
+
+    if (lines.hasNext) truncated = true
+    if (truncated) logLines.append(Messages.truncateLogs(limit))
+
+    ((hasOut && hasErr) || !requireSentinel, truncated, logLines.toVector)
+  }
 }

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClient.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClient.scala
@@ -42,140 +42,144 @@ import scala.collection.concurrent.TrieMap
  * You only need one instance (and you shouldn't get more).
  */
 class DockerClient(dockerHost: Option[String] = None)(executionContext: ExecutionContext)(implicit log: Logging)
-    extends DockerApi with ProcessRunner {
-    implicit private val ec = executionContext
+    extends DockerApi
+    with ProcessRunner {
+  implicit private val ec = executionContext
 
-    // Determines how to run docker. Failure to find a Docker binary implies
-    // a failure to initialize this instance of DockerClient.
-    protected val dockerCmd: Seq[String] = {
-        val alternatives = List("/usr/bin/docker", "/usr/local/bin/docker")
+  // Determines how to run docker. Failure to find a Docker binary implies
+  // a failure to initialize this instance of DockerClient.
+  protected val dockerCmd: Seq[String] = {
+    val alternatives = List("/usr/bin/docker", "/usr/local/bin/docker")
 
-        val dockerBin = Try {
-            alternatives.find(a => Files.isExecutable(Paths.get(a))).get
-        } getOrElse {
-            throw new FileNotFoundException(s"Couldn't locate docker binary (tried: ${alternatives.mkString(", ")}).")
-        }
-
-        val host = dockerHost.map(host => Seq("--host", s"tcp://$host")).getOrElse(Seq.empty[String])
-        Seq(dockerBin) ++ host
+    val dockerBin = Try {
+      alternatives.find(a => Files.isExecutable(Paths.get(a))).get
+    } getOrElse {
+      throw new FileNotFoundException(s"Couldn't locate docker binary (tried: ${alternatives.mkString(", ")}).")
     }
 
-    def run(image: String, args: Seq[String] = Seq.empty[String])(implicit transid: TransactionId): Future[ContainerId] =
-        runCmd((Seq("run", "-d") ++ args ++ Seq(image)): _*).map(ContainerId.apply)
+    val host = dockerHost.map(host => Seq("--host", s"tcp://$host")).getOrElse(Seq.empty[String])
+    Seq(dockerBin) ++ host
+  }
 
-    def inspectIPAddress(id: ContainerId, network: String)(implicit transid: TransactionId): Future[ContainerIp] =
-        runCmd("inspect", "--format", s"{{.NetworkSettings.Networks.${network}.IPAddress}}", id.asString).flatMap {
-            _ match {
-                case "<no value>" => Future.failed(new NoSuchElementException)
-                case stdout       => Future.successful(ContainerIp(stdout))
-            }
-        }
+  def run(image: String, args: Seq[String] = Seq.empty[String])(implicit transid: TransactionId): Future[ContainerId] =
+    runCmd((Seq("run", "-d") ++ args ++ Seq(image)): _*).map(ContainerId.apply)
 
-    def pause(id: ContainerId)(implicit transid: TransactionId): Future[Unit] =
-        runCmd("pause", id.asString).map(_ => ())
-
-    def unpause(id: ContainerId)(implicit transid: TransactionId): Future[Unit] =
-        runCmd("unpause", id.asString).map(_ => ())
-
-    def rm(id: ContainerId)(implicit transid: TransactionId): Future[Unit] =
-        runCmd("rm", "-f", id.asString).map(_ => ())
-
-    def ps(filters: Seq[(String, String)] = Seq(), all: Boolean = false)(implicit transid: TransactionId): Future[Seq[ContainerId]] = {
-        val filterArgs = filters.map { case (attr, value) => Seq("--filter", s"$attr=$value") }.flatten
-        val allArg = if (all) Seq("--all") else Seq.empty[String]
-        val cmd = Seq("ps", "--quiet", "--no-trunc") ++ allArg ++ filterArgs
-        runCmd(cmd: _*).map(_.lines.toSeq.map(ContainerId.apply))
+  def inspectIPAddress(id: ContainerId, network: String)(implicit transid: TransactionId): Future[ContainerIp] =
+    runCmd("inspect", "--format", s"{{.NetworkSettings.Networks.${network}.IPAddress}}", id.asString).flatMap {
+      _ match {
+        case "<no value>" => Future.failed(new NoSuchElementException)
+        case stdout       => Future.successful(ContainerIp(stdout))
+      }
     }
 
-    /**
-     * Stores pulls that are currently being executed and collapses multiple
-     * pulls into just one. After a pull is finished, the cached future is removed
-     * to enable constant updates of an image without changing its tag.
-     */
-    private val pullsInFlight = TrieMap[String, Future[Unit]]()
-    def pull(image: String)(implicit transid: TransactionId): Future[Unit] =
-        pullsInFlight.getOrElseUpdate(image, {
-            runCmd("pull", image).map(_ => pullsInFlight.remove(image))
-        })
+  def pause(id: ContainerId)(implicit transid: TransactionId): Future[Unit] =
+    runCmd("pause", id.asString).map(_ => ())
 
-    private def runCmd(args: String*)(implicit transid: TransactionId): Future[String] = {
-        val cmd = dockerCmd ++ args
-        val start = transid.started(this, LoggingMarkers.INVOKER_DOCKER_CMD(args.head), s"running ${cmd.mkString(" ")}")
-        executeProcess(cmd: _*).andThen {
-            case Success(_) => transid.finished(this, start)
-            case Failure(t) => transid.failed(this, start, t.getMessage, ErrorLevel)
-        }
+  def unpause(id: ContainerId)(implicit transid: TransactionId): Future[Unit] =
+    runCmd("unpause", id.asString).map(_ => ())
+
+  def rm(id: ContainerId)(implicit transid: TransactionId): Future[Unit] =
+    runCmd("rm", "-f", id.asString).map(_ => ())
+
+  def ps(filters: Seq[(String, String)] = Seq(), all: Boolean = false)(
+    implicit transid: TransactionId): Future[Seq[ContainerId]] = {
+    val filterArgs = filters.map { case (attr, value) => Seq("--filter", s"$attr=$value") }.flatten
+    val allArg = if (all) Seq("--all") else Seq.empty[String]
+    val cmd = Seq("ps", "--quiet", "--no-trunc") ++ allArg ++ filterArgs
+    runCmd(cmd: _*).map(_.lines.toSeq.map(ContainerId.apply))
+  }
+
+  /**
+   * Stores pulls that are currently being executed and collapses multiple
+   * pulls into just one. After a pull is finished, the cached future is removed
+   * to enable constant updates of an image without changing its tag.
+   */
+  private val pullsInFlight = TrieMap[String, Future[Unit]]()
+  def pull(image: String)(implicit transid: TransactionId): Future[Unit] =
+    pullsInFlight.getOrElseUpdate(image, {
+      runCmd("pull", image).map(_ => pullsInFlight.remove(image))
+    })
+
+  private def runCmd(args: String*)(implicit transid: TransactionId): Future[String] = {
+    val cmd = dockerCmd ++ args
+    val start = transid.started(this, LoggingMarkers.INVOKER_DOCKER_CMD(args.head), s"running ${cmd.mkString(" ")}")
+    executeProcess(cmd: _*).andThen {
+      case Success(_) => transid.finished(this, start)
+      case Failure(t) => transid.failed(this, start, t.getMessage, ErrorLevel)
     }
+  }
 }
 
 case class ContainerId(val asString: String) {
-    require(asString.nonEmpty, "ContainerId must not be empty")
+  require(asString.nonEmpty, "ContainerId must not be empty")
 }
 case class ContainerIp(val asString: String) {
-    require(asString.nonEmpty, "ContainerIp must not be empty")
+  require(asString.nonEmpty, "ContainerIp must not be empty")
 }
 
 trait DockerApi {
-    /**
-     * Spawns a container in detached mode.
-     *
-     * @param image the image to start the container with
-     * @param args arguments for the docker run command
-     * @return id of the started container
-     */
-    def run(image: String, args: Seq[String] = Seq.empty[String])(implicit transid: TransactionId): Future[ContainerId]
 
-    /**
-     * Gets the IP address of a given container.
-     *
-     * A container may have more than one network. The container has an
-     * IP address in each of these networks such that the network name
-     * is needed.
-     *
-     * @param id the id of the container to get the IP address from
-     * @param network name of the network to get the IP address from
-     * @return ip of the container
-     */
-    def inspectIPAddress(id: ContainerId, network: String)(implicit transid: TransactionId): Future[ContainerIp]
+  /**
+   * Spawns a container in detached mode.
+   *
+   * @param image the image to start the container with
+   * @param args arguments for the docker run command
+   * @return id of the started container
+   */
+  def run(image: String, args: Seq[String] = Seq.empty[String])(implicit transid: TransactionId): Future[ContainerId]
 
-    /**
-     * Pauses the container with the given id.
-     *
-     * @param id the id of the container to pause
-     * @return a Future completing according to the command's exit-code
-     */
-    def pause(id: ContainerId)(implicit transid: TransactionId): Future[Unit]
+  /**
+   * Gets the IP address of a given container.
+   *
+   * A container may have more than one network. The container has an
+   * IP address in each of these networks such that the network name
+   * is needed.
+   *
+   * @param id the id of the container to get the IP address from
+   * @param network name of the network to get the IP address from
+   * @return ip of the container
+   */
+  def inspectIPAddress(id: ContainerId, network: String)(implicit transid: TransactionId): Future[ContainerIp]
 
-    /**
-     * Unpauses the container with the given id.
-     *
-     * @param id the id of the container to unpause
-     * @return a Future completing according to the command's exit-code
-     */
-    def unpause(id: ContainerId)(implicit transid: TransactionId): Future[Unit]
+  /**
+   * Pauses the container with the given id.
+   *
+   * @param id the id of the container to pause
+   * @return a Future completing according to the command's exit-code
+   */
+  def pause(id: ContainerId)(implicit transid: TransactionId): Future[Unit]
 
-    /**
-     * Removes the container with the given id.
-     *
-     * @param id the id of the container to remove
-     * @return a Future completing according to the command's exit-code
-     */
-    def rm(id: ContainerId)(implicit transid: TransactionId): Future[Unit]
+  /**
+   * Unpauses the container with the given id.
+   *
+   * @param id the id of the container to unpause
+   * @return a Future completing according to the command's exit-code
+   */
+  def unpause(id: ContainerId)(implicit transid: TransactionId): Future[Unit]
 
-    /**
-     * Returns a list of ContainerIds in the system.
-     *
-     * @param filters Filters to apply to the 'ps' command
-     * @param all Whether or not to return stopped containers as well
-     * @return A list of ContainerIds
-     */
-    def ps(filters: Seq[(String, String)] = Seq(), all: Boolean = false)(implicit transid: TransactionId): Future[Seq[ContainerId]]
+  /**
+   * Removes the container with the given id.
+   *
+   * @param id the id of the container to remove
+   * @return a Future completing according to the command's exit-code
+   */
+  def rm(id: ContainerId)(implicit transid: TransactionId): Future[Unit]
 
-    /**
-     * Pulls the given image.
-     *
-     * @param image the image to pull
-     * @return a Future completing once the pull is complete
-     */
-    def pull(image: String)(implicit transid: TransactionId): Future[Unit]
+  /**
+   * Returns a list of ContainerIds in the system.
+   *
+   * @param filters Filters to apply to the 'ps' command
+   * @param all Whether or not to return stopped containers as well
+   * @return A list of ContainerIds
+   */
+  def ps(filters: Seq[(String, String)] = Seq(), all: Boolean = false)(
+    implicit transid: TransactionId): Future[Seq[ContainerId]]
+
+  /**
+   * Pulls the given image.
+   *
+   * @param image the image to pull
+   * @return a Future completing once the pull is complete
+   */
+  def pull(image: String)(implicit transid: TransactionId): Future[Unit]
 }

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClientWithFileAccess.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClientWithFileAccess.scala
@@ -34,155 +34,158 @@ import whisk.common.Logging
 import whisk.common.TransactionId
 
 class DockerClientWithFileAccess(
-    dockerHost: Option[String] = None,
-    containersDirectory: File = Paths.get("containers").toFile)(executionContext: ExecutionContext)(implicit log: Logging)
-    extends DockerClient(dockerHost)(executionContext)(log) with DockerApiWithFileAccess {
+  dockerHost: Option[String] = None,
+  containersDirectory: File = Paths.get("containers").toFile)(executionContext: ExecutionContext)(implicit log: Logging)
+    extends DockerClient(dockerHost)(executionContext)(log)
+    with DockerApiWithFileAccess {
 
-    implicit private val ec = executionContext
+  implicit private val ec = executionContext
 
-    /**
-     * Provides the home directory of the specified Docker container.
-     *
-     * Assumes that property "containersDirectory" holds the location of the
-     * home directory of all Docker containers. Default: directory "containers"
-     * in the current working directory.
-     *
-     * Does not verify that the returned directory actually exists.
-     *
-     * @param containerId Id of the desired Docker container
-     * @return canonical location of the container's home directory
-     */
-    protected def containerDirectory(containerId: ContainerId) = {
-        new File(containersDirectory, containerId.asString).getCanonicalFile()
+  /**
+   * Provides the home directory of the specified Docker container.
+   *
+   * Assumes that property "containersDirectory" holds the location of the
+   * home directory of all Docker containers. Default: directory "containers"
+   * in the current working directory.
+   *
+   * Does not verify that the returned directory actually exists.
+   *
+   * @param containerId Id of the desired Docker container
+   * @return canonical location of the container's home directory
+   */
+  protected def containerDirectory(containerId: ContainerId) = {
+    new File(containersDirectory, containerId.asString).getCanonicalFile()
+  }
+
+  /**
+   * Provides the configuration file of the specified Docker container.
+   *
+   * Assumes that the file has the well-known location and name.
+   *
+   * Does not verify that the returned file actually exists.
+   *
+   * @param containerId Id of the desired Docker container
+   * @return canonical location of the container's configuration file
+   */
+  protected def containerConfigFile(containerId: ContainerId) = {
+    new File(containerDirectory(containerId), "config.v2.json").getCanonicalFile()
+  }
+
+  /**
+   * Provides the log file of the specified Docker container written by
+   * Docker's JSON log driver.
+   *
+   * Assumes that the file has the well-known location and name.
+   *
+   * Does not verify that the returned file actually exists.
+   *
+   * @param containerId Id of the desired Docker container
+   * @return canonical location of the container's log file
+   */
+  protected def containerLogFile(containerId: ContainerId) = {
+    new File(containerDirectory(containerId), s"${containerId.asString}-json.log").getCanonicalFile()
+  }
+
+  /**
+   * Provides the contents of the specified Docker container's configuration
+   * file as JSON object.
+   *
+   * @param configFile the container's configuration file in JSON format
+   * @return contents of configuration file as JSON object
+   */
+  protected def configFileContents(configFile: File): Future[JsObject] = Future {
+    blocking { // Needed due to synchronous file operations
+      val source = Source.fromFile(configFile)
+      val config = try source.mkString
+      finally source.close()
+      config.parseJson.asJsObject
     }
+  }
 
-    /**
-     * Provides the configuration file of the specified Docker container.
-     *
-     * Assumes that the file has the well-known location and name.
-     *
-     * Does not verify that the returned file actually exists.
-     *
-     * @param containerId Id of the desired Docker container
-     * @return canonical location of the container's configuration file
-     */
-    protected def containerConfigFile(containerId: ContainerId) = {
-        new File(containerDirectory(containerId), "config.v2.json").getCanonicalFile()
+  /**
+   * Extracts the IP of the container from the local config file of the docker daemon.
+   *
+   * A container may have more than one network. The container has an
+   * IP address in each of these networks such that the network name
+   * is needed.
+   *
+   * @param id the id of the container to get the IP address from
+   * @param network name of the network to get the IP address from
+   * @return the ip address of the container
+   */
+  protected def ipAddressFromFile(id: ContainerId, network: String): Future[ContainerIp] = {
+    configFileContents(containerConfigFile(id)).map { json =>
+      val networks = json.fields("NetworkSettings").asJsObject.fields("Networks").asJsObject
+      val specifiedNetwork = networks.fields(network).asJsObject
+      val ipAddr = specifiedNetwork.fields("IPAddress")
+      ContainerIp(ipAddr.convertTo[String])
     }
+  }
 
-    /**
-     * Provides the log file of the specified Docker container written by
-     * Docker's JSON log driver.
-     *
-     * Assumes that the file has the well-known location and name.
-     *
-     * Does not verify that the returned file actually exists.
-     *
-     * @param containerId Id of the desired Docker container
-     * @return canonical location of the container's log file
-     */
-    protected def containerLogFile(containerId: ContainerId) = {
-        new File(containerDirectory(containerId), s"${containerId.asString}-json.log").getCanonicalFile()
+  // See extended trait for description
+  override def inspectIPAddress(id: ContainerId, network: String)(
+    implicit transid: TransactionId): Future[ContainerIp] = {
+    ipAddressFromFile(id, network).recoverWith {
+      case _ => super.inspectIPAddress(id, network)
     }
+  }
 
-    /**
-     * Provides the contents of the specified Docker container's configuration
-     * file as JSON object.
-     *
-     * @param configFile the container's configuration file in JSON format
-     * @return contents of configuration file as JSON object
-     */
-    protected def configFileContents(configFile: File): Future[JsObject] = Future {
-        blocking { // Needed due to synchronous file operations
-            val source = Source.fromFile(configFile)
-            val config = try source.mkString finally source.close()
-            config.parseJson.asJsObject
+  // See extended trait for description
+  def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = Future {
+    blocking { // Needed due to synchronous file operations
+      var fis: FileInputStream = null
+      try {
+        val file = containerLogFile(containerId)
+        val size = file.length
+
+        fis = new FileInputStream(file)
+        val channel = fis.getChannel().position(fromPos)
+
+        // Buffer allocation may fail if the log file is too large to hold in memory or
+        // too few space is left on the heap, respectively.
+        var remainingBytes = (size - fromPos).toInt
+        val readBuffer = ByteBuffer.allocate(remainingBytes)
+
+        while (remainingBytes > 0) {
+          val readBytes = channel.read(readBuffer)
+          if (readBytes > 0) {
+            remainingBytes -= readBytes
+          } else if (readBytes < 0) {
+            remainingBytes = 0
+          }
         }
+
+        readBuffer
+      } catch {
+        case e: Exception =>
+          throw new IOException(s"rawContainerLogs failed on ${containerId}", e)
+      } finally {
+        if (fis != null) fis.close()
+      }
     }
-
-    /**
-     * Extracts the IP of the container from the local config file of the docker daemon.
-     *
-     * A container may have more than one network. The container has an
-     * IP address in each of these networks such that the network name
-     * is needed.
-     *
-     * @param id the id of the container to get the IP address from
-     * @param network name of the network to get the IP address from
-     * @return the ip address of the container
-     */
-    protected def ipAddressFromFile(id: ContainerId, network: String): Future[ContainerIp] = {
-        configFileContents(containerConfigFile(id)).map { json =>
-            val networks = json.fields("NetworkSettings").asJsObject.fields("Networks").asJsObject
-            val specifiedNetwork = networks.fields(network).asJsObject
-            val ipAddr = specifiedNetwork.fields("IPAddress")
-            ContainerIp(ipAddr.convertTo[String])
-        }
-    }
-
-    // See extended trait for description
-    override def inspectIPAddress(id: ContainerId, network: String)(implicit transid: TransactionId): Future[ContainerIp] = {
-        ipAddressFromFile(id, network).recoverWith {
-            case _ => super.inspectIPAddress(id, network)
-        }
-    }
-
-    // See extended trait for description
-    def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = Future {
-        blocking { // Needed due to synchronous file operations
-            var fis: FileInputStream = null
-            try {
-                val file = containerLogFile(containerId)
-                val size = file.length
-
-                fis = new FileInputStream(file)
-                val channel = fis.getChannel().position(fromPos)
-
-                // Buffer allocation may fail if the log file is too large to hold in memory or
-                // too few space is left on the heap, respectively.
-                var remainingBytes = (size - fromPos).toInt
-                val readBuffer = ByteBuffer.allocate(remainingBytes)
-
-                while (remainingBytes > 0) {
-                    val readBytes = channel.read(readBuffer)
-                    if (readBytes > 0) {
-                        remainingBytes -= readBytes
-                    } else if (readBytes < 0) {
-                        remainingBytes = 0
-                    }
-                }
-
-                readBuffer
-            } catch {
-                case e: Exception =>
-                    throw new IOException(s"rawContainerLogs failed on ${containerId}", e)
-            } finally {
-                if (fis != null) fis.close()
-            }
-        }
-    }
+  }
 }
 
 trait DockerApiWithFileAccess extends DockerApi {
 
-    /**
-     * Obtains the container's stdout and stderr by reading the internal docker log file
-     * for the container. Said file is written by docker's JSON log driver and has
-     * a "well-known" location and name.
-     *
-     * Reads the log file from the specified position to its end. The returned ByteBuffer
-     * indicates how many bytes were actually read from the file.
-     *
-     * Attention: a ByteBuffer is allocated to keep the file from the specified position to its end
-     * fully in memory. At the moment, there is no size limit checking which can lead to
-     * out-of-memory exceptions for very large files.
-     *
-     * Deals with incomplete reads and premature end of file situations. Behavior is undefined
-     * if the log file is changed or truncated while reading.
-     *
-     * @param containerId the container for which to provide logs
-     * @param fromPos position where to start reading the container's log file
-     * @return a ByteBuffer holding the read log file contents
-     */
-    def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer]
+  /**
+   * Obtains the container's stdout and stderr by reading the internal docker log file
+   * for the container. Said file is written by docker's JSON log driver and has
+   * a "well-known" location and name.
+   *
+   * Reads the log file from the specified position to its end. The returned ByteBuffer
+   * indicates how many bytes were actually read from the file.
+   *
+   * Attention: a ByteBuffer is allocated to keep the file from the specified position to its end
+   * fully in memory. At the moment, there is no size limit checking which can lead to
+   * out-of-memory exceptions for very large files.
+   *
+   * Deals with incomplete reads and premature end of file situations. Behavior is undefined
+   * if the log file is changed or truncated while reading.
+   *
+   * @param containerId the container for which to provide logs
+   * @param fromPos position where to start reading the container's log file
+   * @return a ByteBuffer holding the read log file contents
+   */
+  def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer]
 }

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
@@ -42,72 +42,83 @@ import whisk.core.entity.ActivationResponse.ContainerConnectionError
 import whisk.core.entity.ActivationResponse.ContainerResponse
 
 object DockerContainer {
-    /**
-     * Creates a container running on a docker daemon.
-     *
-     * @param transid transaction creating the container
-     * @param image image to create the container from
-     * @param userProvidedImage whether the image is provided by the user
-     *     or is an OpenWhisk provided image
-     * @param memory memorylimit of the container
-     * @param cpuShares sharefactor for the container
-     * @param environment environment variables to set on the container
-     * @param network network to launch the container in
-     * @param dnsServers list of dns servers to use in the container
-     * @param name optional name for the container
-     * @return a Future which either completes with a DockerContainer or one of two specific failures
-     */
-    def create(transid: TransactionId,
-               image: String,
-               userProvidedImage: Boolean = false,
-               memory: ByteSize = 256.MB,
-               cpuShares: Int = 0,
-               environment: Map[String, String] = Map(),
-               network: String = "bridge",
-               dnsServers: Seq[String] = Seq(),
-               name: Option[String] = None)(
-                   implicit docker: DockerApiWithFileAccess, runc: RuncApi, ec: ExecutionContext, log: Logging): Future[DockerContainer] = {
-        implicit val tid = transid
 
-        val environmentArgs = environment.map {
-            case (key, value) => Seq("-e", s"$key=$value")
-        }.flatten
+  /**
+   * Creates a container running on a docker daemon.
+   *
+   * @param transid transaction creating the container
+   * @param image image to create the container from
+   * @param userProvidedImage whether the image is provided by the user
+   *     or is an OpenWhisk provided image
+   * @param memory memorylimit of the container
+   * @param cpuShares sharefactor for the container
+   * @param environment environment variables to set on the container
+   * @param network network to launch the container in
+   * @param dnsServers list of dns servers to use in the container
+   * @param name optional name for the container
+   * @return a Future which either completes with a DockerContainer or one of two specific failures
+   */
+  def create(transid: TransactionId,
+             image: String,
+             userProvidedImage: Boolean = false,
+             memory: ByteSize = 256.MB,
+             cpuShares: Int = 0,
+             environment: Map[String, String] = Map(),
+             network: String = "bridge",
+             dnsServers: Seq[String] = Seq(),
+             name: Option[String] = None)(implicit docker: DockerApiWithFileAccess,
+                                          runc: RuncApi,
+                                          ec: ExecutionContext,
+                                          log: Logging): Future[DockerContainer] = {
+    implicit val tid = transid
 
-        val dnsArgs = dnsServers.map(Seq("--dns", _)).flatten
+    val environmentArgs = environment.map {
+      case (key, value) => Seq("-e", s"$key=$value")
+    }.flatten
 
-        val args = Seq(
-            "--cap-drop", "NET_RAW",
-            "--cap-drop", "NET_ADMIN",
-            "--ulimit", "nofile=1024:1024",
-            "--pids-limit", "1024",
-            "--cpu-shares", cpuShares.toString,
-            "--memory", s"${memory.toMB}m",
-            "--memory-swap", s"${memory.toMB}m",
-            "--network", network) ++
-            dnsArgs ++
-            environmentArgs ++
-            name.map(n => Seq("--name", n)).getOrElse(Seq.empty)
+    val dnsArgs = dnsServers.map(Seq("--dns", _)).flatten
 
-        val pulled = if (userProvidedImage) {
-            docker.pull(image).recoverWith {
-                case _ => Future.failed(BlackboxStartupError(s"Failed to pull container image '${image}'."))
-            }
-        } else Future.successful(())
+    val args = Seq(
+      "--cap-drop",
+      "NET_RAW",
+      "--cap-drop",
+      "NET_ADMIN",
+      "--ulimit",
+      "nofile=1024:1024",
+      "--pids-limit",
+      "1024",
+      "--cpu-shares",
+      cpuShares.toString,
+      "--memory",
+      s"${memory.toMB}m",
+      "--memory-swap",
+      s"${memory.toMB}m",
+      "--network",
+      network) ++
+      dnsArgs ++
+      environmentArgs ++
+      name.map(n => Seq("--name", n)).getOrElse(Seq.empty)
 
-        for {
-            _ <- pulled
-            id <- docker.run(image, args).recoverWith {
-                case _ => Future.failed(WhiskContainerStartupError(s"Failed to run container with image '${image}'."))
-            }
-            ip <- docker.inspectIPAddress(id, network).recoverWith {
-                // remove the container immediately if inspect failed as
-                // we cannot recover that case automatically
-                case _ =>
-                    docker.rm(id)
-                    Future.failed(WhiskContainerStartupError(s"Failed to obtain IP address of container '${id.asString}'."))
-            }
-        } yield new DockerContainer(id, ip)
-    }
+    val pulled = if (userProvidedImage) {
+      docker.pull(image).recoverWith {
+        case _ => Future.failed(BlackboxStartupError(s"Failed to pull container image '${image}'."))
+      }
+    } else Future.successful(())
+
+    for {
+      _ <- pulled
+      id <- docker.run(image, args).recoverWith {
+        case _ => Future.failed(WhiskContainerStartupError(s"Failed to run container with image '${image}'."))
+      }
+      ip <- docker.inspectIPAddress(id, network).recoverWith {
+        // remove the container immediately if inspect failed as
+        // we cannot recover that case automatically
+        case _ =>
+          docker.rm(id)
+          Future.failed(WhiskContainerStartupError(s"Failed to obtain IP address of container '${id.asString}'."))
+      }
+    } yield new DockerContainer(id, ip)
+  }
 }
 
 /**
@@ -120,140 +131,171 @@ object DockerContainer {
  * @param id the id of the container
  * @param ip the ip of the container
  */
-class DockerContainer(id: ContainerId, ip: ContainerIp)(
-    implicit docker: DockerApiWithFileAccess, runc: RuncApi, ec: ExecutionContext, logger: Logging) extends Container with DockerActionLogDriver {
+class DockerContainer(id: ContainerId, ip: ContainerIp)(implicit docker: DockerApiWithFileAccess,
+                                                        runc: RuncApi,
+                                                        ec: ExecutionContext,
+                                                        logger: Logging)
+    extends Container
+    with DockerActionLogDriver {
 
-    /** The last read-position in the log file */
-    private var logFileOffset = 0L
+  /** The last read-position in the log file */
+  private var logFileOffset = 0L
 
-    protected val logsRetryCount = 15
-    protected val logsRetryWait = 100.millis
+  protected val logsRetryCount = 15
+  protected val logsRetryWait = 100.millis
 
-    /** HTTP connection to the container, will be lazily established by callContainer */
-    private var httpConnection: Option[HttpUtils] = None
+  /** HTTP connection to the container, will be lazily established by callContainer */
+  private var httpConnection: Option[HttpUtils] = None
 
-    def suspend()(implicit transid: TransactionId): Future[Unit] = runc.pause(id)
-    def resume()(implicit transid: TransactionId): Future[Unit] = runc.resume(id)
-    def destroy()(implicit transid: TransactionId): Future[Unit] = {
-        httpConnection.foreach(_.close())
-        docker.rm(id)
-    }
+  def suspend()(implicit transid: TransactionId): Future[Unit] = runc.pause(id)
+  def resume()(implicit transid: TransactionId): Future[Unit] = runc.resume(id)
+  def destroy()(implicit transid: TransactionId): Future[Unit] = {
+    httpConnection.foreach(_.close())
+    docker.rm(id)
+  }
 
-    def initialize(initializer: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[Interval] = {
-        val start = transid.started(this, LoggingMarkers.INVOKER_ACTIVATION_INIT, s"sending initialization to $id $ip")
+  def initialize(initializer: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[Interval] = {
+    val start = transid.started(this, LoggingMarkers.INVOKER_ACTIVATION_INIT, s"sending initialization to $id $ip")
 
-        val body = JsObject("value" -> initializer)
-        callContainer("/init", body, timeout, retry = true).andThen { // never fails
-            case Success(r: RunResult) =>
-                transid.finished(this, start.copy(start = r.interval.start), s"initialization result: ${r.toBriefString}", endTime = r.interval.end)
-            case Failure(t) =>
-                transid.failed(this, start, s"initializiation failed with $t")
-        }.flatMap { result =>
-            if (result.ok) {
-                Future.successful(result.interval)
-            } else if (result.interval.duration >= timeout) {
-                Future.failed(InitializationError(result.interval, ActivationResponse.applicationError(Messages.timedoutActivation(timeout, true))))
-            } else {
-                Future.failed(InitializationError(result.interval, ActivationResponse.processInitResponseContent(result.response, logger)))
-            }
+    val body = JsObject("value" -> initializer)
+    callContainer("/init", body, timeout, retry = true)
+      .andThen { // never fails
+        case Success(r: RunResult) =>
+          transid.finished(
+            this,
+            start.copy(start = r.interval.start),
+            s"initialization result: ${r.toBriefString}",
+            endTime = r.interval.end)
+        case Failure(t) =>
+          transid.failed(this, start, s"initializiation failed with $t")
+      }
+      .flatMap { result =>
+        if (result.ok) {
+          Future.successful(result.interval)
+        } else if (result.interval.duration >= timeout) {
+          Future.failed(
+            InitializationError(
+              result.interval,
+              ActivationResponse.applicationError(Messages.timedoutActivation(timeout, true))))
+        } else {
+          Future.failed(
+            InitializationError(
+              result.interval,
+              ActivationResponse.processInitResponseContent(result.response, logger)))
+        }
+      }
+  }
+
+  def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration)(
+    implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
+    val actionName = environment.fields.get("action_name").map(_.convertTo[String]).getOrElse("")
+    val start =
+      transid.started(this, LoggingMarkers.INVOKER_ACTIVATION_RUN, s"sending arguments to $actionName at $id $ip")
+
+    val parameterWrapper = JsObject("value" -> parameters)
+    val body = JsObject(parameterWrapper.fields ++ environment.fields)
+    callContainer("/run", body, timeout, retry = false)
+      .andThen { // never fails
+        case Success(r: RunResult) =>
+          transid.finished(
+            this,
+            start.copy(start = r.interval.start),
+            s"running result: ${r.toBriefString}",
+            endTime = r.interval.end)
+        case Failure(t) =>
+          transid.failed(this, start, s"run failed with $t")
+      }
+      .map { result =>
+        val response = if (result.interval.duration >= timeout) {
+          ActivationResponse.applicationError(Messages.timedoutActivation(timeout, false))
+        } else {
+          ActivationResponse.processRunResponseContent(result.response, logger)
+        }
+
+        (result.interval, response)
+      }
+  }
+
+  /**
+   * Obtains the container's stdout and stderr output and converts it to our own JSON format.
+   * At the moment, this is done by reading the internal Docker log file for the container.
+   * Said file is written by Docker's JSON log driver and has a "well-known" location and name.
+   *
+   * For warm containers, the container log file already holds output from
+   * previous activations that have to be skipped. For this reason, a starting position
+   * is kept and updated upon each invocation.
+   *
+   * If asked, check for sentinel markers - but exclude the identified markers from
+   * the result returned from this method.
+   *
+   * Only parses and returns as much logs as fit in the passed log limit.
+   * Even if the log limit is exceeded, advance the starting position for the next invocation
+   * behind the bytes most recently read - but don't actively read any more until sentinel
+   * markers have been found.
+   *
+   * @param limit the limit to apply to the log size
+   * @param waitForSentinel determines if the processor should wait for a sentinel to appear
+   *
+   * @return a vector of Strings with log lines in our own JSON format
+   */
+  def logs(limit: ByteSize, waitForSentinel: Boolean)(implicit transid: TransactionId): Future[Vector[String]] = {
+
+    def readLogs(retries: Int): Future[Vector[String]] = {
+      docker
+        .rawContainerLogs(id, logFileOffset)
+        .flatMap { rawLogBytes =>
+          val rawLog =
+            new String(rawLogBytes.array, rawLogBytes.arrayOffset, rawLogBytes.position, StandardCharsets.UTF_8)
+          val (isComplete, isTruncated, formattedLogs) = processJsonDriverLogContents(rawLog, waitForSentinel, limit)
+
+          if (retries > 0 && !isComplete && !isTruncated) {
+            logger.info(this, s"log cursor advanced but missing sentinel, trying $retries more times")
+            Thread.sleep(logsRetryWait.toMillis)
+            readLogs(retries - 1)
+          } else {
+            logFileOffset += rawLogBytes.position - rawLogBytes.arrayOffset
+            Future.successful(formattedLogs)
+          }
+        }
+        .andThen {
+          case Failure(e) =>
+            logger.error(this, s"Failed to obtain logs of ${id.asString}: ${e.getClass} - ${e.getMessage}")
         }
     }
 
-    def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
-        val actionName = environment.fields.get("action_name").map(_.convertTo[String]).getOrElse("")
-        val start = transid.started(this, LoggingMarkers.INVOKER_ACTIVATION_RUN, s"sending arguments to $actionName at $id $ip")
+    readLogs(logsRetryCount)
+  }
 
-        val parameterWrapper = JsObject("value" -> parameters)
-        val body = JsObject(parameterWrapper.fields ++ environment.fields)
-        callContainer("/run", body, timeout, retry = false).andThen { // never fails
-            case Success(r: RunResult) =>
-                transid.finished(this, start.copy(start = r.interval.start), s"running result: ${r.toBriefString}", endTime = r.interval.end)
-            case Failure(t) =>
-                transid.failed(this, start, s"run failed with $t")
-        }.map { result =>
-            val response = if (result.interval.duration >= timeout) {
-                ActivationResponse.applicationError(Messages.timedoutActivation(timeout, false))
-            } else {
-                ActivationResponse.processRunResponseContent(result.response, logger)
-            }
-
-            (result.interval, response)
-        }
+  /**
+   * Makes an HTTP request to the container.
+   *
+   * Note that `http.post` will not throw an exception, hence the generated Future cannot fail.
+   *
+   * @param path relative path to use in the http request
+   * @param body body to send
+   * @param timeout timeout of the request
+   * @param retry whether or not to retry the request
+   */
+  protected def callContainer(path: String,
+                              body: JsObject,
+                              timeout: FiniteDuration,
+                              retry: Boolean = false): Future[RunResult] = {
+    val started = Instant.now()
+    val http = httpConnection.getOrElse {
+      val conn = new HttpUtils(s"${ip.asString}:8080", timeout, 1.MB)
+      httpConnection = Some(conn)
+      conn
     }
-
-    /**
-     * Obtains the container's stdout and stderr output and converts it to our own JSON format.
-     * At the moment, this is done by reading the internal Docker log file for the container.
-     * Said file is written by Docker's JSON log driver and has a "well-known" location and name.
-     *
-     * For warm containers, the container log file already holds output from
-     * previous activations that have to be skipped. For this reason, a starting position
-     * is kept and updated upon each invocation.
-     *
-     * If asked, check for sentinel markers - but exclude the identified markers from
-     * the result returned from this method.
-     *
-     * Only parses and returns as much logs as fit in the passed log limit.
-     * Even if the log limit is exceeded, advance the starting position for the next invocation
-     * behind the bytes most recently read - but don't actively read any more until sentinel
-     * markers have been found.
-     *
-     * @param limit the limit to apply to the log size
-     * @param waitForSentinel determines if the processor should wait for a sentinel to appear
-     *
-     * @return a vector of Strings with log lines in our own JSON format
-     */
-    def logs(limit: ByteSize, waitForSentinel: Boolean)(implicit transid: TransactionId): Future[Vector[String]] = {
-
-        def readLogs(retries: Int): Future[Vector[String]] = {
-            docker.rawContainerLogs(id, logFileOffset).flatMap { rawLogBytes =>
-                val rawLog = new String(rawLogBytes.array, rawLogBytes.arrayOffset, rawLogBytes.position, StandardCharsets.UTF_8)
-                val (isComplete, isTruncated, formattedLogs) = processJsonDriverLogContents(rawLog, waitForSentinel, limit)
-
-                if (retries > 0 && !isComplete && !isTruncated) {
-                    logger.info(this, s"log cursor advanced but missing sentinel, trying $retries more times")
-                    Thread.sleep(logsRetryWait.toMillis)
-                    readLogs(retries - 1)
-                } else {
-                    logFileOffset += rawLogBytes.position - rawLogBytes.arrayOffset
-                    Future.successful(formattedLogs)
-                }
-            }.andThen {
-                case Failure(e) =>
-                    logger.error(this, s"Failed to obtain logs of ${id.asString}: ${e.getClass} - ${e.getMessage}")
-            }
-        }
-
-        readLogs(logsRetryCount)
+    Future {
+      http.post(path, body, retry)
+    }.map { response =>
+      val finished = Instant.now()
+      RunResult(Interval(started, finished), response)
     }
-
-    /**
-     * Makes an HTTP request to the container.
-     *
-     * Note that `http.post` will not throw an exception, hence the generated Future cannot fail.
-     *
-     * @param path relative path to use in the http request
-     * @param body body to send
-     * @param timeout timeout of the request
-     * @param retry whether or not to retry the request
-     */
-    protected def callContainer(path: String, body: JsObject, timeout: FiniteDuration, retry: Boolean = false): Future[RunResult] = {
-        val started = Instant.now()
-        val http = httpConnection.getOrElse {
-            val conn = new HttpUtils(s"${ip.asString}:8080", timeout, 1.MB)
-            httpConnection = Some(conn)
-            conn
-        }
-        Future {
-            http.post(path, body, retry)
-        }.map { response =>
-            val finished = Instant.now()
-            RunResult(Interval(started, finished), response)
-        }
-    }
+  }
 }
 
 case class RunResult(interval: Interval, response: Either[ContainerConnectionError, ContainerResponse]) {
-    def ok = response.right.exists(_.ok)
-    def toBriefString = response.fold(_.toString, _.toString)
+  def ok = response.right.exists(_.ok)
+  def toBriefString = response.fold(_.toString, _.toString)
 }

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/HttpUtils.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/HttpUtils.scala
@@ -51,102 +51,104 @@ import scala.Right
  * @param timeoutMsec the timeout in msecs to wait for a response
  * @param maxResponse the maximum size in bytes the connection will accept
  */
-protected[core] class HttpUtils(
-    hostname: String,
-    timeout: FiniteDuration,
-    maxResponse: ByteSize) {
+protected[core] class HttpUtils(hostname: String, timeout: FiniteDuration, maxResponse: ByteSize) {
 
-    def close() = Try(connection.close())
+  def close() = Try(connection.close())
 
-    /**
-     * Posts to hostname/endpoint the given JSON object.
-     * Waits up to timeout before aborting on a good connection.
-     * If the endpoint is not ready, retry up to timeout.
-     * Every retry reduces the available timeout so that this method should not
-     * wait longer than the total timeout (within a small slack allowance).
-     *
-     * @param endpoint the path the api call relative to hostname
-     * @param body the JSON value to post (this is usually a JSON objecT)
-     * @param retry whether or not to retry on connection failure
-     * @return Left(Error Message) or Right(Status Code, Response as UTF-8 String)
-     */
-    def post(endpoint: String, body: JsValue, retry: Boolean): Either[ContainerConnectionError, ContainerResponse] = {
-        val entity = new StringEntity(body.compactPrint, StandardCharsets.UTF_8)
-        entity.setContentType("application/json")
+  /**
+   * Posts to hostname/endpoint the given JSON object.
+   * Waits up to timeout before aborting on a good connection.
+   * If the endpoint is not ready, retry up to timeout.
+   * Every retry reduces the available timeout so that this method should not
+   * wait longer than the total timeout (within a small slack allowance).
+   *
+   * @param endpoint the path the api call relative to hostname
+   * @param body the JSON value to post (this is usually a JSON objecT)
+   * @param retry whether or not to retry on connection failure
+   * @return Left(Error Message) or Right(Status Code, Response as UTF-8 String)
+   */
+  def post(endpoint: String, body: JsValue, retry: Boolean): Either[ContainerConnectionError, ContainerResponse] = {
+    val entity = new StringEntity(body.compactPrint, StandardCharsets.UTF_8)
+    entity.setContentType("application/json")
 
-        val request = new HttpPost(baseUri.setPath(endpoint).build)
-        request.addHeader(HttpHeaders.ACCEPT, "application/json")
-        request.setEntity(entity)
+    val request = new HttpPost(baseUri.setPath(endpoint).build)
+    request.addHeader(HttpHeaders.ACCEPT, "application/json")
+    request.setEntity(entity)
 
-        execute(request, timeout.toMillis.toInt, retry)
-    }
+    execute(request, timeout.toMillis.toInt, retry)
+  }
 
-    private def execute(request: HttpRequestBase, timeoutMsec: Integer, retry: Boolean): Either[ContainerConnectionError, ContainerResponse] = {
-        Try(connection.execute(request)).map { response =>
-            val containerResponse = Option(response.getEntity).map { entity =>
-                val statusCode = response.getStatusLine.getStatusCode
-                val contentLength = entity.getContentLength
+  private def execute(request: HttpRequestBase,
+                      timeoutMsec: Integer,
+                      retry: Boolean): Either[ContainerConnectionError, ContainerResponse] = {
+    Try(connection.execute(request)).map { response =>
+      val containerResponse = Option(response.getEntity)
+        .map { entity =>
+          val statusCode = response.getStatusLine.getStatusCode
+          val contentLength = entity.getContentLength
 
-                if (contentLength >= 0) {
-                    val bytesToRead = Math.min(contentLength, maxResponseBytes)
-                    val bytes = IOUtils.toByteArray(entity.getContent, bytesToRead)
-                    val str = new String(bytes, StandardCharsets.UTF_8)
-                    val truncated = if (contentLength <= maxResponseBytes) None else Some(contentLength.B, maxResponse)
-                    Right(ContainerResponse(statusCode, str, truncated))
-                } else {
-                    Left(NoResponseReceived())
-                }
-            }.getOrElse {
-                // entity is null
-                Left(NoResponseReceived())
-            }
-
-            response.close()
-            containerResponse
-        } match {
-            case Success(r) => r
-            case Failure(t: HttpHostConnectException) if retry =>
-                if (timeoutMsec > 0) {
-                    Thread sleep 100
-                    val newTimeout = timeoutMsec - 100
-                    execute(request, newTimeout, retry)
-                } else {
-                    Left(Timeout())
-                }
-            case Failure(t: Throwable) => Left(ConnectionError(t))
+          if (contentLength >= 0) {
+            val bytesToRead = Math.min(contentLength, maxResponseBytes)
+            val bytes = IOUtils.toByteArray(entity.getContent, bytesToRead)
+            val str = new String(bytes, StandardCharsets.UTF_8)
+            val truncated = if (contentLength <= maxResponseBytes) None else Some(contentLength.B, maxResponse)
+            Right(ContainerResponse(statusCode, str, truncated))
+          } else {
+            Left(NoResponseReceived())
+          }
         }
+        .getOrElse {
+          // entity is null
+          Left(NoResponseReceived())
+        }
+
+      response.close()
+      containerResponse
+    } match {
+      case Success(r) => r
+      case Failure(t: HttpHostConnectException) if retry =>
+        if (timeoutMsec > 0) {
+          Thread sleep 100
+          val newTimeout = timeoutMsec - 100
+          execute(request, newTimeout, retry)
+        } else {
+          Left(Timeout())
+        }
+      case Failure(t: Throwable) => Left(ConnectionError(t))
     }
+  }
 
-    private val maxResponseBytes = maxResponse.toBytes
+  private val maxResponseBytes = maxResponse.toBytes
 
-    private val baseUri = new URIBuilder()
-        .setScheme("http")
-        .setHost(hostname)
+  private val baseUri = new URIBuilder()
+    .setScheme("http")
+    .setHost(hostname)
 
-    private val httpconfig = RequestConfig.custom
-        .setConnectTimeout(timeout.toMillis.toInt)
-        .setConnectionRequestTimeout(timeout.toMillis.toInt)
-        .setSocketTimeout(timeout.toMillis.toInt)
-        .build
+  private val httpconfig = RequestConfig.custom
+    .setConnectTimeout(timeout.toMillis.toInt)
+    .setConnectionRequestTimeout(timeout.toMillis.toInt)
+    .setSocketTimeout(timeout.toMillis.toInt)
+    .build
 
-    private val connection = HttpClientBuilder
-        .create
-        .setDefaultRequestConfig(httpconfig)
-        .useSystemProperties()
-        .build
+  private val connection = HttpClientBuilder.create
+    .setDefaultRequestConfig(httpconfig)
+    .useSystemProperties()
+    .build
 }
 
 object HttpUtils {
-    /** A helper method to post one single request to a connection. Used for container tests. */
-    def post(host: String, port: Int, endPoint: String, content: JsValue): (Int, Option[JsObject]) = {
-        val connection = new HttpUtils(s"$host:$port", 90.seconds, 1.MB)
-        val response = connection.post(endPoint, content, retry = true)
-        connection.close()
-        response match {
-            case Right(r) => (r.statusCode, Try(r.entity.parseJson.asJsObject).toOption)
-            case Left(Timeout()) => throw new java.util.concurrent.TimeoutException()
-            case Left(ConnectionError(t: java.net.SocketTimeoutException)) => throw new java.util.concurrent.TimeoutException()
-            case _ => throw new IllegalStateException()
-        }
+
+  /** A helper method to post one single request to a connection. Used for container tests. */
+  def post(host: String, port: Int, endPoint: String, content: JsValue): (Int, Option[JsObject]) = {
+    val connection = new HttpUtils(s"$host:$port", 90.seconds, 1.MB)
+    val response = connection.post(endPoint, content, retry = true)
+    connection.close()
+    response match {
+      case Right(r)        => (r.statusCode, Try(r.entity.parseJson.asJsObject).toOption)
+      case Left(Timeout()) => throw new java.util.concurrent.TimeoutException()
+      case Left(ConnectionError(t: java.net.SocketTimeoutException)) =>
+        throw new java.util.concurrent.TimeoutException()
+      case _ => throw new IllegalStateException()
     }
+  }
 }

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/ProcessRunner.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/ProcessRunner.scala
@@ -25,29 +25,30 @@ import scala.sys.process._
 
 trait ProcessRunner {
 
-    /**
-     * Runs the specified command with arguments asynchronously and
-     * capture stdout as well as stderr.
-     *
-     * Be cautious with the execution context you pass because the command
-     * is blocking.
-     *
-     * @param args command to be run including arguments
-     * @return a future completing according to the command's exit code
-     */
-    protected def executeProcess(args: String*)(implicit ec: ExecutionContext) =
-        Future(blocking {
-            val out = new mutable.ListBuffer[String]
-            val err = new mutable.ListBuffer[String]
-            val exitCode = args ! ProcessLogger(o => out += o, e => err += e)
+  /**
+   * Runs the specified command with arguments asynchronously and
+   * capture stdout as well as stderr.
+   *
+   * Be cautious with the execution context you pass because the command
+   * is blocking.
+   *
+   * @param args command to be run including arguments
+   * @return a future completing according to the command's exit code
+   */
+  protected def executeProcess(args: String*)(implicit ec: ExecutionContext) =
+    Future(blocking {
+      val out = new mutable.ListBuffer[String]
+      val err = new mutable.ListBuffer[String]
+      val exitCode = args ! ProcessLogger(o => out += o, e => err += e)
 
-            (exitCode, out.mkString("\n"), err.mkString("\n"))
-        }).flatMap {
-            case (0, stdout, _) =>
-                Future.successful(stdout)
-            case (code, stdout, stderr) =>
-                Future.failed(ProcessRunningException(code, stdout, stderr))
-        }
+      (exitCode, out.mkString("\n"), err.mkString("\n"))
+    }).flatMap {
+      case (0, stdout, _) =>
+        Future.successful(stdout)
+      case (code, stdout, stderr) =>
+        Future.failed(ProcessRunningException(code, stdout, stderr))
+    }
 }
 
-case class ProcessRunningException(exitCode: Int, stdout: String, stderr: String) extends Exception(s"code: $exitCode, stdout: $stdout, stderr: $stderr")
+case class ProcessRunningException(exitCode: Int, stdout: String, stderr: String)
+    extends Exception(s"code: $exitCode, stdout: $stdout, stderr: $stderr")

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/RuncClient.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/RuncClient.scala
@@ -35,40 +35,42 @@ import akka.event.Logging.ErrorLevel
  * You only need one instance (and you shouldn't get more).
  */
 class RuncClient(executionContext: ExecutionContext)(implicit log: Logging) extends RuncApi with ProcessRunner {
-    implicit private val ec = executionContext
+  implicit private val ec = executionContext
 
-    // Determines how to run docker. Failure to find a Docker binary implies
-    // a failure to initialize this instance of DockerClient.
-    protected val runcCmd: Seq[String] = Seq("/usr/bin/docker-runc")
+  // Determines how to run docker. Failure to find a Docker binary implies
+  // a failure to initialize this instance of DockerClient.
+  protected val runcCmd: Seq[String] = Seq("/usr/bin/docker-runc")
 
-    def pause(id: ContainerId)(implicit transid: TransactionId): Future[Unit] = runCmd("pause", id.asString).map(_ => ())
+  def pause(id: ContainerId)(implicit transid: TransactionId): Future[Unit] = runCmd("pause", id.asString).map(_ => ())
 
-    def resume(id: ContainerId)(implicit transid: TransactionId): Future[Unit] = runCmd("resume", id.asString).map(_ => ())
+  def resume(id: ContainerId)(implicit transid: TransactionId): Future[Unit] =
+    runCmd("resume", id.asString).map(_ => ())
 
-    private def runCmd(args: String*)(implicit transid: TransactionId): Future[String] = {
-        val cmd = runcCmd ++ args
-        val start = transid.started(this, LoggingMarkers.INVOKER_RUNC_CMD(args.head), s"running ${cmd.mkString(" ")}")
-        executeProcess(cmd: _*).andThen {
-            case Success(_) => transid.finished(this, start)
-            case Failure(t) => transid.failed(this, start, t.getMessage, ErrorLevel)
-        }
+  private def runCmd(args: String*)(implicit transid: TransactionId): Future[String] = {
+    val cmd = runcCmd ++ args
+    val start = transid.started(this, LoggingMarkers.INVOKER_RUNC_CMD(args.head), s"running ${cmd.mkString(" ")}")
+    executeProcess(cmd: _*).andThen {
+      case Success(_) => transid.finished(this, start)
+      case Failure(t) => transid.failed(this, start, t.getMessage, ErrorLevel)
     }
+  }
 }
 
 trait RuncApi {
-    /**
-     * Pauses the container with the given id.
-     *
-     * @param id the id of the container to pause
-     * @return a Future completing according to the command's exit-code
-     */
-    def pause(id: ContainerId)(implicit transid: TransactionId): Future[Unit]
 
-    /**
-     * Unpauses the container with the given id.
-     *
-     * @param id the id of the container to unpause
-     * @return a Future completing according to the command's exit-code
-     */
-    def resume(id: ContainerId)(implicit transid: TransactionId): Future[Unit]
+  /**
+   * Pauses the container with the given id.
+   *
+   * @param id the id of the container to pause
+   * @return a Future completing according to the command's exit-code
+   */
+  def pause(id: ContainerId)(implicit transid: TransactionId): Future[Unit]
+
+  /**
+   * Unpauses the container with the given id.
+   *
+   * @param id the id of the container to unpause
+   * @return a Future completing according to the command's exit-code
+   */
+  def resume(id: ContainerId)(implicit transid: TransactionId): Future[Unit]
 }

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerServer.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerServer.scala
@@ -25,8 +25,4 @@ import whisk.http.BasicRasService
  * Implements web server to handle certain REST API calls.
  * Currently provides a health ping route, only.
  */
-class InvokerServer(
-    override val instance: InstanceId,
-    override val numberOfInstances: Int)
-    extends BasicRasService {
-}
+class InvokerServer(override val instance: InstanceId, override val numberOfInstances: Int) extends BasicRasService {}

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,3 +26,8 @@ gradle.ext.scala = [
     version: '2.11.8',
     compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
 ]
+
+gradle.ext.scalafmt = [
+    version: '1.5.0',
+    config: new File(rootProject.projectDir, '.scalafmt.conf')
+]

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -1,5 +1,17 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath "cz.alenkacz:gradle-scalafmt:${gradle.scalafmt.version}"
+    }
+}
+
 apply plugin: 'scala'
 apply plugin: 'eclipse'
+apply plugin: 'scalafmt'
+
+scalafmt.configFilePath = gradle.scalafmt.config
 compileTestScala.options.encoding = 'UTF-8'
 
 repositories {

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -1,12 +1,3 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath "cz.alenkacz:gradle-scalafmt:${gradle.scalafmt.version}"
-    }
-}
-
 apply plugin: 'scala'
 apply plugin: 'eclipse'
 apply plugin: 'scalafmt'

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -1,8 +1,5 @@
 apply plugin: 'scala'
 apply plugin: 'eclipse'
-apply plugin: 'scalafmt'
-
-scalafmt.configFilePath = gradle.scalafmt.config
 compileTestScala.options.encoding = 'UTF-8'
 
 repositories {

--- a/tests/src/test/scala/actionContainers/ActionContainer.scala
+++ b/tests/src/test/scala/actionContainers/ActionContainer.scala
@@ -46,124 +46,127 @@ import whisk.core.entity.Exec
  * container as blocking method calls of this interface.
  */
 trait ActionContainer {
-    def init(value: JsValue): (Int, Option[JsObject])
-    def run(value: JsValue): (Int, Option[JsObject])
+  def init(value: JsValue): (Int, Option[JsObject])
+  def run(value: JsValue): (Int, Option[JsObject])
 }
 
 trait ActionProxyContainerTestUtils extends FlatSpec with Matchers {
-    import ActionContainer.{ filterSentinel, sentinel }
+  import ActionContainer.{filterSentinel, sentinel}
 
-    def initPayload(code: String, main: String = "main") = {
-        JsObject("value" -> JsObject(
-            "code" -> { if (code != null) JsString(code) else JsNull },
-            "main" -> JsString(main),
-            "binary" -> JsBoolean(Exec.isBinaryCode(code))))
+  def initPayload(code: String, main: String = "main") = {
+    JsObject(
+      "value" -> JsObject(
+        "code" -> { if (code != null) JsString(code) else JsNull },
+        "main" -> JsString(main),
+        "binary" -> JsBoolean(Exec.isBinaryCode(code))))
+  }
+
+  def runPayload(args: JsValue, other: Option[JsObject] = None) = {
+    JsObject(Map("value" -> args) ++ (other map { _.fields } getOrElse Map()))
+  }
+
+  def checkStreams(out: String, err: String, additionalCheck: (String, String) => Unit, sentinelCount: Int = 1) = {
+    withClue("expected number of stdout sentinels") {
+      sentinelCount shouldBe StringUtils.countMatches(out, sentinel)
+    }
+    withClue("expected number of stderr sentinels") {
+      sentinelCount shouldBe StringUtils.countMatches(err, sentinel)
     }
 
-    def runPayload(args: JsValue, other: Option[JsObject] = None) = {
-        JsObject(Map("value" -> args) ++ (other map { _.fields } getOrElse Map()))
-    }
-
-    def checkStreams(out: String, err: String, additionalCheck: (String, String) => Unit, sentinelCount: Int = 1) = {
-        withClue("expected number of stdout sentinels") {
-            sentinelCount shouldBe StringUtils.countMatches(out, sentinel)
-        }
-        withClue("expected number of stderr sentinels") {
-            sentinelCount shouldBe StringUtils.countMatches(err, sentinel)
-        }
-
-        val (o, e) = (filterSentinel(out), filterSentinel(err))
-        o should not include (sentinel)
-        e should not include (sentinel)
-        additionalCheck(o, e)
-    }
+    val (o, e) = (filterSentinel(out), filterSentinel(err))
+    o should not include (sentinel)
+    e should not include (sentinel)
+    additionalCheck(o, e)
+  }
 }
 
 object ActionContainer {
-    private lazy val dockerBin: String = {
-        List("/usr/bin/docker", "/usr/local/bin/docker").find { bin =>
-            new File(bin).isFile()
-        }.getOrElse(???) // This fails if the docker binary couldn't be located.
+  private lazy val dockerBin: String = {
+    List("/usr/bin/docker", "/usr/local/bin/docker")
+      .find { bin =>
+        new File(bin).isFile()
+      }
+      .getOrElse(???) // This fails if the docker binary couldn't be located.
+  }
+
+  private lazy val dockerCmd: String = {
+    val hostStr = if (WhiskProperties.onMacOSX()) {
+      s" --host tcp://${WhiskProperties.getMainDockerEndpoint()} "
+    } else {
+      " "
+    }
+    s"$dockerBin $hostStr"
+  }
+
+  private def docker(command: String): String = s"$dockerCmd $command"
+
+  // Runs a process asynchronously. Returns a future with (exitCode,stdout,stderr)
+  private def proc(cmd: String): Future[(Int, String, String)] = Future {
+    blocking {
+      val out = new ByteArrayOutputStream
+      val err = new ByteArrayOutputStream
+      val outW = new PrintWriter(out)
+      val errW = new PrintWriter(err)
+      val v = cmd ! (ProcessLogger(outW.println, errW.println))
+      outW.close()
+      errW.close()
+      (v, out.toString, err.toString)
+    }
+  }
+
+  // Tying it all together, we have a method that runs docker, waits for
+  // completion for some time then returns the exit code, the output stream
+  // and the error stream.
+  private def awaitDocker(cmd: String, t: Duration): (Int, String, String) = {
+    Await.result(proc(docker(cmd)), t)
+  }
+
+  // Filters out the sentinel markers inserted by the container (see relevant private code in Invoker.scala)
+  val sentinel = "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX"
+  def filterSentinel(str: String) = str.replaceAll(sentinel, "").trim
+
+  def withContainer(imageName: String, environment: Map[String, String] = Map.empty)(code: ActionContainer => Unit)(
+    implicit actorSystem: ActorSystem): (String, String) = {
+    val rand = { val r = Random.nextInt; if (r < 0) -r else r }
+    val name = imageName.toLowerCase.replaceAll("""[^a-z]""", "") + rand
+    val envArgs = environment.toSeq.map {
+      case (k, v) => s"-e ${k}=${v}"
+    } mkString (" ")
+
+    // We create the container...
+    val runOut = awaitDocker(s"run --name $name $envArgs -d $imageName", 10 seconds)
+    assert(runOut._1 == 0, "'docker run' did not exit with 0: " + runOut)
+
+    // ...find out its IP address...
+    val ipOut = awaitDocker(s"""inspect --format '{{.NetworkSettings.IPAddress}}' $name""", 10 seconds)
+    assert(ipOut._1 == 0, "'docker inspect did not exit with 0")
+    val ip = ipOut._2.replaceAll("""[^0-9.]""", "")
+
+    // ...we create an instance of the mock container interface...
+    val mock = new ActionContainer {
+      def init(value: JsValue) = syncPost(ip, 8080, "/init", value)
+      def run(value: JsValue) = syncPost(ip, 8080, "/run", value)
     }
 
-    private lazy val dockerCmd: String = {
-        val hostStr = if (WhiskProperties.onMacOSX()) {
-            s" --host tcp://${WhiskProperties.getMainDockerEndpoint()} "
-        } else {
-            " "
-        }
-        s"$dockerBin $hostStr"
+    try {
+      // ...and finally run the code with it.
+      code(mock)
+      // I'm told this is good for the logs.
+      Thread.sleep(100)
+      val (_, out, err) = awaitDocker(s"logs $name", 10 seconds)
+      (out, err)
+    } finally {
+      awaitDocker(s"kill $name", 10 seconds)
+      awaitDocker(s"rm $name", 10 seconds)
     }
+  }
 
-    private def docker(command: String): String = s"$dockerCmd $command"
+  private def syncPost(host: String, port: Int, endPoint: String, content: JsValue): (Int, Option[JsObject]) = {
+    whisk.core.containerpool.docker.HttpUtils.post(host, port, endPoint, content)
+  }
 
-    // Runs a process asynchronously. Returns a future with (exitCode,stdout,stderr)
-    private def proc(cmd: String): Future[(Int, String, String)] = Future {
-        blocking {
-            val out = new ByteArrayOutputStream
-            val err = new ByteArrayOutputStream
-            val outW = new PrintWriter(out)
-            val errW = new PrintWriter(err)
-            val v = cmd ! (ProcessLogger(outW.println, errW.println))
-            outW.close()
-            errW.close()
-            (v, out.toString, err.toString)
-        }
-    }
-
-    // Tying it all together, we have a method that runs docker, waits for
-    // completion for some time then returns the exit code, the output stream
-    // and the error stream.
-    private def awaitDocker(cmd: String, t: Duration): (Int, String, String) = {
-        Await.result(proc(docker(cmd)), t)
-    }
-
-    // Filters out the sentinel markers inserted by the container (see relevant private code in Invoker.scala)
-    val sentinel = "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX"
-    def filterSentinel(str: String) = str.replaceAll(sentinel, "").trim
-
-    def withContainer(imageName: String, environment: Map[String, String] = Map.empty)(
-        code: ActionContainer => Unit)(implicit actorSystem: ActorSystem): (String, String) = {
-        val rand = { val r = Random.nextInt; if (r < 0) -r else r }
-        val name = imageName.toLowerCase.replaceAll("""[^a-z]""", "") + rand
-        val envArgs = environment.toSeq.map {
-            case (k, v) => s"-e ${k}=${v}"
-        } mkString (" ")
-
-        // We create the container...
-        val runOut = awaitDocker(s"run --name $name $envArgs -d $imageName", 10 seconds)
-        assert(runOut._1 == 0, "'docker run' did not exit with 0: " + runOut)
-
-        // ...find out its IP address...
-        val ipOut = awaitDocker(s"""inspect --format '{{.NetworkSettings.IPAddress}}' $name""", 10 seconds)
-        assert(ipOut._1 == 0, "'docker inspect did not exit with 0")
-        val ip = ipOut._2.replaceAll("""[^0-9.]""", "")
-
-        // ...we create an instance of the mock container interface...
-        val mock = new ActionContainer {
-            def init(value: JsValue) = syncPost(ip, 8080, "/init", value)
-            def run(value: JsValue) = syncPost(ip, 8080, "/run", value)
-        }
-
-        try {
-            // ...and finally run the code with it.
-            code(mock)
-            // I'm told this is good for the logs.
-            Thread.sleep(100)
-            val (_, out, err) = awaitDocker(s"logs $name", 10 seconds)
-            (out, err)
-        } finally {
-            awaitDocker(s"kill $name", 10 seconds)
-            awaitDocker(s"rm $name", 10 seconds)
-        }
-    }
-
-    private def syncPost(host: String, port: Int, endPoint: String, content: JsValue): (Int, Option[JsObject]) = {
-        whisk.core.containerpool.docker.HttpUtils.post(host, port, endPoint, content)
-    }
-
-    private class ActionContainerImpl() extends ActionContainer {
-        override def init(value: JsValue) = ???
-        override def run(value: JsValue) = ???
-    }
+  private class ActionContainerImpl() extends ActionContainer {
+    override def init(value: JsValue) = ???
+    override def run(value: JsValue) = ???
+  }
 }

--- a/tests/src/test/scala/actionContainers/DockerExampleContainerTests.scala
+++ b/tests/src/test/scala/actionContainers/DockerExampleContainerTests.scala
@@ -32,120 +32,118 @@ import spray.json.JsBoolean
 @RunWith(classOf[JUnitRunner])
 class DockerExampleContainerTests extends ActionProxyContainerTestUtils with WskActorSystem {
 
-    // "example" is the image build by /sdk/docker
-    def withPythonContainer(code: ActionContainer => Unit) = withContainer("example")(code)
+  // "example" is the image build by /sdk/docker
+  def withPythonContainer(code: ActionContainer => Unit) = withContainer("example")(code)
 
-    behavior of "openwhisk/example"
+  behavior of "openwhisk/example"
 
-    private def checkresponse(res: Option[JsObject], args: JsObject = JsObject()) = {
-        res shouldBe defined
-        res.get.fields("msg") shouldBe JsString("Hello from arbitrary C program!")
-        res.get.fields("args") shouldBe args
+  private def checkresponse(res: Option[JsObject], args: JsObject = JsObject()) = {
+    res shouldBe defined
+    res.get.fields("msg") shouldBe JsString("Hello from arbitrary C program!")
+    res.get.fields("args") shouldBe args
+  }
+
+  it should "run sample without init" in {
+    val (out, err) = withPythonContainer { c =>
+      val (runCode, out) = c.run(JsObject())
+      runCode should be(200)
+      checkresponse(out)
     }
 
-    it should "run sample without init" in {
-        val (out, err) = withPythonContainer { c =>
-            val (runCode, out) = c.run(JsObject())
-            runCode should be(200)
-            checkresponse(out)
-        }
+    checkStreams(out, err, {
+      case (o, _) => o should include("This is an example log message from an arbitrary C program!")
+    })
+  }
 
-        checkStreams(out, err, {
-            case (o, _) => o should include("This is an example log message from an arbitrary C program!")
-        })
+  it should "run sample with init that does nothing" in {
+    val (out, err) = withPythonContainer { c =>
+      val (initCode, _) = c.init(JsObject())
+      initCode should be(200)
+      val (runCode, out) = c.run(JsObject())
+      runCode should be(200)
+      checkresponse(out)
     }
 
-    it should "run sample with init that does nothing" in {
-        val (out, err) = withPythonContainer { c =>
-            val (initCode, _) = c.init(JsObject())
-            initCode should be(200)
-            val (runCode, out) = c.run(JsObject())
-            runCode should be(200)
-            checkresponse(out)
-        }
+    checkStreams(out, err, {
+      case (o, _) => o should include("This is an example log message from an arbitrary C program!")
+    })
+  }
 
-        checkStreams(out, err, {
-            case (o, _) => o should include("This is an example log message from an arbitrary C program!")
-        })
+  it should "run sample with argument" in {
+    val (out, err) = withPythonContainer { c =>
+      val argss = List(JsObject("a" -> JsString("A")), JsObject("i" -> JsNumber(1)))
+
+      for (args <- argss) {
+        val (runCode, out) = c.run(runPayload(args))
+        runCode should be(200)
+        checkresponse(out, args)
+      }
     }
 
-    it should "run sample with argument" in {
-        val (out, err) = withPythonContainer { c =>
-            val argss = List(
-                JsObject("a" -> JsString("A")),
-                JsObject("i" -> JsNumber(1)))
+    checkStreams(out, err, {
+      case (o, _) => o should include("This is an example log message from an arbitrary C program!")
+    }, 2)
+  }
 
-            for (args <- argss) {
-                val (runCode, out) = c.run(runPayload(args))
-                runCode should be(200)
-                checkresponse(out, args)
-            }
-        }
+  behavior of "bad containers"
 
-        checkStreams(out, err, {
-            case (o, _) => o should include("This is an example log message from an arbitrary C program!")
-        }, 2)
+  it should "timeout init with exception" in {
+    val (out, err) = withContainer("badaction") { c =>
+      a[TimeoutException] should be thrownBy {
+        val (code, out) = c.init(initPayload("sleep"))
+        println(code, out)
+      }
     }
 
-    behavior of "bad containers"
+    out should include("sleeping")
+    err shouldBe empty
+  }
 
-    it should "timeout init with exception" in {
-        val (out, err) = withContainer("badaction") { c =>
-            a[TimeoutException] should be thrownBy {
-                val (code, out) = c.init(initPayload("sleep"))
-                println(code, out)
-            }
-        }
-
-        out should include("sleeping")
-        err shouldBe empty
+  it should "abort init with empty response" in {
+    val (out, err) = withContainer("badaction") { c =>
+      val (code, out) = c.init(initPayload("exit"))
+      code shouldBe 500
+      out shouldBe empty
     }
 
-    it should "abort init with empty response" in {
-        val (out, err) = withContainer("badaction") { c =>
-            val (code, out) = c.init(initPayload("exit"))
-            code shouldBe 500
-            out shouldBe empty
-        }
+    out should include("exit")
+    // err stream may not be empty if the proxy did not get a chance to
+    // drain the action's out/err streams; skip check on err stream
+  }
 
-        out should include("exit")
-        // err stream may not be empty if the proxy did not get a chance to
-        // drain the action's out/err streams; skip check on err stream
+  it should "timeout run with exception" in {
+    val (out, err) = withContainer("badaction") { c =>
+      a[TimeoutException] should be thrownBy {
+        val (code, out) = c.run(runPayload(JsObject("sleep" -> JsBoolean(true))))
+        println(code, out)
+      }
     }
 
-    it should "timeout run with exception" in {
-        val (out, err) = withContainer("badaction") { c =>
-            a[TimeoutException] should be thrownBy {
-                val (code, out) = c.run(runPayload(JsObject("sleep" -> JsBoolean(true))))
-                println(code, out)
-            }
-        }
+    out should include("sleeping")
+    err shouldBe empty
+  }
 
-        out should include("sleeping")
-        err shouldBe empty
+  it should "abort run with empty response" in {
+    val (out, err) = withContainer("badaction") { c =>
+      val (code, out) = c.run(runPayload(JsObject("exit" -> JsBoolean(true))))
+      code shouldBe 500
+      out shouldBe empty
     }
 
-    it should "abort run with empty response" in {
-        val (out, err) = withContainer("badaction") { c =>
-            val (code, out) = c.run(runPayload(JsObject("exit" -> JsBoolean(true))))
-            code shouldBe 500
-            out shouldBe empty
-        }
+    out should include("exit")
+    // err stream may not be empty if the proxy did not get a chance to
+    // drain the action's out/err streams; skip check on err stream
+  }
 
-        out should include("exit")
-        // err stream may not be empty if the proxy did not get a chance to
-        // drain the action's out/err streams; skip check on err stream
+  it should "timeout bad proxy with exception" in {
+    val (out, err) = withContainer("badproxy") { c =>
+      a[TimeoutException] should be thrownBy {
+        val (code, out) = c.init(JsObject())
+        println(code, out)
+      }
     }
 
-    it should "timeout bad proxy with exception" in {
-        val (out, err) = withContainer("badproxy") { c =>
-            a[TimeoutException] should be thrownBy {
-                val (code, out) = c.init(JsObject())
-                println(code, out)
-            }
-        }
-
-        out shouldBe empty
-        err shouldBe empty
-    }
+    out shouldBe empty
+    err shouldBe empty
+  }
 }

--- a/tests/src/test/scala/actionContainers/Python2ActionContainerTests.scala
+++ b/tests/src/test/scala/actionContainers/Python2ActionContainerTests.scala
@@ -24,8 +24,8 @@ import common.WskActorSystem
 @RunWith(classOf[JUnitRunner])
 class Python2ActionContainerTests extends PythonActionContainerTests with WskActorSystem {
 
-    override lazy val imageName = "python2action"
+  override lazy val imageName = "python2action"
 
-    /** indicates if strings in python are unicode by default (i.e., python3 -> true, python2.7 -> false) */
-    override lazy val pythonStringAsUnicode = false
+  /** indicates if strings in python are unicode by default (i.e., python3 -> true, python2.7 -> false) */
+  override lazy val pythonStringAsUnicode = false
 }

--- a/tests/src/test/scala/actionContainers/PythonActionContainerTests.scala
+++ b/tests/src/test/scala/actionContainers/PythonActionContainerTests.scala
@@ -20,7 +20,7 @@ package actionContainers
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import ActionContainer.withContainer
-import ResourceHelpers.{ ZipBuilder, readAsBase64 }
+import ResourceHelpers.{readAsBase64, ZipBuilder}
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 import common.WskActorSystem
@@ -30,25 +30,28 @@ import java.nio.file.Paths
 @RunWith(classOf[JUnitRunner])
 class PythonActionContainerTests extends BasicActionRunnerTests with WskActorSystem {
 
-    lazy val imageName = "python3action"
+  lazy val imageName = "python3action"
 
-    /** indicates if strings in python are unicode by default (i.e., python3 -> true, python2.7 -> false) */
-    lazy val pythonStringAsUnicode = true
+  /** indicates if strings in python are unicode by default (i.e., python3 -> true, python2.7 -> false) */
+  lazy val pythonStringAsUnicode = true
 
-    override def withActionContainer(env: Map[String, String] = Map.empty)(code: ActionContainer => Unit) = {
-        withContainer(imageName, env)(code)
-    }
+  override def withActionContainer(env: Map[String, String] = Map.empty)(code: ActionContainer => Unit) = {
+    withContainer(imageName, env)(code)
+  }
 
-    behavior of imageName
+  behavior of imageName
 
-    testNotReturningJson(
-        """
+  testNotReturningJson(
+    """
         |def main(args):
         |    return "not a json object"
-        """.stripMargin, checkResultInLogs = false)
+        """.stripMargin,
+    checkResultInLogs = false)
 
-    testEcho(Seq {
-        ("python", """
+  testEcho(Seq {
+    (
+      "python",
+      """
          |from __future__ import print_function
          |import sys
          |def main(args):
@@ -56,30 +59,36 @@ class PythonActionContainerTests extends BasicActionRunnerTests with WskActorSys
          |    print('hello stderr', file=sys.stderr)
          |    return args
          """.stripMargin)
-    })
+  })
 
-    testUnicode(Seq {
-        if (pythonStringAsUnicode) {
-            ("python", """
+  testUnicode(Seq {
+    if (pythonStringAsUnicode) {
+      (
+        "python",
+        """
              |def main(args):
              |    sep = args['delimiter']
              |    str = sep + " ☃ " + sep
              |    print(str)
              |    return {"winter" : str }
              """.stripMargin.trim)
-        } else {
-            ("python", """
+    } else {
+      (
+        "python",
+        """
              |def main(args):
              |    sep = args['delimiter']
              |    str = sep + " ☃ ".decode('utf-8') + sep
              |    print(str.encode('utf-8'))
              |    return {"winter" : str }
              """.stripMargin.trim)
-        }
-    })
+    }
+  })
 
-    testEnv(Seq {
-        ("python", """
+  testEnv(Seq {
+    (
+      "python",
+      """
          |import os
          |def main(dict):
          |    return {
@@ -91,199 +100,198 @@ class PythonActionContainerTests extends BasicActionRunnerTests with WskActorSys
          |       "deadline": os.environ['__OW_DEADLINE']
          |    }
          """.stripMargin.trim)
-    })
+  })
 
-    it should "support actions using non-default entry points" in {
-        withActionContainer() { c =>
-            val code = """
+  it should "support actions using non-default entry points" in {
+    withActionContainer() { c =>
+      val code = """
                 |def niam(dict):
                 |  return { "result": "it works" }
                 |""".stripMargin
 
-            val (initCode, initRes) = c.init(initPayload(code, main = "niam"))
-            initCode should be(200)
+      val (initCode, initRes) = c.init(initPayload(code, main = "niam"))
+      initCode should be(200)
 
-            val (_, runRes) = c.run(runPayload(JsObject()))
-            runRes.get.fields.get("result") shouldBe Some(JsString("it works"))
-        }
+      val (_, runRes) = c.run(runPayload(JsObject()))
+      runRes.get.fields.get("result") shouldBe Some(JsString("it works"))
     }
+  }
 
-    it should "support zip-encoded action using non-default entry points" in {
-        val srcs = Seq(
-            Seq("__main__.py") -> """
+  it should "support zip-encoded action using non-default entry points" in {
+    val srcs = Seq(
+      Seq("__main__.py") -> """
                 |from echo import echo
                 |def niam(args):
                 |    return echo(args)
             """.stripMargin,
-            Seq("echo.py") -> """
+      Seq("echo.py") -> """
                 |def echo(args):
                 |  return { "echo": args }
             """.stripMargin)
 
-        val code = ZipBuilder.mkBase64Zip(srcs)
+    val code = ZipBuilder.mkBase64Zip(srcs)
 
-        val (out, err) = withActionContainer() { c =>
-            val (initCode, initRes) = c.init(initPayload(code, main = "niam"))
-            initCode should be(200)
+    val (out, err) = withActionContainer() { c =>
+      val (initCode, initRes) = c.init(initPayload(code, main = "niam"))
+      initCode should be(200)
 
-            val args = JsObject("msg" -> JsString("it works"))
-            val (runCode, runRes) = c.run(runPayload(args))
+      val args = JsObject("msg" -> JsString("it works"))
+      val (runCode, runRes) = c.run(runPayload(args))
 
-            runCode should be(200)
-            runRes.get.fields.get("echo") shouldBe Some(args)
-        }
-
-        checkStreams(out, err, {
-            case (o, e) =>
-                o shouldBe empty
-                e shouldBe empty
-        })
+      runCode should be(200)
+      runRes.get.fields.get("echo") shouldBe Some(args)
     }
 
-    it should "support zip-encoded action which can read from relative paths" in {
-        val srcs = Seq(
-            Seq("__main__.py") -> """
+    checkStreams(out, err, {
+      case (o, e) =>
+        o shouldBe empty
+        e shouldBe empty
+    })
+  }
+
+  it should "support zip-encoded action which can read from relative paths" in {
+    val srcs = Seq(
+      Seq("__main__.py") -> """
                 |def main(args):
                 |    f = open('workfile', 'r')
                 |    return {'file': f.read()}
             """.stripMargin,
-            Seq("workfile") -> "this is a test string")
+      Seq("workfile") -> "this is a test string")
 
-        val code = ZipBuilder.mkBase64Zip(srcs)
+    val code = ZipBuilder.mkBase64Zip(srcs)
 
-        val (out, err) = withActionContainer() { c =>
-            val (initCode, initRes) = c.init(initPayload(code))
-            initCode should be(200)
+    val (out, err) = withActionContainer() { c =>
+      val (initCode, initRes) = c.init(initPayload(code))
+      initCode should be(200)
 
-            val args = JsObject()
-            val (runCode, runRes) = c.run(runPayload(args))
+      val args = JsObject()
+      val (runCode, runRes) = c.run(runPayload(args))
 
-            runCode should be(200)
-            runRes.get.fields.get("file") shouldBe Some("this is a test string".toJson)
-        }
-
-        checkStreams(out, err, {
-            case (o, e) =>
-                o shouldBe empty
-                e shouldBe empty
-        })
+      runCode should be(200)
+      runRes.get.fields.get("file") shouldBe Some("this is a test string".toJson)
     }
 
-    it should "report error if zip-encoded action does not include required file" in {
-        val srcs = Seq(
-            Seq("echo.py") -> """
+    checkStreams(out, err, {
+      case (o, e) =>
+        o shouldBe empty
+        e shouldBe empty
+    })
+  }
+
+  it should "report error if zip-encoded action does not include required file" in {
+    val srcs = Seq(Seq("echo.py") -> """
                 |def echo(args):
                 |  return { "echo": args }
             """.stripMargin)
 
-        val code = ZipBuilder.mkBase64Zip(srcs)
+    val code = ZipBuilder.mkBase64Zip(srcs)
 
-        val (out, err) = withActionContainer() { c =>
-            val (initCode, initRes) = c.init(initPayload(code, main = "echo"))
-            initCode should be(502)
-        }
-
-        checkStreams(out, err, {
-            case (o, e) =>
-                o shouldBe empty
-                e should include("Zip file does not include")
-        })
+    val (out, err) = withActionContainer() { c =>
+      val (initCode, initRes) = c.init(initPayload(code, main = "echo"))
+      initCode should be(502)
     }
 
-    it should "run zipped Python action containing a virtual environment" in {
-        val zippedPythonAction = if (imageName == "python2action") "python2_virtualenv.zip" else "python3_virtualenv.zip"
-        val zippedPythonActionName = TestUtils.getTestActionFilename(zippedPythonAction)
-        val code = readAsBase64(Paths.get(zippedPythonActionName))
+    checkStreams(out, err, {
+      case (o, e) =>
+        o shouldBe empty
+        e should include("Zip file does not include")
+    })
+  }
 
-        val (out, err) = withActionContainer() { c =>
-            val (initCode, initRes) = c.init(initPayload(code, main = "main"))
-            initCode should be(200)
-            val args = JsObject("msg" -> JsString("any"))
-            val (runCode, runRes) = c.run(runPayload(args))
-            runCode should be(200)
-            runRes.get.toString() should include("netmask")
-        }
-        checkStreams(out, err, {
-            case (o, e) =>
-                o should include("netmask")
-                e shouldBe empty
-        })
+  it should "run zipped Python action containing a virtual environment" in {
+    val zippedPythonAction = if (imageName == "python2action") "python2_virtualenv.zip" else "python3_virtualenv.zip"
+    val zippedPythonActionName = TestUtils.getTestActionFilename(zippedPythonAction)
+    val code = readAsBase64(Paths.get(zippedPythonActionName))
+
+    val (out, err) = withActionContainer() { c =>
+      val (initCode, initRes) = c.init(initPayload(code, main = "main"))
+      initCode should be(200)
+      val args = JsObject("msg" -> JsString("any"))
+      val (runCode, runRes) = c.run(runPayload(args))
+      runCode should be(200)
+      runRes.get.toString() should include("netmask")
     }
+    checkStreams(out, err, {
+      case (o, e) =>
+        o should include("netmask")
+        e shouldBe empty
+    })
+  }
 
-    it should "run zipped Python action containing a virtual environment with non-standard entry point" in {
-        val zippedPythonAction = if (imageName == "python2action") "python2_virtualenv.zip" else "python3_virtualenv.zip"
-        val zippedPythonActionName = TestUtils.getTestActionFilename(zippedPythonAction)
-        val code = readAsBase64(Paths.get(zippedPythonActionName))
+  it should "run zipped Python action containing a virtual environment with non-standard entry point" in {
+    val zippedPythonAction = if (imageName == "python2action") "python2_virtualenv.zip" else "python3_virtualenv.zip"
+    val zippedPythonActionName = TestUtils.getTestActionFilename(zippedPythonAction)
+    val code = readAsBase64(Paths.get(zippedPythonActionName))
 
-        val (out, err) = withActionContainer() { c =>
-            val (initCode, initRes) = c.init(initPayload(code, main = "naim"))
-            initCode should be(200)
-            val args = JsObject("msg" -> JsString("any"))
-            val (runCode, runRes) = c.run(runPayload(args))
-            runCode should be(200)
-            runRes.get.toString() should include("netmask")
-        }
-        checkStreams(out, err, {
-            case (o, e) =>
-                o should include("netmask")
-                e shouldBe empty
-        })
+    val (out, err) = withActionContainer() { c =>
+      val (initCode, initRes) = c.init(initPayload(code, main = "naim"))
+      initCode should be(200)
+      val args = JsObject("msg" -> JsString("any"))
+      val (runCode, runRes) = c.run(runPayload(args))
+      runCode should be(200)
+      runRes.get.toString() should include("netmask")
     }
+    checkStreams(out, err, {
+      case (o, e) =>
+        o should include("netmask")
+        e shouldBe empty
+    })
+  }
 
-    it should "report error if zipped Python action containing a virtual environment for wrong python version" in {
-        val zippedPythonAction = if (imageName == "python3action") "python2_virtualenv.zip" else "python3_virtualenv.zip"
-        val zippedPythonActionName = TestUtils.getTestActionFilename(zippedPythonAction)
-        val code = readAsBase64(Paths.get(zippedPythonActionName))
+  it should "report error if zipped Python action containing a virtual environment for wrong python version" in {
+    val zippedPythonAction = if (imageName == "python3action") "python2_virtualenv.zip" else "python3_virtualenv.zip"
+    val zippedPythonActionName = TestUtils.getTestActionFilename(zippedPythonAction)
+    val code = readAsBase64(Paths.get(zippedPythonActionName))
 
-        val (out, err) = withActionContainer() { c =>
-            val (initCode, initRes) = c.init(initPayload(code, main = "main"))
-            initCode should be(200)
-            val args = JsObject("msg" -> JsString("any"))
-            val (runCode, runRes) = c.run(runPayload(args))
-            runCode should be(502)
-        }
-        checkStreams(out, err, {
-            case (o, e) =>
-                o shouldBe empty
-                if (imageName == "python2action") { e should include("ImportError") }
-                if (imageName == "python3action") { e should include("ModuleNotFoundError") }
-        })
+    val (out, err) = withActionContainer() { c =>
+      val (initCode, initRes) = c.init(initPayload(code, main = "main"))
+      initCode should be(200)
+      val args = JsObject("msg" -> JsString("any"))
+      val (runCode, runRes) = c.run(runPayload(args))
+      runCode should be(502)
     }
+    checkStreams(out, err, {
+      case (o, e) =>
+        o shouldBe empty
+        if (imageName == "python2action") { e should include("ImportError") }
+        if (imageName == "python3action") { e should include("ModuleNotFoundError") }
+    })
+  }
 
-    it should "report error if zipped Python action has wrong main module name" in {
-        val zippedPythonActionWrongName = TestUtils.getTestActionFilename("python_virtualenv_name.zip")
+  it should "report error if zipped Python action has wrong main module name" in {
+    val zippedPythonActionWrongName = TestUtils.getTestActionFilename("python_virtualenv_name.zip")
 
-        val code = readAsBase64(Paths.get(zippedPythonActionWrongName))
+    val code = readAsBase64(Paths.get(zippedPythonActionWrongName))
 
-        val (out, err) = withActionContainer() { c =>
-            val (initCode, initRes) = c.init(initPayload(code, main = "main"))
-            initCode should be(502)
-        }
-        checkStreams(out, err, {
-            case (o, e) =>
-                o shouldBe empty
-                e should include("Zip file does not include __main__.py")
-        })
+    val (out, err) = withActionContainer() { c =>
+      val (initCode, initRes) = c.init(initPayload(code, main = "main"))
+      initCode should be(502)
     }
+    checkStreams(out, err, {
+      case (o, e) =>
+        o shouldBe empty
+        e should include("Zip file does not include __main__.py")
+    })
+  }
 
-    it should "report error if zipped Python action has invalid virtualenv directory" in {
-        val zippedPythonActionWrongDir = TestUtils.getTestActionFilename("python_virtualenv_dir.zip")
+  it should "report error if zipped Python action has invalid virtualenv directory" in {
+    val zippedPythonActionWrongDir = TestUtils.getTestActionFilename("python_virtualenv_dir.zip")
 
-        val code = readAsBase64(Paths.get(zippedPythonActionWrongDir))
-        val (out, err) = withActionContainer() { c =>
-            val (initCode, initRes) = c.init(initPayload(code, main = "main"))
-            initCode should be(502)
-        }
-        checkStreams(out, err, {
-            case (o, e) =>
-                o shouldBe empty
-                e should include("Zip file does not include /virtualenv/bin/")
-        })
+    val code = readAsBase64(Paths.get(zippedPythonActionWrongDir))
+    val (out, err) = withActionContainer() { c =>
+      val (initCode, initRes) = c.init(initPayload(code, main = "main"))
+      initCode should be(502)
     }
+    checkStreams(out, err, {
+      case (o, e) =>
+        o shouldBe empty
+        e should include("Zip file does not include /virtualenv/bin/")
+    })
+  }
 
-    it should "return on action error when action fails" in {
-        val (out, err) = withActionContainer() { c =>
-            val code = """
+  it should "return on action error when action fails" in {
+    val (out, err) = withActionContainer() { c =>
+      val code = """
                 |def div(x, y):
                 |    return x/y
                 |
@@ -291,91 +299,91 @@ class PythonActionContainerTests extends BasicActionRunnerTests with WskActorSys
                 |    return {"divBy0": div(5,0)}
             """.stripMargin
 
-            val (initCode, _) = c.init(initPayload(code))
-            initCode should be(200)
+      val (initCode, _) = c.init(initPayload(code))
+      initCode should be(200)
 
-            val (runCode, runRes) = c.run(runPayload(JsObject()))
-            runCode should be(502)
+      val (runCode, runRes) = c.run(runPayload(JsObject()))
+      runCode should be(502)
 
-            runRes shouldBe defined
-            runRes.get.fields.get("error") shouldBe defined
-        }
-
-        checkStreams(out, err, {
-            case (o, e) =>
-                o shouldBe empty
-                e should include("Traceback")
-        })
+      runRes shouldBe defined
+      runRes.get.fields.get("error") shouldBe defined
     }
 
-    it should "log compilation errors" in {
-        val (out, err) = withActionContainer() { c =>
-            val code = """
+    checkStreams(out, err, {
+      case (o, e) =>
+        o shouldBe empty
+        e should include("Traceback")
+    })
+  }
+
+  it should "log compilation errors" in {
+    val (out, err) = withActionContainer() { c =>
+      val code = """
               | 10 PRINT "Hello!"
               | 20 GOTO 10
             """.stripMargin
 
-            val (initCode, res) = c.init(initPayload(code))
-            // init checks whether compilation was successful, so return 502
-            initCode should be(502)
-        }
-
-        checkStreams(out, err, {
-            case (o, e) =>
-                o shouldBe empty
-                e should include("Traceback")
-        })
+      val (initCode, res) = c.init(initPayload(code))
+      // init checks whether compilation was successful, so return 502
+      initCode should be(502)
     }
 
-    it should "support application errors" in {
-        val (out, err) = withActionContainer() { c =>
-            val code = """
+    checkStreams(out, err, {
+      case (o, e) =>
+        o shouldBe empty
+        e should include("Traceback")
+    })
+  }
+
+  it should "support application errors" in {
+    val (out, err) = withActionContainer() { c =>
+      val code = """
                 |def main(args):
                 |    return { "error": "sorry" }
             """.stripMargin
 
-            val (initCode, _) = c.init(initPayload(code))
-            initCode should be(200)
+      val (initCode, _) = c.init(initPayload(code))
+      initCode should be(200)
 
-            val (runCode, runRes) = c.run(runPayload(JsObject()))
-            runCode should be(200) // action writer returning an error is OK
+      val (runCode, runRes) = c.run(runPayload(JsObject()))
+      runCode should be(200) // action writer returning an error is OK
 
-            runRes shouldBe defined
-            runRes should be(Some(JsObject("error" -> JsString("sorry"))))
-        }
-
-        checkStreams(out, err, {
-            case (o, e) =>
-                o shouldBe empty
-                e shouldBe empty
-        })
+      runRes shouldBe defined
+      runRes should be(Some(JsObject("error" -> JsString("sorry"))))
     }
 
-    it should "error when importing a not-supported package" in {
-        val (out, err) = withActionContainer() { c =>
-            val code = """
+    checkStreams(out, err, {
+      case (o, e) =>
+        o shouldBe empty
+        e shouldBe empty
+    })
+  }
+
+  it should "error when importing a not-supported package" in {
+    val (out, err) = withActionContainer() { c =>
+      val code = """
                 |import iamnotsupported
                 |def main(args):
                 |    return { "error": "not reaching here" }
             """.stripMargin
 
-            val (initCode, res) = c.init(initPayload(code))
-            initCode should be(200)
+      val (initCode, res) = c.init(initPayload(code))
+      initCode should be(200)
 
-            val (runCode, runRes) = c.run(runPayload(JsObject()))
-            runCode should be(502)
-        }
-
-        checkStreams(out, err, {
-            case (o, e) =>
-                o shouldBe empty
-                e should include("Traceback")
-        })
+      val (runCode, runRes) = c.run(runPayload(JsObject()))
+      runCode should be(502)
     }
 
-    it should "be able to import additional packages as installed in the image" in {
-        val (out, err) = withActionContainer() { c =>
-            val code = """
+    checkStreams(out, err, {
+      case (o, e) =>
+        o shouldBe empty
+        e should include("Traceback")
+    })
+  }
+
+  it should "be able to import additional packages as installed in the image" in {
+    val (out, err) = withActionContainer() { c =>
+      val code = """
                 |from bs4 import BeautifulSoup
                 |from dateutil.parser import *
                 |import httplib2
@@ -407,27 +415,28 @@ class PythonActionContainerTests extends BasicActionRunnerTests with WskActorSys
                 |    }
             """.stripMargin
 
-            val (initCode, _) = c.init(initPayload(code))
-            initCode should be(200)
+      val (initCode, _) = c.init(initPayload(code))
+      initCode should be(200)
 
-            val (runCode, runRes) = c.run(runPayload(JsObject()))
-            runCode should be(200) // action writer returning an error is OK
+      val (runCode, runRes) = c.run(runPayload(JsObject()))
+      runCode should be(200) // action writer returning an error is OK
 
-            runRes shouldBe defined
-            runRes should be(Some(JsObject(
-                "bs4" -> "<title>python action test</title>".toJson,
-                "httplib2" -> 200.toJson,
-                "dateutil" -> "Monday".toJson,
-                "lxml" -> "root".toJson,
-                "json" -> JsObject("foo" -> "bar".toJson).compactPrint.toJson,
-                "request" -> 200.toJson,
-                "kafka_python" -> "it works".toJson)))
-        }
-
-        checkStreams(out, err, {
-            case (o, e) =>
-                o shouldBe empty
-                e shouldBe empty
-        })
+      runRes shouldBe defined
+      runRes should be(
+        Some(JsObject(
+          "bs4" -> "<title>python action test</title>".toJson,
+          "httplib2" -> 200.toJson,
+          "dateutil" -> "Monday".toJson,
+          "lxml" -> "root".toJson,
+          "json" -> JsObject("foo" -> "bar".toJson).compactPrint.toJson,
+          "request" -> 200.toJson,
+          "kafka_python" -> "it works".toJson)))
     }
+
+    checkStreams(out, err, {
+      case (o, e) =>
+        o shouldBe empty
+        e shouldBe empty
+    })
+  }
 }

--- a/tests/src/test/scala/actionContainers/ResourceHelpers.scala
+++ b/tests/src/test/scala/actionContainers/ResourceHelpers.scala
@@ -38,152 +38,153 @@ import collection.JavaConverters._
  *  on file contents.
  */
 object ResourceHelpers {
-    /** Creates a zip file based on the contents of a top-level directory. */
-    object ZipBuilder {
-        def mkBase64Zip(sources: Seq[(Seq[String], String)]): String = {
-            val (tmpDir, _) = writeSourcesToTempDirectory(sources)
-            val archive = makeZipFromDir(tmpDir)
-            readAsBase64(archive)
-        }
+
+  /** Creates a zip file based on the contents of a top-level directory. */
+  object ZipBuilder {
+    def mkBase64Zip(sources: Seq[(Seq[String], String)]): String = {
+      val (tmpDir, _) = writeSourcesToTempDirectory(sources)
+      val archive = makeZipFromDir(tmpDir)
+      readAsBase64(archive)
+    }
+  }
+
+  /**
+   * A convenience object to compile and package Java sources into a JAR, and to
+   * encode that JAR as a base 64 string. The compilation options include the
+   * current classpath, which is why Google GSON is readily available (though not
+   * packaged in the JAR).
+   */
+  object JarBuilder {
+    def mkBase64Jar(sources: Seq[(Seq[String], String)]): String = {
+      // Note that this pipeline doesn't delete any of the temporary files.
+      val binDir = compile(sources)
+      val jarPath = makeJarFromDir(binDir)
+      val base64 = readAsBase64(jarPath)
+      base64
     }
 
-    /**
-     * A convenience object to compile and package Java sources into a JAR, and to
-     * encode that JAR as a base 64 string. The compilation options include the
-     * current classpath, which is why Google GSON is readily available (though not
-     * packaged in the JAR).
-     */
-    object JarBuilder {
-        def mkBase64Jar(sources: Seq[(Seq[String], String)]): String = {
-            // Note that this pipeline doesn't delete any of the temporary files.
-            val binDir = compile(sources)
-            val jarPath = makeJarFromDir(binDir)
-            val base64 = readAsBase64(jarPath)
-            base64
-        }
+    def mkBase64Jar(source: (Seq[String], String)): String = {
+      mkBase64Jar(Seq(source))
+    }
 
-        def mkBase64Jar(source: (Seq[String], String)): String = {
-            mkBase64Jar(Seq(source))
-        }
+    private def compile(sources: Seq[(Seq[String], String)]): Path = {
+      require(!sources.isEmpty)
 
-        private def compile(sources: Seq[(Seq[String], String)]): Path = {
-            require(!sources.isEmpty)
+      // The absolute paths of the source file
+      val (srcDir, srcAbsPaths) = writeSourcesToTempDirectory(sources)
 
-            // The absolute paths of the source file
-            val (srcDir, srcAbsPaths) = writeSourcesToTempDirectory(sources)
+      // A temporary directory for the destination files.
+      val binDir = Files.createTempDirectory("bin").toAbsolutePath()
 
-            // A temporary directory for the destination files.
-            val binDir = Files.createTempDirectory("bin").toAbsolutePath()
+      // Preparing the compiler
+      val compiler = ToolProvider.getSystemJavaCompiler()
+      val fileManager = compiler.getStandardFileManager(null, null, StandardCharsets.UTF_8)
 
-            // Preparing the compiler
-            val compiler = ToolProvider.getSystemJavaCompiler()
-            val fileManager = compiler.getStandardFileManager(null, null, StandardCharsets.UTF_8)
+      // Collecting all files to be compiled
+      val compUnit = fileManager.getJavaFileObjectsFromFiles(srcAbsPaths.map(_.toFile).asJava)
 
-            // Collecting all files to be compiled
-            val compUnit = fileManager.getJavaFileObjectsFromFiles(srcAbsPaths.map(_.toFile).asJava)
+      // Setting the options
+      val compOptions = Seq("-d", binDir.toAbsolutePath().toString(), "-classpath", buildClassPath())
+      val compTask = compiler.getTask(null, fileManager, null, compOptions.asJava, null, compUnit)
 
-            // Setting the options
-            val compOptions = Seq(
-                "-d", binDir.toAbsolutePath().toString(),
-                "-classpath", buildClassPath())
-            val compTask = compiler.getTask(null, fileManager, null, compOptions.asJava, null, compUnit)
+      // ...and off we go.
+      compTask.call()
 
-            // ...and off we go.
-            compTask.call()
+      binDir
+    }
 
-            binDir
-        }
+    private def buildClassPath(): String = {
+      val bcp = System.getProperty("java.class.path")
 
-        private def buildClassPath(): String = {
-            val bcp = System.getProperty("java.class.path")
+      val list = this.getClass().getClassLoader() match {
+        case ucl: URLClassLoader =>
+          bcp :: ucl.getURLs().map(_.getFile().toString()).toList
 
-            val list = this.getClass().getClassLoader() match {
-                case ucl: URLClassLoader =>
-                    bcp :: ucl.getURLs().map(_.getFile().toString()).toList
+        case _ =>
+          List(bcp)
+      }
 
-                case _ =>
-                    List(bcp)
+      list.mkString(System.getProperty("path.separator"))
+    }
+  }
+
+  /**
+   * Creates a temporary directory and reproduces the desired file structure
+   * in it. Returns the path of the temporary directory and the path of each
+   * file as represented in it.
+   */
+  private def writeSourcesToTempDirectory(sources: Seq[(Seq[String], String)]): (Path, Seq[Path]) = {
+    // A temporary directory for the source files.
+    val srcDir = Files.createTempDirectory("src").toAbsolutePath()
+
+    val srcAbsPaths = for ((sourceName, sourceContent) <- sources) yield {
+      // The relative path of the source file
+      val srcRelPath = Paths.get(sourceName.head, sourceName.tail: _*)
+      // The absolute path of the source file
+      val srcAbsPath = srcDir.resolve(srcRelPath)
+      // Create parent directories if needed.
+      Files.createDirectories(srcAbsPath.getParent)
+      // Writing contents
+      Files.write(srcAbsPath, sourceContent.getBytes(StandardCharsets.UTF_8))
+
+      srcAbsPath
+    }
+
+    (srcDir, srcAbsPaths)
+  }
+
+  private def makeZipFromDir(dir: Path): Path = makeArchiveFromDir(dir, ".zip")
+
+  private def makeJarFromDir(dir: Path): Path = makeArchiveFromDir(dir, ".jar")
+
+  /**
+   * Compresses all files beyond a directory into a zip file.
+   * Note that Jar files are just zip files.
+   */
+  private def makeArchiveFromDir(dir: Path, extension: String): Path = {
+    // Any temporary file name for the archive.
+    val arPath = Files.createTempFile("output", extension).toAbsolutePath()
+
+    // We "mount" it as a filesystem, so we can just copy files into it.
+    val dstUri = new URI("jar:" + arPath.toUri().getScheme(), arPath.toAbsolutePath().toString(), null)
+    // OK, that's a hack. Doing this because newFileSystem wants to create that file.
+    arPath.toFile().delete()
+    val fs = FileSystems.newFileSystem(dstUri, Map(("create" -> "true")).asJava)
+
+    // Traversing all files in the bin directory...
+    Files.walkFileTree(
+      dir,
+      new SimpleFileVisitor[Path]() {
+        override def visitFile(path: Path, attributes: BasicFileAttributes) = {
+          // The path relative to the src dir
+          val relPath = dir.relativize(path)
+
+          // The corresponding path in the zip
+          val arRelPath = fs.getPath(relPath.toString())
+
+          // If this file is not top-level in the src dir...
+          if (relPath.getParent() != null) {
+            // ...create the directory structure if it doesn't exist.
+            if (!Files.exists(arRelPath.getParent())) {
+              Files.createDirectories(arRelPath.getParent())
             }
+          }
 
-            list.mkString(System.getProperty("path.separator"))
+          // Finally we can copy that file.
+          Files.copy(path, arRelPath)
+
+          FileVisitResult.CONTINUE
         }
-    }
+      })
 
-    /**
-     * Creates a temporary directory and reproduces the desired file structure
-     * in it. Returns the path of the temporary directory and the path of each
-     * file as represented in it.
-     */
-    private def writeSourcesToTempDirectory(sources: Seq[(Seq[String], String)]): (Path, Seq[Path]) = {
-        // A temporary directory for the source files.
-        val srcDir = Files.createTempDirectory("src").toAbsolutePath()
+    fs.close()
 
-        val srcAbsPaths = for ((sourceName, sourceContent) <- sources) yield {
-            // The relative path of the source file
-            val srcRelPath = Paths.get(sourceName.head, sourceName.tail: _*)
-            // The absolute path of the source file
-            val srcAbsPath = srcDir.resolve(srcRelPath)
-            // Create parent directories if needed.
-            Files.createDirectories(srcAbsPath.getParent)
-            // Writing contents
-            Files.write(srcAbsPath, sourceContent.getBytes(StandardCharsets.UTF_8))
+    arPath
+  }
 
-            srcAbsPath
-        }
-
-        (srcDir, srcAbsPaths)
-    }
-
-    private def makeZipFromDir(dir: Path): Path = makeArchiveFromDir(dir, ".zip")
-
-    private def makeJarFromDir(dir: Path): Path = makeArchiveFromDir(dir, ".jar")
-
-    /**
-     * Compresses all files beyond a directory into a zip file.
-     * Note that Jar files are just zip files.
-     */
-    private def makeArchiveFromDir(dir: Path, extension: String): Path = {
-        // Any temporary file name for the archive.
-        val arPath = Files.createTempFile("output", extension).toAbsolutePath()
-
-        // We "mount" it as a filesystem, so we can just copy files into it.
-        val dstUri = new URI("jar:" + arPath.toUri().getScheme(), arPath.toAbsolutePath().toString(), null)
-        // OK, that's a hack. Doing this because newFileSystem wants to create that file.
-        arPath.toFile().delete()
-        val fs = FileSystems.newFileSystem(dstUri, Map(("create" -> "true")).asJava)
-
-        // Traversing all files in the bin directory...
-        Files.walkFileTree(dir, new SimpleFileVisitor[Path]() {
-            override def visitFile(path: Path, attributes: BasicFileAttributes) = {
-                // The path relative to the src dir
-                val relPath = dir.relativize(path)
-
-                // The corresponding path in the zip
-                val arRelPath = fs.getPath(relPath.toString())
-
-                // If this file is not top-level in the src dir...
-                if (relPath.getParent() != null) {
-                    // ...create the directory structure if it doesn't exist.
-                    if (!Files.exists(arRelPath.getParent())) {
-                        Files.createDirectories(arRelPath.getParent())
-                    }
-                }
-
-                // Finally we can copy that file.
-                Files.copy(path, arRelPath)
-
-                FileVisitResult.CONTINUE
-            }
-        })
-
-        fs.close()
-
-        arPath
-    }
-
-    /** Reads the contents of a (possibly binary) file into a base64-encoded String */
-    def readAsBase64(path: Path): String = {
-        val encoder = Base64.getEncoder()
-        new String(encoder.encode(Files.readAllBytes(path)), StandardCharsets.UTF_8)
-    }
+  /** Reads the contents of a (possibly binary) file into a base64-encoded String */
+  def readAsBase64(path: Path): String = {
+    val encoder = Base64.getEncoder()
+    new String(encoder.encode(Files.readAllBytes(path)), StandardCharsets.UTF_8)
+  }
 }

--- a/tests/src/test/scala/actionContainers/Swift311ActionContainerTests.scala
+++ b/tests/src/test/scala/actionContainers/Swift311ActionContainerTests.scala
@@ -22,9 +22,9 @@ import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class Swift311ActionContainerTests extends Swift3ActionContainerTests {
-    override lazy val swiftContainerImageName = "action-swift-v3.1.1"
+  override lazy val swiftContainerImageName = "action-swift-v3.1.1"
 
-    override lazy val watsonCode = """
+  override lazy val watsonCode = """
                 | import AlchemyDataNewsV1
                 | import ConversationV1
                 | import DiscoveryV1
@@ -41,5 +41,5 @@ class Swift311ActionContainerTests extends Swift3ActionContainerTests {
                 |     return ["message": "I compiled and was able to import Watson SDKs"]
                 | }
             """.stripMargin
-    override lazy val swiftBinaryName = "helloSwift311.zip"
+  override lazy val swiftBinaryName = "helloSwift311.zip"
 }

--- a/tests/src/test/scala/apigw/healthtests/ApiGwEndToEndTests.scala
+++ b/tests/src/test/scala/apigw/healthtests/ApiGwEndToEndTests.scala
@@ -53,118 +53,119 @@ class ApiGwEndToEndTests
     with WskTestHelpers
     with BeforeAndAfterAll {
 
-    implicit val wskprops = WskProps()
-    val wsk = new Wsk
-    val clinamespace = wsk.namespace.whois()
+  implicit val wskprops = WskProps()
+  val wsk = new Wsk
+  val clinamespace = wsk.namespace.whois()
 
-    // Custom CLI properties file
-    val cliWskPropsFile = File.createTempFile("wskprops", ".tmp")
+  // Custom CLI properties file
+  val cliWskPropsFile = File.createTempFile("wskprops", ".tmp")
 
-    /*
-     * Create a CLI properties file for use by the tests
-     */
-    override def beforeAll() = {
-        cliWskPropsFile.deleteOnExit()
-        val wskprops = WskProps(token = "SOME TOKEN")
-        wskprops.writeFile(cliWskPropsFile)
-        println(s"wsk temporary props file created here: ${cliWskPropsFile.getCanonicalPath()}")
+  /*
+   * Create a CLI properties file for use by the tests
+   */
+  override def beforeAll() = {
+    cliWskPropsFile.deleteOnExit()
+    val wskprops = WskProps(token = "SOME TOKEN")
+    wskprops.writeFile(cliWskPropsFile)
+    println(s"wsk temporary props file created here: ${cliWskPropsFile.getCanonicalPath()}")
+  }
+
+  behavior of "Wsk api"
+
+  it should s"create an API and successfully invoke that API" in {
+    val testName = "APIGW_HEALTHTEST1"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_echo"
+    val urlqueryparam = "name"
+    val urlqueryvalue = testName
+
+    try {
+      println("cli namespace: " + clinamespace)
+
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo-web-http.js")
+      wsk.action.create(
+        name = actionName,
+        artifact = Some(file),
+        expectedExitCode = SUCCESS_EXIT,
+        annotations = Map("web-export" -> true.toJson))
+
+      // Create the API
+      var rr = wsk.api.create(
+        basepath = Some(testbasepath),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        action = Some(actionName),
+        apiname = Some(testapiname),
+        responsetype = Some("http"),
+        cliCfgFile = Some(cliWskPropsFile.getCanonicalPath()))
+      rr.stdout should include("ok: created API")
+      val apiurl = rr.stdout.split("\n")(1)
+      println(s"apiurl: '$apiurl'")
+
+      // Validate the API was successfully created
+      // List result will look like:
+      // ok: APIs
+      // Action                            Verb             API Name  URL
+      // /_//whisk.system/utils/echo          get  APIGW_HEALTHTEST1 API Name  http://172.17.0.1:9001/api/ab9082cd-ea8e-465a-8a65-b491725cc4ef/APIGW_HEALTHTEST1_bp/path
+      rr = wsk.api.list(
+        basepathOrApiName = Some(testbasepath),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        cliCfgFile = Some(cliWskPropsFile.getCanonicalPath()))
+      rr.stdout should include("ok: APIs")
+      rr.stdout should include regex (s"$actionName\\s+$testurlop\\s+$testapiname\\s+")
+      rr.stdout should include(testbasepath + testrelpath)
+
+      // Recreate the API using a JSON swagger file
+      rr = wsk.api.get(basepathOrApiName = Some(testbasepath), cliCfgFile = Some(cliWskPropsFile.getCanonicalPath()))
+      val swaggerfile = File.createTempFile("api", ".json")
+      swaggerfile.deleteOnExit()
+      val bw = new BufferedWriter(new FileWriter(swaggerfile))
+      bw.write(rr.stdout)
+      bw.close()
+
+      // Delete API to that it can be recreated again using the generated swagger file
+      val deleteApiResult = wsk.api.delete(
+        basepathOrApiName = testbasepath,
+        expectedExitCode = DONTCARE_EXIT,
+        cliCfgFile = Some(cliWskPropsFile.getCanonicalPath()))
+
+      // Create the API again, but use the swagger file this time
+      rr = wsk.api
+        .create(swagger = Some(swaggerfile.getAbsolutePath()), cliCfgFile = Some(cliWskPropsFile.getCanonicalPath()))
+      rr.stdout should include("ok: created API")
+      val swaggerapiurl = rr.stdout.split("\n")(1)
+      println(s"Returned api url: '${swaggerapiurl}'")
+
+      // Call the API URL and validate the results
+      val start = java.lang.System.currentTimeMillis
+      val apiToInvoke = s"$swaggerapiurl?$urlqueryparam=$urlqueryvalue&guid=$start"
+      println(s"Invoking: '${apiToInvoke}'")
+      val response = whisk.utils.retry({
+        val response = RestAssured.given().config(sslconfig).get(s"$apiToInvoke")
+        println("URL invocation response status: " + response.statusCode)
+        response.statusCode should be(200)
+        response
+      }, 6, Some(2.second))
+      val end = java.lang.System.currentTimeMillis
+      val elapsed = end - start
+      println("Elapsed time (milliseconds) for a successful response: " + elapsed)
+      val responseString = response.body.asString
+      println("URL invocation response: " + responseString)
+      responseString.parseJson.asJsObject.fields(urlqueryparam).convertTo[String] should be(urlqueryvalue)
+
+    } finally {
+      println("Deleting action: " + actionName)
+      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      println("Deleting API: " + testbasepath)
+      val finallydeleteApiResult = wsk.api.delete(
+        basepathOrApiName = testbasepath,
+        expectedExitCode = DONTCARE_EXIT,
+        cliCfgFile = Some(cliWskPropsFile.getCanonicalPath()))
     }
-
-    behavior of "Wsk api"
-
-    it should s"create an API and successfully invoke that API" in {
-        val testName = "APIGW_HEALTHTEST1"
-        val testbasepath = "/" + testName + "_bp"
-        val testrelpath = "/path"
-        val testurlop = "get"
-        val testapiname = testName + " API Name"
-        val actionName = testName + "_echo"
-        val urlqueryparam = "name"
-        val urlqueryvalue = testName
-
-        try {
-            println("cli namespace: " + clinamespace)
-
-            // Create the action for the API.  It must be a "web-action" action.
-            val file = TestUtils.getTestActionFilename(s"echo-web-http.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
-
-            // Create the API
-            var rr = wsk.api.create(
-                basepath = Some(testbasepath),
-                relpath = Some(testrelpath),
-                operation = Some(testurlop),
-                action = Some(actionName),
-                apiname = Some(testapiname),
-                responsetype = Some("http"),
-                cliCfgFile = Some(cliWskPropsFile.getCanonicalPath()))
-            rr.stdout should include("ok: created API")
-            val apiurl = rr.stdout.split("\n")(1)
-            println(s"apiurl: '$apiurl'")
-
-            // Validate the API was successfully created
-            // List result will look like:
-            // ok: APIs
-            // Action                            Verb             API Name  URL
-            // /_//whisk.system/utils/echo          get  APIGW_HEALTHTEST1 API Name  http://172.17.0.1:9001/api/ab9082cd-ea8e-465a-8a65-b491725cc4ef/APIGW_HEALTHTEST1_bp/path
-            rr = wsk.api.list(
-                basepathOrApiName = Some(testbasepath),
-                relpath = Some(testrelpath),
-                operation = Some(testurlop),
-                cliCfgFile = Some(cliWskPropsFile.getCanonicalPath()))
-            rr.stdout should include("ok: APIs")
-            rr.stdout should include regex (s"$actionName\\s+$testurlop\\s+$testapiname\\s+")
-            rr.stdout should include(testbasepath + testrelpath)
-
-            // Recreate the API using a JSON swagger file
-            rr = wsk.api.get(
-                basepathOrApiName = Some(testbasepath),
-                cliCfgFile = Some(cliWskPropsFile.getCanonicalPath()))
-            val swaggerfile = File.createTempFile("api", ".json")
-            swaggerfile.deleteOnExit()
-            val bw = new BufferedWriter(new FileWriter(swaggerfile))
-            bw.write(rr.stdout)
-            bw.close()
-
-            // Delete API to that it can be recreated again using the generated swagger file
-            val deleteApiResult = wsk.api.delete(
-                basepathOrApiName = testbasepath,
-                expectedExitCode = DONTCARE_EXIT,
-                cliCfgFile = Some(cliWskPropsFile.getCanonicalPath()))
-
-            // Create the API again, but use the swagger file this time
-            rr = wsk.api.create(
-                swagger = Some(swaggerfile.getAbsolutePath()),
-                cliCfgFile = Some(cliWskPropsFile.getCanonicalPath()))
-            rr.stdout should include("ok: created API")
-            val swaggerapiurl = rr.stdout.split("\n")(1)
-            println(s"Returned api url: '${swaggerapiurl}'")
-
-            // Call the API URL and validate the results
-            val start = java.lang.System.currentTimeMillis
-            val apiToInvoke = s"$swaggerapiurl?$urlqueryparam=$urlqueryvalue&guid=$start"
-            println(s"Invoking: '${apiToInvoke}'")
-            val response = whisk.utils.retry({
-                val response = RestAssured.given().config(sslconfig).get(s"$apiToInvoke")
-                println("URL invocation response status: " + response.statusCode)
-                response.statusCode should be(200)
-                response
-            }, 6, Some(2.second))
-            val end = java.lang.System.currentTimeMillis
-            val elapsed = end - start
-            println("Elapsed time (milliseconds) for a successful response: " + elapsed)
-            val responseString = response.body.asString
-            println("URL invocation response: " + responseString)
-            responseString.parseJson.asJsObject.fields(urlqueryparam).convertTo[String] should be(urlqueryvalue)
-
-        } finally {
-            println("Deleting action: " + actionName)
-            val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-            println("Deleting API: " + testbasepath)
-            val finallydeleteApiResult = wsk.api.delete(
-                basepathOrApiName = testbasepath,
-                expectedExitCode = DONTCARE_EXIT,
-                cliCfgFile = Some(cliWskPropsFile.getCanonicalPath()))
-        }
-    }
+  }
 }

--- a/tests/src/test/scala/common/JsHelpers.scala
+++ b/tests/src/test/scala/common/JsHelpers.scala
@@ -27,13 +27,13 @@ import spray.json.JsValue
  */
 @Deprecated
 trait JsHelpers {
-    implicit class JsObjectHelper(js: JsObject) {
-        def getFieldPath(path: String*): Option[JsValue] = {
-            whisk.utils.JsHelpers.getFieldPath(js, path.toList)
-        }
-
-        def fieldPathExists(path: String*): Boolean = {
-            whisk.utils.JsHelpers.fieldPathExists(js, path.toList)
-        }
+  implicit class JsObjectHelper(js: JsObject) {
+    def getFieldPath(path: String*): Option[JsValue] = {
+      whisk.utils.JsHelpers.getFieldPath(js, path.toList)
     }
+
+    def fieldPathExists(path: String*): Boolean = {
+      whisk.utils.JsHelpers.fieldPathExists(js, path.toList)
+    }
+  }
 }

--- a/tests/src/test/scala/common/LoggedFunction.scala
+++ b/tests/src/test/scala/common/LoggedFunction.scala
@@ -28,46 +28,45 @@ import scala.collection.mutable
  *     func.calls should have size 1
  *     func.calls.head shouldBe (1, 2)
  */
-
 class LoggedFunction2[A1, A2, B](body: (A1, A2) => B) extends Function2[A1, A2, B] {
-    val calls = mutable.Buffer[(A1, A2)]()
+  val calls = mutable.Buffer[(A1, A2)]()
 
-    override def apply(v1: A1, v2: A2): B = {
-        calls += ((v1, v2))
-        body(v1, v2)
-    }
+  override def apply(v1: A1, v2: A2): B = {
+    calls += ((v1, v2))
+    body(v1, v2)
+  }
 }
 
 class LoggedFunction3[A1, A2, A3, B](body: (A1, A2, A3) => B) extends Function3[A1, A2, A3, B] {
-    val calls = mutable.Buffer[(A1, A2, A3)]()
+  val calls = mutable.Buffer[(A1, A2, A3)]()
 
-    override def apply(v1: A1, v2: A2, v3: A3): B = {
-        calls += ((v1, v2, v3))
-        body(v1, v2, v3)
-    }
+  override def apply(v1: A1, v2: A2, v3: A3): B = {
+    calls += ((v1, v2, v3))
+    body(v1, v2, v3)
+  }
 }
 
 class LoggedFunction4[A1, A2, A3, A4, B](body: (A1, A2, A3, A4) => B) extends Function4[A1, A2, A3, A4, B] {
-    val calls = mutable.Buffer[(A1, A2, A3, A4)]()
+  val calls = mutable.Buffer[(A1, A2, A3, A4)]()
 
-    override def apply(v1: A1, v2: A2, v3: A3, v4: A4): B = {
-        calls += ((v1, v2, v3, v4))
-        body(v1, v2, v3, v4)
-    }
+  override def apply(v1: A1, v2: A2, v3: A3, v4: A4): B = {
+    calls += ((v1, v2, v3, v4))
+    body(v1, v2, v3, v4)
+  }
 }
 
 class LoggedFunction5[A1, A2, A3, A4, A5, B](body: (A1, A2, A3, A4, A5) => B) extends Function5[A1, A2, A3, A4, A5, B] {
-    val calls = mutable.Buffer[(A1, A2, A3, A4, A5)]()
+  val calls = mutable.Buffer[(A1, A2, A3, A4, A5)]()
 
-    override def apply(v1: A1, v2: A2, v3: A3, v4: A4, v5: A5): B = {
-        calls += ((v1, v2, v3, v4, v5))
-        body(v1, v2, v3, v4, v5)
-    }
+  override def apply(v1: A1, v2: A2, v3: A3, v4: A4, v5: A5): B = {
+    calls += ((v1, v2, v3, v4, v5))
+    body(v1, v2, v3, v4, v5)
+  }
 }
 
 object LoggedFunction {
-    def apply[A1, A2, B](body: (A1, A2) => B) = new LoggedFunction2(body)
-    def apply[A1, A2, A3, B](body: (A1, A2, A3) => B) = new LoggedFunction3(body)
-    def apply[A1, A2, A3, A4, B](body: (A1, A2, A3, A4) => B) = new LoggedFunction4(body)
-    def apply[A1, A2, A3, A4, A5, B](body: (A1, A2, A3, A4, A5) => B) = new LoggedFunction5(body)
+  def apply[A1, A2, B](body: (A1, A2) => B) = new LoggedFunction2(body)
+  def apply[A1, A2, A3, B](body: (A1, A2, A3) => B) = new LoggedFunction3(body)
+  def apply[A1, A2, A3, A4, B](body: (A1, A2, A3, A4) => B) = new LoggedFunction4(body)
+  def apply[A1, A2, A3, A4, A5, B](body: (A1, A2, A3, A4, A5) => B) = new LoggedFunction5(body)
 }

--- a/tests/src/test/scala/common/StreamLogging.scala
+++ b/tests/src/test/scala/common/StreamLogging.scala
@@ -31,9 +31,9 @@ import java.nio.charset.StandardCharsets
  * the logger logs to the stream, that can be accessed from your test, to check if a specific message has been written.
  */
 trait StreamLogging {
-    lazy val stream = new ByteArrayOutputStream
-    lazy val printstream = new PrintStream(stream)
-    implicit lazy val logging: Logging = new PrintStreamLogging(printstream)
+  lazy val stream = new ByteArrayOutputStream
+  lazy val printstream = new PrintStream(stream)
+  implicit lazy val logging: Logging = new PrintStreamLogging(printstream)
 
-    def logLines = new String(stream.toByteArray, StandardCharsets.UTF_8).lines.toList
+  def logLines = new String(stream.toByteArray, StandardCharsets.UTF_8).lines.toList
 }

--- a/tests/src/test/scala/common/TestHelpers.scala
+++ b/tests/src/test/scala/common/TestHelpers.scala
@@ -21,17 +21,15 @@ import org.scalatest.BeforeAndAfterEachTestData
 import org.scalatest.FlatSpec
 import org.scalatest.TestData
 
-trait TestHelpers
-    extends FlatSpec
-    with BeforeAndAfterEachTestData {
+trait TestHelpers extends FlatSpec with BeforeAndAfterEachTestData {
 
-    override def beforeEach(td: TestData) {
-        println(s"\nStarting test ${td.name} at ${TestUtils.getDateTime()}")
-        super.beforeEach(td)
-    }
+  override def beforeEach(td: TestData) {
+    println(s"\nStarting test ${td.name} at ${TestUtils.getDateTime()}")
+    super.beforeEach(td)
+  }
 
-    override def afterEach(td: TestData) {
-        println(s"\nFinished test ${td.name} at ${TestUtils.getDateTime()}")
-        super.afterEach(td)
-    }
+  override def afterEach(td: TestData) {
+    println(s"\nFinished test ${td.name} at ${TestUtils.getDateTime()}")
+    super.afterEach(td)
+  }
 }

--- a/tests/src/test/scala/common/Wsk.scala
+++ b/tests/src/test/scala/common/Wsk.scala
@@ -68,956 +68,1094 @@ import whisk.utils.retry
  * It also sets the apihost and apiversion explicitly to avoid ambiguity with
  * a local property file if it exists.
  */
-
 case class WskProps(
-    authKey: String = WhiskProperties.readAuthKey(WhiskProperties.getAuthFileForTesting),
-    cert: String = WhiskProperties.getFileRelativeToWhiskHome("ansible/roles/nginx/files/openwhisk-client-cert.pem").getAbsolutePath,
-    key: String = WhiskProperties.getFileRelativeToWhiskHome("ansible/roles/nginx/files/openwhisk-client-key.pem").getAbsolutePath ,
-    namespace: String = "_",
-    apiversion: String = "v1",
-    apihost: String = WhiskProperties.getEdgeHost,
-    token: String = "") {
-    def overrides = Seq("-i", "--apihost", apihost, "--apiversion", apiversion)
-    def writeFile(propsfile: File) = {
-        val propsStr = s"NAMESPACE=$namespace\nAPIVERSION=$apiversion\nAUTH=$authKey\nAPIHOST=$apihost\nAPIGW_ACCESS_TOKEN=$token\n"
-        val bw = new BufferedWriter(new FileWriter(propsfile))
-        try {
-            bw.write(propsStr)
-        } finally {
-            bw.close()
-        }
+  authKey: String = WhiskProperties.readAuthKey(WhiskProperties.getAuthFileForTesting),
+  cert: String =
+    WhiskProperties.getFileRelativeToWhiskHome("ansible/roles/nginx/files/openwhisk-client-cert.pem").getAbsolutePath,
+  key: String =
+    WhiskProperties.getFileRelativeToWhiskHome("ansible/roles/nginx/files/openwhisk-client-key.pem").getAbsolutePath,
+  namespace: String = "_",
+  apiversion: String = "v1",
+  apihost: String = WhiskProperties.getEdgeHost,
+  token: String = "") {
+  def overrides = Seq("-i", "--apihost", apihost, "--apiversion", apiversion)
+  def writeFile(propsfile: File) = {
+    val propsStr =
+      s"NAMESPACE=$namespace\nAPIVERSION=$apiversion\nAUTH=$authKey\nAPIHOST=$apihost\nAPIGW_ACCESS_TOKEN=$token\n"
+    val bw = new BufferedWriter(new FileWriter(propsfile))
+    try {
+      bw.write(propsStr)
+    } finally {
+      bw.close()
     }
+  }
 }
 
 class Wsk() extends RunWskCmd {
-    implicit val action = new WskAction
-    implicit val trigger = new WskTrigger
-    implicit val rule = new WskRule
-    implicit val activation = new WskActivation
-    implicit val pkg = new WskPackage
-    implicit val namespace = new WskNamespace
-    implicit val api = new WskApi
+  implicit val action = new WskAction
+  implicit val trigger = new WskTrigger
+  implicit val rule = new WskRule
+  implicit val activation = new WskActivation
+  implicit val pkg = new WskPackage
+  implicit val namespace = new WskNamespace
+  implicit val api = new WskApi
 }
 
 trait FullyQualifiedNames {
-    /**
-     * Fully qualifies the name of an entity with its namespace.
-     * If the name already starts with the PATHSEP character, then
-     * it already is fully qualified. Otherwise (package name or
-     * basic entity name) it is prefixed with the namespace. The
-     * namespace is derived from the implicit whisk properties.
-     *
-     * @param name to fully qualify iff it is not already fully qualified
-     * @param wp whisk properties
-     * @return name if it is fully qualified else a name fully qualified for a namespace
-     */
-    def fqn(name: String)(implicit wp: WskProps) = {
-        val sep = "/" // Namespace.PATHSEP
-        if (name.startsWith(sep) || name.count(_ == sep(0)) == 2) name
-        else s"$sep${wp.namespace}$sep$name"
-    }
 
-    /**
-     * Resolves a namespace. If argument is defined, it takes precedence.
-     * else resolve to namespace in implicit WskProps.
-     *
-     * @param namespace an optional namespace
-     * @param wp whisk properties
-     * @return resolved namespace
-     */
-    def resolve(namespace: Option[String])(implicit wp: WskProps) = {
-        val sep = "/" // Namespace.PATHSEP
-        namespace getOrElse s"$sep${wp.namespace}"
-    }
+  /**
+   * Fully qualifies the name of an entity with its namespace.
+   * If the name already starts with the PATHSEP character, then
+   * it already is fully qualified. Otherwise (package name or
+   * basic entity name) it is prefixed with the namespace. The
+   * namespace is derived from the implicit whisk properties.
+   *
+   * @param name to fully qualify iff it is not already fully qualified
+   * @param wp whisk properties
+   * @return name if it is fully qualified else a name fully qualified for a namespace
+   */
+  def fqn(name: String)(implicit wp: WskProps) = {
+    val sep = "/" // Namespace.PATHSEP
+    if (name.startsWith(sep) || name.count(_ == sep(0)) == 2) name
+    else s"$sep${wp.namespace}$sep$name"
+  }
+
+  /**
+   * Resolves a namespace. If argument is defined, it takes precedence.
+   * else resolve to namespace in implicit WskProps.
+   *
+   * @param namespace an optional namespace
+   * @param wp whisk properties
+   * @return resolved namespace
+   */
+  def resolve(namespace: Option[String])(implicit wp: WskProps) = {
+    val sep = "/" // Namespace.PATHSEP
+    namespace getOrElse s"$sep${wp.namespace}"
+  }
 }
 
 trait ListOrGetFromCollection extends FullyQualifiedNames {
-    self: RunWskCmd =>
+  self: RunWskCmd =>
 
-    protected val noun: String
+  protected val noun: String
 
-    /**
-     * List entities in collection.
-     *
-     * @param namespace (optional) if specified must be  fully qualified namespace
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def list(
-        namespace: Option[String] = None,
-        limit: Option[Int] = None,
-        nameSort: Option[Boolean] = None,
-        expectedExitCode: Int = SUCCESS_EXIT)(
-            implicit wp: WskProps): RunResult = {
-        val params = Seq(noun, "list", resolve(namespace), "--auth", wp.authKey) ++
-            { limit map { l => Seq("--limit", l.toString) } getOrElse Seq() } ++
-            { nameSort map { n => Seq("--name-sort") } getOrElse Seq() }
-        cli(wp.overrides ++ params, expectedExitCode)
+  /**
+   * List entities in collection.
+   *
+   * @param namespace (optional) if specified must be  fully qualified namespace
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  def list(namespace: Option[String] = None,
+           limit: Option[Int] = None,
+           nameSort: Option[Boolean] = None,
+           expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RunResult = {
+    val params = Seq(noun, "list", resolve(namespace), "--auth", wp.authKey) ++ {
+      limit map { l =>
+        Seq("--limit", l.toString)
+      } getOrElse Seq()
+    } ++ {
+      nameSort map { n =>
+        Seq("--name-sort")
+      } getOrElse Seq()
+    }
+    cli(wp.overrides ++ params, expectedExitCode)
+  }
+
+  /**
+   * Gets entity from collection.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  def get(name: String,
+          expectedExitCode: Int = SUCCESS_EXIT,
+          summary: Boolean = false,
+          fieldFilter: Option[String] = None,
+          url: Option[Boolean] = None)(implicit wp: WskProps): RunResult = {
+    val params = Seq(noun, "get", "--auth", wp.authKey) ++
+      Seq(fqn(name)) ++ { if (summary) Seq("--summary") else Seq() } ++ {
+      fieldFilter map { f =>
+        Seq(f)
+      } getOrElse Seq()
+    } ++ {
+      url map { u =>
+        Seq("--url")
+      } getOrElse Seq()
     }
 
-    /**
-     * Gets entity from collection.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def get(
-        name: String,
-        expectedExitCode: Int = SUCCESS_EXIT,
-        summary: Boolean = false,
-        fieldFilter: Option[String] = None,
-        url: Option[Boolean] = None)(
-            implicit wp: WskProps): RunResult = {
-        val params = Seq(noun, "get", "--auth", wp.authKey) ++
-            Seq(fqn(name)) ++
-            { if (summary) Seq("--summary") else Seq() } ++
-            { fieldFilter map { f => Seq(f) } getOrElse Seq() } ++
-            { url map { u => Seq("--url") } getOrElse Seq() }
-
-        cli(wp.overrides ++ params, expectedExitCode)
-    }
+    cli(wp.overrides ++ params, expectedExitCode)
+  }
 }
 
 trait DeleteFromCollection extends FullyQualifiedNames {
-    self: RunWskCmd =>
+  self: RunWskCmd =>
 
-    protected val noun: String
+  protected val noun: String
 
-    /**
-     * Deletes entity from collection.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def delete(
-        name: String,
-        expectedExitCode: Int = SUCCESS_EXIT)(
-            implicit wp: WskProps): RunResult = {
-        cli(wp.overrides ++ Seq(noun, "delete", "--auth", wp.authKey, fqn(name)), expectedExitCode)
-    }
+  /**
+   * Deletes entity from collection.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  def delete(name: String, expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RunResult = {
+    cli(wp.overrides ++ Seq(noun, "delete", "--auth", wp.authKey, fqn(name)), expectedExitCode)
+  }
 
-    /**
-     * Deletes entity from collection but does not assert that the command succeeds.
-     * Use this if deleting an entity that may not exist and it is OK if it does not.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     */
-    def sanitize(name: String)(implicit wp: WskProps): RunResult = {
-        delete(name, DONTCARE_EXIT)
-    }
+  /**
+   * Deletes entity from collection but does not assert that the command succeeds.
+   * Use this if deleting an entity that may not exist and it is OK if it does not.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   */
+  def sanitize(name: String)(implicit wp: WskProps): RunResult = {
+    delete(name, DONTCARE_EXIT)
+  }
 }
 
 trait HasActivation {
-    /**
-     * Extracts activation id from invoke (action or trigger) or activation get
-     */
-    def extractActivationId(result: RunResult): Option[String] = {
-        Try {
-            // try to interpret the run result as the result of an invoke
-            extractActivationIdFromInvoke(result) getOrElse extractActivationIdFromActivation(result).get
-        } toOption
-    }
 
-    /**
-     * Extracts activation id from 'wsk activation get' run result
-     */
-    private def extractActivationIdFromActivation(result: RunResult): Option[String] = {
-        Try {
-            // a characteristic string that comes right before the activationId
-            val idPrefix = "ok: got activation "
-            val output = if (result.exitCode != SUCCESS_EXIT) result.stderr else result.stdout
-            assert(output.contains(idPrefix), output)
-            extractActivationId(idPrefix, output).get
-        } toOption
-    }
+  /**
+   * Extracts activation id from invoke (action or trigger) or activation get
+   */
+  def extractActivationId(result: RunResult): Option[String] = {
+    Try {
+      // try to interpret the run result as the result of an invoke
+      extractActivationIdFromInvoke(result) getOrElse extractActivationIdFromActivation(result).get
+    } toOption
+  }
 
-    /**
-     * Extracts activation id from 'wsk action invoke' or 'wsk trigger invoke'
-     */
-    private def extractActivationIdFromInvoke(result: RunResult): Option[String] = {
-        Try {
-            val output = if (result.exitCode != SUCCESS_EXIT) result.stderr else result.stdout
-            assert(output.contains("ok: invoked") || output.contains("ok: triggered"), output)
-            // a characteristic string that comes right before the activationId
-            val idPrefix = "with id "
-            extractActivationId(idPrefix, output).get
-        } toOption
-    }
+  /**
+   * Extracts activation id from 'wsk activation get' run result
+   */
+  private def extractActivationIdFromActivation(result: RunResult): Option[String] = {
+    Try {
+      // a characteristic string that comes right before the activationId
+      val idPrefix = "ok: got activation "
+      val output = if (result.exitCode != SUCCESS_EXIT) result.stderr else result.stdout
+      assert(output.contains(idPrefix), output)
+      extractActivationId(idPrefix, output).get
+    } toOption
+  }
 
-    /**
-     * Extracts activation id preceded by a prefix (idPrefix) from a string (output)
-     *
-     * @param idPrefix the prefix of the activation id
-     * @param output the string to be used in the extraction
-     * @return an option containing the id as a string or None if the extraction failed for any reason
-     */
-    private def extractActivationId(idPrefix: String, output: String): Option[String] = {
-        Try {
-            val start = output.indexOf(idPrefix) + idPrefix.length
-            var end = start
-            assert(start > 0)
-            while (end < output.length && output.charAt(end) != '\n')
-                end = end + 1
-            output.substring(start, end) // a uuid
-        } toOption
-    }
+  /**
+   * Extracts activation id from 'wsk action invoke' or 'wsk trigger invoke'
+   */
+  private def extractActivationIdFromInvoke(result: RunResult): Option[String] = {
+    Try {
+      val output = if (result.exitCode != SUCCESS_EXIT) result.stderr else result.stdout
+      assert(output.contains("ok: invoked") || output.contains("ok: triggered"), output)
+      // a characteristic string that comes right before the activationId
+      val idPrefix = "with id "
+      extractActivationId(idPrefix, output).get
+    } toOption
+  }
+
+  /**
+   * Extracts activation id preceded by a prefix (idPrefix) from a string (output)
+   *
+   * @param idPrefix the prefix of the activation id
+   * @param output the string to be used in the extraction
+   * @return an option containing the id as a string or None if the extraction failed for any reason
+   */
+  private def extractActivationId(idPrefix: String, output: String): Option[String] = {
+    Try {
+      val start = output.indexOf(idPrefix) + idPrefix.length
+      var end = start
+      assert(start > 0)
+      while (end < output.length && output.charAt(end) != '\n') end = end + 1
+      output.substring(start, end) // a uuid
+    } toOption
+  }
 }
 
-class WskAction()
-    extends RunWskCmd
-    with ListOrGetFromCollection
-    with DeleteFromCollection
-    with HasActivation {
+class WskAction() extends RunWskCmd with ListOrGetFromCollection with DeleteFromCollection with HasActivation {
 
-    override protected val noun = "action"
+  override protected val noun = "action"
 
-    /**
-     * Creates action. Parameters mirror those available in the CLI.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def create(
-        name: String,
-        artifact: Option[String],
-        kind: Option[String] = None, // one of docker, copy, sequence or none for autoselect else an explicit type
-        main: Option[String] = None,
-        docker: Option[String] = None,
-        parameters: Map[String, JsValue] = Map(),
-        annotations: Map[String, JsValue] = Map(),
-        parameterFile: Option[String] = None,
-        annotationFile: Option[String] = None,
-        timeout: Option[Duration] = None,
-        memory: Option[ByteSize] = None,
-        logsize: Option[ByteSize] = None,
-        shared: Option[Boolean] = None,
-        update: Boolean = false,
-        web: Option[String] = None,
-        expectedExitCode: Int = SUCCESS_EXIT)(
-            implicit wp: WskProps): RunResult = {
-        val params = Seq(noun, if (!update) "create" else "update", "--auth", wp.authKey, fqn(name)) ++
-            { artifact map { Seq(_) } getOrElse Seq() } ++
-            {
-                kind map { k =>
-                    if (k == "sequence" || k == "copy" || k == "native") Seq(s"--$k")
-                    else Seq("--kind", k)
-                } getOrElse Seq()
-            } ++
-            { main.toSeq flatMap { p => Seq("--main", p) } } ++
-            { docker.toSeq flatMap { p => Seq("--docker", p) } } ++
-            { parameters flatMap { p => Seq("-p", p._1, p._2.compactPrint) } } ++
-            { annotations flatMap { p => Seq("-a", p._1, p._2.compactPrint) } } ++
-            { parameterFile map { pf => Seq("-P", pf) } getOrElse Seq() } ++
-            { annotationFile map { af => Seq("-A", af) } getOrElse Seq() } ++
-            { timeout map { t => Seq("-t", t.toMillis.toString) } getOrElse Seq() } ++
-            { memory map { m => Seq("-m", m.toMB.toString) } getOrElse Seq() } ++
-            { logsize map { l => Seq("-l", l.toMB.toString) } getOrElse Seq() } ++
-            { shared map { s => Seq("--shared", if (s) "yes" else "no") } getOrElse Seq() } ++
-            { web map { w => Seq("--web", w) } getOrElse Seq() }
-        cli(wp.overrides ++ params, expectedExitCode)
+  /**
+   * Creates action. Parameters mirror those available in the CLI.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  def create(name: String,
+             artifact: Option[String],
+             kind: Option[String] = None, // one of docker, copy, sequence or none for autoselect else an explicit type
+             main: Option[String] = None,
+             docker: Option[String] = None,
+             parameters: Map[String, JsValue] = Map(),
+             annotations: Map[String, JsValue] = Map(),
+             parameterFile: Option[String] = None,
+             annotationFile: Option[String] = None,
+             timeout: Option[Duration] = None,
+             memory: Option[ByteSize] = None,
+             logsize: Option[ByteSize] = None,
+             shared: Option[Boolean] = None,
+             update: Boolean = false,
+             web: Option[String] = None,
+             expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RunResult = {
+    val params = Seq(noun, if (!update) "create" else "update", "--auth", wp.authKey, fqn(name)) ++ {
+      artifact map { Seq(_) } getOrElse Seq()
+    } ++ {
+      kind map { k =>
+        if (k == "sequence" || k == "copy" || k == "native") Seq(s"--$k")
+        else Seq("--kind", k)
+      } getOrElse Seq()
+    } ++ {
+      main.toSeq flatMap { p =>
+        Seq("--main", p)
+      }
+    } ++ {
+      docker.toSeq flatMap { p =>
+        Seq("--docker", p)
+      }
+    } ++ {
+      parameters flatMap { p =>
+        Seq("-p", p._1, p._2.compactPrint)
+      }
+    } ++ {
+      annotations flatMap { p =>
+        Seq("-a", p._1, p._2.compactPrint)
+      }
+    } ++ {
+      parameterFile map { pf =>
+        Seq("-P", pf)
+      } getOrElse Seq()
+    } ++ {
+      annotationFile map { af =>
+        Seq("-A", af)
+      } getOrElse Seq()
+    } ++ {
+      timeout map { t =>
+        Seq("-t", t.toMillis.toString)
+      } getOrElse Seq()
+    } ++ {
+      memory map { m =>
+        Seq("-m", m.toMB.toString)
+      } getOrElse Seq()
+    } ++ {
+      logsize map { l =>
+        Seq("-l", l.toMB.toString)
+      } getOrElse Seq()
+    } ++ {
+      shared map { s =>
+        Seq("--shared", if (s) "yes" else "no")
+      } getOrElse Seq()
+    } ++ {
+      web map { w =>
+        Seq("--web", w)
+      } getOrElse Seq()
     }
+    cli(wp.overrides ++ params, expectedExitCode)
+  }
 
-    /**
-     * Invokes action. Parameters mirror those available in the CLI.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def invoke(
-        name: String,
-        parameters: Map[String, JsValue] = Map(),
-        parameterFile: Option[String] = None,
-        blocking: Boolean = false,
-        result: Boolean = false,
-        expectedExitCode: Int = SUCCESS_EXIT)(
-            implicit wp: WskProps): RunResult = {
-        val params = Seq(noun, "invoke", "--auth", wp.authKey, fqn(name)) ++
-            { parameters flatMap { p => Seq("-p", p._1, p._2.compactPrint) } } ++
-            { parameterFile map { pf => Seq("-P", pf) } getOrElse Seq() } ++
-            { if (blocking) Seq("--blocking") else Seq() } ++
-            { if (result) Seq("--result") else Seq() }
-        cli(wp.overrides ++ params, expectedExitCode)
-    }
+  /**
+   * Invokes action. Parameters mirror those available in the CLI.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  def invoke(name: String,
+             parameters: Map[String, JsValue] = Map(),
+             parameterFile: Option[String] = None,
+             blocking: Boolean = false,
+             result: Boolean = false,
+             expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RunResult = {
+    val params = Seq(noun, "invoke", "--auth", wp.authKey, fqn(name)) ++ {
+      parameters flatMap { p =>
+        Seq("-p", p._1, p._2.compactPrint)
+      }
+    } ++ {
+      parameterFile map { pf =>
+        Seq("-P", pf)
+      } getOrElse Seq()
+    } ++ { if (blocking) Seq("--blocking") else Seq() } ++ { if (result) Seq("--result") else Seq() }
+    cli(wp.overrides ++ params, expectedExitCode)
+  }
 }
 
-class WskTrigger()
-    extends RunWskCmd
-    with ListOrGetFromCollection
-    with DeleteFromCollection
-    with HasActivation {
+class WskTrigger() extends RunWskCmd with ListOrGetFromCollection with DeleteFromCollection with HasActivation {
 
-    override protected val noun = "trigger"
+  override protected val noun = "trigger"
 
-    /**
-     * Creates trigger. Parameters mirror those available in the CLI.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def create(
-        name: String,
-        parameters: Map[String, JsValue] = Map(),
-        annotations: Map[String, JsValue] = Map(),
-        parameterFile: Option[String] = None,
-        annotationFile: Option[String] = None,
-        feed: Option[String] = None,
-        shared: Option[Boolean] = None,
-        update: Boolean = false,
-        expectedExitCode: Int = SUCCESS_EXIT)(
-            implicit wp: WskProps): RunResult = {
-        val params = Seq(noun, if (!update) "create" else "update", "--auth", wp.authKey, fqn(name)) ++
-            { feed map { f => Seq("--feed", fqn(f)) } getOrElse Seq() } ++
-            { parameters flatMap { p => Seq("-p", p._1, p._2.compactPrint) } } ++
-            { annotations flatMap { p => Seq("-a", p._1, p._2.compactPrint) } } ++
-            { parameterFile map { pf => Seq("-P", pf) } getOrElse Seq() } ++
-            { annotationFile map { af => Seq("-A", af) } getOrElse Seq() } ++
-            { shared map { s => Seq("--shared", if (s) "yes" else "no") } getOrElse Seq() }
-        cli(wp.overrides ++ params, expectedExitCode)
+  /**
+   * Creates trigger. Parameters mirror those available in the CLI.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  def create(name: String,
+             parameters: Map[String, JsValue] = Map(),
+             annotations: Map[String, JsValue] = Map(),
+             parameterFile: Option[String] = None,
+             annotationFile: Option[String] = None,
+             feed: Option[String] = None,
+             shared: Option[Boolean] = None,
+             update: Boolean = false,
+             expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RunResult = {
+    val params = Seq(noun, if (!update) "create" else "update", "--auth", wp.authKey, fqn(name)) ++ {
+      feed map { f =>
+        Seq("--feed", fqn(f))
+      } getOrElse Seq()
+    } ++ {
+      parameters flatMap { p =>
+        Seq("-p", p._1, p._2.compactPrint)
+      }
+    } ++ {
+      annotations flatMap { p =>
+        Seq("-a", p._1, p._2.compactPrint)
+      }
+    } ++ {
+      parameterFile map { pf =>
+        Seq("-P", pf)
+      } getOrElse Seq()
+    } ++ {
+      annotationFile map { af =>
+        Seq("-A", af)
+      } getOrElse Seq()
+    } ++ {
+      shared map { s =>
+        Seq("--shared", if (s) "yes" else "no")
+      } getOrElse Seq()
     }
+    cli(wp.overrides ++ params, expectedExitCode)
+  }
 
-    /**
-     * Fires trigger. Parameters mirror those available in the CLI.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def fire(
-        name: String,
-        parameters: Map[String, JsValue] = Map(),
-        parameterFile: Option[String] = None,
-        expectedExitCode: Int = SUCCESS_EXIT)(
-            implicit wp: WskProps): RunResult = {
-        val params = Seq(noun, "fire", "--auth", wp.authKey, fqn(name)) ++
-            { parameters flatMap { p => Seq("-p", p._1, p._2.compactPrint) } } ++
-            { parameterFile map { pf => Seq("-P", pf) } getOrElse Seq() }
-        cli(wp.overrides ++ params, expectedExitCode)
+  /**
+   * Fires trigger. Parameters mirror those available in the CLI.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  def fire(name: String,
+           parameters: Map[String, JsValue] = Map(),
+           parameterFile: Option[String] = None,
+           expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RunResult = {
+    val params = Seq(noun, "fire", "--auth", wp.authKey, fqn(name)) ++ {
+      parameters flatMap { p =>
+        Seq("-p", p._1, p._2.compactPrint)
+      }
+    } ++ {
+      parameterFile map { pf =>
+        Seq("-P", pf)
+      } getOrElse Seq()
     }
+    cli(wp.overrides ++ params, expectedExitCode)
+  }
 }
 
-class WskRule()
-    extends RunWskCmd
-    with ListOrGetFromCollection
-    with DeleteFromCollection
-    with WaitFor {
+class WskRule() extends RunWskCmd with ListOrGetFromCollection with DeleteFromCollection with WaitFor {
 
-    override protected val noun = "rule"
+  override protected val noun = "rule"
 
-    /**
-     * Creates rule. Parameters mirror those available in the CLI.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     * @param trigger must be a simple name
-     * @param action must be a simple name
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def create(
-        name: String,
-        trigger: String,
-        action: String,
-        annotations: Map[String, JsValue] = Map(),
-        shared: Option[Boolean] = None,
-        update: Boolean = false,
-        expectedExitCode: Int = SUCCESS_EXIT)(
-            implicit wp: WskProps): RunResult = {
-        val params = Seq(noun, if (!update) "create" else "update", "--auth", wp.authKey, fqn(name), (trigger), (action)) ++
-            { annotations flatMap { p => Seq("-a", p._1, p._2.compactPrint) } } ++
-            { shared map { s => Seq("--shared", if (s) "yes" else "no") } getOrElse Seq() }
-        cli(wp.overrides ++ params, expectedExitCode)
+  /**
+   * Creates rule. Parameters mirror those available in the CLI.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   * @param trigger must be a simple name
+   * @param action must be a simple name
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  def create(name: String,
+             trigger: String,
+             action: String,
+             annotations: Map[String, JsValue] = Map(),
+             shared: Option[Boolean] = None,
+             update: Boolean = false,
+             expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RunResult = {
+    val params = Seq(noun, if (!update) "create" else "update", "--auth", wp.authKey, fqn(name), (trigger), (action)) ++ {
+      annotations flatMap { p =>
+        Seq("-a", p._1, p._2.compactPrint)
+      }
+    } ++ {
+      shared map { s =>
+        Seq("--shared", if (s) "yes" else "no")
+      } getOrElse Seq()
     }
+    cli(wp.overrides ++ params, expectedExitCode)
+  }
 
-    /**
-     * Deletes rule.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    override def delete(
-        name: String,
-        expectedExitCode: Int = SUCCESS_EXIT)(
-            implicit wp: WskProps): RunResult = {
-        super.delete(name, expectedExitCode)
-    }
+  /**
+   * Deletes rule.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  override def delete(name: String, expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RunResult = {
+    super.delete(name, expectedExitCode)
+  }
 
-    /**
-     * Enables rule.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def enable(
-        name: String,
-        expectedExitCode: Int = SUCCESS_EXIT)(
-            implicit wp: WskProps): RunResult = {
-        cli(wp.overrides ++ Seq(noun, "enable", "--auth", wp.authKey, fqn(name)), expectedExitCode)
-    }
+  /**
+   * Enables rule.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  def enable(name: String, expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RunResult = {
+    cli(wp.overrides ++ Seq(noun, "enable", "--auth", wp.authKey, fqn(name)), expectedExitCode)
+  }
 
-    /**
-     * Disables rule.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def disable(
-        name: String,
-        expectedExitCode: Int = SUCCESS_EXIT)(
-            implicit wp: WskProps): RunResult = {
-        cli(wp.overrides ++ Seq(noun, "disable", "--auth", wp.authKey, fqn(name)), expectedExitCode)
-    }
+  /**
+   * Disables rule.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  def disable(name: String, expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RunResult = {
+    cli(wp.overrides ++ Seq(noun, "disable", "--auth", wp.authKey, fqn(name)), expectedExitCode)
+  }
 
-    /**
-     * Checks state of rule.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def state(
-        name: String,
-        expectedExitCode: Int = SUCCESS_EXIT)(
-            implicit wp: WskProps): RunResult = {
-        cli(wp.overrides ++ Seq(noun, "status", "--auth", wp.authKey, fqn(name)), expectedExitCode)
-    }
+  /**
+   * Checks state of rule.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  def state(name: String, expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RunResult = {
+    cli(wp.overrides ++ Seq(noun, "status", "--auth", wp.authKey, fqn(name)), expectedExitCode)
+  }
 }
 
-class WskActivation()
-    extends RunWskCmd
-    with HasActivation
-    with WaitFor {
+class WskActivation() extends RunWskCmd with HasActivation with WaitFor {
 
-    protected val noun = "activation"
+  protected val noun = "activation"
 
-    /**
-     * Activation polling console.
-     *
-     * @param duration exits console after duration
-     * @param since (optional) time travels back to activation since given duration
-     */
-    def console(
-        duration: Duration,
-        since: Option[Duration] = None,
-        expectedExitCode: Int = SUCCESS_EXIT)(
-            implicit wp: WskProps): RunResult = {
-        val params = Seq(noun, "poll", "--auth", wp.authKey, "--exit", duration.toSeconds.toString) ++
-            { since map { s => Seq("--since-seconds", s.toSeconds.toString) } getOrElse Seq() }
-        cli(wp.overrides ++ params, expectedExitCode)
+  /**
+   * Activation polling console.
+   *
+   * @param duration exits console after duration
+   * @param since (optional) time travels back to activation since given duration
+   */
+  def console(duration: Duration, since: Option[Duration] = None, expectedExitCode: Int = SUCCESS_EXIT)(
+    implicit wp: WskProps): RunResult = {
+    val params = Seq(noun, "poll", "--auth", wp.authKey, "--exit", duration.toSeconds.toString) ++ {
+      since map { s =>
+        Seq("--since-seconds", s.toSeconds.toString)
+      } getOrElse Seq()
     }
+    cli(wp.overrides ++ params, expectedExitCode)
+  }
 
-    /**
-     * Lists activations.
-     *
-     * @param filter (optional) if define, must be a simple entity name
-     * @param limit (optional) the maximum number of activation to return
-     * @param since (optional) only the activations since this timestamp are included
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def list(
-        filter: Option[String] = None,
-        limit: Option[Int] = None,
-        since: Option[Instant] = None,
-        expectedExitCode: Int = SUCCESS_EXIT)(
-            implicit wp: WskProps): RunResult = {
-        val params = Seq(noun, "list", "--auth", wp.authKey) ++
-            { filter map { Seq(_) } getOrElse Seq() } ++
-            { limit map { l => Seq("--limit", l.toString) } getOrElse Seq() } ++
-            { since map { i => Seq("--since", i.toEpochMilli.toString) } getOrElse Seq() }
-        cli(wp.overrides ++ params, expectedExitCode)
+  /**
+   * Lists activations.
+   *
+   * @param filter (optional) if define, must be a simple entity name
+   * @param limit (optional) the maximum number of activation to return
+   * @param since (optional) only the activations since this timestamp are included
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  def list(filter: Option[String] = None,
+           limit: Option[Int] = None,
+           since: Option[Instant] = None,
+           expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RunResult = {
+    val params = Seq(noun, "list", "--auth", wp.authKey) ++ { filter map { Seq(_) } getOrElse Seq() } ++ {
+      limit map { l =>
+        Seq("--limit", l.toString)
+      } getOrElse Seq()
+    } ++ {
+      since map { i =>
+        Seq("--since", i.toEpochMilli.toString)
+      } getOrElse Seq()
     }
+    cli(wp.overrides ++ params, expectedExitCode)
+  }
 
-    /**
-     * Parses result of WskActivation.list to extract sequence of activation ids.
-     *
-     * @param rr run result, should be from WhiskActivation.list otherwise behavior is undefined
-     * @return sequence of activations
-     */
-    def ids(rr: RunResult): Seq[String] = {
-        rr.stdout.split("\n") filter {
-            // remove empty lines the header
-            s => s.nonEmpty && s != "activations"
+  /**
+   * Parses result of WskActivation.list to extract sequence of activation ids.
+   *
+   * @param rr run result, should be from WhiskActivation.list otherwise behavior is undefined
+   * @return sequence of activations
+   */
+  def ids(rr: RunResult): Seq[String] = {
+    rr.stdout.split("\n") filter {
+      // remove empty lines the header
+      s =>
+        s.nonEmpty && s != "activations"
+    } map {
+      // split into (id, name)
+      _.split(" ")(0)
+    }
+  }
+
+  /**
+   * Gets activation by id.
+   *
+   * @param activationId the activation id
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   * @param last retrieves latest acitvation
+   */
+  def get(activationId: Option[String] = None,
+          expectedExitCode: Int = SUCCESS_EXIT,
+          fieldFilter: Option[String] = None,
+          last: Option[Boolean] = None)(implicit wp: WskProps): RunResult = {
+    val params = {
+      activationId map { a =>
+        Seq(a)
+      } getOrElse Seq()
+    } ++ {
+      fieldFilter map { f =>
+        Seq(f)
+      } getOrElse Seq()
+    } ++ {
+      last map { l =>
+        Seq("--last")
+      } getOrElse Seq()
+    }
+    cli(wp.overrides ++ Seq(noun, "get", "--auth", wp.authKey) ++ params, expectedExitCode)
+  }
+
+  /**
+   * Gets activation logs by id.
+   *
+   * @param activationId the activation id
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   * @param last retrieves latest acitvation
+   */
+  def logs(activationId: Option[String] = None, expectedExitCode: Int = SUCCESS_EXIT, last: Option[Boolean] = None)(
+    implicit wp: WskProps): RunResult = {
+    val params = {
+      activationId map { a =>
+        Seq(a)
+      } getOrElse Seq()
+    } ++ {
+      last map { l =>
+        Seq("--last")
+      } getOrElse Seq()
+    }
+    cli(wp.overrides ++ Seq(noun, "logs", "--auth", wp.authKey) ++ params, expectedExitCode)
+  }
+
+  /**
+   * Gets activation result by id.
+   *
+   * @param activationId the activation id
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   * @param last retrieves latest acitvation
+   */
+  def result(activationId: Option[String] = None, expectedExitCode: Int = SUCCESS_EXIT, last: Option[Boolean] = None)(
+    implicit wp: WskProps): RunResult = {
+    val params = {
+      activationId map { a =>
+        Seq(a)
+      } getOrElse Seq()
+    } ++ {
+      last map { l =>
+        Seq("--last")
+      } getOrElse Seq()
+    }
+    cli(wp.overrides ++ Seq(noun, "result", "--auth", wp.authKey) ++ params, expectedExitCode)
+  }
+
+  /**
+   * Polls activations list for at least N activations. The activations
+   * are optionally filtered for the given entity. Will return as soon as
+   * N activations are found. If after retry budget is exhausted, N activations
+   * are still not present, will return a partial result. Hence caller must
+   * check length of the result and not assume it is >= N.
+   *
+   * @param N the number of activations desired
+   * @param entity the name of the entity to filter from activation list
+   * @param limit the maximum number of entities to list (if entity name is not unique use Some(0))
+   * @param since (optional) only the activations since this timestamp are included
+   * @param retries the maximum retries (total timeout is retries + 1 seconds)
+   * @return activation ids found, caller must check length of sequence
+   */
+  def pollFor(N: Int,
+              entity: Option[String],
+              limit: Option[Int] = None,
+              since: Option[Instant] = None,
+              retries: Int = 10,
+              pollPeriod: Duration = 1.second)(implicit wp: WskProps): Seq[String] = {
+    Try {
+      retry({
+        val result = ids(list(filter = entity, limit = limit, since = since))
+        if (result.length >= N) result else throw PartialResult(result)
+      }, retries, waitBeforeRetry = Some(pollPeriod))
+    } match {
+      case Success(ids)                => ids
+      case Failure(PartialResult(ids)) => ids
+      case _                           => Seq()
+    }
+  }
+
+  /**
+   * Polls for an activation matching the given id. If found
+   * return Right(activation) else Left(result of running CLI command).
+   *
+   * @return either Left(error message) or Right(activation as JsObject)
+   */
+  def waitForActivation(activationId: String,
+                        initialWait: Duration = 1 second,
+                        pollPeriod: Duration = 1 second,
+                        totalWait: Duration = 30 seconds)(implicit wp: WskProps): Either[String, JsObject] = {
+    val activation = waitfor(
+      () => {
+        val result =
+          cli(wp.overrides ++ Seq(noun, "get", activationId, "--auth", wp.authKey), expectedExitCode = DONTCARE_EXIT)
+        if (result.exitCode == NOT_FOUND) {
+          null
+        } else if (result.exitCode == SUCCESS_EXIT) {
+          Right(result.stdout)
+        } else Left(s"$result")
+      },
+      initialWait,
+      pollPeriod,
+      totalWait)
+
+    Option(activation) map {
+      case Right(stdout) =>
+        Try {
+          // strip first line and convert the rest to JsObject
+          assert(stdout.startsWith("ok: got activation"))
+          parseJsonString(stdout)
         } map {
-            // split into (id, name)
-            _.split(" ")(0)
-        }
-    }
+          Right(_)
+        } getOrElse Left(s"cannot parse activation from '$stdout'")
+      case Left(error) => Left(error)
+    } getOrElse Left(s"$activationId not found")
+  }
 
-    /**
-     * Gets activation by id.
-     *
-     * @param activationId the activation id
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     * @param last retrieves latest acitvation
-     */
-    def get(
-        activationId: Option[String] = None,
-        expectedExitCode: Int = SUCCESS_EXIT,
-        fieldFilter: Option[String] = None,
-        last: Option[Boolean] = None)(
-            implicit wp: WskProps): RunResult = {
-        val params =
-          { activationId map { a => Seq(a) } getOrElse Seq() } ++
-          { fieldFilter map { f => Seq(f) } getOrElse Seq() } ++
-          { last map { l => Seq("--last") } getOrElse Seq() }
-        cli(wp.overrides ++ Seq(noun, "get", "--auth", wp.authKey) ++ params, expectedExitCode)
-    }
-
-    /**
-     * Gets activation logs by id.
-     *
-     * @param activationId the activation id
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     * @param last retrieves latest acitvation
-     */
-    def logs(
-        activationId: Option[String] = None,
-        expectedExitCode: Int = SUCCESS_EXIT,
-        last: Option[Boolean] = None)(
-            implicit wp: WskProps): RunResult = {
-        val params =
-          { activationId map { a => Seq(a) } getOrElse Seq() } ++
-          { last map { l => Seq("--last") } getOrElse Seq() }
-        cli(wp.overrides ++ Seq(noun, "logs", "--auth", wp.authKey) ++ params, expectedExitCode)
-    }
-
-    /**
-     * Gets activation result by id.
-     *
-     * @param activationId the activation id
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     * @param last retrieves latest acitvation
-     */
-    def result(
-        activationId: Option[String] = None,
-        expectedExitCode: Int = SUCCESS_EXIT,
-        last: Option[Boolean] = None)(
-            implicit wp: WskProps): RunResult = {
-        val params =
-          { activationId map { a => Seq(a) } getOrElse Seq() } ++
-          { last map { l => Seq("--last") } getOrElse Seq() }
-        cli(wp.overrides ++ Seq(noun, "result", "--auth", wp.authKey) ++ params, expectedExitCode)
-    }
-
-    /**
-     * Polls activations list for at least N activations. The activations
-     * are optionally filtered for the given entity. Will return as soon as
-     * N activations are found. If after retry budget is exhausted, N activations
-     * are still not present, will return a partial result. Hence caller must
-     * check length of the result and not assume it is >= N.
-     *
-     * @param N the number of activations desired
-     * @param entity the name of the entity to filter from activation list
-     * @param limit the maximum number of entities to list (if entity name is not unique use Some(0))
-     * @param since (optional) only the activations since this timestamp are included
-     * @param retries the maximum retries (total timeout is retries + 1 seconds)
-     * @return activation ids found, caller must check length of sequence
-     */
-    def pollFor(
-        N: Int,
-        entity: Option[String],
-        limit: Option[Int] = None,
-        since: Option[Instant] = None,
-        retries: Int = 10,
-        pollPeriod: Duration = 1.second)(
-            implicit wp: WskProps): Seq[String] = {
-        Try {
-            retry({
-                val result = ids(list(filter = entity, limit = limit, since = since))
-                if (result.length >= N) result else throw PartialResult(result)
-            }, retries, waitBeforeRetry = Some(pollPeriod))
-        } match {
-            case Success(ids)                => ids
-            case Failure(PartialResult(ids)) => ids
-            case _                           => Seq()
-        }
-    }
-
-    /**
-     * Polls for an activation matching the given id. If found
-     * return Right(activation) else Left(result of running CLI command).
-     *
-     * @return either Left(error message) or Right(activation as JsObject)
-     */
-    def waitForActivation(
-        activationId: String,
-        initialWait: Duration = 1 second,
-        pollPeriod: Duration = 1 second,
-        totalWait: Duration = 30 seconds)(
-            implicit wp: WskProps): Either[String, JsObject] = {
-        val activation = waitfor(() => {
-            val result = cli(wp.overrides ++ Seq(noun, "get", activationId, "--auth", wp.authKey),
-                expectedExitCode = DONTCARE_EXIT)
-            if (result.exitCode == NOT_FOUND) {
-                null
-            } else if (result.exitCode == SUCCESS_EXIT) {
-                Right(result.stdout)
-            } else Left(s"$result")
-        }, initialWait, pollPeriod, totalWait)
-
-        Option(activation) map {
-            case Right(stdout) =>
-                Try {
-                    // strip first line and convert the rest to JsObject
-                    assert(stdout.startsWith("ok: got activation"))
-                    parseJsonString(stdout)
-                } map {
-                    Right(_)
-                } getOrElse Left(s"cannot parse activation from '$stdout'")
-            case Left(error) => Left(error)
-        } getOrElse Left(s"$activationId not found")
-    }
-
-    /** Used in polling for activations to record partial results from retry poll. */
-    private case class PartialResult(ids: Seq[String]) extends Throwable
+  /** Used in polling for activations to record partial results from retry poll. */
+  private case class PartialResult(ids: Seq[String]) extends Throwable
 }
 
-class WskNamespace()
-    extends RunWskCmd
-    with FullyQualifiedNames {
+class WskNamespace() extends RunWskCmd with FullyQualifiedNames {
 
-    protected val noun = "namespace"
+  protected val noun = "namespace"
 
-    /**
-     * Lists available namespaces for whisk properties.
-     *
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def list(
-        expectedExitCode: Int = SUCCESS_EXIT,
-        nameSort: Option[Boolean] = None)(
-        implicit wp: WskProps): RunResult = {
-        val params = Seq(noun, "list", "--auth", wp.authKey) ++
-            { nameSort map { n => Seq("--name-sort") } getOrElse Seq() }
-        cli(wp.overrides ++ params, expectedExitCode)
+  /**
+   * Lists available namespaces for whisk properties.
+   *
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  def list(expectedExitCode: Int = SUCCESS_EXIT, nameSort: Option[Boolean] = None)(implicit wp: WskProps): RunResult = {
+    val params = Seq(noun, "list", "--auth", wp.authKey) ++ {
+      nameSort map { n =>
+        Seq("--name-sort")
+      } getOrElse Seq()
     }
+    cli(wp.overrides ++ params, expectedExitCode)
+  }
 
-    /**
-     * Looks up namespace for whisk props.
-     *
-     * @param wskprops instance of WskProps with an auth key to lookup
-     * @return namespace as string
-     */
-    def whois()(implicit wskprops: WskProps): String = {
-        // the invariant that list() returns a conforming result is enforced in a test in WskBasicTests
-        val ns = list().stdout.lines.toSeq.last.trim
-        assert(ns != "_") // this is not permitted
-        ns
-    }
+  /**
+   * Looks up namespace for whisk props.
+   *
+   * @param wskprops instance of WskProps with an auth key to lookup
+   * @return namespace as string
+   */
+  def whois()(implicit wskprops: WskProps): String = {
+    // the invariant that list() returns a conforming result is enforced in a test in WskBasicTests
+    val ns = list().stdout.lines.toSeq.last.trim
+    assert(ns != "_") // this is not permitted
+    ns
+  }
 
-    /**
-     * Gets entities in namespace.
-     *
-     * @param namespace (optional) if specified must be  fully qualified namespace
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def get(
-        namespace: Option[String] = None,
-        expectedExitCode: Int,
-        nameSort: Option[Boolean] = None)(
-            implicit wp: WskProps): RunResult = {
-            val params = { nameSort map { n => Seq("--name-sort") } getOrElse Seq() }
-        cli(wp.overrides ++ Seq(noun, "get", resolve(namespace), "--auth", wp.authKey) ++ params, expectedExitCode)
+  /**
+   * Gets entities in namespace.
+   *
+   * @param namespace (optional) if specified must be  fully qualified namespace
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  def get(namespace: Option[String] = None, expectedExitCode: Int, nameSort: Option[Boolean] = None)(
+    implicit wp: WskProps): RunResult = {
+    val params = {
+      nameSort map { n =>
+        Seq("--name-sort")
+      } getOrElse Seq()
     }
+    cli(wp.overrides ++ Seq(noun, "get", resolve(namespace), "--auth", wp.authKey) ++ params, expectedExitCode)
+  }
 }
 
-class WskPackage()
-    extends RunWskCmd
-    with ListOrGetFromCollection
-    with DeleteFromCollection {
-    override protected val noun = "package"
+class WskPackage() extends RunWskCmd with ListOrGetFromCollection with DeleteFromCollection {
+  override protected val noun = "package"
 
-    /**
-     * Creates package. Parameters mirror those available in the CLI.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def create(
-        name: String,
-        parameters: Map[String, JsValue] = Map(),
-        annotations: Map[String, JsValue] = Map(),
-        parameterFile: Option[String] = None,
-        annotationFile: Option[String] = None,
-        shared: Option[Boolean] = None,
-        update: Boolean = false,
-        expectedExitCode: Int = SUCCESS_EXIT)(
-            implicit wp: WskProps): RunResult = {
-        val params = Seq(noun, if (!update) "create" else "update", "--auth", wp.authKey, fqn(name)) ++
-            { parameters flatMap { p => Seq("-p", p._1, p._2.compactPrint) } } ++
-            { annotations flatMap { p => Seq("-a", p._1, p._2.compactPrint) } } ++
-            { parameterFile map { pf => Seq("-P", pf) } getOrElse Seq() } ++
-            { annotationFile map { af => Seq("-A", af) } getOrElse Seq() } ++
-            { shared map { s => Seq("--shared", if (s) "yes" else "no") } getOrElse Seq() }
-        cli(wp.overrides ++ params, expectedExitCode)
+  /**
+   * Creates package. Parameters mirror those available in the CLI.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  def create(name: String,
+             parameters: Map[String, JsValue] = Map(),
+             annotations: Map[String, JsValue] = Map(),
+             parameterFile: Option[String] = None,
+             annotationFile: Option[String] = None,
+             shared: Option[Boolean] = None,
+             update: Boolean = false,
+             expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RunResult = {
+    val params = Seq(noun, if (!update) "create" else "update", "--auth", wp.authKey, fqn(name)) ++ {
+      parameters flatMap { p =>
+        Seq("-p", p._1, p._2.compactPrint)
+      }
+    } ++ {
+      annotations flatMap { p =>
+        Seq("-a", p._1, p._2.compactPrint)
+      }
+    } ++ {
+      parameterFile map { pf =>
+        Seq("-P", pf)
+      } getOrElse Seq()
+    } ++ {
+      annotationFile map { af =>
+        Seq("-A", af)
+      } getOrElse Seq()
+    } ++ {
+      shared map { s =>
+        Seq("--shared", if (s) "yes" else "no")
+      } getOrElse Seq()
     }
+    cli(wp.overrides ++ params, expectedExitCode)
+  }
 
-    /**
-     * Binds package. Parameters mirror those available in the CLI.
-     *
-     * @param name either a fully qualified name or a simple entity name
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def bind(
-        provider: String,
-        name: String,
-        parameters: Map[String, JsValue] = Map(),
-        annotations: Map[String, JsValue] = Map(),
-        expectedExitCode: Int = SUCCESS_EXIT)(
-            implicit wp: WskProps): RunResult = {
-        val params = Seq(noun, "bind", "--auth", wp.authKey, fqn(provider), fqn(name)) ++
-            { parameters flatMap { p => Seq("-p", p._1, p._2.compactPrint) } } ++
-            { annotations flatMap { p => Seq("-a", p._1, p._2.compactPrint) } }
-        cli(wp.overrides ++ params, expectedExitCode)
+  /**
+   * Binds package. Parameters mirror those available in the CLI.
+   *
+   * @param name either a fully qualified name or a simple entity name
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  def bind(provider: String,
+           name: String,
+           parameters: Map[String, JsValue] = Map(),
+           annotations: Map[String, JsValue] = Map(),
+           expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RunResult = {
+    val params = Seq(noun, "bind", "--auth", wp.authKey, fqn(provider), fqn(name)) ++ {
+      parameters flatMap { p =>
+        Seq("-p", p._1, p._2.compactPrint)
+      }
+    } ++ {
+      annotations flatMap { p =>
+        Seq("-a", p._1, p._2.compactPrint)
+      }
     }
+    cli(wp.overrides ++ params, expectedExitCode)
+  }
 }
 
-class WskApi()
-    extends RunWskCmd {
-    protected val noun = "api"
+class WskApi() extends RunWskCmd {
+  protected val noun = "api"
 
-    /**
-     * Creates and API endpoint. Parameters mirror those available in the CLI.
-     *
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def create(
-        basepath: Option[String] = None,
-        relpath: Option[String] = None,
-        operation: Option[String] = None,
-        action: Option[String] = None,
-        apiname: Option[String] = None,
-        swagger: Option[String] = None,
-        responsetype: Option[String] = None,
-        expectedExitCode: Int = SUCCESS_EXIT,
-        cliCfgFile: Option[String] = None)(
-            implicit wp: WskProps): RunResult = {
-        val params = Seq(noun, "create", "--auth", wp.authKey) ++
-            { basepath map { b => Seq(b) } getOrElse Seq() } ++
-            { relpath map { r => Seq(r) } getOrElse Seq() } ++
-            { operation map { o => Seq(o) } getOrElse Seq() } ++
-            { action map { aa => Seq(aa) } getOrElse Seq() } ++
-            { apiname map { a => Seq("--apiname", a) } getOrElse Seq() } ++
-            { swagger map { s => Seq("--config-file", s) } getOrElse Seq() } ++
-            { responsetype map { t => Seq("--response-type", t) } getOrElse Seq() }
-        cli(wp.overrides ++ params, expectedExitCode, showCmd = true, env = Map("WSK_CONFIG_FILE" -> cliCfgFile.getOrElse("")))
+  /**
+   * Creates and API endpoint. Parameters mirror those available in the CLI.
+   *
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  def create(basepath: Option[String] = None,
+             relpath: Option[String] = None,
+             operation: Option[String] = None,
+             action: Option[String] = None,
+             apiname: Option[String] = None,
+             swagger: Option[String] = None,
+             responsetype: Option[String] = None,
+             expectedExitCode: Int = SUCCESS_EXIT,
+             cliCfgFile: Option[String] = None)(implicit wp: WskProps): RunResult = {
+    val params = Seq(noun, "create", "--auth", wp.authKey) ++ {
+      basepath map { b =>
+        Seq(b)
+      } getOrElse Seq()
+    } ++ {
+      relpath map { r =>
+        Seq(r)
+      } getOrElse Seq()
+    } ++ {
+      operation map { o =>
+        Seq(o)
+      } getOrElse Seq()
+    } ++ {
+      action map { aa =>
+        Seq(aa)
+      } getOrElse Seq()
+    } ++ {
+      apiname map { a =>
+        Seq("--apiname", a)
+      } getOrElse Seq()
+    } ++ {
+      swagger map { s =>
+        Seq("--config-file", s)
+      } getOrElse Seq()
+    } ++ {
+      responsetype map { t =>
+        Seq("--response-type", t)
+      } getOrElse Seq()
     }
+    cli(
+      wp.overrides ++ params,
+      expectedExitCode,
+      showCmd = true,
+      env = Map("WSK_CONFIG_FILE" -> cliCfgFile.getOrElse("")))
+  }
 
-    /**
-     * Retrieve a list of API endpoints. Parameters mirror those available in the CLI.
-     *
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def list(
-        basepathOrApiName: Option[String] = None,
-        relpath: Option[String] = None,
-        operation: Option[String] = None,
-        limit: Option[Int] = None,
-        since: Option[Instant] = None,
-        full: Option[Boolean] = None,
-        nameSort: Option[Boolean] = None,
-        expectedExitCode: Int = SUCCESS_EXIT,
-        cliCfgFile: Option[String] = None)(
-            implicit wp: WskProps): RunResult = {
-        val params = Seq(noun, "list", "--auth", wp.authKey) ++
-            { basepathOrApiName map { b => Seq(b) } getOrElse Seq() } ++
-            { relpath map { r => Seq(r) } getOrElse Seq() } ++
-            { operation map { o => Seq(o) } getOrElse Seq() } ++
-            { limit map { l => Seq("--limit", l.toString) } getOrElse Seq() } ++
-            { since map { i => Seq("--since", i.toEpochMilli.toString) } getOrElse Seq() } ++
-            { full map { r => Seq("--full") } getOrElse Seq() } ++
-            { nameSort map { n => Seq("--name-sort") } getOrElse Seq() }
-        cli(wp.overrides ++ params, expectedExitCode, showCmd = true, env = Map("WSK_CONFIG_FILE" -> cliCfgFile.getOrElse("")))
+  /**
+   * Retrieve a list of API endpoints. Parameters mirror those available in the CLI.
+   *
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  def list(basepathOrApiName: Option[String] = None,
+           relpath: Option[String] = None,
+           operation: Option[String] = None,
+           limit: Option[Int] = None,
+           since: Option[Instant] = None,
+           full: Option[Boolean] = None,
+           nameSort: Option[Boolean] = None,
+           expectedExitCode: Int = SUCCESS_EXIT,
+           cliCfgFile: Option[String] = None)(implicit wp: WskProps): RunResult = {
+    val params = Seq(noun, "list", "--auth", wp.authKey) ++ {
+      basepathOrApiName map { b =>
+        Seq(b)
+      } getOrElse Seq()
+    } ++ {
+      relpath map { r =>
+        Seq(r)
+      } getOrElse Seq()
+    } ++ {
+      operation map { o =>
+        Seq(o)
+      } getOrElse Seq()
+    } ++ {
+      limit map { l =>
+        Seq("--limit", l.toString)
+      } getOrElse Seq()
+    } ++ {
+      since map { i =>
+        Seq("--since", i.toEpochMilli.toString)
+      } getOrElse Seq()
+    } ++ {
+      full map { r =>
+        Seq("--full")
+      } getOrElse Seq()
+    } ++ {
+      nameSort map { n =>
+        Seq("--name-sort")
+      } getOrElse Seq()
     }
+    cli(
+      wp.overrides ++ params,
+      expectedExitCode,
+      showCmd = true,
+      env = Map("WSK_CONFIG_FILE" -> cliCfgFile.getOrElse("")))
+  }
 
-    /**
-     * Retieves an API's configuration. Parameters mirror those available in the CLI.
-     * Runs a command wsk [params] where the arguments come in as a sequence.
-     *
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def get(
-        basepathOrApiName: Option[String] = None,
-        full: Option[Boolean] = None,
-        expectedExitCode: Int = SUCCESS_EXIT,
-        cliCfgFile: Option[String] = None,
-        format: Option[String] = None)(
-            implicit wp: WskProps): RunResult = {
-        val params = Seq(noun, "get", "--auth", wp.authKey) ++
-            { basepathOrApiName map { b => Seq(b) } getOrElse Seq() } ++
-            { full map { f => if (f) Seq("--full") else Seq() } getOrElse Seq() } ++
-            { format map { ft => Seq("--format", ft) } getOrElse Seq() }
-        cli(wp.overrides ++ params, expectedExitCode, showCmd = true, env = Map("WSK_CONFIG_FILE" -> cliCfgFile.getOrElse("")))
+  /**
+   * Retieves an API's configuration. Parameters mirror those available in the CLI.
+   * Runs a command wsk [params] where the arguments come in as a sequence.
+   *
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  def get(basepathOrApiName: Option[String] = None,
+          full: Option[Boolean] = None,
+          expectedExitCode: Int = SUCCESS_EXIT,
+          cliCfgFile: Option[String] = None,
+          format: Option[String] = None)(implicit wp: WskProps): RunResult = {
+    val params = Seq(noun, "get", "--auth", wp.authKey) ++ {
+      basepathOrApiName map { b =>
+        Seq(b)
+      } getOrElse Seq()
+    } ++ {
+      full map { f =>
+        if (f) Seq("--full") else Seq()
+      } getOrElse Seq()
+    } ++ {
+      format map { ft =>
+        Seq("--format", ft)
+      } getOrElse Seq()
     }
+    cli(
+      wp.overrides ++ params,
+      expectedExitCode,
+      showCmd = true,
+      env = Map("WSK_CONFIG_FILE" -> cliCfgFile.getOrElse("")))
+  }
 
-    /**
-     * Delete an entire API or a subset of API endpoints. Parameters mirror those available in the CLI.
-     *
-     * @param expectedExitCode (optional) the expected exit code for the command
-     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
-     */
-    def delete(
-        basepathOrApiName: String,
-        relpath: Option[String] = None,
-        operation: Option[String] = None,
-        expectedExitCode: Int = SUCCESS_EXIT,
-        cliCfgFile: Option[String] = None)(
-            implicit wp: WskProps): RunResult = {
-        val params = Seq(noun, "delete", "--auth", wp.authKey, basepathOrApiName) ++
-            { relpath map { r => Seq(r) } getOrElse Seq() } ++
-            { operation map { o => Seq(o) } getOrElse Seq() }
-        cli(wp.overrides ++ params, expectedExitCode, showCmd = true, env = Map("WSK_CONFIG_FILE" -> cliCfgFile.getOrElse("")))
+  /**
+   * Delete an entire API or a subset of API endpoints. Parameters mirror those available in the CLI.
+   *
+   * @param expectedExitCode (optional) the expected exit code for the command
+   * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+   */
+  def delete(basepathOrApiName: String,
+             relpath: Option[String] = None,
+             operation: Option[String] = None,
+             expectedExitCode: Int = SUCCESS_EXIT,
+             cliCfgFile: Option[String] = None)(implicit wp: WskProps): RunResult = {
+    val params = Seq(noun, "delete", "--auth", wp.authKey, basepathOrApiName) ++ {
+      relpath map { r =>
+        Seq(r)
+      } getOrElse Seq()
+    } ++ {
+      operation map { o =>
+        Seq(o)
+      } getOrElse Seq()
     }
+    cli(
+      wp.overrides ++ params,
+      expectedExitCode,
+      showCmd = true,
+      env = Map("WSK_CONFIG_FILE" -> cliCfgFile.getOrElse("")))
+  }
 }
 
 trait WaitFor {
-    /**
-     * Waits up to totalWait seconds for a 'step' to return value.
-     * Often tests call this routine immediately after starting work.
-     * Performs an initial wait before entering poll loop.
-     */
-    def waitfor[T](
-        step: () => T,
-        initialWait: Duration = 1 second,
-        pollPeriod: Duration = 1 second,
-        totalWait: Duration = 30 seconds): T = {
-        Thread.sleep(initialWait.toMillis)
-        val endTime = System.currentTimeMillis() + totalWait.toMillis
-        while (System.currentTimeMillis() < endTime) {
-            val predicate = step()
-            predicate match {
-                case (t: Boolean) if t =>
-                    return predicate
-                case (t: Any) if t != null && !t.isInstanceOf[Boolean] =>
-                    return predicate
-                case _ if System.currentTimeMillis() >= endTime =>
-                    return predicate
-                case _ =>
-                    Thread.sleep(pollPeriod.toMillis)
-            }
-        }
-        null.asInstanceOf[T]
+
+  /**
+   * Waits up to totalWait seconds for a 'step' to return value.
+   * Often tests call this routine immediately after starting work.
+   * Performs an initial wait before entering poll loop.
+   */
+  def waitfor[T](step: () => T,
+                 initialWait: Duration = 1 second,
+                 pollPeriod: Duration = 1 second,
+                 totalWait: Duration = 30 seconds): T = {
+    Thread.sleep(initialWait.toMillis)
+    val endTime = System.currentTimeMillis() + totalWait.toMillis
+    while (System.currentTimeMillis() < endTime) {
+      val predicate = step()
+      predicate match {
+        case (t: Boolean) if t =>
+          return predicate
+        case (t: Any) if t != null && !t.isInstanceOf[Boolean] =>
+          return predicate
+        case _ if System.currentTimeMillis() >= endTime =>
+          return predicate
+        case _ =>
+          Thread.sleep(pollPeriod.toMillis)
+      }
     }
+    null.asInstanceOf[T]
+  }
 }
 
 object Wsk {
-    private val binaryName = "wsk"
-    private val cliPath = if (WhiskProperties.useCLIDownload) getDownloadedGoCLIPath else WhiskProperties.getCLIPath
+  private val binaryName = "wsk"
+  private val cliPath = if (WhiskProperties.useCLIDownload) getDownloadedGoCLIPath else WhiskProperties.getCLIPath
 
-    assert((new File(cliPath)).exists, s"did not find $cliPath")
+  assert((new File(cliPath)).exists, s"did not find $cliPath")
 
-    /** What is the path to a downloaded CLI? **/
-    private def getDownloadedGoCLIPath = {
-        s"${System.getProperty("user.home")}${File.separator}.local${File.separator}bin${File.separator}${binaryName}"
-    }
+  /** What is the path to a downloaded CLI? **/
+  private def getDownloadedGoCLIPath = {
+    s"${System.getProperty("user.home")}${File.separator}.local${File.separator}bin${File.separator}${binaryName}"
+  }
 
-    def baseCommand = Buffer(cliPath)
+  def baseCommand = Buffer(cliPath)
 }
 
 trait RunWskCmd extends Matchers {
 
-    /**
-     * The base command to run.
-     */
-    def baseCommand = Wsk.baseCommand
+  /**
+   * The base command to run.
+   */
+  def baseCommand = Wsk.baseCommand
 
-    /**
-     * Runs a command wsk [params] where the arguments come in as a sequence.
-     *
-     * @return RunResult which contains stdout, stderr, exit code
-     */
-    def cli(params: Seq[String],
-            expectedExitCode: Int = SUCCESS_EXIT,
-            verbose: Boolean = false,
-            env: Map[String, String] = Map("WSK_CONFIG_FILE" -> ""),
-            workingDir: File = new File("."),
-            stdinFile: Option[File] = None,
-            showCmd: Boolean = false,
-            hideFromOutput: Seq[String] = Seq()): RunResult = {
-        val args = baseCommand
-        if (verbose) args += "--verbose"
-        if (showCmd) println(args.mkString(" ") + " " + params.mkString(" "))
-        val rr = TestUtils.runCmd(DONTCARE_EXIT, workingDir, TestUtils.logger, sys.env ++ env, stdinFile.getOrElse(null), args ++ params: _*)
+  /**
+   * Runs a command wsk [params] where the arguments come in as a sequence.
+   *
+   * @return RunResult which contains stdout, stderr, exit code
+   */
+  def cli(params: Seq[String],
+          expectedExitCode: Int = SUCCESS_EXIT,
+          verbose: Boolean = false,
+          env: Map[String, String] = Map("WSK_CONFIG_FILE" -> ""),
+          workingDir: File = new File("."),
+          stdinFile: Option[File] = None,
+          showCmd: Boolean = false,
+          hideFromOutput: Seq[String] = Seq()): RunResult = {
+    val args = baseCommand
+    if (verbose) args += "--verbose"
+    if (showCmd) println(args.mkString(" ") + " " + params.mkString(" "))
+    val rr = TestUtils.runCmd(
+      DONTCARE_EXIT,
+      workingDir,
+      TestUtils.logger,
+      sys.env ++ env,
+      stdinFile.getOrElse(null),
+      args ++ params: _*)
 
-        withClue(hideStr(reportFailure(args ++ params, expectedExitCode, rr).toString(), hideFromOutput)) {
-            if (expectedExitCode != TestUtils.DONTCARE_EXIT) {
-                val ok = (rr.exitCode == expectedExitCode) || (expectedExitCode == TestUtils.ANY_ERROR_EXIT && rr.exitCode != 0)
-                if (!ok) {
-                    rr.exitCode shouldBe expectedExitCode
-                }
-            }
+    withClue(hideStr(reportFailure(args ++ params, expectedExitCode, rr).toString(), hideFromOutput)) {
+      if (expectedExitCode != TestUtils.DONTCARE_EXIT) {
+        val ok = (rr.exitCode == expectedExitCode) || (expectedExitCode == TestUtils.ANY_ERROR_EXIT && rr.exitCode != 0)
+        if (!ok) {
+          rr.exitCode shouldBe expectedExitCode
         }
-
-        rr
+      }
     }
 
-    // Takes a string and a list of sensitive strings. Any sensistive string found in
-    // the target string will be replaced with "XXXXX", returning the processed string
-    def hideStr(str: String, hideThese: Seq[String]): String = {
-        // Iterate through each string to hide, replacing it in the target string (str)
-        hideThese.fold(str)((updatedStr, replaceThis) => updatedStr.replace(replaceThis, "XXXXX"))
-    }
+    rr
+  }
 
-    /*
-     * Utility function to return a JSON object from the CLI output that returns
-     * an optional a status line following by the JSON data
-     */
-    def parseJsonString(jsonStr: String): JsObject = {
-        jsonStr.substring(jsonStr.indexOf("\n") + 1).parseJson.asJsObject // Skip optional status line before parsing
-    }
+  // Takes a string and a list of sensitive strings. Any sensistive string found in
+  // the target string will be replaced with "XXXXX", returning the processed string
+  def hideStr(str: String, hideThese: Seq[String]): String = {
+    // Iterate through each string to hide, replacing it in the target string (str)
+    hideThese.fold(str)((updatedStr, replaceThis) => updatedStr.replace(replaceThis, "XXXXX"))
+  }
 
-    private def reportFailure(args: Buffer[String], ec: Integer, rr: RunResult) = {
-        val s = new StringBuilder()
-        s.append(args.mkString(" ") + "\n")
-        if (rr.stdout.nonEmpty) s.append(rr.stdout + "\n")
-        if (rr.stderr.nonEmpty) s.append(rr.stderr)
-        s.append("exit code:")
-    }
+  /*
+   * Utility function to return a JSON object from the CLI output that returns
+   * an optional a status line following by the JSON data
+   */
+  def parseJsonString(jsonStr: String): JsObject = {
+    jsonStr.substring(jsonStr.indexOf("\n") + 1).parseJson.asJsObject // Skip optional status line before parsing
+  }
+
+  private def reportFailure(args: Buffer[String], ec: Integer, rr: RunResult) = {
+    val s = new StringBuilder()
+    s.append(args.mkString(" ") + "\n")
+    if (rr.stdout.nonEmpty) s.append(rr.stdout + "\n")
+    if (rr.stderr.nonEmpty) s.append(rr.stderr)
+    s.append("exit code:")
+  }
 }
 
 object WskAdmin {
-    private val binDir = WhiskProperties.getFileRelativeToWhiskHome("bin")
-    private val binaryName = "wskadmin"
+  private val binDir = WhiskProperties.getFileRelativeToWhiskHome("bin")
+  private val binaryName = "wskadmin"
 
-    def exists = {
-        val dir = binDir
-        val exec = new File(dir, binaryName)
-        assert(dir.exists, s"did not find $dir")
-        assert(exec.exists, s"did not find $exec")
-    }
+  def exists = {
+    val dir = binDir
+    val exec = new File(dir, binaryName)
+    assert(dir.exists, s"did not find $dir")
+    assert(exec.exists, s"did not find $exec")
+  }
 
-    def baseCommand = {
-        Buffer(WhiskProperties.python, new File(binDir, binaryName).toString)
-    }
+  def baseCommand = {
+    Buffer(WhiskProperties.python, new File(binDir, binaryName).toString)
+  }
 
-    def listKeys(namespace: String, pick: Integer = 1): List[(String, String)] = {
-        val wskadmin = new RunWskAdminCmd {}
-        wskadmin.cli(Seq("user", "list", namespace, "--pick", pick.toString))
-            .stdout
-            .split("\n")
-            .map("""\s+""".r.split(_))
-            .map(parts => (parts(0), parts(1)))
-            .toList
-    }
+  def listKeys(namespace: String, pick: Integer = 1): List[(String, String)] = {
+    val wskadmin = new RunWskAdminCmd {}
+    wskadmin
+      .cli(Seq("user", "list", namespace, "--pick", pick.toString))
+      .stdout
+      .split("\n")
+      .map("""\s+""".r.split(_))
+      .map(parts => (parts(0), parts(1)))
+      .toList
+  }
 }
 
 trait RunWskAdminCmd extends RunWskCmd {
-    override def baseCommand = WskAdmin.baseCommand
+  override def baseCommand = WskAdmin.baseCommand
 }

--- a/tests/src/test/scala/common/WskActorSystem.scala
+++ b/tests/src/test/scala/common/WskActorSystem.scala
@@ -34,19 +34,19 @@ import org.scalatest.Suite
  *  If you use this trait and override afterAll(), make sure to also call super.afterAll().
  */
 trait WskActorSystem extends BeforeAndAfterAll {
-    self: Suite =>
+  self: Suite =>
 
-    implicit val actorSystem: ActorSystem = ActorSystem()
+  implicit val actorSystem: ActorSystem = ActorSystem()
 
-    implicit def executionContext: ExecutionContext = actorSystem.dispatcher
+  implicit def executionContext: ExecutionContext = actorSystem.dispatcher
 
-    override def afterAll() {
-        try {
-            Await.result(Http().shutdownAllConnectionPools(), 30.seconds)
-        } finally {
-            actorSystem.terminate()
-            Await.result(actorSystem.whenTerminated, 30.seconds)
-        }
-        super.afterAll()
+  override def afterAll() {
+    try {
+      Await.result(Http().shutdownAllConnectionPools(), 30.seconds)
+    } finally {
+      actorSystem.terminate()
+      Await.result(actorSystem.whenTerminated, 30.seconds)
     }
+    super.afterAll()
+  }
 }

--- a/tests/src/test/scala/common/WskTestHelpers.scala
+++ b/tests/src/test/scala/common/WskTestHelpers.scala
@@ -44,7 +44,7 @@ import TestUtils.CONFLICT
 case class ActivationResponse(result: Option[JsObject], status: String, success: Boolean)
 
 object ActivationResponse extends DefaultJsonProtocol {
-    implicit val serdes = jsonFormat3(ActivationResponse.apply)
+  implicit val serdes = jsonFormat3(ActivationResponse.apply)
 }
 
 /**
@@ -59,61 +59,68 @@ object ActivationResponse extends DefaultJsonProtocol {
  * @param cases String to save the cause of failure if the activation fails
  * @param annotations a list of JSON objects to save the annotations of the activation
  */
-case class ActivationResult(
-    activationId: String,
-    logs: Option[List[String]],
-    response: ActivationResponse,
-    start: Instant,
-    end: Instant,
-    duration: Long,
-    cause: Option[String],
-    annotations: Option[List[JsObject]]) {
+case class ActivationResult(activationId: String,
+                            logs: Option[List[String]],
+                            response: ActivationResponse,
+                            start: Instant,
+                            end: Instant,
+                            duration: Long,
+                            cause: Option[String],
+                            annotations: Option[List[JsObject]]) {
 
-    def getAnnotationValue(key: String): Option[JsValue] = {
-        Try {
-            val annotation = annotations.get.filter(x => x.getFields("key")(0) == JsString(key))
-            assert(annotation.size == 1) // only one annotation with this value
-            val value = annotation(0).getFields("value")
-            assert(value.size == 1)
-            value(0)
-        } toOption
-    }
+  def getAnnotationValue(key: String): Option[JsValue] = {
+    Try {
+      val annotation = annotations.get.filter(x => x.getFields("key")(0) == JsString(key))
+      assert(annotation.size == 1) // only one annotation with this value
+      val value = annotation(0).getFields("value")
+      assert(value.size == 1)
+      value(0)
+    } toOption
+  }
 }
 
 object ActivationResult extends DefaultJsonProtocol {
-    private implicit val instantSerdes = new RootJsonFormat[Instant] {
-        def write(t: Instant) = t.toEpochMilli.toJson
+  private implicit val instantSerdes = new RootJsonFormat[Instant] {
+    def write(t: Instant) = t.toEpochMilli.toJson
 
-        def read(value: JsValue) = Try {
-            value match {
-                case JsNumber(i) => Instant.ofEpochMilli(i.bigDecimal.longValue)
-                case _           => deserializationError("timetsamp malformed")
-            }
-        } getOrElse deserializationError("timetsamp malformed 2")
-    }
-
-    implicit val serdes = new RootJsonFormat[ActivationResult] {
-        private val format = jsonFormat8(ActivationResult.apply)
-
-        def write(result: ActivationResult) = format.write(result)
-
-        def read(value: JsValue) = {
-            val obj = value.asJsObject
-            obj.getFields("activationId", "response", "start") match {
-                case Seq(JsString(activationId), response, start) =>
-                    Try {
-                        val logs = obj.fields.get("logs").map(_.convertTo[List[String]])
-                        val end = obj.fields.get("end").map(_.convertTo[Instant]).getOrElse(Instant.EPOCH)
-                        val duration = obj.fields.get("duration").map(_.convertTo[Long]).getOrElse(0L)
-                        val cause = obj.fields.get("cause").map(_.convertTo[String])
-                        val annotations = obj.fields.get("annotations").map(_.convertTo[List[JsObject]])
-                        new ActivationResult(activationId, logs, response.convertTo[ActivationResponse],
-                            start.convertTo[Instant], end, duration, cause, annotations)
-                    } getOrElse deserializationError("Failed to deserialize the activation result.")
-                case _ => deserializationError("Failed to deserialize the activation ID, response or start.")
-            }
+    def read(value: JsValue) =
+      Try {
+        value match {
+          case JsNumber(i) => Instant.ofEpochMilli(i.bigDecimal.longValue)
+          case _           => deserializationError("timetsamp malformed")
         }
+      } getOrElse deserializationError("timetsamp malformed 2")
+  }
+
+  implicit val serdes = new RootJsonFormat[ActivationResult] {
+    private val format = jsonFormat8(ActivationResult.apply)
+
+    def write(result: ActivationResult) = format.write(result)
+
+    def read(value: JsValue) = {
+      val obj = value.asJsObject
+      obj.getFields("activationId", "response", "start") match {
+        case Seq(JsString(activationId), response, start) =>
+          Try {
+            val logs = obj.fields.get("logs").map(_.convertTo[List[String]])
+            val end = obj.fields.get("end").map(_.convertTo[Instant]).getOrElse(Instant.EPOCH)
+            val duration = obj.fields.get("duration").map(_.convertTo[Long]).getOrElse(0L)
+            val cause = obj.fields.get("cause").map(_.convertTo[String])
+            val annotations = obj.fields.get("annotations").map(_.convertTo[List[JsObject]])
+            new ActivationResult(
+              activationId,
+              logs,
+              response.convertTo[ActivationResponse],
+              start.convertTo[Instant],
+              end,
+              duration,
+              cause,
+              annotations)
+          } getOrElse deserializationError("Failed to deserialize the activation result.")
+        case _ => deserializationError("Failed to deserialize the activation ID, response or start.")
+      }
     }
+  }
 }
 
 /**
@@ -123,175 +130,170 @@ object ActivationResult extends DefaultJsonProtocol {
  * completed, will delete them all.
  */
 trait WskTestHelpers extends Matchers {
-    type Assets = ListBuffer[(DeleteFromCollection, String, Boolean)]
+  type Assets = ListBuffer[(DeleteFromCollection, String, Boolean)]
 
-    /**
-     * Helper to register an entity to delete once a test completes.
-     * The helper sanitizes (deletes) a previous instance of the entity if it exists
-     * in given collection.
-     *
-     */
-    class AssetCleaner(assetsToDeleteAfterTest: Assets, wskprops: WskProps) {
-        def withCleaner[T <: DeleteFromCollection](cli: T, name: String, confirmDelete: Boolean = true)(
-            cmd: (T, String) => RunResult): RunResult = {
-            // sanitize (delete) if asset exists
-            cli.sanitize(name)(wskprops)
+  /**
+   * Helper to register an entity to delete once a test completes.
+   * The helper sanitizes (deletes) a previous instance of the entity if it exists
+   * in given collection.
+   *
+   */
+  class AssetCleaner(assetsToDeleteAfterTest: Assets, wskprops: WskProps) {
+    def withCleaner[T <: DeleteFromCollection](cli: T, name: String, confirmDelete: Boolean = true)(
+      cmd: (T, String) => RunResult): RunResult = {
+      // sanitize (delete) if asset exists
+      cli.sanitize(name)(wskprops)
 
-            assetsToDeleteAfterTest += ((cli, name, confirmDelete))
-            cmd(cli, name)
-        }
+      assetsToDeleteAfterTest += ((cli, name, confirmDelete))
+      cmd(cli, name)
     }
+  }
 
-    /**
-     * Creates a test closure which records all entities created inside the test into a
-     * list that is iterated at the end of the test so that these entities are deleted
-     * (from most recently created to oldest).
-     */
-    def withAssetCleaner(wskprops: WskProps)(test: (WskProps, AssetCleaner) => Any) = {
-        // create new asset list to track what must be deleted after test completes
-        val assetsToDeleteAfterTest = new Assets()
+  /**
+   * Creates a test closure which records all entities created inside the test into a
+   * list that is iterated at the end of the test so that these entities are deleted
+   * (from most recently created to oldest).
+   */
+  def withAssetCleaner(wskprops: WskProps)(test: (WskProps, AssetCleaner) => Any) = {
+    // create new asset list to track what must be deleted after test completes
+    val assetsToDeleteAfterTest = new Assets()
 
-        try {
-            test(wskprops, new AssetCleaner(assetsToDeleteAfterTest, wskprops))
-        } catch {
-            case t: Throwable =>
-                // log the exception that occurred in the test and rethrow it
-                println(s"Exception occurred during test execution: $t")
-                throw t
-        } finally {
-            // delete assets in reverse order so that was created last is deleted first
-            val deletedAll = assetsToDeleteAfterTest.reverse map {
-                case ((cli, n, delete)) => n -> Try {
-                    cli match {
-                        case _: WskPackage if delete =>
-                            val rr = cli.delete(n)(wskprops)
-                            rr.exitCode match {
-                                case CONFLICT => whisk.utils.retry(cli.delete(n)(wskprops), 5, Some(1.second))
-                                case _        => rr
-                            }
-                        case _ => if (delete) cli.delete(n)(wskprops) else cli.sanitize(n)(wskprops)
-                    }
+    try {
+      test(wskprops, new AssetCleaner(assetsToDeleteAfterTest, wskprops))
+    } catch {
+      case t: Throwable =>
+        // log the exception that occurred in the test and rethrow it
+        println(s"Exception occurred during test execution: $t")
+        throw t
+    } finally {
+      // delete assets in reverse order so that was created last is deleted first
+      val deletedAll = assetsToDeleteAfterTest.reverse map {
+        case ((cli, n, delete)) =>
+          n -> Try {
+            cli match {
+              case _: WskPackage if delete =>
+                val rr = cli.delete(n)(wskprops)
+                rr.exitCode match {
+                  case CONFLICT => whisk.utils.retry(cli.delete(n)(wskprops), 5, Some(1.second))
+                  case _        => rr
                 }
-            } forall {
-                case (n, Failure(t)) =>
-                    println(s"ERROR: deleting asset failed for $n: $t")
-                    false
-                case _ =>
-                    true
+              case _ => if (delete) cli.delete(n)(wskprops) else cli.sanitize(n)(wskprops)
             }
-            assert(deletedAll, "some assets were not deleted")
-        }
+          }
+      } forall {
+        case (n, Failure(t)) =>
+          println(s"ERROR: deleting asset failed for $n: $t")
+          false
+        case _ =>
+          true
+      }
+      assert(deletedAll, "some assets were not deleted")
+    }
+  }
+
+  /**
+   * Extracts an activation id from a wsk command producing a RunResult with such an id.
+   * If id is found, polls activations until one matching id is found. If found, pass
+   * the activation to the post processor which then check for expected values.
+   */
+  def withActivation(
+    wsk: WskActivation,
+    run: RunResult,
+    initialWait: Duration = 1 second,
+    pollPeriod: Duration = 1 second,
+    totalWait: Duration = 30 seconds)(check: ActivationResult => Unit)(implicit wskprops: WskProps): Unit = {
+    val activationId = wsk.extractActivationId(run)
+
+    withClue(s"did not find an activation id in '$run'") {
+      activationId shouldBe a[Some[_]]
     }
 
-    /**
-     * Extracts an activation id from a wsk command producing a RunResult with such an id.
-     * If id is found, polls activations until one matching id is found. If found, pass
-     * the activation to the post processor which then check for expected values.
-     */
-    def withActivation(
-        wsk: WskActivation,
-        run: RunResult,
-        initialWait: Duration = 1 second,
-        pollPeriod: Duration = 1 second,
-        totalWait: Duration = 30 seconds)(
-            check: ActivationResult => Unit)(
-                implicit wskprops: WskProps): Unit = {
-        val activationId = wsk.extractActivationId(run)
+    withActivation(wsk, activationId.get, initialWait, pollPeriod, totalWait)(check)
+  }
 
-        withClue(s"did not find an activation id in '$run'") {
-            activationId shouldBe a[Some[_]]
-        }
+  /**
+   * Polls activations until one matching id is found. If found, pass
+   * the activation to the post processor which then check for expected values.
+   */
+  def withActivation(wsk: WskActivation,
+                     activationId: String,
+                     initialWait: Duration,
+                     pollPeriod: Duration,
+                     totalWait: Duration)(check: ActivationResult => Unit)(implicit wskprops: WskProps): Unit = {
+    val id = activationId
+    val activation = wsk.waitForActivation(id, initialWait, pollPeriod, totalWait)
+    if (activation.isLeft) {
+      assert(false, s"error waiting for activation $id: ${activation.left.get}")
+    } else
+      try {
+        check(activation.right.get.convertTo[ActivationResult])
+      } catch {
+        case error: Throwable =>
+          println(s"check failed for activation $id: ${activation.right.get}")
+          throw error
+      }
+  }
 
-        withActivation(wsk, activationId.get, initialWait, pollPeriod, totalWait)(check)
+  /**
+   * Polls until it finds {@code N} activationIds from an entity. Asserts the count
+   * of the activationIds actually equal {@code N}. Takes a {@code since} parameter
+   * defining the oldest activationId to consider valid.
+   */
+  def withActivationsFromEntity(
+    wsk: WskActivation,
+    entity: String,
+    N: Int = 1,
+    since: Option[Instant] = None,
+    pollPeriod: Duration = 1 second,
+    totalWait: Duration = 30 seconds)(check: Seq[ActivationResult] => Unit)(implicit wskprops: WskProps): Unit = {
+
+    val activationIds =
+      wsk.pollFor(N, Some(entity), since = since, retries = (totalWait / pollPeriod).toInt, pollPeriod = pollPeriod)
+    withClue(
+      s"expecting $N activations matching '$entity' name since $since but found ${activationIds.mkString(",")} instead") {
+      activationIds.length shouldBe N
     }
 
-    /**
-     * Polls activations until one matching id is found. If found, pass
-     * the activation to the post processor which then check for expected values.
-     */
-    def withActivation(
-        wsk: WskActivation,
-        activationId: String,
-        initialWait: Duration,
-        pollPeriod: Duration,
-        totalWait: Duration)(
-            check: ActivationResult => Unit)(
-                implicit wskprops: WskProps): Unit = {
-        val id = activationId
-        val activation = wsk.waitForActivation(id, initialWait, pollPeriod, totalWait)
-        if (activation.isLeft) {
-            assert(false, s"error waiting for activation $id: ${activation.left.get}")
-        } else try {
-            check(activation.right.get.convertTo[ActivationResult])
-        } catch {
-            case error: Throwable =>
-                println(s"check failed for activation $id: ${activation.right.get}")
-                throw error
-        }
+    val parsed = activationIds.map { id =>
+      wsk.parseJsonString(wsk.get(Some(id)).stdout).convertTo[ActivationResult]
     }
-
-    /**
-     * Polls until it finds {@code N} activationIds from an entity. Asserts the count
-     * of the activationIds actually equal {@code N}. Takes a {@code since} parameter
-     * defining the oldest activationId to consider valid.
-     */
-    def withActivationsFromEntity(
-        wsk: WskActivation,
-        entity: String,
-        N: Int = 1,
-        since: Option[Instant] = None,
-        pollPeriod: Duration = 1 second,
-        totalWait: Duration = 30 seconds)(
-            check: Seq[ActivationResult] => Unit)(
-                implicit wskprops: WskProps): Unit = {
-
-        val activationIds = wsk.pollFor(N, Some(entity), since = since, retries = (totalWait / pollPeriod).toInt, pollPeriod = pollPeriod)
-        withClue(s"expecting $N activations matching '$entity' name since $since but found ${activationIds.mkString(",")} instead") {
-            activationIds.length shouldBe N
-        }
-
-        val parsed = activationIds.map { id =>
-            wsk.parseJsonString(wsk.get(Some(id)).stdout).convertTo[ActivationResult]
-        }
-        try {
-            check(parsed)
-        } catch {
-            case error: Throwable =>
-                println(s"check failed for activations $activationIds: ${parsed}")
-                throw error
-        }
+    try {
+      check(parsed)
+    } catch {
+      case error: Throwable =>
+        println(s"check failed for activations $activationIds: ${parsed}")
+        throw error
     }
+  }
 
-    /**
-     * In the case that test throws an exception, print stderr and stdout
-     * from the provided RunResult.
-     */
-    def withPrintOnFailure(runResult: RunResult)(test: () => Unit) {
-        try {
-            test()
-        } catch {
-            case error: Throwable =>
-                println(s"[stderr] ${runResult.stderr}")
-                println(s"[stdout] ${runResult.stdout}")
-                throw error
-        }
+  /**
+   * In the case that test throws an exception, print stderr and stdout
+   * from the provided RunResult.
+   */
+  def withPrintOnFailure(runResult: RunResult)(test: () => Unit) {
+    try {
+      test()
+    } catch {
+      case error: Throwable =>
+        println(s"[stderr] ${runResult.stderr}")
+        println(s"[stdout] ${runResult.stdout}")
+        throw error
     }
+  }
 
-    def removeCLIHeader(response: String): String = response.substring(response.indexOf("\n"))
+  def removeCLIHeader(response: String): String = response.substring(response.indexOf("\n"))
 
-    def getJSONFromCLIResponse(response: String): JsObject = removeCLIHeader(response).parseJson.asJsObject
+  def getJSONFromCLIResponse(response: String): JsObject = removeCLIHeader(response).parseJson.asJsObject
 
-    def getAdditionalTestSubject(newUser: String): WskProps = {
-        val wskadmin = new RunWskAdminCmd {}
-        WskProps(
-            namespace = newUser,
-            authKey = wskadmin.cli(Seq("user", "create", newUser)).stdout.trim)
+  def getAdditionalTestSubject(newUser: String): WskProps = {
+    val wskadmin = new RunWskAdminCmd {}
+    WskProps(namespace = newUser, authKey = wskadmin.cli(Seq("user", "create", newUser)).stdout.trim)
+  }
+
+  def disposeAdditionalTestSubject(subject: String): Unit = {
+    val wskadmin = new RunWskAdminCmd {}
+    withClue(s"failed to delete temporary subject $subject") {
+      wskadmin.cli(Seq("user", "delete", subject)).stdout should include("Subject deleted")
     }
-
-    def disposeAdditionalTestSubject(subject: String): Unit = {
-        val wskadmin = new RunWskAdminCmd {}
-        withClue(s"failed to delete temporary subject $subject") {
-            wskadmin.cli(Seq("user", "delete", subject)).stdout should include("Subject deleted")
-        }
-    }
+  }
 }

--- a/tests/src/test/scala/ha/CacheInvalidationTests.scala
+++ b/tests/src/test/scala/ha/CacheInvalidationTests.scala
@@ -41,125 +41,136 @@ import spray.json.DefaultJsonProtocol._
 import whisk.core.WhiskConfig
 
 @RunWith(classOf[JUnitRunner])
-class CacheInvalidationTests
-    extends FlatSpec
-    with Matchers
-    with WskTestHelpers
-    with WskActorSystem {
+class CacheInvalidationTests extends FlatSpec with Matchers with WskTestHelpers with WskActorSystem {
 
-    implicit val materializer = ActorMaterializer()
+  implicit val materializer = ActorMaterializer()
 
-    val hosts = WhiskProperties.getProperty("controller.hosts").split(",")
-    def ports(instance: Int) = WhiskProperties.getControllerBasePort + instance
+  val hosts = WhiskProperties.getProperty("controller.hosts").split(",")
+  def ports(instance: Int) = WhiskProperties.getControllerBasePort + instance
 
-    def controllerUri(instance: Int) = {
-        require(instance >= 0 && instance < hosts.length, "Controller instance not known.")
-        Uri().withScheme("http").withHost(hosts(instance)).withPort(ports(instance))
-    }
-    def actionPath(name: String) = Uri.Path(s"/api/v1/namespaces/_/actions/$name")
+  def controllerUri(instance: Int) = {
+    require(instance >= 0 && instance < hosts.length, "Controller instance not known.")
+    Uri().withScheme("http").withHost(hosts(instance)).withPort(ports(instance))
+  }
+  def actionPath(name: String) = Uri.Path(s"/api/v1/namespaces/_/actions/$name")
 
-    val Array(username, password) = WhiskProperties.readAuthKey(WhiskProperties.getAuthFileForTesting).split(":")
-    val authHeader = Authorization(BasicHttpCredentials(username, password))
+  val Array(username, password) = WhiskProperties.readAuthKey(WhiskProperties.getAuthFileForTesting).split(":")
+  val authHeader = Authorization(BasicHttpCredentials(username, password))
 
-    val timeout = 15.seconds
+  val timeout = 15.seconds
 
-    def retry[T](fn: => T) = whisk.utils.retry(fn, 15, Some(1.second))
+  def retry[T](fn: => T) = whisk.utils.retry(fn, 15, Some(1.second))
 
-    def updateAction(name: String, code: String, controllerInstance: Int = 0) = {
-        val body = JsObject("namespace" -> JsString("_"), "name" -> JsString(name), "exec" -> JsObject("kind" -> JsString("nodejs:default"), "code" -> JsString(code)))
+  def updateAction(name: String, code: String, controllerInstance: Int = 0) = {
+    val body = JsObject(
+      "namespace" -> JsString("_"),
+      "name" -> JsString(name),
+      "exec" -> JsObject("kind" -> JsString("nodejs:default"), "code" -> JsString(code)))
 
-        val request = Marshal(body).to[RequestEntity].flatMap { entity =>
-            Http().singleRequest(HttpRequest(
-                method = HttpMethods.PUT,
-                uri = controllerUri(controllerInstance).withPath(actionPath(name)).withQuery(Uri.Query("overwrite" -> true.toString)),
-                headers = List(authHeader),
-                entity = entity)).flatMap { response =>
-                Unmarshal(response).to[JsObject].map { resBody =>
-                    withClue(s"Error in Body: $resBody")(response.status shouldBe StatusCodes.OK)
-                    resBody
-                }
-            }
-        }
-
-        Await.result(request, timeout)
-    }
-
-    def getAction(name: String, controllerInstance: Int = 0, expectedCode: StatusCode = StatusCodes.OK) = {
-        val request = Http().singleRequest(HttpRequest(
-            method = HttpMethods.GET,
-            uri = controllerUri(controllerInstance).withPath(actionPath(name)),
-            headers = List(authHeader))).flatMap { response =>
-            Unmarshal(response).to[JsObject].map { resBody =>
-                withClue(s"Wrong statuscode from controller. Body is: $resBody")(response.status shouldBe expectedCode)
-                resBody
-            }
-        }
-
-        Await.result(request, timeout)
-    }
-
-    def deleteAction(name: String, controllerInstance: Int = 0, expectedCode: Option[StatusCode] = Some(StatusCodes.OK)) = {
-        val request = Http().singleRequest(HttpRequest(
-            method = HttpMethods.DELETE,
-            uri = controllerUri(controllerInstance).withPath(actionPath(name)),
-            headers = List(authHeader))).flatMap { response =>
-            Unmarshal(response).to[JsObject].map { resBody =>
-                expectedCode.map { code =>
-                    withClue(s"Wrong statuscode from controller. Body is: $resBody")(response.status shouldBe code)
-                }
-                resBody
-            }
-        }
-
-        Await.result(request, timeout)
-    }
-
-    behavior of "The cache"
-
-    if (WhiskProperties.getProperty(WhiskConfig.controllerInstances).toInt >= 2) {
-
-        it should "be invalidated on updating an entity" in {
-            val actionName = "invalidateRemoteCacheOnUpdate"
-
-            deleteAction(actionName, 0, None)
-            deleteAction(actionName, 1, None)
-
-            // Create an action on controller0
-            val createdAction = updateAction(actionName, "CODE_CODE_CODE", 0)
-
-            // Get action from controller1
-            val actionFromController1 = getAction(actionName, 1)
-            createdAction shouldBe actionFromController1
-
-            // Update the action on controller0
-            val updatedAction = updateAction(actionName, "CODE_CODE", 0)
-
-            retry({
-                // Get action from controller1
-                val updatedActionFromController1 = getAction(actionName, 1)
-                updatedAction shouldBe updatedActionFromController1
-            })
-        }
-
-        it should "be invalidated on deleting an entity" in {
-            val actionName = "invalidateRemoteCacheOnDelete"
-
-            deleteAction(actionName, 0, None)
-            deleteAction(actionName, 1, None)
-
-            // Create an action on controller0
-            val createdAction = updateAction(actionName, "CODE_CODE_CODE", 0)
-            // Get action from controller1 (Now its in the cache of controller 0 and 1)
-            val actionFromController1 = getAction(actionName, 1)
-            createdAction shouldBe actionFromController1
-
-            // Delete the action on controller0 (It should be deleted automatically from the cache of controller1)
-            val updatedAction = deleteAction(actionName, 0)
-
-            retry({
-                // Get action from controller1 should fail with 404
-                getAction(actionName, 1, StatusCodes.NotFound)
-            })
+    val request = Marshal(body).to[RequestEntity].flatMap { entity =>
+      Http()
+        .singleRequest(HttpRequest(
+          method = HttpMethods.PUT,
+          uri = controllerUri(controllerInstance)
+            .withPath(actionPath(name))
+            .withQuery(Uri.Query("overwrite" -> true.toString)),
+          headers = List(authHeader),
+          entity = entity))
+        .flatMap { response =>
+          Unmarshal(response).to[JsObject].map { resBody =>
+            withClue(s"Error in Body: $resBody")(response.status shouldBe StatusCodes.OK)
+            resBody
+          }
         }
     }
+
+    Await.result(request, timeout)
+  }
+
+  def getAction(name: String, controllerInstance: Int = 0, expectedCode: StatusCode = StatusCodes.OK) = {
+    val request = Http()
+      .singleRequest(
+        HttpRequest(
+          method = HttpMethods.GET,
+          uri = controllerUri(controllerInstance).withPath(actionPath(name)),
+          headers = List(authHeader)))
+      .flatMap { response =>
+        Unmarshal(response).to[JsObject].map { resBody =>
+          withClue(s"Wrong statuscode from controller. Body is: $resBody")(response.status shouldBe expectedCode)
+          resBody
+        }
+      }
+
+    Await.result(request, timeout)
+  }
+
+  def deleteAction(name: String,
+                   controllerInstance: Int = 0,
+                   expectedCode: Option[StatusCode] = Some(StatusCodes.OK)) = {
+    val request = Http()
+      .singleRequest(
+        HttpRequest(
+          method = HttpMethods.DELETE,
+          uri = controllerUri(controllerInstance).withPath(actionPath(name)),
+          headers = List(authHeader)))
+      .flatMap { response =>
+        Unmarshal(response).to[JsObject].map { resBody =>
+          expectedCode.map { code =>
+            withClue(s"Wrong statuscode from controller. Body is: $resBody")(response.status shouldBe code)
+          }
+          resBody
+        }
+      }
+
+    Await.result(request, timeout)
+  }
+
+  behavior of "The cache"
+
+  if (WhiskProperties.getProperty(WhiskConfig.controllerInstances).toInt >= 2) {
+
+    it should "be invalidated on updating an entity" in {
+      val actionName = "invalidateRemoteCacheOnUpdate"
+
+      deleteAction(actionName, 0, None)
+      deleteAction(actionName, 1, None)
+
+      // Create an action on controller0
+      val createdAction = updateAction(actionName, "CODE_CODE_CODE", 0)
+
+      // Get action from controller1
+      val actionFromController1 = getAction(actionName, 1)
+      createdAction shouldBe actionFromController1
+
+      // Update the action on controller0
+      val updatedAction = updateAction(actionName, "CODE_CODE", 0)
+
+      retry({
+        // Get action from controller1
+        val updatedActionFromController1 = getAction(actionName, 1)
+        updatedAction shouldBe updatedActionFromController1
+      })
+    }
+
+    it should "be invalidated on deleting an entity" in {
+      val actionName = "invalidateRemoteCacheOnDelete"
+
+      deleteAction(actionName, 0, None)
+      deleteAction(actionName, 1, None)
+
+      // Create an action on controller0
+      val createdAction = updateAction(actionName, "CODE_CODE_CODE", 0)
+      // Get action from controller1 (Now its in the cache of controller 0 and 1)
+      val actionFromController1 = getAction(actionName, 1)
+      createdAction shouldBe actionFromController1
+
+      // Delete the action on controller0 (It should be deleted automatically from the cache of controller1)
+      val updatedAction = deleteAction(actionName, 0)
+
+      retry({
+        // Get action from controller1 should fail with 404
+        getAction(actionName, 1, StatusCodes.NotFound)
+      })
+    }
+  }
 }

--- a/tests/src/test/scala/limits/ThrottleTests.scala
+++ b/tests/src/test/scala/limits/ThrottleTests.scala
@@ -55,226 +55,230 @@ class ThrottleTests
     with ScalaFutures
     with Matchers {
 
-    // use an infinite thread pool so that activations do not wait to send the activation requests
-    override implicit val executionContext = ExecutionContextFactory.makeCachedThreadPoolExecutionContext()
+  // use an infinite thread pool so that activations do not wait to send the activation requests
+  override implicit val executionContext = ExecutionContextFactory.makeCachedThreadPoolExecutionContext()
 
-    implicit val testConfig = PatienceConfig(5.minutes)
-    implicit val wskprops = WskProps()
-    val wsk = new Wsk
-    val defaultAction = Some(TestUtils.getTestActionFilename("hello.js"))
+  implicit val testConfig = PatienceConfig(5.minutes)
+  implicit val wskprops = WskProps()
+  val wsk = new Wsk
+  val defaultAction = Some(TestUtils.getTestActionFilename("hello.js"))
 
-    val throttleWindow = 1.minute
+  val throttleWindow = 1.minute
 
-    val maximumInvokesPerMinute = getLimit("limits.actions.invokes.perMinute")
-    val maximumFiringsPerMinute = getLimit("limits.triggers.fires.perMinute")
-    val maximumConcurrentInvokes = getLimit("limits.actions.invokes.concurrent")
+  val maximumInvokesPerMinute = getLimit("limits.actions.invokes.perMinute")
+  val maximumFiringsPerMinute = getLimit("limits.triggers.fires.perMinute")
+  val maximumConcurrentInvokes = getLimit("limits.actions.invokes.concurrent")
 
-    println(s"maximumInvokesPerMinute  = $maximumInvokesPerMinute")
-    println(s"maximumFiringsPerMinute  = $maximumFiringsPerMinute")
-    println(s"maximumConcurrentInvokes = $maximumConcurrentInvokes")
+  println(s"maximumInvokesPerMinute  = $maximumInvokesPerMinute")
+  println(s"maximumFiringsPerMinute  = $maximumFiringsPerMinute")
+  println(s"maximumConcurrentInvokes = $maximumConcurrentInvokes")
 
-    /*
-     * Retrieve a numeric limit for the key from the property set.
-     */
-    def getLimit(key: String) = WhiskProperties.getProperty(key).toInt
+  /*
+   * Retrieve a numeric limit for the key from the property set.
+   */
+  def getLimit(key: String) = WhiskProperties.getProperty(key).toInt
 
-    /**
-     * Extracts the number of throttled results from a sequence of <code>RunResult</code>
-     *
-     * @param results the sequence of results
-     * @param message the message to determine the type of throttling
-     */
-    def throttledActivations(results: List[RunResult], message: String) = {
-        val count = results.count { result =>
-            result.exitCode == TestUtils.THROTTLED && result.stderr.contains(message)
+  /**
+   * Extracts the number of throttled results from a sequence of <code>RunResult</code>
+   *
+   * @param results the sequence of results
+   * @param message the message to determine the type of throttling
+   */
+  def throttledActivations(results: List[RunResult], message: String) = {
+    val count = results.count { result =>
+      result.exitCode == TestUtils.THROTTLED && result.stderr.contains(message)
+    }
+    println(s"number of throttled activations: $count out of ${results.length}")
+    count
+  }
+
+  /**
+   * Waits until all successful activations are finished. Used to prevent the testcases from
+   * leaking activations.
+   *
+   * @param results the sequence of results from invocations or firings
+   */
+  def waitForActivations(results: ParSeq[RunResult]) = results.foreach { result =>
+    if (result.exitCode == SUCCESS_EXIT) {
+      withActivation(wsk.activation, result, totalWait = 5.minutes)(identity)
+    }
+  }
+
+  /**
+   * Settles throttles of 1 minute. Waits up to 1 minute depending on the time already waited.
+   *
+   * @param waitedAlready the time already gone after the last invoke or fire
+   */
+  def settleThrottles(waitedAlready: FiniteDuration) = {
+    val timeToWait = (throttleWindow - waitedAlready).max(Duration.Zero)
+    println(s"Waiting for ${timeToWait.toSeconds} seconds, already waited for ${waitedAlready.toSeconds} seconds")
+    Thread.sleep(timeToWait.toMillis)
+  }
+
+  /**
+   * Calculates the <code>Duration</code> between two <code>Instant</code>
+   *
+   * @param start the Instant something started
+   * @param end the Instant something ended
+   */
+  def durationBetween(start: Instant, end: Instant) = Duration.fromNanos(java.time.Duration.between(start, end).toNanos)
+
+  /**
+   * Invokes the given action up to 'count' times until one of the invokes is throttled.
+   *
+   * @param count maximum invocations to make
+   */
+  def untilThrottled(count: Int, retries: Int = 3)(run: () => RunResult): List[RunResult] = {
+    val p = Promise[Unit]
+
+    val results = List.fill(count)(Future {
+      if (!p.isCompleted) {
+        val rr = run()
+        if (rr.exitCode != SUCCESS_EXIT) {
+          println(s"exitCode = ${rr.exitCode}   stderr = ${rr.stderr.trim}")
         }
-        println(s"number of throttled activations: $count out of ${results.length}")
-        count
-    }
-
-    /**
-     * Waits until all successful activations are finished. Used to prevent the testcases from
-     * leaking activations.
-     *
-     * @param results the sequence of results from invocations or firings
-     */
-    def waitForActivations(results: ParSeq[RunResult]) = results.foreach { result =>
-        if (result.exitCode == SUCCESS_EXIT) {
-            withActivation(wsk.activation, result, totalWait = 5.minutes)(identity)
+        if (rr.exitCode == THROTTLED) {
+          p.trySuccess(())
         }
+        Some(rr)
+      } else {
+        println("already throttled, skipping additional runs")
+        None
+      }
+    })
+
+    val finished = Future.sequence(results).futureValue.flatten
+    // some activations may need to be retried
+    val failed = finished filter { rr =>
+      rr.exitCode != SUCCESS_EXIT && rr.exitCode != THROTTLED
     }
 
-    /**
-     * Settles throttles of 1 minute. Waits up to 1 minute depending on the time already waited.
-     *
-     * @param waitedAlready the time already gone after the last invoke or fire
-     */
-    def settleThrottles(waitedAlready: FiniteDuration) = {
-        val timeToWait = (throttleWindow - waitedAlready).max(Duration.Zero)
-        println(s"Waiting for ${timeToWait.toSeconds} seconds, already waited for ${waitedAlready.toSeconds} seconds")
-        Thread.sleep(timeToWait.toMillis)
+    println(
+      s"Executed ${finished.length} requests, maximum was $count, need to retry ${failed.length} (retries left: $retries)")
+    if (failed.isEmpty || retries <= 0) {
+      finished
+    } else {
+      finished ++ untilThrottled(failed.length, retries - 1)(run)
+    }
+  }
+
+  behavior of "Throttles"
+
+  it should "throttle multiple activations of one action" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "checkPerMinuteActionThrottle"
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, defaultAction)
     }
 
-    /**
-     * Calculates the <code>Duration</code> between two <code>Instant</code>
-     *
-     * @param start the Instant something started
-     * @param end the Instant something ended
-     */
-    def durationBetween(start: Instant, end: Instant) = Duration.fromNanos(java.time.Duration.between(start, end).toNanos)
-
-    /**
-     * Invokes the given action up to 'count' times until one of the invokes is throttled.
-     *
-     * @param count maximum invocations to make
-     */
-    def untilThrottled(count: Int, retries: Int = 3)(run: () => RunResult): List[RunResult] = {
-        val p = Promise[Unit]
-
-        val results = List.fill(count)(Future {
-            if (!p.isCompleted) {
-                val rr = run()
-                if (rr.exitCode != SUCCESS_EXIT) {
-                    println(s"exitCode = ${rr.exitCode}   stderr = ${rr.stderr.trim}")
-                }
-                if (rr.exitCode == THROTTLED) {
-                    p.trySuccess(())
-                }
-                Some(rr)
-            } else {
-                println("already throttled, skipping additional runs")
-                None
-            }
-        })
-
-        val finished = Future.sequence(results).futureValue.flatten
-        // some activations may need to be retried
-        val failed = finished filter {
-            rr => rr.exitCode != SUCCESS_EXIT && rr.exitCode != THROTTLED
+    // Three things to be careful of:
+    //   1) We do not know the minute boundary so we perform twice max so that it will trigger no matter where they fall
+    //   2) We cannot issue too quickly or else the concurrency throttle will be triggered
+    //   3) In the worst case, we do about almost the limit in the first min and just exceed the limit in the second min.
+    val totalInvokes = 2 * maximumInvokesPerMinute
+    val numGroups = (totalInvokes / maximumConcurrentInvokes) + 1
+    val invokesPerGroup = (totalInvokes / numGroups) + 1
+    val interGroupSleep = 5.seconds
+    val results = (1 to numGroups)
+      .map { i =>
+        if (i != 1) { Thread.sleep(interGroupSleep.toMillis) }
+        untilThrottled(invokesPerGroup) { () =>
+          wsk.action.invoke(name, Map("payload" -> "testWord".toJson), expectedExitCode = DONTCARE_EXIT)
         }
+      }
+      .flatten
+      .toList
+    val afterInvokes = Instant.now
 
-        println(s"Executed ${finished.length} requests, maximum was $count, need to retry ${failed.length} (retries left: $retries)")
-        if (failed.isEmpty || retries <= 0) {
-            finished
-        } else {
-            finished ++ untilThrottled(failed.length, retries - 1)(run)
-        }
+    try {
+      val throttledCount = throttledActivations(results, tooManyRequests)
+      throttledCount should be > 0
+    } finally {
+      val alreadyWaited = durationBetween(afterInvokes, Instant.now)
+      settleThrottles(alreadyWaited)
+      println("clearing activations")
+    }
+    // wait for the activations last, if these fail, the throttle should be settled
+    // and this gives the activations time to complete and may avoid unnecessarily polling
+    println("waiting for activations to complete")
+    waitForActivations(results.par)
+  }
+
+  it should "throttle multiple activations of one trigger" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "checkPerMinuteTriggerThrottle"
+    assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+      trigger.create(name)
     }
 
-    behavior of "Throttles"
+    // invokes per minute * 2 because the current minute could advance which resets the throttle
+    val results = untilThrottled(maximumFiringsPerMinute * 2 + 1) { () =>
+      wsk.trigger.fire(name, Map("payload" -> "testWord".toJson), expectedExitCode = DONTCARE_EXIT)
+    }
+    val afterFirings = Instant.now
 
-    it should "throttle multiple activations of one action" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "checkPerMinuteActionThrottle"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, defaultAction)
-            }
+    try {
+      val throttledCount = throttledActivations(results, tooManyRequests)
+      throttledCount should be > 0
+    } finally {
+      // no need to wait for activations of triggers since they consume no resources
+      // (because there is no rule attached in this test)
+      val alreadyWaited = durationBetween(afterFirings, Instant.now)
+      settleThrottles(alreadyWaited)
+    }
+  }
 
-            // Three things to be careful of:
-            //   1) We do not know the minute boundary so we perform twice max so that it will trigger no matter where they fall
-            //   2) We cannot issue too quickly or else the concurrency throttle will be triggered
-            //   3) In the worst case, we do about almost the limit in the first min and just exceed the limit in the second min.
-            val totalInvokes = 2 * maximumInvokesPerMinute
-            val numGroups = (totalInvokes / maximumConcurrentInvokes) + 1
-            val invokesPerGroup = (totalInvokes / numGroups) + 1
-            val interGroupSleep = 5.seconds
-            val results = (1 to numGroups).map { i =>
-                if (i != 1) { Thread.sleep(interGroupSleep.toMillis) }
-                untilThrottled(invokesPerGroup) { () =>
-                    wsk.action.invoke(name, Map("payload" -> "testWord".toJson), expectedExitCode = DONTCARE_EXIT)
-                }
-            }.flatten.toList
-            val afterInvokes = Instant.now
-
-            try {
-                val throttledCount = throttledActivations(results, tooManyRequests)
-                throttledCount should be > 0
-            } finally {
-                val alreadyWaited = durationBetween(afterInvokes, Instant.now)
-                settleThrottles(alreadyWaited)
-                println("clearing activations")
-            }
-            // wait for the activations last, if these fail, the throttle should be settled
-            // and this gives the activations time to complete and may avoid unnecessarily polling
-            println("waiting for activations to complete")
-            waitForActivations(results.par)
+  it should "throttle 'concurrent' activations of one action" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "checkConcurrentActionThrottle"
+    assetHelper.withCleaner(wsk.action, name) {
+      val timeoutAction = Some(TestUtils.getTestActionFilename("timeout.js"))
+      (action, _) =>
+        action.create(name, timeoutAction)
     }
 
-    it should "throttle multiple activations of one trigger" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "checkPerMinuteTriggerThrottle"
-            assetHelper.withCleaner(wsk.trigger, name) {
-                (trigger, _) => trigger.create(name)
-            }
+    // The sleep is necessary as the load balancer currently has a latency before recognizing concurency.
+    val sleep = 15.seconds
+    val slowInvokes = maximumConcurrentInvokes
+    val fastInvokes = 2
+    val fastInvokeDuration = 4.seconds
+    val slowInvokeDuration = sleep + fastInvokeDuration
 
-            // invokes per minute * 2 because the current minute could advance which resets the throttle
-            val results = untilThrottled(maximumFiringsPerMinute * 2 + 1) { () =>
-                wsk.trigger.fire(name, Map("payload" -> "testWord".toJson), expectedExitCode = DONTCARE_EXIT)
-            }
-            val afterFirings = Instant.now
-
-            try {
-                val throttledCount = throttledActivations(results, tooManyRequests)
-                throttledCount should be > 0
-            } finally {
-                // no need to wait for activations of triggers since they consume no resources
-                // (because there is no rule attached in this test)
-                val alreadyWaited = durationBetween(afterFirings, Instant.now)
-                settleThrottles(alreadyWaited)
-            }
+    // These invokes will stay active long enough that all are issued and load balancer has recognized concurrency.
+    val startSlowInvokes = Instant.now
+    val slowResults = untilThrottled(slowInvokes) { () =>
+      wsk.action.invoke(name, Map("payload" -> slowInvokeDuration.toMillis.toJson), expectedExitCode = DONTCARE_EXIT)
     }
+    val afterSlowInvokes = Instant.now
+    val slowIssueDuration = durationBetween(startSlowInvokes, afterSlowInvokes)
+    println(
+      s"$slowInvokes slow invokes (dur = ${slowInvokeDuration.toSeconds} sec) took ${slowIssueDuration.toSeconds} seconds to issue")
 
-    it should "throttle 'concurrent' activations of one action" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "checkConcurrentActionThrottle"
-            assetHelper.withCleaner(wsk.action, name) {
-                val timeoutAction = Some(TestUtils.getTestActionFilename("timeout.js"))
-                (action, _) => action.create(name, timeoutAction)
-            }
+    // Sleep to let the background thread get the newest values (refreshes every 2 seconds)
+    println(s"Sleeping for ${sleep.toSeconds} sec")
+    Thread.sleep(sleep.toMillis)
 
-            // The sleep is necessary as the load balancer currently has a latency before recognizing concurency.
-            val sleep = 15.seconds
-            val slowInvokes = maximumConcurrentInvokes
-            val fastInvokes = 2
-            val fastInvokeDuration = 4.seconds
-            val slowInvokeDuration = sleep + fastInvokeDuration
-
-            // These invokes will stay active long enough that all are issued and load balancer has recognized concurrency.
-            val startSlowInvokes = Instant.now
-            val slowResults = untilThrottled(slowInvokes) { () =>
-                wsk.action.invoke(name, Map("payload" -> slowInvokeDuration.toMillis.toJson), expectedExitCode = DONTCARE_EXIT)
-            }
-            val afterSlowInvokes = Instant.now
-            val slowIssueDuration = durationBetween(startSlowInvokes, afterSlowInvokes)
-            println(s"$slowInvokes slow invokes (dur = ${slowInvokeDuration.toSeconds} sec) took ${slowIssueDuration.toSeconds} seconds to issue")
-
-            // Sleep to let the background thread get the newest values (refreshes every 2 seconds)
-            println(s"Sleeping for ${sleep.toSeconds} sec")
-            Thread.sleep(sleep.toMillis)
-
-            // These fast invokes will trigger the concurrency-based throttling.
-            val startFastInvokes = Instant.now
-            val fastResults = untilThrottled(fastInvokes) { () =>
-                wsk.action.invoke(name, Map("payload" -> slowInvokeDuration.toMillis.toJson), expectedExitCode = DONTCARE_EXIT)
-            }
-            val afterFastInvokes = Instant.now
-            val fastIssueDuration = durationBetween(afterFastInvokes, startFastInvokes)
-            println(s"$fastInvokes fast invokes (dur = ${fastInvokeDuration.toSeconds} sec) took ${fastIssueDuration.toSeconds} seconds to issue")
-
-            val combinedResults = slowResults ++ fastResults
-            try {
-                val throttledCount = throttledActivations(combinedResults, tooManyConcurrentRequests)
-                throttledCount should be > 0
-            } finally {
-                val alreadyWaited = durationBetween(afterSlowInvokes, Instant.now)
-                settleThrottles(alreadyWaited)
-                println("clearing activations")
-            }
-            // wait for the activations last, giving the activations time to complete and
-            // may avoid unnecessarily polling; if these fail, the throttle may not be settled
-            println("waiting for activations to complete")
-            waitForActivations(combinedResults.par)
+    // These fast invokes will trigger the concurrency-based throttling.
+    val startFastInvokes = Instant.now
+    val fastResults = untilThrottled(fastInvokes) { () =>
+      wsk.action.invoke(name, Map("payload" -> slowInvokeDuration.toMillis.toJson), expectedExitCode = DONTCARE_EXIT)
     }
+    val afterFastInvokes = Instant.now
+    val fastIssueDuration = durationBetween(afterFastInvokes, startFastInvokes)
+    println(
+      s"$fastInvokes fast invokes (dur = ${fastInvokeDuration.toSeconds} sec) took ${fastIssueDuration.toSeconds} seconds to issue")
+
+    val combinedResults = slowResults ++ fastResults
+    try {
+      val throttledCount = throttledActivations(combinedResults, tooManyConcurrentRequests)
+      throttledCount should be > 0
+    } finally {
+      val alreadyWaited = durationBetween(afterSlowInvokes, Instant.now)
+      settleThrottles(alreadyWaited)
+      println("clearing activations")
+    }
+    // wait for the activations last, giving the activations time to complete and
+    // may avoid unnecessarily polling; if these fail, the throttle may not be settled
+    println("waiting for activations to complete")
+    waitForActivations(combinedResults.par)
+  }
 }
 
 @RunWith(classOf[JUnitRunner])
@@ -285,96 +289,104 @@ class NamespaceSpecificThrottleTests
     with Matchers
     with BeforeAndAfterAll {
 
-    val wskadmin = new RunWskAdminCmd {}
-    val wsk = new Wsk
+  val wskadmin = new RunWskAdminCmd {}
+  val wsk = new Wsk
 
-    val defaultAction = Some(TestUtils.getTestActionFilename("hello.js"))
+  val defaultAction = Some(TestUtils.getTestActionFilename("hello.js"))
 
-    // Create a subject with rate limits == 0
-    val zeroProps = getAdditionalTestSubject("zeroSubject")
-    wskadmin.cli(Seq("limits", "set", zeroProps.namespace, "--invocationsPerMinute", "0", "--firesPerMinute", "0", "--concurrentInvocations", "0"))
+  // Create a subject with rate limits == 0
+  val zeroProps = getAdditionalTestSubject("zeroSubject")
+  wskadmin.cli(
+    Seq(
+      "limits",
+      "set",
+      zeroProps.namespace,
+      "--invocationsPerMinute",
+      "0",
+      "--firesPerMinute",
+      "0",
+      "--concurrentInvocations",
+      "0"))
 
-    // Create a subject where only the concurrency limit is set to 0
-    val zeroConcProps = getAdditionalTestSubject("zeroConcSubject")
-    wskadmin.cli(Seq("limits", "set", zeroConcProps.namespace, "--concurrentInvocations", "0"))
+  // Create a subject where only the concurrency limit is set to 0
+  val zeroConcProps = getAdditionalTestSubject("zeroConcSubject")
+  wskadmin.cli(Seq("limits", "set", zeroConcProps.namespace, "--concurrentInvocations", "0"))
 
-    // Create a subject where the rate limits are set to 1
-    val oneProps = getAdditionalTestSubject("oneSubject")
-    wskadmin.cli(Seq("limits", "set", oneProps.namespace, "--invocationsPerMinute", "1", "--firesPerMinute", "1"))
+  // Create a subject where the rate limits are set to 1
+  val oneProps = getAdditionalTestSubject("oneSubject")
+  wskadmin.cli(Seq("limits", "set", oneProps.namespace, "--invocationsPerMinute", "1", "--firesPerMinute", "1"))
 
-    override def afterAll() = {
-        Seq(zeroProps, zeroConcProps, oneProps).foreach { wp =>
-            val ns = wp.namespace
-            disposeAdditionalTestSubject(ns)
-            withClue(s"failed to delete temporary limits for $ns") {
-                wskadmin.cli(Seq("limits", "delete", ns))
-            }
-        }
+  override def afterAll() = {
+    Seq(zeroProps, zeroConcProps, oneProps).foreach { wp =>
+      val ns = wp.namespace
+      disposeAdditionalTestSubject(ns)
+      withClue(s"failed to delete temporary limits for $ns") {
+        wskadmin.cli(Seq("limits", "delete", ns))
+      }
+    }
+  }
+
+  behavior of "Namespace-specific throttles"
+
+  it should "respect overridden rate-throttles of 0" in withAssetCleaner(zeroProps) { (wp, assetHelper) =>
+    implicit val props = wp
+    val triggerName = "zeroTrigger"
+    val actionName = "zeroAction"
+
+    assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
+      action.create(actionName, defaultAction)
+    }
+    assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
+      trigger.create(triggerName)
     }
 
-    behavior of "Namespace-specific throttles"
+    wsk.action.invoke(actionName, expectedExitCode = TestUtils.THROTTLED).stderr should include(tooManyRequests)
+    wsk.trigger.fire(triggerName, expectedExitCode = TestUtils.THROTTLED).stderr should include(tooManyRequests)
+  }
 
-    it should "respect overridden rate-throttles of 0" in withAssetCleaner(zeroProps) {
-        (wp, assetHelper) =>
-            implicit val props = wp
-            val triggerName = "zeroTrigger"
-            val actionName = "zeroAction"
+  it should "respect overridden rate-throttles of 1" in withAssetCleaner(oneProps) { (wp, assetHelper) =>
+    implicit val props = wp
+    val triggerName = "oneTrigger"
+    val actionName = "oneAction"
 
-            assetHelper.withCleaner(wsk.action, actionName) {
-                (action, _) => action.create(actionName, defaultAction)
-            }
-            assetHelper.withCleaner(wsk.trigger, triggerName) {
-                (trigger, _) => trigger.create(triggerName)
-            }
-
-            wsk.action.invoke(actionName, expectedExitCode = TestUtils.THROTTLED).stderr should include(tooManyRequests)
-            wsk.trigger.fire(triggerName, expectedExitCode = TestUtils.THROTTLED).stderr should include(tooManyRequests)
+    assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
+      action.create(actionName, defaultAction)
+    }
+    assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
+      trigger.create(triggerName)
     }
 
-    it should "respect overridden rate-throttles of 1" in withAssetCleaner(oneProps) {
-        (wp, assetHelper) =>
-            implicit val props = wp
-            val triggerName = "oneTrigger"
-            val actionName = "oneAction"
+    // One invoke should be allowed, the second one throttled
+    // Due to the current implementation of the rate throttling, it could be possible, that the counter gets deleted, because the minute switches
+    retry({
+      val results = (1 to 2).map { _ =>
+        wsk.action.invoke(actionName, expectedExitCode = TestUtils.DONTCARE_EXIT)
+      }
+      results.map(_.exitCode) should contain(TestUtils.THROTTLED)
+      results.map(_.stderr).mkString should include(tooManyRequests)
+    }, 2, Some(1.second))
 
-            assetHelper.withCleaner(wsk.action, actionName) {
-                (action, _) => action.create(actionName, defaultAction)
-            }
-            assetHelper.withCleaner(wsk.trigger, triggerName) {
-                (trigger, _) => trigger.create(triggerName)
-            }
+    // One fire should be allowed, the second one throttled
+    // Due to the current implementation of the rate throttling, it could be possible, that the counter gets deleted, because the minute switches
+    retry({
+      val results = (1 to 2).map { _ =>
+        wsk.trigger.fire(triggerName, expectedExitCode = TestUtils.DONTCARE_EXIT)
+      }
+      results.map(_.exitCode) should contain(TestUtils.THROTTLED)
+      results.map(_.stderr).mkString should include(tooManyRequests)
+    }, 2, Some(1.second))
+  }
 
-            // One invoke should be allowed, the second one throttled
-            // Due to the current implementation of the rate throttling, it could be possible, that the counter gets deleted, because the minute switches
-            retry({
-                val results = (1 to 2).map { _ =>
-                    wsk.action.invoke(actionName, expectedExitCode = TestUtils.DONTCARE_EXIT)
-                }
-                results.map(_.exitCode) should contain(TestUtils.THROTTLED)
-                results.map(_.stderr).mkString should include(tooManyRequests)
-            }, 2, Some(1.second))
+  it should "respect overridden concurrent throttle of 0" in withAssetCleaner(zeroConcProps) { (wp, assetHelper) =>
+    implicit val props = wp
+    val actionName = "zeroConcurrentAction"
 
-            // One fire should be allowed, the second one throttled
-            // Due to the current implementation of the rate throttling, it could be possible, that the counter gets deleted, because the minute switches
-            retry({
-                val results = (1 to 2).map { _ =>
-                    wsk.trigger.fire(triggerName, expectedExitCode = TestUtils.DONTCARE_EXIT)
-                }
-                results.map(_.exitCode) should contain(TestUtils.THROTTLED)
-                results.map(_.stderr).mkString should include(tooManyRequests)
-            }, 2, Some(1.second))
+    assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
+      action.create(actionName, defaultAction)
     }
 
-    it should "respect overridden concurrent throttle of 0" in withAssetCleaner(zeroConcProps) {
-        (wp, assetHelper) =>
-            implicit val props = wp
-            val actionName = "zeroConcurrentAction"
-
-            assetHelper.withCleaner(wsk.action, actionName) {
-                (action, _) => action.create(actionName, defaultAction)
-            }
-
-            wsk.action.invoke(actionName, expectedExitCode = TestUtils.THROTTLED).stderr should include(tooManyConcurrentRequests)
-    }
+    wsk.action.invoke(actionName, expectedExitCode = TestUtils.THROTTLED).stderr should include(
+      tooManyConcurrentRequests)
+  }
 
 }

--- a/tests/src/test/scala/services/KafkaConnectorTests.scala
+++ b/tests/src/test/scala/services/KafkaConnectorTests.scala
@@ -40,76 +40,76 @@ import whisk.core.connector.Message
 import whisk.utils.ExecutionContextFactory
 
 @RunWith(classOf[JUnitRunner])
-class KafkaConnectorTests
-    extends FlatSpec
-    with Matchers
-    with WskActorSystem
-    with BeforeAndAfterAll
-    with StreamLogging {
-    implicit val transid = TransactionId.testing
-    implicit val ec = ExecutionContextFactory.makeCachedThreadPoolExecutionContext()
+class KafkaConnectorTests extends FlatSpec with Matchers with WskActorSystem with BeforeAndAfterAll with StreamLogging {
+  implicit val transid = TransactionId.testing
+  implicit val ec = ExecutionContextFactory.makeCachedThreadPoolExecutionContext()
 
-    val config = new WhiskConfig(WhiskConfig.kafkaHost)
-    assert(config.isValid)
+  val config = new WhiskConfig(WhiskConfig.kafkaHost)
+  assert(config.isValid)
 
-    val groupid = "kafkatest"
-    val topic = "Dinosaurs"
-    val sessionTimeout = 10 seconds
-    val maxPollInterval = 10 seconds
-    val producer = new KafkaProducerConnector(config.kafkaHost, ec)
-    val consumer = new KafkaConsumerConnector(config.kafkaHost, groupid, topic, sessionTimeout = sessionTimeout, maxPollInterval = maxPollInterval)
+  val groupid = "kafkatest"
+  val topic = "Dinosaurs"
+  val sessionTimeout = 10 seconds
+  val maxPollInterval = 10 seconds
+  val producer = new KafkaProducerConnector(config.kafkaHost, ec)
+  val consumer = new KafkaConsumerConnector(
+    config.kafkaHost,
+    groupid,
+    topic,
+    sessionTimeout = sessionTimeout,
+    maxPollInterval = maxPollInterval)
 
-    override def afterAll() {
-        producer.close()
-        consumer.close()
-        super.afterAll()
+  override def afterAll() {
+    producer.close()
+    consumer.close()
+    super.afterAll()
+  }
+
+  behavior of "Kafka connector"
+
+  it should "send and receive a kafka message which sets up the topic" in {
+    for (i <- 0 until 5) {
+      val message = new Message { override val serialize = Calendar.getInstance().getTime().toString }
+      val start = java.lang.System.currentTimeMillis
+      val sent = Await.result(producer.send(topic, message), 20 seconds)
+      val received = consumer.peek(10 seconds).map { case (_, _, _, msg) => new String(msg, "utf-8") }
+      val end = java.lang.System.currentTimeMillis
+      val elapsed = end - start
+      println(s"($i) Received ${received.size}. Took $elapsed msec: $received\n")
+      received.size should be >= 1
+      received.last should be(message.serialize)
+      consumer.commit()
     }
+  }
 
-    behavior of "Kafka connector"
+  it should "send and receive a kafka message even after session timeout" in {
+    for (i <- 0 until 4) {
+      val message = new Message { override val serialize = Calendar.getInstance().getTime().toString }
+      val start = java.lang.System.currentTimeMillis
+      val sent = Await.result(producer.send(topic, message), 1 seconds)
+      val received = consumer.peek(1 seconds).map { case (_, _, _, msg) => new String(msg, "utf-8") }
+      val end = java.lang.System.currentTimeMillis
+      val elapsed = end - start
+      println(s"($i) Received ${received.size}. Took $elapsed msec: $received\n")
 
-    it should "send and receive a kafka message which sets up the topic" in {
-        for (i <- 0 until 5) {
-            val message = new Message { override val serialize = Calendar.getInstance().getTime().toString }
-            val start = java.lang.System.currentTimeMillis
-            val sent = Await.result(producer.send(topic, message), 20 seconds)
-            val received = consumer.peek(10 seconds).map { case (_, _, _, msg) => new String(msg, "utf-8") }
-            val end = java.lang.System.currentTimeMillis
-            val elapsed = end - start
-            println(s"($i) Received ${received.size}. Took $elapsed msec: $received\n")
-            received.size should be >= 1
-            received.last should be(message.serialize)
-            consumer.commit()
+      // only the last iteration will have an updated cursor
+      // iteration 0: get whatever is on the topic (at least 1 but may be more if a previous test failed)
+      // iteration 1: get iteration 0 records + 1 more (since we intentionally failed the commit on previous iteration)
+      // iteration 2: get iteration 1 records + 1 more (since we intentionally failed the commit on previous iteration)
+      // iteration 3: get exactly 1 records since iteration 2 should have forwarded the cursor
+      if (i < 3) {
+        received.size should be >= i + 1
+      } else {
+        received.size should be(1)
+      }
+      received.last should be(message.serialize)
+
+      if (i < 2) {
+        Thread.sleep((maxPollInterval + 1.second).toMillis)
+        a[CommitFailedException] should be thrownBy {
+          consumer.commit() // sleep should cause commit to fail
         }
+      } else consumer.commit()
     }
-
-    it should "send and receive a kafka message even after session timeout" in {
-        for (i <- 0 until 4) {
-            val message = new Message { override val serialize = Calendar.getInstance().getTime().toString }
-            val start = java.lang.System.currentTimeMillis
-            val sent = Await.result(producer.send(topic, message), 1 seconds)
-            val received = consumer.peek(1 seconds).map { case (_, _, _, msg) => new String(msg, "utf-8") }
-            val end = java.lang.System.currentTimeMillis
-            val elapsed = end - start
-            println(s"($i) Received ${received.size}. Took $elapsed msec: $received\n")
-
-            // only the last iteration will have an updated cursor
-            // iteration 0: get whatever is on the topic (at least 1 but may be more if a previous test failed)
-            // iteration 1: get iteration 0 records + 1 more (since we intentionally failed the commit on previous iteration)
-            // iteration 2: get iteration 1 records + 1 more (since we intentionally failed the commit on previous iteration)
-            // iteration 3: get exactly 1 records since iteration 2 should have forwarded the cursor
-            if (i < 3) {
-                received.size should be >= i + 1
-            } else {
-                received.size should be(1)
-            }
-            received.last should be(message.serialize)
-
-            if (i < 2) {
-                Thread.sleep((maxPollInterval + 1.second).toMillis)
-                a[CommitFailedException] should be thrownBy {
-                    consumer.commit() // sleep should cause commit to fail
-                }
-            } else consumer.commit()
-        }
-    }
+  }
 }

--- a/tests/src/test/scala/system/basic/WskActionTests.scala
+++ b/tests/src/test/scala/system/basic/WskActionTests.scala
@@ -33,327 +33,274 @@ import spray.json.JsObject
 import spray.json.pimpAny
 
 @RunWith(classOf[JUnitRunner])
-class WskActionTests
-    extends TestHelpers
-    with WskTestHelpers
-    with JsHelpers {
+class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers {
 
-    implicit val wskprops = WskProps()
-    val wsk = new Wsk
+  implicit val wskprops = WskProps()
+  val wsk = new Wsk
 
-    val testString = "this is a test"
-    val testResult = JsObject("count" -> testString.split(" ").length.toJson)
-    val guestNamespace = wskprops.namespace
+  val testString = "this is a test"
+  val testResult = JsObject("count" -> testString.split(" ").length.toJson)
+  val guestNamespace = wskprops.namespace
 
-    behavior of "Whisk actions"
+  behavior of "Whisk actions"
 
-    it should "invoke an action returning a promise" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "hello promise"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("helloPromise.js")))
-            }
-
-            val run = wsk.action.invoke(name)
-            withActivation(wsk.activation, run) {
-                activation =>
-                    activation.response.status shouldBe "success"
-                    activation.response.result shouldBe Some(JsObject("done" -> true.toJson))
-                    activation.logs.get.mkString(" ") shouldBe empty
-            }
+  it should "invoke an action returning a promise" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "hello promise"
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, Some(TestUtils.getTestActionFilename("helloPromise.js")))
     }
 
-    it should "invoke an action with a space in the name" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "hello Async"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("helloAsync.js")))
-            }
+    val run = wsk.action.invoke(name)
+    withActivation(wsk.activation, run) { activation =>
+      activation.response.status shouldBe "success"
+      activation.response.result shouldBe Some(JsObject("done" -> true.toJson))
+      activation.logs.get.mkString(" ") shouldBe empty
+    }
+  }
 
-            val run = wsk.action.invoke(name, Map("payload" -> testString.toJson))
-            withActivation(wsk.activation, run) {
-                activation =>
-                    activation.response.status shouldBe "success"
-                    activation.response.result shouldBe Some(testResult)
-                    activation.logs.get.mkString(" ") should include(testString)
-            }
+  it should "invoke an action with a space in the name" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "hello Async"
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, Some(TestUtils.getTestActionFilename("helloAsync.js")))
     }
 
-    it should "pass parameters bound on creation-time to the action" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "printParams"
-            val params = Map(
-                "param1" -> "test1",
-                "param2" -> "test2")
+    val run = wsk.action.invoke(name, Map("payload" -> testString.toJson))
+    withActivation(wsk.activation, run) { activation =>
+      activation.response.status shouldBe "success"
+      activation.response.result shouldBe Some(testResult)
+      activation.logs.get.mkString(" ") should include(testString)
+    }
+  }
 
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(
-                        name,
-                        Some(TestUtils.getTestActionFilename("printParams.js")),
-                        parameters = params.mapValues(_.toJson))
-            }
+  it should "pass parameters bound on creation-time to the action" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "printParams"
+    val params = Map("param1" -> "test1", "param2" -> "test2")
 
-            val invokeParams = Map("payload" -> testString)
-            val run = wsk.action.invoke(name, invokeParams.mapValues(_.toJson))
-            withActivation(wsk.activation, run) {
-                activation =>
-                    val logs = activation.logs.get.mkString(" ")
-
-                    (params ++ invokeParams).foreach {
-                        case (key, value) =>
-                            logs should include(s"params.$key: $value")
-                    }
-            }
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(
+        name,
+        Some(TestUtils.getTestActionFilename("printParams.js")),
+        parameters = params.mapValues(_.toJson))
     }
 
-    it should "copy an action and invoke it successfully" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "copied"
-            val packageName = "samples"
-            val actionName = "wordcount"
-            val fullQualifiedName = s"/$guestNamespace/$packageName/$actionName"
+    val invokeParams = Map("payload" -> testString)
+    val run = wsk.action.invoke(name, invokeParams.mapValues(_.toJson))
+    withActivation(wsk.activation, run) { activation =>
+      val logs = activation.logs.get.mkString(" ")
 
-            assetHelper.withCleaner(wsk.pkg, packageName) {
-                (pkg, _) => pkg.create(packageName, shared = Some(true))
-            }
+      (params ++ invokeParams).foreach {
+        case (key, value) =>
+          logs should include(s"params.$key: $value")
+      }
+    }
+  }
 
-            assetHelper.withCleaner(wsk.action, fullQualifiedName) {
-                val file = Some(TestUtils.getTestActionFilename("wc.js"))
-                (action, _) => action.create(fullQualifiedName, file)
-            }
+  it should "copy an action and invoke it successfully" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "copied"
+    val packageName = "samples"
+    val actionName = "wordcount"
+    val fullQualifiedName = s"/$guestNamespace/$packageName/$actionName"
 
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(fullQualifiedName), Some("copy"))
-            }
-
-            val run = wsk.action.invoke(name, Map("payload" -> testString.toJson))
-            withActivation(wsk.activation, run) {
-                activation =>
-                    activation.response.status shouldBe "success"
-                    activation.response.result shouldBe Some(testResult)
-                    activation.logs.get.mkString(" ") should include(testString)
-            }
+    assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, _) =>
+      pkg.create(packageName, shared = Some(true))
     }
 
-    it should "copy an action and ensure exec, parameters, and annotations copied" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val origActionName = "origAction"
-            val copiedActionName = "copiedAction"
-            val params = Map("a" -> "A".toJson)
-            val annots = Map("b" -> "B".toJson)
-
-            assetHelper.withCleaner(wsk.action, origActionName) {
-                val file = Some(TestUtils.getTestActionFilename("wc.js"))
-                (action, _) => action.create(origActionName, file, parameters = params, annotations = annots)
-            }
-
-            assetHelper.withCleaner(wsk.action, copiedActionName) {
-                (action, _) => action.create(copiedActionName, Some(origActionName), Some("copy"))
-            }
-
-            val copiedAction = getJSONFromCLIResponse(wsk.action.get(copiedActionName).stdout)
-            val origAction = getJSONFromCLIResponse(wsk.action.get(copiedActionName).stdout)
-
-            copiedAction.fields("annotations") shouldBe origAction.fields("annotations")
-            copiedAction.fields("parameters") shouldBe origAction.fields("parameters")
-            copiedAction.fields("exec") shouldBe origAction.fields("exec")
-            copiedAction.fields("version") shouldBe JsString("0.0.1")
+    assetHelper.withCleaner(wsk.action, fullQualifiedName) {
+      val file = Some(TestUtils.getTestActionFilename("wc.js"))
+      (action, _) =>
+        action.create(fullQualifiedName, file)
     }
 
-    it should "add new parameters and annotations while copying an action" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val origName = "origAction"
-            val copiedName = "copiedAction"
-            val origParams = Map("origParam1" -> "origParamValue1".toJson, "origParam2" -> 999.toJson)
-            val copiedParams = Map("copiedParam1" -> "copiedParamValue1".toJson, "copiedParam2" -> 123.toJson)
-            val origAnnots = Map("origAnnot1" -> "origAnnotValue1".toJson, "origAnnot2" -> true.toJson)
-            val copiedAnnots = Map("copiedAnnot1" -> "copiedAnnotValue1".toJson, "copiedAnnot2" -> false.toJson)
-            val resParams = Seq(
-                JsObject(
-                    "key" -> JsString("copiedParam1"),
-                    "value" -> JsString("copiedParamValue1")
-                ),
-                JsObject(
-                    "key" -> JsString("copiedParam2"),
-                    "value" -> JsNumber(123)
-                ),
-                JsObject(
-                    "key" -> JsString("origParam1"),
-                    "value" -> JsString("origParamValue1")
-                ),
-                JsObject(
-                    "key" -> JsString("origParam2"),
-                    "value" -> JsNumber(999)
-                )
-            )
-            val resAnnots = Seq(
-                JsObject(
-                    "key" -> JsString("origAnnot1"),
-                    "value" -> JsString("origAnnotValue1")
-                ),
-                JsObject(
-                    "key" -> JsString("copiedAnnot2"),
-                    "value" -> JsBoolean(false)
-                ),
-                JsObject(
-                    "key" -> JsString("copiedAnnot1"),
-                    "value" -> JsString("copiedAnnotValue1")
-                ),
-                JsObject(
-                    "key" -> JsString("origAnnot2"),
-                    "value" -> JsBoolean(true)
-                ),
-                JsObject(
-                    "key" -> JsString("exec"),
-                    "value" -> JsString("nodejs:6")
-                )
-            )
-
-            assetHelper.withCleaner(wsk.action, origName) {
-                val file = Some(TestUtils.getTestActionFilename("echo.js"))
-                (action, _) => action.create(origName, file, parameters = origParams, annotations = origAnnots)
-            }
-
-            assetHelper.withCleaner(wsk.action, copiedName) {
-                (action, _) => action.create(copiedName, Some(origName), Some("copy"), parameters = copiedParams, annotations = copiedAnnots)
-            }
-
-            val copiedAction = getJSONFromCLIResponse(wsk.action.get(copiedName).stdout)
-
-            // CLI does not guarantee order of annotations and parameters so do a diff to compare the values
-            copiedAction.fields("parameters").convertTo[Seq[JsObject]] diff resParams shouldBe List()
-            copiedAction.fields("annotations").convertTo[Seq[JsObject]] diff resAnnots shouldBe List()
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, Some(fullQualifiedName), Some("copy"))
     }
 
-    it should "recreate and invoke a new action with different code" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "recreatedAction"
-            assetHelper.withCleaner(wsk.action, name, false) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("wc.js")))
-            }
+    val run = wsk.action.invoke(name, Map("payload" -> testString.toJson))
+    withActivation(wsk.activation, run) { activation =>
+      activation.response.status shouldBe "success"
+      activation.response.result shouldBe Some(testResult)
+      activation.logs.get.mkString(" ") should include(testString)
+    }
+  }
 
-            val run1 = wsk.action.invoke(name, Map("payload" -> testString.toJson))
-            withActivation(wsk.activation, run1) {
-                activation =>
-                    activation.response.status shouldBe "success"
-                    activation.logs.get.mkString(" ") should include(s"The message '$testString' has")
-            }
+  it should "copy an action and ensure exec, parameters, and annotations copied" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val origActionName = "origAction"
+      val copiedActionName = "copiedAction"
+      val params = Map("a" -> "A".toJson)
+      val annots = Map("b" -> "B".toJson)
 
-            wsk.action.delete(name)
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("hello.js")))
-            }
+      assetHelper.withCleaner(wsk.action, origActionName) {
+        val file = Some(TestUtils.getTestActionFilename("wc.js"))
+        (action, _) =>
+          action.create(origActionName, file, parameters = params, annotations = annots)
+      }
 
-            val run2 = wsk.action.invoke(name, Map("payload" -> testString.toJson))
-            withActivation(wsk.activation, run2) {
-                activation =>
-                    activation.response.status shouldBe "success"
-                    activation.logs.get.mkString(" ") should include(s"hello, $testString")
-            }
+      assetHelper.withCleaner(wsk.action, copiedActionName) { (action, _) =>
+        action.create(copiedActionName, Some(origActionName), Some("copy"))
+      }
+
+      val copiedAction = getJSONFromCLIResponse(wsk.action.get(copiedActionName).stdout)
+      val origAction = getJSONFromCLIResponse(wsk.action.get(copiedActionName).stdout)
+
+      copiedAction.fields("annotations") shouldBe origAction.fields("annotations")
+      copiedAction.fields("parameters") shouldBe origAction.fields("parameters")
+      copiedAction.fields("exec") shouldBe origAction.fields("exec")
+      copiedAction.fields("version") shouldBe JsString("0.0.1")
+  }
+
+  it should "add new parameters and annotations while copying an action" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val origName = "origAction"
+      val copiedName = "copiedAction"
+      val origParams = Map("origParam1" -> "origParamValue1".toJson, "origParam2" -> 999.toJson)
+      val copiedParams = Map("copiedParam1" -> "copiedParamValue1".toJson, "copiedParam2" -> 123.toJson)
+      val origAnnots = Map("origAnnot1" -> "origAnnotValue1".toJson, "origAnnot2" -> true.toJson)
+      val copiedAnnots = Map("copiedAnnot1" -> "copiedAnnotValue1".toJson, "copiedAnnot2" -> false.toJson)
+      val resParams = Seq(
+        JsObject("key" -> JsString("copiedParam1"), "value" -> JsString("copiedParamValue1")),
+        JsObject("key" -> JsString("copiedParam2"), "value" -> JsNumber(123)),
+        JsObject("key" -> JsString("origParam1"), "value" -> JsString("origParamValue1")),
+        JsObject("key" -> JsString("origParam2"), "value" -> JsNumber(999)))
+      val resAnnots = Seq(
+        JsObject("key" -> JsString("origAnnot1"), "value" -> JsString("origAnnotValue1")),
+        JsObject("key" -> JsString("copiedAnnot2"), "value" -> JsBoolean(false)),
+        JsObject("key" -> JsString("copiedAnnot1"), "value" -> JsString("copiedAnnotValue1")),
+        JsObject("key" -> JsString("origAnnot2"), "value" -> JsBoolean(true)),
+        JsObject("key" -> JsString("exec"), "value" -> JsString("nodejs:6")))
+
+      assetHelper.withCleaner(wsk.action, origName) {
+        val file = Some(TestUtils.getTestActionFilename("echo.js"))
+        (action, _) =>
+          action.create(origName, file, parameters = origParams, annotations = origAnnots)
+      }
+
+      assetHelper.withCleaner(wsk.action, copiedName) { (action, _) =>
+        action.create(copiedName, Some(origName), Some("copy"), parameters = copiedParams, annotations = copiedAnnots)
+      }
+
+      val copiedAction = getJSONFromCLIResponse(wsk.action.get(copiedName).stdout)
+
+      // CLI does not guarantee order of annotations and parameters so do a diff to compare the values
+      copiedAction.fields("parameters").convertTo[Seq[JsObject]] diff resParams shouldBe List()
+      copiedAction.fields("annotations").convertTo[Seq[JsObject]] diff resAnnots shouldBe List()
+  }
+
+  it should "recreate and invoke a new action with different code" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "recreatedAction"
+    assetHelper.withCleaner(wsk.action, name, false) { (action, _) =>
+      action.create(name, Some(TestUtils.getTestActionFilename("wc.js")))
     }
 
-    it should "fail to invoke an action with an empty file" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "empty"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("empty.js")))
-            }
-            val run = wsk.action.invoke(name)
-            withActivation(wsk.activation, run) {
-                activation =>
-                    activation.response.status shouldBe "action developer error"
-                    activation.response.result shouldBe Some(JsObject("error" -> "Missing main/no code to execute.".toJson))
-            }
+    val run1 = wsk.action.invoke(name, Map("payload" -> testString.toJson))
+    withActivation(wsk.activation, run1) { activation =>
+      activation.response.status shouldBe "success"
+      activation.logs.get.mkString(" ") should include(s"The message '$testString' has")
     }
 
-    it should "create an action with an empty file" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "empty"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("empty.js")))
-            }
-            val rr = wsk.action.get(name)
-            wsk.parseJsonString(rr.stdout).getFieldPath("exec", "code") shouldBe Some(JsString(""))
+    wsk.action.delete(name)
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, Some(TestUtils.getTestActionFilename("hello.js")))
     }
 
-    it should "blocking invoke of nested blocking actions" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "nestedBlockingAction"
-            val child = "wc"
+    val run2 = wsk.action.invoke(name, Map("payload" -> testString.toJson))
+    withActivation(wsk.activation, run2) { activation =>
+      activation.response.status shouldBe "success"
+      activation.logs.get.mkString(" ") should include(s"hello, $testString")
+    }
+  }
 
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("wcbin.js")))
-            }
-            assetHelper.withCleaner(wsk.action, child) {
-                (action, _) => action.create(child, Some(TestUtils.getTestActionFilename("wc.js")))
-            }
+  it should "fail to invoke an action with an empty file" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "empty"
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, Some(TestUtils.getTestActionFilename("empty.js")))
+    }
+    val run = wsk.action.invoke(name)
+    withActivation(wsk.activation, run) { activation =>
+      activation.response.status shouldBe "action developer error"
+      activation.response.result shouldBe Some(JsObject("error" -> "Missing main/no code to execute.".toJson))
+    }
+  }
 
-            val run = wsk.action.invoke(name, Map("payload" -> testString.toJson), blocking = true)
-            val activation = wsk.parseJsonString(run.stdout).convertTo[ActivationResult]
+  it should "create an action with an empty file" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "empty"
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, Some(TestUtils.getTestActionFilename("empty.js")))
+    }
+    val rr = wsk.action.get(name)
+    wsk.parseJsonString(rr.stdout).getFieldPath("exec", "code") shouldBe Some(JsString(""))
+  }
 
-            withClue(s"check failed for activation: $activation") {
-                val wordCount = testString.split(" ").length
-                activation.response.result.get shouldBe JsObject("binaryCount" -> s"${wordCount.toBinaryString} (base 2)".toJson)
-            }
+  it should "blocking invoke of nested blocking actions" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "nestedBlockingAction"
+    val child = "wc"
+
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, Some(TestUtils.getTestActionFilename("wcbin.js")))
+    }
+    assetHelper.withCleaner(wsk.action, child) { (action, _) =>
+      action.create(child, Some(TestUtils.getTestActionFilename("wc.js")))
     }
 
-    it should "blocking invoke an asynchronous action" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "helloAsync"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("helloAsync.js")))
-            }
+    val run = wsk.action.invoke(name, Map("payload" -> testString.toJson), blocking = true)
+    val activation = wsk.parseJsonString(run.stdout).convertTo[ActivationResult]
 
-            val run = wsk.action.invoke(name, Map("payload" -> testString.toJson), blocking = true)
-            val activation = wsk.parseJsonString(run.stdout).convertTo[ActivationResult]
+    withClue(s"check failed for activation: $activation") {
+      val wordCount = testString.split(" ").length
+      activation.response.result.get shouldBe JsObject("binaryCount" -> s"${wordCount.toBinaryString} (base 2)".toJson)
+    }
+  }
 
-            withClue(s"check failed for activation: $activation") {
-                activation.response.status shouldBe "success"
-                activation.response.result shouldBe Some(testResult)
-                activation.logs shouldBe Some(List())
-            }
+  it should "blocking invoke an asynchronous action" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "helloAsync"
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, Some(TestUtils.getTestActionFilename("helloAsync.js")))
     }
 
-    it should "reject an invoke with the wrong parameters set" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val fullQualifiedName = s"/$guestNamespace/samples/helloWorld"
-            val payload = "bob"
-            val rr = wsk.cli(Seq("action", "invoke", fullQualifiedName, payload) ++ wskprops.overrides,
-                expectedExitCode = TestUtils.ERROR_EXIT)
-            rr.stderr should include("Run 'wsk --help' for usage.")
-            rr.stderr should include(s"error: Invalid argument(s): $payload")
+    val run = wsk.action.invoke(name, Map("payload" -> testString.toJson), blocking = true)
+    val activation = wsk.parseJsonString(run.stdout).convertTo[ActivationResult]
+
+    withClue(s"check failed for activation: $activation") {
+      activation.response.status shouldBe "success"
+      activation.response.result shouldBe Some(testResult)
+      activation.logs shouldBe Some(List())
+    }
+  }
+
+  it should "reject an invoke with the wrong parameters set" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val fullQualifiedName = s"/$guestNamespace/samples/helloWorld"
+    val payload = "bob"
+    val rr = wsk.cli(
+      Seq("action", "invoke", fullQualifiedName, payload) ++ wskprops.overrides,
+      expectedExitCode = TestUtils.ERROR_EXIT)
+    rr.stderr should include("Run 'wsk --help' for usage.")
+    rr.stderr should include(s"error: Invalid argument(s): $payload")
+  }
+
+  it should "not be able to use 'ping' in an action" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "ping"
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, Some(TestUtils.getTestActionFilename("ping.js")))
     }
 
-    it should "not be able to use 'ping' in an action" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "ping"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("ping.js")))
-            }
+    val run = wsk.action.invoke(name, Map("payload" -> "google.com".toJson))
+    withActivation(wsk.activation, run) { activation =>
+      activation.response.result shouldBe Some(
+        JsObject("stderr" -> "ping: icmp open socket: Operation not permitted\n".toJson, "stdout" -> "".toJson))
+    }
+  }
 
-            val run = wsk.action.invoke(name, Map("payload" -> "google.com".toJson))
-            withActivation(wsk.activation, run) {
-                activation =>
-                    activation.response.result shouldBe Some(JsObject(
-                        "stderr" -> "ping: icmp open socket: Operation not permitted\n".toJson,
-                        "stdout" -> "".toJson))
-            }
+  ignore should "support UTF-8 as input and output format" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "utf8Test"
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, Some(TestUtils.getTestActionFilename("hello.js")))
     }
 
-    ignore should "support UTF-8 as input and output format" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "utf8Test"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("hello.js")))
-            }
-
-            val utf8 = "«ταБЬℓσö»: 1<2 & 4+1>³, now 20%€§$ off!"
-            val run = wsk.action.invoke(name, Map("payload" -> utf8.toJson))
-            withActivation(wsk.activation, run) {
-                activation =>
-                    activation.response.status shouldBe "success"
-                    activation.logs.get.mkString(" ") should include(s"hello $utf8")
-            }
+    val utf8 = "«ταБЬℓσö»: 1<2 & 4+1>³, now 20%€§$ off!"
+    val run = wsk.action.invoke(name, Map("payload" -> utf8.toJson))
+    withActivation(wsk.activation, run) { activation =>
+      activation.response.status shouldBe "success"
+      activation.logs.get.mkString(" ") should include(s"hello $utf8")
     }
+  }
 }

--- a/tests/src/test/scala/system/basic/WskBasicNodeTests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicNodeTests.scala
@@ -32,123 +32,109 @@ import spray.json._
 import spray.json.DefaultJsonProtocol._
 
 @RunWith(classOf[JUnitRunner])
-class WskBasicNodeTests
-    extends TestHelpers
-    with WskTestHelpers
-    with JsHelpers {
+class WskBasicNodeTests extends TestHelpers with WskTestHelpers with JsHelpers {
 
-    implicit val wskprops = WskProps()
-    val wsk = new Wsk
-    val defaultAction = Some(TestUtils.getTestActionFilename("hello.js"))
-    val currentNodeJsDefaultKind = "nodejs:6"
+  implicit val wskprops = WskProps()
+  val wsk = new Wsk
+  val defaultAction = Some(TestUtils.getTestActionFilename("hello.js"))
+  val currentNodeJsDefaultKind = "nodejs:6"
 
-    behavior of "NodeJS runtime"
+  behavior of "NodeJS runtime"
 
-    it should "Map a kind of nodejs:default to the current default NodeJS runtime" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "usingDefaultNodeAlias"
+  it should "Map a kind of nodejs:default to the current default NodeJS runtime" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "usingDefaultNodeAlias"
 
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(name, defaultAction, kind = Some("nodejs:default"))
-            }
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, defaultAction, kind = Some("nodejs:default"))
+      }
 
-            val result = wsk.action.get(name)
-            withPrintOnFailure(result) {
-                () =>
-                    val action = convertRunResultToJsObject(result)
-                    action.getFieldPath("exec", "kind") should be(Some(currentNodeJsDefaultKind.toJson))
-            }
+      val result = wsk.action.get(name)
+      withPrintOnFailure(result) { () =>
+        val action = convertRunResultToJsObject(result)
+        action.getFieldPath("exec", "kind") should be(Some(currentNodeJsDefaultKind.toJson))
+      }
+  }
+
+  it should "Ensure that NodeJS actions can have a non-default entrypoint" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "niamNpmAction"
+      val file = Some(TestUtils.getTestActionFilename("niam.js"))
+
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, file, main = Some("niam"))
+      }
+
+      withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
+        val response = activation.response
+        response.result.get.fields.get("error") shouldBe empty
+        response.result.get.fields.get("greetings") should be(Some(JsString("Hello from a non-standard entrypoint.")))
+      }
+  }
+
+  it should "Ensure that zipped actions are encoded and uploaded as NodeJS actions" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "zippedNpmAction"
+      val file = Some(TestUtils.getTestActionFilename("zippedaction.zip"))
+
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, file, kind = Some("nodejs:default"))
+      }
+
+      withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
+        val response = activation.response
+        response.result.get.fields.get("error") shouldBe empty
+        response.result.get.fields.get("author") shouldBe defined
+      }
+  }
+
+  it should "Ensure that zipped actions cannot be created without a kind specified" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "zippedNpmActionWithNoKindSpecified"
+      val file = Some(TestUtils.getTestActionFilename("zippedaction.zip"))
+
+      val createResult = assetHelper.withCleaner(wsk.action, name, confirmDelete = false) { (action, _) =>
+        action.create(name, file, expectedExitCode = ANY_ERROR_EXIT)
+      }
+
+      val output = s"${createResult.stdout}\n${createResult.stderr}"
+
+      output should include("kind")
+  }
+
+  it should "Ensure that JS actions created with no explicit kind use the current default NodeJS runtime" in withAssetCleaner(
+    wskprops) { (wp, assetHelper) =>
+    val name = "jsWithNoKindSpecified"
+
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, defaultAction)
     }
 
-    it should "Ensure that NodeJS actions can have a non-default entrypoint" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "niamNpmAction"
-            val file = Some(TestUtils.getTestActionFilename("niam.js"))
+    val result = wsk.action.get(name)
+    withPrintOnFailure(result) { () =>
+      val action = convertRunResultToJsObject(result)
+      action.getFieldPath("exec", "kind") should be(Some(currentNodeJsDefaultKind.toJson))
+    }
+  }
 
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(name, file, main = Some("niam"))
-            }
+  it should "Ensure that returning an empty rejected Promise results in an errored activation" in withAssetCleaner(
+    wskprops) { (wp, assetHelper) =>
+    val name = "jsEmptyRejectPromise"
 
-            withActivation(wsk.activation, wsk.action.invoke(name)) {
-                activation =>
-                    val response = activation.response
-                    response.result.get.fields.get("error") shouldBe empty
-                    response.result.get.fields.get("greetings") should be(Some(JsString("Hello from a non-standard entrypoint.")))
-            }
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, Some(TestUtils.getTestActionFilename("issue-1562.js")))
     }
 
-    it should "Ensure that zipped actions are encoded and uploaded as NodeJS actions" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "zippedNpmAction"
-            val file = Some(TestUtils.getTestActionFilename("zippedaction.zip"))
-
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(name, file, kind = Some("nodejs:default"))
-            }
-
-            withActivation(wsk.activation, wsk.action.invoke(name)) {
-                activation =>
-                    val response = activation.response
-                    response.result.get.fields.get("error") shouldBe empty
-                    response.result.get.fields.get("author") shouldBe defined
-            }
+    withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
+      val response = activation.response
+      response.success should be(false)
+      response.result.get.fields.get("error") shouldBe defined
     }
+  }
 
-    it should "Ensure that zipped actions cannot be created without a kind specified" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "zippedNpmActionWithNoKindSpecified"
-            val file = Some(TestUtils.getTestActionFilename("zippedaction.zip"))
-
-            val createResult = assetHelper.withCleaner(wsk.action, name, confirmDelete = false) {
-                (action, _) =>
-                    action.create(name, file, expectedExitCode = ANY_ERROR_EXIT)
-            }
-
-            val output = s"${createResult.stdout}\n${createResult.stderr}"
-
-            output should include("kind")
-    }
-
-    it should "Ensure that JS actions created with no explicit kind use the current default NodeJS runtime" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "jsWithNoKindSpecified"
-
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(name, defaultAction)
-            }
-
-            val result = wsk.action.get(name)
-            withPrintOnFailure(result) {
-                () =>
-                    val action = convertRunResultToJsObject(result)
-                    action.getFieldPath("exec", "kind") should be(Some(currentNodeJsDefaultKind.toJson))
-            }
-    }
-
-    it should "Ensure that returning an empty rejected Promise results in an errored activation" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "jsEmptyRejectPromise"
-
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(name, Some(TestUtils.getTestActionFilename("issue-1562.js")))
-            }
-
-            withActivation(wsk.activation, wsk.action.invoke(name)) {
-                activation =>
-                    val response = activation.response
-                    response.success should be(false)
-                    response.result.get.fields.get("error") shouldBe defined
-            }
-    }
-
-    def convertRunResultToJsObject(result: RunResult): JsObject = {
-        val stdout = result.stdout
-        val firstNewline = stdout.indexOf("\n")
-        stdout.substring(firstNewline + 1).parseJson.asJsObject
-    }
+  def convertRunResultToJsObject(result: RunResult): JsObject = {
+    val stdout = result.stdout
+    val firstNewline = stdout.indexOf("\n")
+    stdout.substring(firstNewline + 1).parseJson.asJsObject
+  }
 }

--- a/tests/src/test/scala/system/basic/WskBasicPythonTests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicPythonTests.scala
@@ -32,118 +32,111 @@ import common.WskTestHelpers
 import common.WhiskProperties
 
 @RunWith(classOf[JUnitRunner])
-class WskBasicPythonTests
-    extends TestHelpers
-    with WskTestHelpers
-    with Matchers
-    with JsHelpers {
+class WskBasicPythonTests extends TestHelpers with WskTestHelpers with Matchers with JsHelpers {
 
-    implicit val wskprops = WskProps()
-    val wsk = new Wsk
+  implicit val wskprops = WskProps()
+  val wsk = new Wsk
 
-    behavior of "Native Python Action"
+  behavior of "Native Python Action"
 
-    it should "invoke an action and get the result" in withAssetCleaner(wskprops) {
+  it should "invoke an action and get the result" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "basicInvoke"
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, Some(TestUtils.getTestActionFilename("hello.py")))
+    }
+
+    withActivation(wsk.activation, wsk.action.invoke(name, Map("name" -> "Prince".toJson))) {
+      _.response.result.get.toString should include("Prince")
+    }
+  }
+
+  it should "invoke an action with a non-default entry point" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "nonDefaultEntryPoint"
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, Some(TestUtils.getTestActionFilename("niam.py")), main = Some("niam"))
+    }
+
+    withActivation(wsk.activation, wsk.action.invoke(name, Map())) {
+      _.response.result.get.fields.get("greetings") should be(Some(JsString("Hello from a non-standard entrypoint.")))
+    }
+  }
+
+  it should "invoke an action from a zip file with a non-default entry point" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "pythonZipWithNonDefaultEntryPoint"
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(
+          name,
+          Some(TestUtils.getTestActionFilename("python.zip")),
+          main = Some("niam"),
+          kind = Some("python:default"))
+      }
+
+      withActivation(wsk.activation, wsk.action.invoke(name, Map("name" -> "Prince".toJson))) {
+        _.response.result.get shouldBe JsObject("greeting" -> JsString("Hello Prince!"))
+      }
+  }
+
+  Seq("python:2", "python:3").foreach { kind =>
+    it should s"invoke a $kind action" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+      val name = s"${kind.replace(":", "")}-action"
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, Some(TestUtils.getTestActionFilename("pythonVersion.py")), kind = Some(kind))
+      }
+
+      withActivation(wsk.activation, wsk.action.invoke(name)) {
+        _.response.result.get shouldBe JsObject("version" -> JsNumber(kind.takeRight(1).toInt))
+      }
+    }
+  }
+
+  it should "invoke an action and confirm expected environment is defined" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "stdenv"
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, Some(TestUtils.getTestActionFilename("stdenv.py")))
+      }
+
+      withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
+        val result = activation.response.result.get
+        result.fields.get("error") shouldBe empty
+        result.fields.get("auth") shouldBe Some(
+          JsString(WhiskProperties.readAuthKey(WhiskProperties.getAuthFileForTesting)))
+        result.fields.get("edge").toString.trim should not be empty
+      }
+  }
+
+  it should "invoke an invalid action and get error back" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "bad code"
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, Some(TestUtils.getTestActionFilename("malformed.py")))
+    }
+
+    withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
+      activation.response.result.get.fields.get("error") shouldBe Some(
+        JsString("The action failed to generate or locate a binary. See logs for details."))
+      activation.logs.get.mkString("\n") should { not include ("pythonaction.py") and not include ("flask") }
+    }
+  }
+
+  behavior of "Python virtualenv"
+
+  Seq(("python2_virtualenv.zip", "python:2"), ("python3_virtualenv.zip", "python:3")).foreach {
+    case (filename, kind) =>
+      it should s"invoke a zipped $kind action with virtualenv package" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val name = "basicInvoke"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("hello.py")))
-            }
+          val name = filename
+          val zippedPythonAction = Some(TestUtils.getTestActionFilename(filename))
 
-            withActivation(wsk.activation, wsk.action.invoke(name, Map("name" -> "Prince".toJson))) {
-                _.response.result.get.toString should include("Prince")
-            }
-    }
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, zippedPythonAction, kind = Some(kind))
+          }
 
-    it should "invoke an action with a non-default entry point" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "nonDefaultEntryPoint"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("niam.py")), main = Some("niam"))
-            }
-
-            withActivation(wsk.activation, wsk.action.invoke(name, Map())) {
-                _.response.result.get.fields.get("greetings") should be(Some(JsString("Hello from a non-standard entrypoint.")))
-            }
-    }
-
-    it should "invoke an action from a zip file with a non-default entry point" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "pythonZipWithNonDefaultEntryPoint"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("python.zip")), main = Some("niam"), kind = Some("python:default"))
-            }
-
-            withActivation(wsk.activation, wsk.action.invoke(name, Map("name" -> "Prince".toJson))) {
-                _.response.result.get shouldBe JsObject("greeting" -> JsString("Hello Prince!"))
-            }
-    }
-
-    Seq("python:2", "python:3").foreach { kind =>
-        it should s"invoke a $kind action" in withAssetCleaner(wskprops) {
-            (wp, assetHelper) =>
-                val name = s"${kind.replace(":", "")}-action"
-                assetHelper.withCleaner(wsk.action, name) {
-                    (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("pythonVersion.py")), kind = Some(kind))
-                }
-
-                withActivation(wsk.activation, wsk.action.invoke(name)) {
-                    _.response.result.get shouldBe JsObject("version" -> JsNumber(kind.takeRight(1).toInt))
-                }
-        }
-    }
-
-    it should "invoke an action and confirm expected environment is defined" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "stdenv"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("stdenv.py")))
-            }
-
-            withActivation(wsk.activation, wsk.action.invoke(name)) {
-                activation =>
-                    val result = activation.response.result.get
-                    result.fields.get("error") shouldBe empty
-                    result.fields.get("auth") shouldBe Some(JsString(WhiskProperties.readAuthKey(WhiskProperties.getAuthFileForTesting)))
-                    result.fields.get("edge").toString.trim should not be empty
-            }
-    }
-
-    it should "invoke an invalid action and get error back" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "bad code"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("malformed.py")))
-            }
-
-            withActivation(wsk.activation, wsk.action.invoke(name)) {
-                activation =>
-                    activation.response.result.get.fields.get("error") shouldBe Some(JsString("The action failed to generate or locate a binary. See logs for details."))
-                    activation.logs.get.mkString("\n") should { not include ("pythonaction.py") and not include ("flask") }
-            }
-    }
-
-    behavior of "Python virtualenv"
-
-    Seq(("python2_virtualenv.zip", "python:2"),
-        ("python3_virtualenv.zip", "python:3")).foreach {
-            case (filename, kind) =>
-                it should s"invoke a zipped $kind action with virtualenv package" in withAssetCleaner(wskprops) {
-                    (wp, assetHelper) =>
-                        val name = filename
-                        val zippedPythonAction = Some(TestUtils.getTestActionFilename(filename))
-
-                        assetHelper.withCleaner(wsk.action, name) {
-                            (action, _) =>
-                                action.create(name, zippedPythonAction, kind = Some(kind))
-                        }
-
-                        withActivation(wsk.activation, wsk.action.invoke(name), totalWait = 120.seconds) {
-                            activation =>
-                                val response = activation.response
-                                response.result.get.fields.get("error") shouldBe empty
-                                response.result.get.fields.get("Networkinfo: ") shouldBe defined
-                        }
-                }
-        }
+          withActivation(wsk.activation, wsk.action.invoke(name), totalWait = 120.seconds) { activation =>
+            val response = activation.response
+            response.result.get.fields.get("error") shouldBe empty
+            response.result.get.fields.get("Networkinfo: ") shouldBe defined
+          }
+      }
+  }
 }

--- a/tests/src/test/scala/system/basic/WskBasicSwift311Tests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicSwift311Tests.scala
@@ -21,8 +21,7 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class WskBasicSwift311Tests
-    extends WskBasicSwift3Tests {
+class WskBasicSwift311Tests extends WskBasicSwift3Tests {
 
-    override lazy val currentSwiftDefaultKind = "swift:3.1.1"
+  override lazy val currentSwiftDefaultKind = "swift:3.1.1"
 }

--- a/tests/src/test/scala/system/basic/WskBasicSwift3Tests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicSwift3Tests.scala
@@ -32,39 +32,34 @@ import common.TestUtils.RunResult
 import spray.json.JsObject
 
 @RunWith(classOf[JUnitRunner])
-class WskBasicSwift3Tests
-    extends TestHelpers
-    with WskTestHelpers
-    with JsHelpers {
+class WskBasicSwift3Tests extends TestHelpers with WskTestHelpers with JsHelpers {
 
-    implicit val wskprops = WskProps()
-    val wsk = new Wsk
-    val defaultAction = Some(TestUtils.getTestActionFilename("hello.swift"))
-    lazy val currentSwiftDefaultKind = "swift:3"
+  implicit val wskprops = WskProps()
+  val wsk = new Wsk
+  val defaultAction = Some(TestUtils.getTestActionFilename("hello.swift"))
+  lazy val currentSwiftDefaultKind = "swift:3"
 
-    behavior of "Swift runtime"
+  behavior of "Swift runtime"
 
-    it should "Ensure that Swift actions can have a non-default entrypoint" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "niamSwiftAction"
-            val file = Some(TestUtils.getTestActionFilename("niam.swift"))
+  it should "Ensure that Swift actions can have a non-default entrypoint" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "niamSwiftAction"
+      val file = Some(TestUtils.getTestActionFilename("niam.swift"))
 
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(name, file, main = Some("niam"))
-            }
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, file, main = Some("niam"))
+      }
 
-            withActivation(wsk.activation, wsk.action.invoke(name)) {
-                activation =>
-                    val response = activation.response
-                    response.result.get.fields.get("error") shouldBe empty
-                    response.result.get.fields.get("greetings") should be(Some(JsString("Hello from a non-standard entrypoint.")))
-            }
-    }
+      withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
+        val response = activation.response
+        response.result.get.fields.get("error") shouldBe empty
+        response.result.get.fields.get("greetings") should be(Some(JsString("Hello from a non-standard entrypoint.")))
+      }
+  }
 
-    def convertRunResultToJsObject(result: RunResult): JsObject = {
-        val stdout = result.stdout
-        val firstNewline = stdout.indexOf("\n")
-        stdout.substring(firstNewline + 1).parseJson.asJsObject
-    }
+  def convertRunResultToJsObject(result: RunResult): JsObject = {
+    val stdout = result.stdout
+    val firstNewline = stdout.indexOf("\n")
+    stdout.substring(firstNewline + 1).parseJson.asJsObject
+  }
 }

--- a/tests/src/test/scala/system/basic/WskBasicTests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicTests.scala
@@ -37,823 +37,831 @@ import spray.json.DefaultJsonProtocol._
 import spray.json.pimpAny
 
 @RunWith(classOf[JUnitRunner])
-class WskBasicTests
-    extends TestHelpers
-    with WskTestHelpers {
+class WskBasicTests extends TestHelpers with WskTestHelpers {
 
-    implicit val wskprops = WskProps()
-    val wsk = new Wsk
-    val defaultAction = Some(TestUtils.getTestActionFilename("hello.js"))
+  implicit val wskprops = WskProps()
+  val wsk = new Wsk
+  val defaultAction = Some(TestUtils.getTestActionFilename("hello.js"))
 
-    behavior of "Wsk CLI"
+  behavior of "Wsk CLI"
 
-    it should "reject creating duplicate entity" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "testDuplicateCreate"
-            assetHelper.withCleaner(wsk.trigger, name) {
-                (trigger, _) => trigger.create(name)
-            }
-            assetHelper.withCleaner(wsk.action, name, confirmDelete = false) {
-                (action, _) => action.create(name, defaultAction, expectedExitCode = CONFLICT)
-            }
+  it should "reject creating duplicate entity" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "testDuplicateCreate"
+    assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+      trigger.create(name)
+    }
+    assetHelper.withCleaner(wsk.action, name, confirmDelete = false) { (action, _) =>
+      action.create(name, defaultAction, expectedExitCode = CONFLICT)
+    }
+  }
+
+  it should "reject deleting entity in wrong collection" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "testCrossDelete"
+    assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+      trigger.create(name)
+    }
+    wsk.action.delete(name, expectedExitCode = CONFLICT)
+  }
+
+  it should "reject unauthenticated access" in {
+    implicit val wskprops = WskProps("xxx") // shadow properties
+    val errormsg = "The supplied authentication is invalid"
+    wsk.namespace.list(expectedExitCode = UNAUTHORIZED).stderr should include(errormsg)
+    wsk.namespace.get(expectedExitCode = UNAUTHORIZED).stderr should include(errormsg)
+  }
+
+  behavior of "Wsk Package CLI"
+
+  it should "create, update, get and list a package" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "testPackage"
+    val params = Map("a" -> "A".toJson)
+    assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
+      pkg.create(name, parameters = params, shared = Some(true))
+      pkg.create(name, update = true)
+    }
+    val stdout = wsk.pkg.get(name).stdout
+    stdout should include regex (""""key": "a"""")
+    stdout should include regex (""""value": "A"""")
+    stdout should include regex (""""publish": true""")
+    stdout should include regex (""""version": "0.0.2"""")
+    wsk.pkg.list().stdout should include(name)
+  }
+
+  it should "create, and get a package summary" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val packageName = "packageName"
+    val actionName = "actionName"
+    val packageAnnots = Map(
+      "description" -> JsString("Package description"),
+      "parameters" -> JsArray(
+        JsObject("name" -> JsString("paramName1"), "description" -> JsString("Parameter description 1")),
+        JsObject("name" -> JsString("paramName2"), "description" -> JsString("Parameter description 2"))))
+    val actionAnnots = Map(
+      "description" -> JsString("Action description"),
+      "parameters" -> JsArray(
+        JsObject("name" -> JsString("paramName1"), "description" -> JsString("Parameter description 1")),
+        JsObject("name" -> JsString("paramName2"), "description" -> JsString("Parameter description 2"))))
+
+    assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, _) =>
+      pkg.create(packageName, annotations = packageAnnots)
     }
 
-    it should "reject deleting entity in wrong collection" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "testCrossDelete"
-            assetHelper.withCleaner(wsk.trigger, name) {
-                (trigger, _) => trigger.create(name)
-            }
-            wsk.action.delete(name, expectedExitCode = CONFLICT)
+    wsk.action.create(packageName + "/" + actionName, defaultAction, annotations = actionAnnots)
+    val stdout = wsk.pkg.get(packageName, summary = true).stdout
+    val ns = wsk.namespace.whois()
+    wsk.action.delete(packageName + "/" + actionName)
+
+    stdout should include regex (s"(?i)package /$ns/$packageName: Package description\\s*\\(parameters: paramName1, paramName2\\)")
+    stdout should include regex (s"(?i)action /$ns/$packageName/$actionName: Action description\\s*\\(parameters: paramName1, paramName2\\)")
+  }
+
+  it should "create a package with a name that contains spaces" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "package with spaces"
+
+    val res = assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
+      pkg.create(name)
     }
 
-    it should "reject unauthenticated access" in {
-        implicit val wskprops = WskProps("xxx") // shadow properties
-        val errormsg = "The supplied authentication is invalid"
-        wsk.namespace.list(expectedExitCode = UNAUTHORIZED).
-            stderr should include(errormsg)
-        wsk.namespace.get(expectedExitCode = UNAUTHORIZED).
-            stderr should include(errormsg)
+    res.stdout should include(s"ok: created package $name")
+  }
+
+  it should "create a package, and get its individual fields" in withAssetCleaner(wskprops) {
+    val name = "packageFields"
+    val paramInput = Map("payload" -> "test".toJson)
+    val successMsg = s"ok: got package $name, displaying field"
+
+    (wp, assetHelper) =>
+      assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
+        pkg.create(name, parameters = paramInput)
+      }
+
+      val expectedParam = JsObject("payload" -> JsString("test"))
+      val ns = wsk.namespace.whois()
+
+      wsk.pkg
+        .get(name, fieldFilter = Some("namespace"))
+        .stdout should include regex (s"""(?i)$successMsg namespace\n"$ns"""")
+      wsk.pkg.get(name, fieldFilter = Some("name")).stdout should include(s"""$successMsg name\n"$name"""")
+      wsk.pkg.get(name, fieldFilter = Some("version")).stdout should include(s"""$successMsg version\n"0.0.1"""")
+      wsk.pkg.get(name, fieldFilter = Some("publish")).stdout should include(s"""$successMsg publish\nfalse""")
+      wsk.pkg.get(name, fieldFilter = Some("binding")).stdout should include regex (s"""\\{\\}""")
+      wsk.pkg.get(name, fieldFilter = Some("invalid"), expectedExitCode = ERROR_EXIT).stderr should include(
+        "error: Invalid field filter 'invalid'.")
+  }
+
+  it should "reject creation of duplication packages" in withAssetCleaner(wskprops) {
+    val name = "dupePackage"
+
+    (wp, assetHelper) =>
+      assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
+        pkg.create(name)
+      }
+
+      val stderr = wsk.pkg.create(name, expectedExitCode = CONFLICT).stderr
+      stderr should include regex (s"""Unable to create package '$name': resource already exists \\(code \\d+\\)""")
+  }
+
+  it should "reject delete of package that does not exist" in {
+    val name = "nonexistentPackage"
+    val stderr = wsk.pkg.delete(name, expectedExitCode = NOT_FOUND).stderr
+    stderr should include regex (s"""Unable to delete package '$name'. The requested resource does not exist. \\(code \\d+\\)""")
+  }
+
+  it should "reject get of package that does not exist" in {
+    val name = "nonexistentPackage"
+    val stderr = wsk.pkg.get(name, expectedExitCode = NOT_FOUND).stderr
+    stderr should include regex (s"""Unable to get package '$name': The requested resource does not exist. \\(code \\d+\\)""")
+  }
+
+  behavior of "Wsk Action CLI"
+
+  it should "create the same action twice with different cases" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    assetHelper.withCleaner(wsk.action, "TWICE") { (action, name) =>
+      action.create(name, defaultAction)
+    }
+    assetHelper.withCleaner(wsk.action, "twice") { (action, name) =>
+      action.create(name, defaultAction)
+    }
+  }
+
+  it should "create, update, get and list an action" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "createAndUpdate"
+    val file = Some(TestUtils.getTestActionFilename("hello.js"))
+    val params = Map("a" -> "A".toJson)
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, file, parameters = params)
+      action.create(name, None, parameters = Map("b" -> "B".toJson), update = true)
     }
 
-    behavior of "Wsk Package CLI"
+    val stdout = wsk.action.get(name).stdout
+    stdout should not include regex(""""key": "a"""")
+    stdout should not include regex(""""value": "A"""")
+    stdout should include regex (""""key": "b""")
+    stdout should include regex (""""value": "B"""")
+    stdout should include regex (""""publish": false""")
+    stdout should include regex (""""version": "0.0.2"""")
+    wsk.action.list().stdout should include(name)
+  }
 
-    it should "create, update, get and list a package" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "testPackage"
-            val params = Map("a" -> "A".toJson)
-            assetHelper.withCleaner(wsk.pkg, name) {
-                (pkg, _) =>
-                    pkg.create(name, parameters = params, shared = Some(true))
-                    pkg.create(name, update = true)
-            }
-            val stdout = wsk.pkg.get(name).stdout
-            stdout should include regex (""""key": "a"""")
-            stdout should include regex (""""value": "A"""")
-            stdout should include regex (""""publish": true""")
-            stdout should include regex (""""version": "0.0.2"""")
-            wsk.pkg.list().stdout should include(name)
+  it should "reject create of an action that already exists" in withAssetCleaner(wskprops) {
+    val name = "dupeAction"
+    val file = Some(TestUtils.getTestActionFilename("echo.js"))
+
+    (wp, assetHelper) =>
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, file)
+      }
+
+      val stderr = wsk.action.create(name, file, expectedExitCode = CONFLICT).stderr
+      stderr should include regex (s"""Unable to create action '$name': resource already exists \\(code \\d+\\)""")
+  }
+
+  it should "reject delete of action that does not exist" in {
+    val name = "nonexistentAction"
+    val stderr = wsk.action.delete(name, expectedExitCode = NOT_FOUND).stderr
+    stderr should include regex (s"""Unable to delete action '$name'. The requested resource does not exist. \\(code \\d+\\)""")
+  }
+
+  it should "reject invocation of action that does not exist" in {
+    val name = "nonexistentAction"
+    val stderr = wsk.action.invoke(name, expectedExitCode = NOT_FOUND).stderr
+    stderr should include regex (s"""Unable to invoke action '$name': The requested resource does not exist. \\(code \\d+\\)""")
+  }
+
+  it should "reject get of an action that does not exist" in {
+    val name = "nonexistentAction"
+    val stderr = wsk.action.get(name, expectedExitCode = NOT_FOUND).stderr
+    stderr should include regex (s"""Unable to get action '$name': The requested resource does not exist. \\(code \\d+\\)""")
+  }
+
+  it should "create, and invoke an action that utilizes a docker container" in withAssetCleaner(wskprops) {
+    val name = "dockerContainer"
+    (wp, assetHelper) =>
+      assetHelper.withCleaner(wsk.action, name) {
+        // this docker image will be need to be pulled from dockerhub and hence has to be published there first
+        (action, _) =>
+          action.create(name, None, docker = Some("openwhisk/example"))
+      }
+
+      val args = Map("payload" -> "test".toJson)
+      val run = wsk.action.invoke(name, args)
+      withActivation(wsk.activation, run) { activation =>
+        activation.response.result shouldBe Some(
+          JsObject("args" -> args.toJson, "msg" -> "Hello from arbitrary C program!".toJson))
+      }
+  }
+
+  it should "create, and invoke an action that utilizes dockerskeleton with native zip" in withAssetCleaner(wskprops) {
+    val name = "dockerContainerWithZip"
+    (wp, assetHelper) =>
+      assetHelper.withCleaner(wsk.action, name) {
+        // this docker image will be need to be pulled from dockerhub and hence has to be published there first
+        (action, _) =>
+          action.create(name, Some(TestUtils.getTestActionFilename("blackbox.zip")), kind = Some("native"))
+      }
+
+      val run = wsk.action.invoke(name, Map())
+      withActivation(wsk.activation, run) { activation =>
+        activation.response.result shouldBe Some(JsObject("msg" -> "hello zip".toJson))
+        activation.logs shouldBe defined
+        val logs = activation.logs.get.toString
+        logs should include("This is an example zip used with the docker skeleton action.")
+        logs should not include ("XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX")
+      }
+  }
+
+  it should "create, and invoke an action using a parameter file" in withAssetCleaner(wskprops) {
+    val name = "paramFileAction"
+    val file = Some(TestUtils.getTestActionFilename("argCheck.js"))
+    val argInput = Some(TestUtils.getTestActionFilename("validInput2.json"))
+
+    (wp, assetHelper) =>
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, file)
+      }
+
+      val expectedOutput = JsObject("payload" -> JsString("test"))
+      val run = wsk.action.invoke(name, parameterFile = argInput)
+      withActivation(wsk.activation, run) { activation =>
+        activation.response.result shouldBe Some(expectedOutput)
+      }
+  }
+
+  it should "create an action, and get its individual fields" in withAssetCleaner(wskprops) {
+    val name = "actionFields"
+    val paramInput = Map("payload" -> "test".toJson)
+    val successMsg = s"ok: got action $name, displaying field"
+
+    (wp, assetHelper) =>
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, defaultAction, parameters = paramInput)
+      }
+
+      val expectedParam = JsObject("payload" -> JsString("test"))
+      val ns = wsk.namespace.whois()
+
+      wsk.action.get(name, fieldFilter = Some("name")).stdout should include(s"""$successMsg name\n"$name"""")
+      wsk.action.get(name, fieldFilter = Some("version")).stdout should include(s"""$successMsg version\n"0.0.1"""")
+      wsk.action.get(name, fieldFilter = Some("exec")).stdout should include(s"""$successMsg""")
+      wsk.action
+        .get(name, fieldFilter = Some("exec"))
+        .stdout should include regex (s"""$successMsg exec\n\\{\\s+"kind":\\s+"nodejs:6",\\s+"code":\\s+"\\/\\*\\*[\\\\r]*\\\\n \\* Hello, world.[\\\\r]*\\\\n \\*\\/[\\\\r]*\\\\nfunction main\\(params\\) \\{[\\\\r]*\\\\n    greeting \\= 'hello, ' \\+ params.payload \\+ '!'[\\\\r]*\\\\n    console.log\\(greeting\\);[\\\\r]*\\\\n    return \\{payload: greeting\\}[\\\\r]*\\\\n\\}""")
+      wsk.action
+        .get(name, fieldFilter = Some("parameters"))
+        .stdout should include regex (s"""$successMsg parameters\n\\[\\s+\\{\\s+"key":\\s+"payload",\\s+"value":\\s+"test"\\s+\\}\\s+\\]""")
+      wsk.action
+        .get(name, fieldFilter = Some("annotations"))
+        .stdout should include regex (s"""$successMsg annotations\n\\[\\s+\\{\\s+"key":\\s+"exec",\\s+"value":\\s+"nodejs:6"\\s+\\}\\s+\\]""")
+      wsk.action
+        .get(name, fieldFilter = Some("limits"))
+        .stdout should include regex (s"""$successMsg limits\n\\{\\s+"timeout":\\s+60000,\\s+"memory":\\s+256,\\s+"logs":\\s+10\\s+\\}""")
+      wsk.action
+        .get(name, fieldFilter = Some("namespace"))
+        .stdout should include regex (s"""(?i)$successMsg namespace\n"$ns"""")
+      wsk.action.get(name, fieldFilter = Some("invalid"), expectedExitCode = MISUSE_EXIT).stderr should include(
+        "error: Invalid field filter 'invalid'.")
+      wsk.action.get(name, fieldFilter = Some("publish")).stdout should include(s"""$successMsg publish\nfalse""")
+  }
+
+  /**
+   * Tests creating an action from a malformed js file. This should fail in
+   * some way - preferably when trying to create the action. If not, then
+   * surely when it runs there should be some indication in the logs. Don't
+   * think this is true currently.
+   */
+  it should "create and invoke action with malformed js resulting in activation error" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "MALFORMED"
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, Some(TestUtils.getTestActionFilename("malformed.js")))
+      }
+
+      val run = wsk.action.invoke(name, Map("payload" -> "whatever".toJson))
+      withActivation(wsk.activation, run) { activation =>
+        activation.response.status shouldBe "action developer error"
+        // representing nodejs giving an error when given malformed.js
+        activation.response.result.get.toString should include("ReferenceError")
+      }
+  }
+
+  it should "create and invoke a blocking action resulting in an application error response" in withAssetCleaner(
+    wskprops) { (wp, assetHelper) =>
+    val name = "applicationError"
+    val strErrInput = Map("error" -> "Error message".toJson)
+    val numErrInput = Map("error" -> 502.toJson)
+    val boolErrInput = Map("error" -> true.toJson)
+
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, Some(TestUtils.getTestActionFilename("echo.js")))
     }
 
-    it should "create, and get a package summary" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val packageName = "packageName"
-            val actionName = "actionName"
-            val packageAnnots = Map(
-                "description" -> JsString("Package description"),
-                "parameters" -> JsArray(
-                    JsObject(
-                        "name" -> JsString("paramName1"),
-                        "description" -> JsString("Parameter description 1")),
-                    JsObject(
-                        "name" -> JsString("paramName2"),
-                        "description" -> JsString("Parameter description 2"))))
-            val actionAnnots = Map(
-                "description" -> JsString("Action description"),
-                "parameters" -> JsArray(
-                    JsObject(
-                        "name" -> JsString("paramName1"),
-                        "description" -> JsString("Parameter description 1")),
-                    JsObject(
-                        "name" -> JsString("paramName2"),
-                        "description" -> JsString("Parameter description 2"))))
+    Seq(strErrInput, numErrInput, boolErrInput) foreach { input =>
+      getJSONFromCLIResponse(
+        wsk.action.invoke(name, parameters = input, blocking = true, expectedExitCode = 246).stderr)
+        .fields("response")
+        .asJsObject
+        .fields("result")
+        .asJsObject shouldBe input.toJson.asJsObject
 
-            assetHelper.withCleaner(wsk.pkg, packageName) {
-                (pkg, _) => pkg.create(packageName, annotations = packageAnnots)
-            }
+      wsk.action
+        .invoke(name, parameters = input, blocking = true, result = true, expectedExitCode = 246)
+        .stderr
+        .parseJson
+        .asJsObject shouldBe input.toJson.asJsObject
+    }
+  }
 
-            wsk.action.create(packageName + "/" + actionName, defaultAction, annotations = actionAnnots)
-            val stdout = wsk.pkg.get(packageName, summary = true).stdout
-            val ns = wsk.namespace.whois()
-            wsk.action.delete(packageName + "/" + actionName)
+  it should "create and invoke a blocking action resulting in an failed promise" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "errorResponseObject"
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, Some(TestUtils.getTestActionFilename("asyncError.js")))
+      }
 
-            stdout should include regex (s"(?i)package /$ns/$packageName: Package description\\s*\\(parameters: paramName1, paramName2\\)")
-            stdout should include regex (s"(?i)action /$ns/$packageName/$actionName: Action description\\s*\\(parameters: paramName1, paramName2\\)")
+      val stderr = wsk.action.invoke(name, blocking = true, expectedExitCode = 246).stderr
+      ActivationResult.serdes.read(removeCLIHeader(stderr).parseJson).response.result shouldBe Some {
+        JsObject("error" -> JsObject("msg" -> "failed activation on purpose".toJson))
+      }
+  }
+
+  it should "invoke a blocking action and get only the result" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "basicInvoke"
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, Some(TestUtils.getTestActionFilename("wc.js")))
     }
 
-    it should "create a package with a name that contains spaces" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "package with spaces"
+    wsk.action
+      .invoke(name, Map("payload" -> "one two three".toJson), result = true)
+      .stdout should include regex (""""count": 3""")
+  }
 
-            val res = assetHelper.withCleaner(wsk.pkg, name) {
-                (pkg, _) => pkg.create(name)
-            }
+  it should "create, and get an action summary" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "actionName"
+    val annots = Map(
+      "description" -> JsString("Action description"),
+      "parameters" -> JsArray(
+        JsObject("name" -> JsString("paramName1"), "description" -> JsString("Parameter description 1")),
+        JsObject("name" -> JsString("paramName2"), "description" -> JsString("Parameter description 2"))))
 
-            res.stdout should include(s"ok: created package $name")
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, defaultAction, annotations = annots)
     }
 
-    it should "create a package, and get its individual fields" in withAssetCleaner(wskprops) {
-        val name = "packageFields"
-        val paramInput = Map("payload" -> "test".toJson)
-        val successMsg = s"ok: got package $name, displaying field"
+    val stdout = wsk.action.get(name, summary = true).stdout
+    val ns = wsk.namespace.whois()
 
-        (wp, assetHelper) =>
-            assetHelper.withCleaner(wsk.pkg, name) {
-                (pkg, _) => pkg.create(name, parameters = paramInput)
-            }
+    stdout should include regex (s"(?i)action /$ns/$name: Action description\\s*\\(parameters: paramName1, paramName2\\)")
+  }
 
-            val expectedParam = JsObject("payload" -> JsString("test"))
-            val ns = wsk.namespace.whois()
+  it should "create an action with a name that contains spaces" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "action with spaces"
 
-            wsk.pkg.get(name, fieldFilter = Some("namespace")).stdout should include regex (s"""(?i)$successMsg namespace\n"$ns"""")
-            wsk.pkg.get(name, fieldFilter = Some("name")).stdout should include(s"""$successMsg name\n"$name"""")
-            wsk.pkg.get(name, fieldFilter = Some("version")).stdout should include(s"""$successMsg version\n"0.0.1"""")
-            wsk.pkg.get(name, fieldFilter = Some("publish")).stdout should include(s"""$successMsg publish\nfalse""")
-            wsk.pkg.get(name, fieldFilter = Some("binding")).stdout should include regex (s"""\\{\\}""")
-            wsk.pkg.get(name, fieldFilter = Some("invalid"), expectedExitCode = ERROR_EXIT).stderr should include("error: Invalid field filter 'invalid'.")
+    val res = assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, defaultAction)
     }
 
-    it should "reject creation of duplication packages" in withAssetCleaner(wskprops) {
-        val name = "dupePackage"
+    res.stdout should include(s"ok: created action $name")
+  }
 
-        (wp, assetHelper) => assetHelper.withCleaner(wsk.pkg, name) {
-            (pkg, _) => pkg.create(name)
-        }
+  it should "create an action, and invoke an action that returns an empty JSON object" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "emptyJSONAction"
 
-        val stderr = wsk.pkg.create(name, expectedExitCode = CONFLICT).stderr
-        stderr should include regex (s"""Unable to create package '$name': resource already exists \\(code \\d+\\)""")
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, Some(TestUtils.getTestActionFilename("emptyJSONResult.js")))
+      }
+
+      val stdout = wsk.action.invoke(name, result = true).stdout
+      stdout.parseJson.asJsObject shouldBe JsObject()
+  }
+
+  it should "create, and invoke an action that times out to ensure the proper response is received" in withAssetCleaner(
+    wskprops) { (wp, assetHelper) =>
+    val name = "sleepAction"
+    val params = Map("payload" -> "100000".toJson)
+    val allowedActionDuration = 120 seconds
+    val res = assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, Some(TestUtils.getTestActionFilename("timeout.js")), timeout = Some(allowedActionDuration))
+      action.invoke(name, parameters = params, result = true, expectedExitCode = ACCEPTED)
     }
 
-    it should "reject delete of package that does not exist" in {
-        val name = "nonexistentPackage"
-        val stderr = wsk.pkg.delete(name, expectedExitCode = NOT_FOUND).stderr
-        stderr should include regex (s"""Unable to delete package '$name'. The requested resource does not exist. \\(code \\d+\\)""")
+    res.stderr should include("""but the request has not yet finished""")
+  }
+
+  it should "create, and get docker action get ensure exec code is omitted" in withAssetCleaner(wskprops) {
+    val name = "dockerContainer"
+    (wp, assetHelper) =>
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, None, docker = Some("fake-container"))
+      }
+
+      wsk.action.get(name).stdout should not include (""""code"""")
+  }
+
+  behavior of "Wsk Trigger CLI"
+
+  it should "create, update, get, fire and list trigger" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "listTriggers"
+    val params = Map("a" -> "A".toJson)
+    assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+      trigger.create(name, parameters = params)
+      trigger.create(name, update = true)
+    }
+    val stdout = wsk.trigger.get(name).stdout
+    stdout should include regex (""""key": "a"""")
+    stdout should include regex (""""value": "A"""")
+    stdout should include regex (""""publish": false""")
+    stdout should include regex (""""version": "0.0.2"""")
+
+    val dynamicParams = Map("t" -> "T".toJson)
+    val run = wsk.trigger.fire(name, dynamicParams)
+    withActivation(wsk.activation, run) { activation =>
+      activation.response.result shouldBe Some(dynamicParams.toJson)
+      activation.duration shouldBe 0L // shouldn't exist but CLI generates it
+      activation.end shouldBe Instant.EPOCH // shouldn't exist but CLI generates it
     }
 
-    it should "reject get of package that does not exist" in {
-        val name = "nonexistentPackage"
-        val stderr = wsk.pkg.get(name, expectedExitCode = NOT_FOUND).stderr
-        stderr should include regex (s"""Unable to get package '$name': The requested resource does not exist. \\(code \\d+\\)""")
+    val runWithNoParams = wsk.trigger.fire(name, Map())
+    withActivation(wsk.activation, runWithNoParams) { activation =>
+      activation.response.result shouldBe Some(JsObject())
+      activation.duration shouldBe 0L // shouldn't exist but CLI generates it
+      activation.end shouldBe Instant.EPOCH // shouldn't exist but CLI generates it
     }
 
-    behavior of "Wsk Action CLI"
+    wsk.trigger.list().stdout should include(name)
+  }
 
-    it should "create the same action twice with different cases" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            assetHelper.withCleaner(wsk.action, "TWICE") { (action, name) => action.create(name, defaultAction) }
-            assetHelper.withCleaner(wsk.action, "twice") { (action, name) => action.create(name, defaultAction) }
+  it should "create, and get a trigger summary" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "triggerName"
+    val annots = Map(
+      "description" -> JsString("Trigger description"),
+      "parameters" -> JsArray(
+        JsObject("name" -> JsString("paramName1"), "description" -> JsString("Parameter description 1")),
+        JsObject("name" -> JsString("paramName2"), "description" -> JsString("Parameter description 2"))))
+
+    assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+      trigger.create(name, annotations = annots)
     }
 
-    it should "create, update, get and list an action" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "createAndUpdate"
-            val file = Some(TestUtils.getTestActionFilename("hello.js"))
-            val params = Map("a" -> "A".toJson)
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(name, file, parameters = params)
-                    action.create(name, None, parameters = Map("b" -> "B".toJson), update = true)
-            }
+    val stdout = wsk.trigger.get(name, summary = true).stdout
+    val ns = wsk.namespace.whois()
 
-            val stdout = wsk.action.get(name).stdout
-            stdout should not include regex(""""key": "a"""")
-            stdout should not include regex(""""value": "A"""")
-            stdout should include regex (""""key": "b""")
-            stdout should include regex (""""value": "B"""")
-            stdout should include regex (""""publish": false""")
-            stdout should include regex (""""version": "0.0.2"""")
-            wsk.action.list().stdout should include(name)
+    stdout should include regex (s"trigger /$ns/$name: Trigger description\\s*\\(parameters: paramName1, paramName2\\)")
+  }
+
+  it should "create a trigger with a name that contains spaces" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "trigger with spaces"
+
+    val res = assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+      trigger.create(name)
     }
 
-    it should "reject create of an action that already exists" in withAssetCleaner(wskprops) {
-        val name = "dupeAction"
-        val file = Some(TestUtils.getTestActionFilename("echo.js"))
+    res.stdout should include regex (s"ok: created trigger $name")
+  }
 
-        (wp, assetHelper) => assetHelper.withCleaner(wsk.action, name) {
-            (action, _) => action.create(name, file)
-        }
+  it should "create, and fire a trigger using a parameter file" in withAssetCleaner(wskprops) {
+    val name = "paramFileTrigger"
+    val file = Some(TestUtils.getTestActionFilename("argCheck.js"))
+    val argInput = Some(TestUtils.getTestActionFilename("validInput2.json"))
 
-        val stderr = wsk.action.create(name, file, expectedExitCode = CONFLICT).stderr
-        stderr should include regex (s"""Unable to create action '$name': resource already exists \\(code \\d+\\)""")
+    (wp, assetHelper) =>
+      assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+        trigger.create(name)
+      }
+
+      val expectedOutput = JsObject("payload" -> JsString("test"))
+      val run = wsk.trigger.fire(name, parameterFile = argInput)
+      withActivation(wsk.activation, run) { activation =>
+        activation.response.result shouldBe Some(expectedOutput)
+      }
+  }
+
+  it should "create a trigger, and get its individual fields" in withAssetCleaner(wskprops) {
+    val name = "triggerFields"
+    val paramInput = Map("payload" -> "test".toJson)
+    val successMsg = s"ok: got trigger $name, displaying field"
+
+    (wp, assetHelper) =>
+      assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+        trigger.create(name, parameters = paramInput)
+      }
+
+      val expectedParam = JsObject("payload" -> JsString("test"))
+      val ns = wsk.namespace.whois()
+
+      wsk.trigger
+        .get(name, fieldFilter = Some("namespace"))
+        .stdout should include regex (s"""(?i)$successMsg namespace\n"$ns"""")
+      wsk.trigger.get(name, fieldFilter = Some("name")).stdout should include(s"""$successMsg name\n"$name"""")
+      wsk.trigger.get(name, fieldFilter = Some("version")).stdout should include(s"""$successMsg version\n"0.0.1"""")
+      wsk.trigger.get(name, fieldFilter = Some("publish")).stdout should include(s"""$successMsg publish\nfalse""")
+      wsk.trigger.get(name, fieldFilter = Some("annotations")).stdout should include(s"""$successMsg annotations\n[]""")
+      wsk.trigger
+        .get(name, fieldFilter = Some("parameters"))
+        .stdout should include regex (s"""$successMsg parameters\n\\[\\s+\\{\\s+"key":\\s+"payload",\\s+"value":\\s+"test"\\s+\\}\\s+\\]""")
+      wsk.trigger.get(name, fieldFilter = Some("limits")).stdout should include(s"""$successMsg limits\n{}""")
+      wsk.trigger.get(name, fieldFilter = Some("invalid"), expectedExitCode = ERROR_EXIT).stderr should include(
+        "error: Invalid field filter 'invalid'.")
+  }
+
+  it should "create, and fire a trigger to ensure result is empty" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "emptyResultTrigger"
+    assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+      trigger.create(name)
     }
 
-    it should "reject delete of action that does not exist" in {
-        val name = "nonexistentAction"
-        val stderr = wsk.action.delete(name, expectedExitCode = NOT_FOUND).stderr
-        stderr should include regex (s"""Unable to delete action '$name'. The requested resource does not exist. \\(code \\d+\\)""")
+    val run = wsk.trigger.fire(name)
+    withActivation(wsk.activation, run) { activation =>
+      activation.response.result shouldBe Some(JsObject())
+    }
+  }
+
+  it should "reject creation of duplicate triggers" in withAssetCleaner(wskprops) {
+    val name = "dupeTrigger"
+
+    (wp, assetHelper) =>
+      assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+        trigger.create(name)
+      }
+
+      val stderr = wsk.trigger.create(name, expectedExitCode = CONFLICT).stderr
+      stderr should include regex (s"""Unable to create trigger '$name': resource already exists \\(code \\d+\\)""")
+  }
+
+  it should "reject delete of trigger that does not exist" in {
+    val name = "nonexistentTrigger"
+    val stderr = wsk.trigger.delete(name, expectedExitCode = NOT_FOUND).stderr
+    stderr should include regex (s"""Unable to get trigger '$name'. The requested resource does not exist. \\(code \\d+\\)""")
+  }
+
+  it should "reject get of trigger that does not exist" in {
+    val name = "nonexistentTrigger"
+    val stderr = wsk.trigger.get(name, expectedExitCode = NOT_FOUND).stderr
+    stderr should include regex (s"""Unable to get trigger '$name': The requested resource does not exist. \\(code \\d+\\)""")
+  }
+
+  it should "reject firing of a trigger that does not exist" in {
+    val name = "nonexistentTrigger"
+    val stderr = wsk.trigger.fire(name, expectedExitCode = NOT_FOUND).stderr
+    stderr should include regex (s"""Unable to fire trigger '$name': The requested resource does not exist. \\(code \\d+\\)""")
+  }
+
+  behavior of "Wsk Rule CLI"
+
+  it should "create rule, get rule, update rule and list rule" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val ruleName = "listRules"
+    val triggerName = "listRulesTrigger"
+    val actionName = "listRulesAction"
+
+    assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
+      trigger.create(name)
+    }
+    assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
+      action.create(name, defaultAction)
+    }
+    assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
+      rule.create(name, trigger = triggerName, action = actionName)
     }
 
-    it should "reject invocation of action that does not exist" in {
-        val name = "nonexistentAction"
-        val stderr = wsk.action.invoke(name, expectedExitCode = NOT_FOUND).stderr
-        stderr should include regex (s"""Unable to invoke action '$name': The requested resource does not exist. \\(code \\d+\\)""")
+    // finally, we perform the update, and expect success this time
+    wsk.rule.create(ruleName, trigger = triggerName, action = actionName, update = true)
+
+    val stdout = wsk.rule.get(ruleName).stdout
+    stdout should include(ruleName)
+    stdout should include(triggerName)
+    stdout should include(actionName)
+    stdout should include regex (""""version": "0.0.2"""")
+    wsk.rule.list().stdout should include(ruleName)
+  }
+
+  it should "create rule, get rule, ensure rule is enabled by default" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val ruleName = "enabledRule"
+      val triggerName = "enabledRuleTrigger"
+      val actionName = "enabledRuleAction"
+
+      assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
+        trigger.create(name)
+      }
+      assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
+        action.create(name, defaultAction)
+      }
+      assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
+        rule.create(name, trigger = triggerName, action = actionName)
+      }
+
+      val stdout = wsk.rule.get(ruleName).stdout
+      stdout should include regex (""""status":\s*"active"""")
+  }
+
+  it should "display a rule summary when --summary flag is used with 'wsk rule get'" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val ruleName = "mySummaryRule"
+      val triggerName = "summaryRuleTrigger"
+      val actionName = "summaryRuleAction"
+
+      assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
+        trigger.create(name)
+      }
+      assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
+        action.create(name, defaultAction)
+      }
+      assetHelper.withCleaner(wsk.rule, ruleName, confirmDelete = false) { (rule, name) =>
+        rule.create(name, trigger = triggerName, action = actionName)
+      }
+
+      // Summary namespace should match one of the allowable namespaces (typically 'guest')
+      val ns = wsk.namespace.whois()
+      val stdout = wsk.rule.get(ruleName, summary = true).stdout
+
+      stdout should include regex (s"(?i)rule /$ns/$ruleName\\s*\\(status: active\\)")
+  }
+
+  it should "create a rule, and get its individual fields" in withAssetCleaner(wskprops) {
+    val ruleName = "ruleFields"
+    val triggerName = "ruleTriggerFields"
+    val actionName = "ruleActionFields"
+    val paramInput = Map("payload" -> "test".toJson)
+    val successMsg = s"ok: got rule $ruleName, displaying field"
+
+    (wp, assetHelper) =>
+      assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
+        trigger.create(name)
+      }
+      assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
+        action.create(name, defaultAction)
+      }
+      assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
+        rule.create(name, trigger = triggerName, action = actionName)
+      }
+
+      val ns = wsk.namespace.whois()
+      wsk.rule
+        .get(ruleName, fieldFilter = Some("namespace"))
+        .stdout should include regex (s"""(?i)$successMsg namespace\n"$ns"""")
+      wsk.rule.get(ruleName, fieldFilter = Some("name")).stdout should include(s"""$successMsg name\n"$ruleName"""")
+      wsk.rule.get(ruleName, fieldFilter = Some("version")).stdout should include(s"""$successMsg version\n"0.0.1"\n""")
+      wsk.rule.get(ruleName, fieldFilter = Some("status")).stdout should include(s"""$successMsg status\n"active"""")
+      val trigger = wsk.rule.get(ruleName, fieldFilter = Some("trigger")).stdout
+      trigger should include regex (s"""$successMsg trigger\n""")
+      trigger should include(triggerName)
+      trigger should not include (actionName)
+      val action = wsk.rule.get(ruleName, fieldFilter = Some("action")).stdout
+      action should include regex (s"""$successMsg action\n""")
+      action should include(actionName)
+      action should not include (triggerName)
+  }
+
+  it should "reject creation of duplicate rules" in withAssetCleaner(wskprops) {
+    val ruleName = "dupeRule"
+    val triggerName = "triggerName"
+    val actionName = "actionName"
+
+    (wp, assetHelper) =>
+      assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
+        trigger.create(name)
+      }
+      assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
+        action.create(name, defaultAction)
+      }
+      assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
+        rule.create(name, trigger = triggerName, action = actionName)
+      }
+
+      val stderr =
+        wsk.rule.create(ruleName, trigger = triggerName, action = actionName, expectedExitCode = CONFLICT).stderr
+      stderr should include regex (s"""Unable to create rule '$ruleName': resource already exists \\(code \\d+\\)""")
+  }
+
+  it should "reject delete of rule that does not exist" in {
+    val name = "nonexistentRule"
+    val stderr = wsk.rule.delete(name, expectedExitCode = NOT_FOUND).stderr
+    stderr should include regex (s"""Unable to delete rule '$name'. The requested resource does not exist. \\(code \\d+\\)""")
+  }
+
+  it should "reject enable of rule that does not exist" in {
+    val name = "nonexistentRule"
+    val stderr = wsk.rule.enable(name, expectedExitCode = NOT_FOUND).stderr
+    stderr should include regex (s"""Unable to enable rule '$name': The requested resource does not exist. \\(code \\d+\\)""")
+  }
+
+  it should "reject disable of rule that does not exist" in {
+    val name = "nonexistentRule"
+    val stderr = wsk.rule.disable(name, expectedExitCode = NOT_FOUND).stderr
+    stderr should include regex (s"""Unable to disable rule '$name': The requested resource does not exist. \\(code \\d+\\)""")
+  }
+
+  it should "reject status of rule that does not exist" in {
+    val name = "nonexistentRule"
+    val stderr = wsk.rule.state(name, expectedExitCode = NOT_FOUND).stderr
+    stderr should include regex (s"""Unable to get status of rule '$name': The requested resource does not exist. \\(code \\d+\\)""")
+  }
+
+  it should "reject get of rule that does not exist" in {
+    val name = "nonexistentRule"
+    val stderr = wsk.rule.get(name, expectedExitCode = NOT_FOUND).stderr
+    stderr should include regex (s"""Unable to get rule '$name': The requested resource does not exist. \\(code \\d+\\)""")
+  }
+
+  behavior of "Wsk Namespace CLI"
+
+  it should "return a list of exactly one namespace" in {
+    val lines = wsk.namespace.list().stdout.lines.toSeq
+    lines should have size 2
+    lines.head shouldBe "namespaces"
+    lines(1).trim should not be empty
+  }
+
+  it should "list entities in default namespace" in {
+    // use a fresh wsk props instance that is guaranteed to use
+    // the default namespace
+    wsk.namespace.get(expectedExitCode = SUCCESS_EXIT)(WskProps()).stdout should include("default")
+  }
+
+  it should "not list entities with an invalid namespace" in {
+    val namespace = "fakeNamespace"
+    val stderr = wsk.namespace.get(Some(s"/${namespace}"), expectedExitCode = FORBIDDEN).stderr
+
+    stderr should include(s"Unable to obtain the list of entities for namespace '${namespace}'")
+  }
+
+  behavior of "Wsk Activation CLI"
+
+  it should "create a trigger, and fire a trigger to get its individual fields from an activation" in withAssetCleaner(
+    wskprops) { (wp, assetHelper) =>
+    val name = "activationFields"
+
+    assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+      trigger.create(name)
     }
 
-    it should "reject get of an action that does not exist" in {
-        val name = "nonexistentAction"
-        val stderr = wsk.action.get(name, expectedExitCode = NOT_FOUND).stderr
-        stderr should include regex (s"""Unable to get action '$name': The requested resource does not exist. \\(code \\d+\\)""")
+    val ns = s""""${wsk.namespace.whois()}""""
+    val run = wsk.trigger.fire(name)
+    withActivation(wsk.activation, run) { activation =>
+      val successMsg = s"ok: got activation ${activation.activationId}, displaying field"
+      wsk.activation
+        .get(Some(activation.activationId), fieldFilter = Some("namespace"))
+        .stdout should include regex (s"""(?i)$successMsg namespace\n$ns""")
+      wsk.activation.get(Some(activation.activationId), fieldFilter = Some("name")).stdout should include(
+        s"""$successMsg name\n"$name"""")
+      wsk.activation.get(Some(activation.activationId), fieldFilter = Some("version")).stdout should include(
+        s"""$successMsg version\n"0.0.1"""")
+      wsk.activation.get(Some(activation.activationId), fieldFilter = Some("publish")).stdout should include(
+        s"""$successMsg publish\nfalse""")
+      wsk.activation
+        .get(Some(activation.activationId), fieldFilter = Some("subject"))
+        .stdout should include regex (s"""(?i)$successMsg subject\n""")
+      wsk.activation.get(Some(activation.activationId), fieldFilter = Some("activationid")).stdout should include(
+        s"""$successMsg activationid\n"${activation.activationId}""")
+      wsk.activation
+        .get(Some(activation.activationId), fieldFilter = Some("start"))
+        .stdout should include regex (s"""$successMsg start\n\\d""")
+      wsk.activation
+        .get(Some(activation.activationId), fieldFilter = Some("end"))
+        .stdout should include regex (s"""$successMsg end\n\\d""")
+      wsk.activation
+        .get(Some(activation.activationId), fieldFilter = Some("duration"))
+        .stdout should include regex (s"""$successMsg duration\n\\d""")
+      wsk.activation.get(Some(activation.activationId), fieldFilter = Some("annotations")).stdout should include(
+        s"""$successMsg annotations\n[]""")
     }
-
-    it should "create, and invoke an action that utilizes a docker container" in withAssetCleaner(wskprops) {
-        val name = "dockerContainer"
-        (wp, assetHelper) => assetHelper.withCleaner(wsk.action, name) {
-            // this docker image will be need to be pulled from dockerhub and hence has to be published there first
-            (action, _) => action.create(name, None, docker = Some("openwhisk/example"))
-        }
-
-        val args = Map("payload" -> "test".toJson)
-        val run = wsk.action.invoke(name, args)
-        withActivation(wsk.activation, run) {
-            activation =>
-                activation.response.result shouldBe Some(JsObject(
-                    "args" -> args.toJson,
-                    "msg" -> "Hello from arbitrary C program!".toJson))
-        }
-    }
-
-    it should "create, and invoke an action that utilizes dockerskeleton with native zip" in withAssetCleaner(wskprops) {
-        val name = "dockerContainerWithZip"
-        (wp, assetHelper) => assetHelper.withCleaner(wsk.action, name) {
-            // this docker image will be need to be pulled from dockerhub and hence has to be published there first
-            (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("blackbox.zip")), kind = Some("native"))
-        }
-
-        val run = wsk.action.invoke(name, Map())
-        withActivation(wsk.activation, run) {
-            activation =>
-                activation.response.result shouldBe Some(JsObject(
-                    "msg" -> "hello zip".toJson))
-                activation.logs shouldBe defined
-                val logs = activation.logs.get.toString
-                logs should include("This is an example zip used with the docker skeleton action.")
-                logs should not include ("XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX")
-        }
-    }
-
-    it should "create, and invoke an action using a parameter file" in withAssetCleaner(wskprops) {
-        val name = "paramFileAction"
-        val file = Some(TestUtils.getTestActionFilename("argCheck.js"))
-        val argInput = Some(TestUtils.getTestActionFilename("validInput2.json"))
-
-        (wp, assetHelper) => assetHelper.withCleaner(wsk.action, name) {
-            (action, _) => action.create(name, file)
-        }
-
-        val expectedOutput = JsObject("payload" -> JsString("test"))
-        val run = wsk.action.invoke(name, parameterFile = argInput)
-        withActivation(wsk.activation, run) {
-            activation => activation.response.result shouldBe Some(expectedOutput)
-        }
-    }
-
-    it should "create an action, and get its individual fields" in withAssetCleaner(wskprops) {
-        val name = "actionFields"
-        val paramInput = Map("payload" -> "test".toJson)
-        val successMsg = s"ok: got action $name, displaying field"
-
-        (wp, assetHelper) => assetHelper.withCleaner(wsk.action, name) {
-            (action, _) => action.create(name, defaultAction, parameters = paramInput)
-        }
-
-        val expectedParam = JsObject("payload" -> JsString("test"))
-        val ns = wsk.namespace.whois()
-
-        wsk.action.get(name, fieldFilter = Some("name")).stdout should include(s"""$successMsg name\n"$name"""")
-        wsk.action.get(name, fieldFilter = Some("version")).stdout should include(s"""$successMsg version\n"0.0.1"""")
-        wsk.action.get(name, fieldFilter = Some("exec")).stdout should include(s"""$successMsg""")
-        wsk.action.get(name, fieldFilter = Some("exec")).stdout should include regex (s"""$successMsg exec\n\\{\\s+"kind":\\s+"nodejs:6",\\s+"code":\\s+"\\/\\*\\*[\\\\r]*\\\\n \\* Hello, world.[\\\\r]*\\\\n \\*\\/[\\\\r]*\\\\nfunction main\\(params\\) \\{[\\\\r]*\\\\n    greeting \\= 'hello, ' \\+ params.payload \\+ '!'[\\\\r]*\\\\n    console.log\\(greeting\\);[\\\\r]*\\\\n    return \\{payload: greeting\\}[\\\\r]*\\\\n\\}""")
-        wsk.action.get(name, fieldFilter = Some("parameters")).stdout should include regex (s"""$successMsg parameters\n\\[\\s+\\{\\s+"key":\\s+"payload",\\s+"value":\\s+"test"\\s+\\}\\s+\\]""")
-        wsk.action.get(name, fieldFilter = Some("annotations")).stdout should include regex (s"""$successMsg annotations\n\\[\\s+\\{\\s+"key":\\s+"exec",\\s+"value":\\s+"nodejs:6"\\s+\\}\\s+\\]""")
-        wsk.action.get(name, fieldFilter = Some("limits")).stdout should include regex (s"""$successMsg limits\n\\{\\s+"timeout":\\s+60000,\\s+"memory":\\s+256,\\s+"logs":\\s+10\\s+\\}""")
-        wsk.action.get(name, fieldFilter = Some("namespace")).stdout should include regex (s"""(?i)$successMsg namespace\n"$ns"""")
-        wsk.action.get(name, fieldFilter = Some("invalid"), expectedExitCode = MISUSE_EXIT).stderr should include("error: Invalid field filter 'invalid'.")
-        wsk.action.get(name, fieldFilter = Some("publish")).stdout should include(s"""$successMsg publish\nfalse""")
-    }
-
-    /**
-     * Tests creating an action from a malformed js file. This should fail in
-     * some way - preferably when trying to create the action. If not, then
-     * surely when it runs there should be some indication in the logs. Don't
-     * think this is true currently.
-     */
-    it should "create and invoke action with malformed js resulting in activation error" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "MALFORMED"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("malformed.js")))
-            }
-
-            val run = wsk.action.invoke(name, Map("payload" -> "whatever".toJson))
-            withActivation(wsk.activation, run) {
-                activation =>
-                    activation.response.status shouldBe "action developer error"
-                    // representing nodejs giving an error when given malformed.js
-                    activation.response.result.get.toString should include("ReferenceError")
-            }
-    }
-
-    it should "create and invoke a blocking action resulting in an application error response" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "applicationError"
-            val strErrInput = Map("error" -> "Error message".toJson)
-            val numErrInput = Map("error" -> 502.toJson)
-            val boolErrInput = Map("error" -> true.toJson)
-
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("echo.js")))
-            }
-
-            Seq(strErrInput, numErrInput, boolErrInput) foreach { input =>
-                getJSONFromCLIResponse(wsk.action.invoke(name, parameters = input, blocking = true, expectedExitCode = 246).stderr).
-                    fields("response").asJsObject.fields("result").asJsObject shouldBe input.toJson.asJsObject
-
-                wsk.action.invoke(name, parameters = input, blocking = true, result = true, expectedExitCode = 246).
-                    stderr.parseJson.asJsObject shouldBe input.toJson.asJsObject
-            }
-    }
-
-    it should "create and invoke a blocking action resulting in an failed promise" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "errorResponseObject"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("asyncError.js")))
-            }
-
-            val stderr = wsk.action.invoke(name, blocking = true, expectedExitCode = 246).stderr
-            ActivationResult.serdes.read(removeCLIHeader(stderr).parseJson).response.result shouldBe Some {
-                JsObject("error" -> JsObject("msg" -> "failed activation on purpose".toJson))
-            }
-    }
-
-    it should "invoke a blocking action and get only the result" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "basicInvoke"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("wc.js")))
-            }
-
-            wsk.action.invoke(name, Map("payload" -> "one two three".toJson), result = true)
-                .stdout should include regex (""""count": 3""")
-    }
-
-    it should "create, and get an action summary" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "actionName"
-            val annots = Map(
-                "description" -> JsString("Action description"),
-                "parameters" -> JsArray(
-                    JsObject(
-                        "name" -> JsString("paramName1"),
-                        "description" -> JsString("Parameter description 1")),
-                    JsObject(
-                        "name" -> JsString("paramName2"),
-                        "description" -> JsString("Parameter description 2"))))
-
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(name, defaultAction, annotations = annots)
-            }
-
-            val stdout = wsk.action.get(name, summary = true).stdout
-            val ns = wsk.namespace.whois()
-
-            stdout should include regex (s"(?i)action /$ns/$name: Action description\\s*\\(parameters: paramName1, paramName2\\)")
-    }
-
-    it should "create an action with a name that contains spaces" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "action with spaces"
-
-            val res = assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(name, defaultAction)
-            }
-
-            res.stdout should include(s"ok: created action $name")
-    }
-
-    it should "create an action, and invoke an action that returns an empty JSON object" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "emptyJSONAction"
-
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(name, Some(TestUtils.getTestActionFilename("emptyJSONResult.js")))
-            }
-
-            val stdout = wsk.action.invoke(name, result = true).stdout
-            stdout.parseJson.asJsObject shouldBe JsObject()
-    }
-
-    it should "create, and invoke an action that times out to ensure the proper response is received" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "sleepAction"
-            val params = Map("payload" -> "100000".toJson)
-            val allowedActionDuration = 120 seconds
-            val res = assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(name, Some(TestUtils.getTestActionFilename("timeout.js")),
-                        timeout = Some(allowedActionDuration))
-                    action.invoke(name, parameters = params, result = true, expectedExitCode = ACCEPTED)
-            }
-
-            res.stderr should include("""but the request has not yet finished""")
-    }
-
-    it should "create, and get docker action get ensure exec code is omitted" in withAssetCleaner(wskprops) {
-        val name = "dockerContainer"
-        (wp, assetHelper) => assetHelper.withCleaner(wsk.action, name) {
-            (action, _) => action.create(name, None, docker = Some("fake-container"))
-        }
-
-        wsk.action.get(name).stdout should not include (""""code"""")
-    }
-
-    behavior of "Wsk Trigger CLI"
-
-    it should "create, update, get, fire and list trigger" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "listTriggers"
-            val params = Map("a" -> "A".toJson)
-            assetHelper.withCleaner(wsk.trigger, name) {
-                (trigger, _) =>
-                    trigger.create(name, parameters = params)
-                    trigger.create(name, update = true)
-            }
-            val stdout = wsk.trigger.get(name).stdout
-            stdout should include regex (""""key": "a"""")
-            stdout should include regex (""""value": "A"""")
-            stdout should include regex (""""publish": false""")
-            stdout should include regex (""""version": "0.0.2"""")
-
-            val dynamicParams = Map("t" -> "T".toJson)
-            val run = wsk.trigger.fire(name, dynamicParams)
-            withActivation(wsk.activation, run) {
-                activation =>
-                    activation.response.result shouldBe Some(dynamicParams.toJson)
-                    activation.duration shouldBe 0L // shouldn't exist but CLI generates it
-                    activation.end shouldBe Instant.EPOCH // shouldn't exist but CLI generates it
-            }
-
-            val runWithNoParams = wsk.trigger.fire(name, Map())
-            withActivation(wsk.activation, runWithNoParams) {
-                activation =>
-                    activation.response.result shouldBe Some(JsObject())
-                    activation.duration shouldBe 0L // shouldn't exist but CLI generates it
-                    activation.end shouldBe Instant.EPOCH // shouldn't exist but CLI generates it
-            }
-
-            wsk.trigger.list().stdout should include(name)
-    }
-
-    it should "create, and get a trigger summary" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "triggerName"
-            val annots = Map(
-                "description" -> JsString("Trigger description"),
-                "parameters" -> JsArray(
-                    JsObject(
-                        "name" -> JsString("paramName1"),
-                        "description" -> JsString("Parameter description 1")),
-                    JsObject(
-                        "name" -> JsString("paramName2"),
-                        "description" -> JsString("Parameter description 2"))))
-
-            assetHelper.withCleaner(wsk.trigger, name) {
-                (trigger, _) =>
-                    trigger.create(name, annotations = annots)
-            }
-
-            val stdout = wsk.trigger.get(name, summary = true).stdout
-            val ns = wsk.namespace.whois()
-
-            stdout should include regex (s"trigger /$ns/$name: Trigger description\\s*\\(parameters: paramName1, paramName2\\)")
-    }
-
-    it should "create a trigger with a name that contains spaces" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "trigger with spaces"
-
-            val res = assetHelper.withCleaner(wsk.trigger, name) {
-                (trigger, _) => trigger.create(name)
-            }
-
-            res.stdout should include regex (s"ok: created trigger $name")
-    }
-
-    it should "create, and fire a trigger using a parameter file" in withAssetCleaner(wskprops) {
-        val name = "paramFileTrigger"
-        val file = Some(TestUtils.getTestActionFilename("argCheck.js"))
-        val argInput = Some(TestUtils.getTestActionFilename("validInput2.json"))
-
-        (wp, assetHelper) => assetHelper.withCleaner(wsk.trigger, name) {
-            (trigger, _) => trigger.create(name)
-        }
-
-        val expectedOutput = JsObject("payload" -> JsString("test"))
-        val run = wsk.trigger.fire(name, parameterFile = argInput)
-        withActivation(wsk.activation, run) {
-            activation => activation.response.result shouldBe Some(expectedOutput)
-        }
-    }
-
-    it should "create a trigger, and get its individual fields" in withAssetCleaner(wskprops) {
-        val name = "triggerFields"
-        val paramInput = Map("payload" -> "test".toJson)
-        val successMsg = s"ok: got trigger $name, displaying field"
-
-        (wp, assetHelper) => assetHelper.withCleaner(wsk.trigger, name) {
-            (trigger, _) => trigger.create(name, parameters = paramInput)
-        }
-
-        val expectedParam = JsObject("payload" -> JsString("test"))
-        val ns = wsk.namespace.whois()
-
-        wsk.trigger.get(name, fieldFilter = Some("namespace")).stdout should include regex (s"""(?i)$successMsg namespace\n"$ns"""")
-        wsk.trigger.get(name, fieldFilter = Some("name")).stdout should include(s"""$successMsg name\n"$name"""")
-        wsk.trigger.get(name, fieldFilter = Some("version")).stdout should include(s"""$successMsg version\n"0.0.1"""")
-        wsk.trigger.get(name, fieldFilter = Some("publish")).stdout should include(s"""$successMsg publish\nfalse""")
-        wsk.trigger.get(name, fieldFilter = Some("annotations")).stdout should include(s"""$successMsg annotations\n[]""")
-        wsk.trigger.get(name, fieldFilter = Some("parameters")).stdout should include regex (s"""$successMsg parameters\n\\[\\s+\\{\\s+"key":\\s+"payload",\\s+"value":\\s+"test"\\s+\\}\\s+\\]""")
-        wsk.trigger.get(name, fieldFilter = Some("limits")).stdout should include(s"""$successMsg limits\n{}""")
-        wsk.trigger.get(name, fieldFilter = Some("invalid"), expectedExitCode = ERROR_EXIT).stderr should include("error: Invalid field filter 'invalid'.")
-    }
-
-    it should "create, and fire a trigger to ensure result is empty" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "emptyResultTrigger"
-            assetHelper.withCleaner(wsk.trigger, name) {
-                (trigger, _) => trigger.create(name)
-            }
-
-            val run = wsk.trigger.fire(name)
-            withActivation(wsk.activation, run) {
-                activation => activation.response.result shouldBe Some(JsObject())
-            }
-    }
-
-    it should "reject creation of duplicate triggers" in withAssetCleaner(wskprops) {
-        val name = "dupeTrigger"
-
-        (wp, assetHelper) => assetHelper.withCleaner(wsk.trigger, name) {
-            (trigger, _) => trigger.create(name)
-        }
-
-        val stderr = wsk.trigger.create(name, expectedExitCode = CONFLICT).stderr
-        stderr should include regex (s"""Unable to create trigger '$name': resource already exists \\(code \\d+\\)""")
-    }
-
-    it should "reject delete of trigger that does not exist" in {
-        val name = "nonexistentTrigger"
-        val stderr = wsk.trigger.delete(name, expectedExitCode = NOT_FOUND).stderr
-        stderr should include regex (s"""Unable to get trigger '$name'. The requested resource does not exist. \\(code \\d+\\)""")
-    }
-
-    it should "reject get of trigger that does not exist" in {
-        val name = "nonexistentTrigger"
-        val stderr = wsk.trigger.get(name, expectedExitCode = NOT_FOUND).stderr
-        stderr should include regex (s"""Unable to get trigger '$name': The requested resource does not exist. \\(code \\d+\\)""")
-    }
-
-    it should "reject firing of a trigger that does not exist" in {
-        val name = "nonexistentTrigger"
-        val stderr = wsk.trigger.fire(name, expectedExitCode = NOT_FOUND).stderr
-        stderr should include regex (s"""Unable to fire trigger '$name': The requested resource does not exist. \\(code \\d+\\)""")
-    }
-
-    behavior of "Wsk Rule CLI"
-
-    it should "create rule, get rule, update rule and list rule" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val ruleName = "listRules"
-            val triggerName = "listRulesTrigger"
-            val actionName = "listRulesAction"
-
-            assetHelper.withCleaner(wsk.trigger, triggerName) {
-                (trigger, name) => trigger.create(name)
-            }
-            assetHelper.withCleaner(wsk.action, actionName) {
-                (action, name) => action.create(name, defaultAction)
-            }
-            assetHelper.withCleaner(wsk.rule, ruleName) {
-                (rule, name) =>
-                    rule.create(name, trigger = triggerName, action = actionName)
-            }
-
-            // finally, we perform the update, and expect success this time
-            wsk.rule.create(ruleName, trigger = triggerName, action = actionName, update = true)
-
-            val stdout = wsk.rule.get(ruleName).stdout
-            stdout should include(ruleName)
-            stdout should include(triggerName)
-            stdout should include(actionName)
-            stdout should include regex (""""version": "0.0.2"""")
-            wsk.rule.list().stdout should include(ruleName)
-    }
-
-    it should "create rule, get rule, ensure rule is enabled by default" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val ruleName = "enabledRule"
-            val triggerName = "enabledRuleTrigger"
-            val actionName = "enabledRuleAction"
-
-            assetHelper.withCleaner(wsk.trigger, triggerName) {
-                (trigger, name) => trigger.create(name)
-            }
-            assetHelper.withCleaner(wsk.action, actionName) {
-                (action, name) => action.create(name, defaultAction)
-            }
-            assetHelper.withCleaner(wsk.rule, ruleName) {
-                (rule, name) => rule.create(name, trigger = triggerName, action = actionName)
-            }
-
-            val stdout = wsk.rule.get(ruleName).stdout
-            stdout should include regex (""""status":\s*"active"""")
-    }
-
-    it should "display a rule summary when --summary flag is used with 'wsk rule get'" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val ruleName = "mySummaryRule"
-            val triggerName = "summaryRuleTrigger"
-            val actionName = "summaryRuleAction"
-
-            assetHelper.withCleaner(wsk.trigger, triggerName) {
-                (trigger, name) => trigger.create(name)
-            }
-            assetHelper.withCleaner(wsk.action, actionName) {
-                (action, name) => action.create(name, defaultAction)
-            }
-            assetHelper.withCleaner(wsk.rule, ruleName, confirmDelete = false) {
-                (rule, name) => rule.create(name, trigger = triggerName, action = actionName)
-            }
-
-            // Summary namespace should match one of the allowable namespaces (typically 'guest')
-            val ns = wsk.namespace.whois()
-            val stdout = wsk.rule.get(ruleName, summary = true).stdout
-
-            stdout should include regex (s"(?i)rule /$ns/$ruleName\\s*\\(status: active\\)")
-    }
-
-    it should "create a rule, and get its individual fields" in withAssetCleaner(wskprops) {
-        val ruleName = "ruleFields"
-        val triggerName = "ruleTriggerFields"
-        val actionName = "ruleActionFields"
-        val paramInput = Map("payload" -> "test".toJson)
-        val successMsg = s"ok: got rule $ruleName, displaying field"
-
-        (wp, assetHelper) => assetHelper.withCleaner(wsk.trigger, triggerName) {
-            (trigger, name) => trigger.create(name)
-        }
-        assetHelper.withCleaner(wsk.action, actionName) {
-            (action, name) => action.create(name, defaultAction)
-        }
-        assetHelper.withCleaner(wsk.rule, ruleName) {
-            (rule, name) => rule.create(name, trigger = triggerName, action = actionName)
-        }
-
-        val ns = wsk.namespace.whois()
-        wsk.rule.get(ruleName, fieldFilter = Some("namespace")).stdout should include regex (s"""(?i)$successMsg namespace\n"$ns"""")
-        wsk.rule.get(ruleName, fieldFilter = Some("name")).stdout should include(s"""$successMsg name\n"$ruleName"""")
-        wsk.rule.get(ruleName, fieldFilter = Some("version")).stdout should include(s"""$successMsg version\n"0.0.1"\n""")
-        wsk.rule.get(ruleName, fieldFilter = Some("status")).stdout should include(s"""$successMsg status\n"active"""")
-        val trigger = wsk.rule.get(ruleName, fieldFilter = Some("trigger")).stdout
-        trigger should include regex (s"""$successMsg trigger\n""")
-        trigger should include(triggerName)
-        trigger should not include (actionName)
-        val action = wsk.rule.get(ruleName, fieldFilter = Some("action")).stdout
-        action should include regex (s"""$successMsg action\n""")
-        action should include(actionName)
-        action should not include (triggerName)
-    }
-
-    it should "reject creation of duplicate rules" in withAssetCleaner(wskprops) {
-        val ruleName = "dupeRule"
-        val triggerName = "triggerName"
-        val actionName = "actionName"
-
-        (wp, assetHelper) => assetHelper.withCleaner(wsk.trigger, triggerName) {
-            (trigger, name) => trigger.create(name)
-        }
-        assetHelper.withCleaner(wsk.action, actionName) {
-            (action, name) => action.create(name, defaultAction)
-        }
-        assetHelper.withCleaner(wsk.rule, ruleName) {
-            (rule, name) => rule.create(name, trigger = triggerName, action = actionName)
-        }
-
-        val stderr = wsk.rule.create(ruleName, trigger = triggerName, action = actionName, expectedExitCode = CONFLICT).stderr
-        stderr should include regex (s"""Unable to create rule '$ruleName': resource already exists \\(code \\d+\\)""")
-    }
-
-    it should "reject delete of rule that does not exist" in {
-        val name = "nonexistentRule"
-        val stderr = wsk.rule.delete(name, expectedExitCode = NOT_FOUND).stderr
-        stderr should include regex (s"""Unable to delete rule '$name'. The requested resource does not exist. \\(code \\d+\\)""")
-    }
-
-    it should "reject enable of rule that does not exist" in {
-        val name = "nonexistentRule"
-        val stderr = wsk.rule.enable(name, expectedExitCode = NOT_FOUND).stderr
-        stderr should include regex (s"""Unable to enable rule '$name': The requested resource does not exist. \\(code \\d+\\)""")
-    }
-
-    it should "reject disable of rule that does not exist" in {
-        val name = "nonexistentRule"
-        val stderr = wsk.rule.disable(name, expectedExitCode = NOT_FOUND).stderr
-        stderr should include regex (s"""Unable to disable rule '$name': The requested resource does not exist. \\(code \\d+\\)""")
-    }
-
-    it should "reject status of rule that does not exist" in {
-        val name = "nonexistentRule"
-        val stderr = wsk.rule.state(name, expectedExitCode = NOT_FOUND).stderr
-        stderr should include regex (s"""Unable to get status of rule '$name': The requested resource does not exist. \\(code \\d+\\)""")
-    }
-
-    it should "reject get of rule that does not exist" in {
-        val name = "nonexistentRule"
-        val stderr = wsk.rule.get(name, expectedExitCode = NOT_FOUND).stderr
-        stderr should include regex (s"""Unable to get rule '$name': The requested resource does not exist. \\(code \\d+\\)""")
-    }
-
-    behavior of "Wsk Namespace CLI"
-
-    it should "return a list of exactly one namespace" in {
-        val lines = wsk.namespace.list().stdout.lines.toSeq
-        lines should have size 2
-        lines.head shouldBe "namespaces"
-        lines(1).trim should not be empty
-    }
-
-    it should "list entities in default namespace" in {
-        // use a fresh wsk props instance that is guaranteed to use
-        // the default namespace
-        wsk.namespace.get(expectedExitCode = SUCCESS_EXIT)(WskProps()).
-            stdout should include("default")
-    }
-
-    it should "not list entities with an invalid namespace" in {
-        val namespace = "fakeNamespace"
-        val stderr = wsk.namespace.get(Some(s"/${namespace}"), expectedExitCode = FORBIDDEN).stderr
-
-        stderr should include(s"Unable to obtain the list of entities for namespace '${namespace}'")
-    }
-
-    behavior of "Wsk Activation CLI"
-
-    it should "create a trigger, and fire a trigger to get its individual fields from an activation" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "activationFields"
-
-            assetHelper.withCleaner(wsk.trigger, name) {
-                (trigger, _) =>
-                    trigger.create(name)
-            }
-
-            val ns = s""""${wsk.namespace.whois()}""""
-            val run = wsk.trigger.fire(name)
-            withActivation(wsk.activation, run) {
-                activation =>
-                    val successMsg = s"ok: got activation ${activation.activationId}, displaying field"
-                    wsk.activation.get(Some(activation.activationId), fieldFilter = Some("namespace")).stdout should include regex (s"""(?i)$successMsg namespace\n$ns""")
-                    wsk.activation.get(Some(activation.activationId), fieldFilter = Some("name")).stdout should include(s"""$successMsg name\n"$name"""")
-                    wsk.activation.get(Some(activation.activationId), fieldFilter = Some("version")).stdout should include(s"""$successMsg version\n"0.0.1"""")
-                    wsk.activation.get(Some(activation.activationId), fieldFilter = Some("publish")).stdout should include(s"""$successMsg publish\nfalse""")
-                    wsk.activation.get(Some(activation.activationId), fieldFilter = Some("subject")).stdout should include regex (s"""(?i)$successMsg subject\n""")
-                    wsk.activation.get(Some(activation.activationId), fieldFilter = Some("activationid")).stdout should include(s"""$successMsg activationid\n"${activation.activationId}""")
-                    wsk.activation.get(Some(activation.activationId), fieldFilter = Some("start")).stdout should include regex (s"""$successMsg start\n\\d""")
-                    wsk.activation.get(Some(activation.activationId), fieldFilter = Some("end")).stdout should include regex (s"""$successMsg end\n\\d""")
-                    wsk.activation.get(Some(activation.activationId), fieldFilter = Some("duration")).stdout should include regex (s"""$successMsg duration\n\\d""")
-                    wsk.activation.get(Some(activation.activationId), fieldFilter = Some("annotations")).stdout should include(s"""$successMsg annotations\n[]""")
-            }
-    }
-
-    it should "reject get of activation that does not exist" in {
-        val name = "0" * 32
-        val stderr = wsk.activation.get(Some(name), expectedExitCode = NOT_FOUND).stderr
-        stderr should include regex (s"""Unable to get activation '$name': The requested resource does not exist. \\(code \\d+\\)""")
-    }
-
-    it should "reject logs of activation that does not exist" in {
-        val name = "0" * 32
-        val stderr = wsk.activation.logs(Some(name), expectedExitCode = NOT_FOUND).stderr
-        stderr should include regex (s"""Unable to get logs for activation '$name': The requested resource does not exist. \\(code \\d+\\)""")
-    }
-
-    it should "reject result of activation that does not exist" in {
-        val name = "0" * 32
-        val stderr = wsk.activation.result(Some(name), expectedExitCode = NOT_FOUND).stderr
-        stderr should include regex (s"""Unable to get result for activation '$name': The requested resource does not exist. \\(code \\d+\\)""")
-    }
-
-    it should "reject activation request when using activation ID with --last Flag" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val auth: Seq[String] = Seq("--auth", wskprops.authKey)
-
-            val lastId = "dummyActivationId"
-            val tooManyArgsMsg = s"${lastId}. An activation ID is required."
-            val invalidField = s"Invalid field filter '${lastId}'."
-
-            val invalidCmd = Seq(
-                (Seq("activation", "get", s"$lastId", "publish", "--last"), tooManyArgsMsg),
-                (Seq("activation", "get", s"$lastId", "--last"), invalidField),
-                (Seq("activation", "logs", s"$lastId", "--last"), tooManyArgsMsg),
-                (Seq("activation", "result", s"$lastId", "--last"), tooManyArgsMsg))
-
-            invalidCmd foreach {
-                case (cmd, err) =>
-                    val stderr = wsk.cli(cmd ++ wskprops.overrides ++ auth, expectedExitCode = ERROR_EXIT).stderr
-                    stderr should include(err)
-            }
-    }
+  }
+
+  it should "reject get of activation that does not exist" in {
+    val name = "0" * 32
+    val stderr = wsk.activation.get(Some(name), expectedExitCode = NOT_FOUND).stderr
+    stderr should include regex (s"""Unable to get activation '$name': The requested resource does not exist. \\(code \\d+\\)""")
+  }
+
+  it should "reject logs of activation that does not exist" in {
+    val name = "0" * 32
+    val stderr = wsk.activation.logs(Some(name), expectedExitCode = NOT_FOUND).stderr
+    stderr should include regex (s"""Unable to get logs for activation '$name': The requested resource does not exist. \\(code \\d+\\)""")
+  }
+
+  it should "reject result of activation that does not exist" in {
+    val name = "0" * 32
+    val stderr = wsk.activation.result(Some(name), expectedExitCode = NOT_FOUND).stderr
+    stderr should include regex (s"""Unable to get result for activation '$name': The requested resource does not exist. \\(code \\d+\\)""")
+  }
+
+  it should "reject activation request when using activation ID with --last Flag" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val auth: Seq[String] = Seq("--auth", wskprops.authKey)
+
+      val lastId = "dummyActivationId"
+      val tooManyArgsMsg = s"${lastId}. An activation ID is required."
+      val invalidField = s"Invalid field filter '${lastId}'."
+
+      val invalidCmd = Seq(
+        (Seq("activation", "get", s"$lastId", "publish", "--last"), tooManyArgsMsg),
+        (Seq("activation", "get", s"$lastId", "--last"), invalidField),
+        (Seq("activation", "logs", s"$lastId", "--last"), tooManyArgsMsg),
+        (Seq("activation", "result", s"$lastId", "--last"), tooManyArgsMsg))
+
+      invalidCmd foreach {
+        case (cmd, err) =>
+          val stderr = wsk.cli(cmd ++ wskprops.overrides ++ auth, expectedExitCode = ERROR_EXIT).stderr
+          stderr should include(err)
+      }
+  }
 }

--- a/tests/src/test/scala/system/basic/WskConsoleTests.scala
+++ b/tests/src/test/scala/system/basic/WskConsoleTests.scala
@@ -41,59 +41,53 @@ import spray.json.pimpAny
  * Tests of the text console
  */
 @RunWith(classOf[JUnitRunner])
-class WskConsoleTests
-    extends TestHelpers
-    with WskTestHelpers {
+class WskConsoleTests extends TestHelpers with WskTestHelpers {
 
-    implicit val wskprops = WskProps()
-    val wsk = new Wsk
-    val guestNamespace = wskprops.namespace
+  implicit val wskprops = WskProps()
+  val wsk = new Wsk
+  val guestNamespace = wskprops.namespace
 
-    behavior of "Wsk Activation Console"
+  behavior of "Wsk Activation Console"
 
-    it should "show an activation log message for hello world" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val packageName = "samples"
-            val actionName = "helloWorld"
-            val fullActionName = s"/$guestNamespace/$packageName/$actionName"
-            assetHelper.withCleaner(wsk.pkg, packageName) {
-                (pkg, _) => pkg.create(packageName, shared = Some(true))
-            }
-
-            assetHelper.withCleaner(wsk.action, fullActionName) {
-                (action, _) => action.create(fullActionName, Some(TestUtils.getTestActionFilename("hello.js")))
-            }
-
-            val duration = Some(30 seconds)
-            val payload = new String("from the console!".getBytes, "UTF-8")
-            val run = wsk.action.invoke(fullActionName, Map("payload" -> payload.toJson))
-            withActivation(wsk.activation, run, totalWait = duration.get) {
-                activation =>
-                    val console = wsk.activation.console(10 seconds, since = duration)
-                    println(console.stdout)
-                    console.stdout should include(payload)
-            }
+  it should "show an activation log message for hello world" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val packageName = "samples"
+    val actionName = "helloWorld"
+    val fullActionName = s"/$guestNamespace/$packageName/$actionName"
+    assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, _) =>
+      pkg.create(packageName, shared = Some(true))
     }
 
-    it should "show repeated activations" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "countdown"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("countdown.js")))
-            }
-
-            val start = Instant.now(Clock.systemUTC())
-            val run = wsk.action.invoke(name, Map("n" -> 3.toJson))
-            withActivation(wsk.activation, run) {
-                activation =>
-                    val activations = wsk.activation.pollFor(N = 4, Some(name), since = Some(start), retries = 80).length
-                    withClue(s"expected activations:") {
-                        activations should be(4)
-                    }
-                    val duration = Duration(Instant.now(Clock.systemUTC()).toEpochMilli - start.toEpochMilli, MILLISECONDS)
-                    val console = wsk.activation.console(10 seconds, since = Some(duration))
-                    console.stdout should include("Happy New Year")
-            }
+    assetHelper.withCleaner(wsk.action, fullActionName) { (action, _) =>
+      action.create(fullActionName, Some(TestUtils.getTestActionFilename("hello.js")))
     }
+
+    val duration = Some(30 seconds)
+    val payload = new String("from the console!".getBytes, "UTF-8")
+    val run = wsk.action.invoke(fullActionName, Map("payload" -> payload.toJson))
+    withActivation(wsk.activation, run, totalWait = duration.get) { activation =>
+      val console = wsk.activation.console(10 seconds, since = duration)
+      println(console.stdout)
+      console.stdout should include(payload)
+    }
+  }
+
+  it should "show repeated activations" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "countdown"
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, Some(TestUtils.getTestActionFilename("countdown.js")))
+    }
+
+    val start = Instant.now(Clock.systemUTC())
+    val run = wsk.action.invoke(name, Map("n" -> 3.toJson))
+    withActivation(wsk.activation, run) { activation =>
+      val activations = wsk.activation.pollFor(N = 4, Some(name), since = Some(start), retries = 80).length
+      withClue(s"expected activations:") {
+        activations should be(4)
+      }
+      val duration = Duration(Instant.now(Clock.systemUTC()).toEpochMilli - start.toEpochMilli, MILLISECONDS)
+      val console = wsk.activation.console(10 seconds, since = Some(duration))
+      console.stdout should include("Happy New Year")
+    }
+  }
 
 }

--- a/tests/src/test/scala/system/basic/WskPackageTests.scala
+++ b/tests/src/test/scala/system/basic/WskPackageTests.scala
@@ -34,110 +34,103 @@ import common.TestHelpers
 import common.WskProps
 
 @RunWith(classOf[JUnitRunner])
-class WskPackageTests
-    extends TestHelpers
-    with WskTestHelpers {
+class WskPackageTests extends TestHelpers with WskTestHelpers {
 
-    implicit val wskprops = WskProps()
-    val wsk = new Wsk
-    val LOG_DELAY = 80 seconds
+  implicit val wskprops = WskProps()
+  val wsk = new Wsk
+  val LOG_DELAY = 80 seconds
 
-    behavior of "Wsk Package"
+  behavior of "Wsk Package"
 
-    it should "allow creation and deletion of a package" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "simplepackage"
-            assetHelper.withCleaner(wsk.pkg, name) {
-                (pkg, _) => pkg.create(name, Map())
-            }
+  it should "allow creation and deletion of a package" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "simplepackage"
+    assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
+      pkg.create(name, Map())
+    }
+  }
+
+  val params1 = Map("p1" -> "v1".toJson, "p2" -> "".toJson)
+  val params2 = Map("p1" -> "v1".toJson, "p2" -> "v2".toJson, "p3" -> "v3".toJson)
+
+  it should "allow creation of a package with parameters" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "simplepackagewithparams"
+    assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
+      pkg.create(name, params1)
+    }
+  }
+
+  it should "allow updating a package" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "simplepackagetoupdate"
+    assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
+      pkg.create(name, params1)
+      pkg.create(name, params2, update = true)
+    }
+  }
+
+  it should "allow binding of a package" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "simplepackagetobind"
+    val bindName = "simplebind"
+    assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
+      pkg.create(name, params1)
+    }
+    assetHelper.withCleaner(wsk.pkg, bindName) { (pkg, _) =>
+      pkg.bind(name, bindName, params2)
+    }
+  }
+
+  it should "perform package binds so parameters are inherited" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val packageName = "package1"
+    val bindName = "package2"
+    val actionName = "print"
+    val packageActionName = packageName + "/" + actionName
+    val bindActionName = bindName + "/" + actionName
+    val packageParams = Map("key1a" -> "value1a".toJson, "key1b" -> "value1b".toJson)
+    val bindParams = Map("key2a" -> "value2a".toJson, "key1b" -> "value2b".toJson)
+    val actionParams = Map("key0" -> "value0".toJson)
+    val file = TestUtils.getTestActionFilename("printParams.js")
+    assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, _) =>
+      pkg.create(packageName, packageParams)
+    }
+    assetHelper.withCleaner(wsk.action, packageActionName) { (action, _) =>
+      action.create(packageActionName, Some(file), parameters = actionParams)
+    }
+    assetHelper.withCleaner(wsk.pkg, bindName) { (pkg, _) =>
+      pkg.bind(packageName, bindName, bindParams)
     }
 
-    val params1 = Map("p1" -> "v1".toJson, "p2" -> "".toJson)
-    val params2 = Map("p1" -> "v1".toJson, "p2" -> "v2".toJson, "p3" -> "v3".toJson)
+    // Check that the description of packages and actions includes all the inherited parameters.
+    val packageDescription = wsk.pkg.get(packageName).stdout
+    val bindDescription = wsk.pkg.get(bindName).stdout
+    val packageActionDescription = wsk.action.get(packageActionName).stdout
+    val bindActionDescription = wsk.action.get(bindActionName).stdout
+    checkForParameters(packageDescription, packageParams)
+    checkForParameters(bindDescription, packageParams, bindParams)
+    checkForParameters(packageActionDescription, packageParams, actionParams)
+    checkForParameters(bindActionDescription, packageParams, bindParams, actionParams)
 
-    it should "allow creation of a package with parameters" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "simplepackagewithparams"
-            assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
-                pkg.create(name, params1)
-            }
+    // Check that inherited parameters are passed to the action.
+    val now = new Date().toString()
+    val run = wsk.action.invoke(bindActionName, Map("payload" -> now.toJson))
+    withActivation(wsk.activation, run, totalWait = LOG_DELAY) {
+      _.logs.get.mkString(" ") should include regex (String
+        .format(".*key0: value0.*key1a: value1a.*key1b: value2b.*key2a: value2a.*payload: %s", now))
     }
+  }
 
-    it should "allow updating a package" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "simplepackagetoupdate"
-            assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
-                pkg.create(name, params1)
-                pkg.create(name, params2, update = true)
-            }
+  /**
+   * Check that a description of an item includes the specified parameters.
+   * Parameters keys in later parameter maps override earlier ones.
+   */
+  def checkForParameters(itemDescription: String, paramSets: Map[String, JsValue]*) {
+    // Merge and the parameters handling overrides.
+    val merged = HashMap.empty[String, JsValue]
+    paramSets.foreach { merged ++= _ }
+    val flatDescription = itemDescription.replace("\n", "").replace("\r", "")
+    merged.foreach {
+      case (key: String, value: JsValue) =>
+        val toFind = s""""key": "${key}",.*"value": ${value.toString}"""
+        flatDescription should include regex toFind
     }
-
-    it should "allow binding of a package" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "simplepackagetobind"
-            val bindName = "simplebind"
-            assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
-                pkg.create(name, params1)
-            }
-            assetHelper.withCleaner(wsk.pkg, bindName) { (pkg, _) =>
-                pkg.bind(name, bindName, params2)
-            }
-    }
-
-    it should "perform package binds so parameters are inherited" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val packageName = "package1"
-            val bindName = "package2"
-            val actionName = "print"
-            val packageActionName = packageName + "/" + actionName
-            val bindActionName = bindName + "/" + actionName
-            val packageParams = Map("key1a" -> "value1a".toJson, "key1b" -> "value1b".toJson)
-            val bindParams = Map("key2a" -> "value2a".toJson, "key1b" -> "value2b".toJson)
-            val actionParams = Map("key0" -> "value0".toJson)
-            val file = TestUtils.getTestActionFilename("printParams.js")
-            assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, _) =>
-                pkg.create(packageName, packageParams)
-            }
-            assetHelper.withCleaner(wsk.action, packageActionName) { (action, _) =>
-                action.create(packageActionName, Some(file), parameters = actionParams)
-            }
-            assetHelper.withCleaner(wsk.pkg, bindName) { (pkg, _) =>
-                pkg.bind(packageName, bindName, bindParams)
-            }
-
-            // Check that the description of packages and actions includes all the inherited parameters.
-            val packageDescription = wsk.pkg.get(packageName).stdout
-            val bindDescription = wsk.pkg.get(bindName).stdout
-            val packageActionDescription = wsk.action.get(packageActionName).stdout
-            val bindActionDescription = wsk.action.get(bindActionName).stdout
-            checkForParameters(packageDescription, packageParams)
-            checkForParameters(bindDescription, packageParams, bindParams)
-            checkForParameters(packageActionDescription, packageParams, actionParams)
-            checkForParameters(bindActionDescription, packageParams, bindParams, actionParams)
-
-            // Check that inherited parameters are passed to the action.
-            val now = new Date().toString()
-            val run = wsk.action.invoke(bindActionName, Map("payload" -> now.toJson))
-            withActivation(wsk.activation, run, totalWait = LOG_DELAY) {
-                _.logs.get.mkString(" ") should include regex (
-                    String.format(".*key0: value0.*key1a: value1a.*key1b: value2b.*key2a: value2a.*payload: %s", now))
-            }
-    }
-
-    /**
-     * Check that a description of an item includes the specified parameters.
-     * Parameters keys in later parameter maps override earlier ones.
-     */
-    def checkForParameters(itemDescription: String, paramSets: Map[String, JsValue]*) {
-        // Merge and the parameters handling overrides.
-        val merged = HashMap.empty[String, JsValue]
-        paramSets.foreach { merged ++= _ }
-        val flatDescription = itemDescription.replace("\n", "").replace("\r", "")
-        merged.foreach {
-            case (key: String, value: JsValue) =>
-                val toFind = s""""key": "${key}",.*"value": ${value.toString}"""
-                flatDescription should include regex toFind
-        }
-    }
+  }
 
 }

--- a/tests/src/test/scala/system/basic/WskRuleTests.scala
+++ b/tests/src/test/scala/system/basic/WskRuleTests.scala
@@ -29,364 +29,394 @@ import spray.json.DefaultJsonProtocol._
 import java.time.Instant
 
 @RunWith(classOf[JUnitRunner])
-class WskRuleTests
-    extends TestHelpers
-    with WskTestHelpers {
+class WskRuleTests extends TestHelpers with WskTestHelpers {
 
-    implicit val wskprops = WskProps()
-    val wsk = new Wsk
-    val defaultAction = TestUtils.getTestActionFilename("wc.js")
-    val secondAction = TestUtils.getTestActionFilename("hello.js")
-    val testString = "this is a test"
-    val testResult = JsObject("count" -> testString.split(" ").length.toJson)
+  implicit val wskprops = WskProps()
+  val wsk = new Wsk
+  val defaultAction = TestUtils.getTestActionFilename("wc.js")
+  val secondAction = TestUtils.getTestActionFilename("hello.js")
+  val testString = "this is a test"
+  val testResult = JsObject("count" -> testString.split(" ").length.toJson)
 
-    /**
-     * Invoker clock skew can sometimes make it appear as if an action was invoked
-     * _before_ the trigger was fired. The "fudge factor" below allows the test to look
-     * for action activations that occur starting at most this amount of time before
-     * the trigger was fired.
-     */
-    val activationTimeSkewFactorMs = 500
+  /**
+   * Invoker clock skew can sometimes make it appear as if an action was invoked
+   * _before_ the trigger was fired. The "fudge factor" below allows the test to look
+   * for action activations that occur starting at most this amount of time before
+   * the trigger was fired.
+   */
+  val activationTimeSkewFactorMs = 500
 
-    /**
-     * Sets up trigger -> rule -> action triplets. Deduplicates triggers and rules
-     * and links it all up.
-     *
-     * @param rules Tuple3s containing
-     *   (rule, trigger, (action name for created action, action name for the rule binding, actionFile))
-     *   where the action name for the created action is allowed to differ from that used by the rule binding
-     *   for cases that reference actions in a package binding.
-     */
-    def ruleSetup(rules: Seq[(String, String, (String, String, String))], assetHelper: AssetCleaner) = {
-        val triggers = rules.map(_._2).distinct
-        val actions = rules.map(_._3).distinct
+  /**
+   * Sets up trigger -> rule -> action triplets. Deduplicates triggers and rules
+   * and links it all up.
+   *
+   * @param rules Tuple3s containing
+   *   (rule, trigger, (action name for created action, action name for the rule binding, actionFile))
+   *   where the action name for the created action is allowed to differ from that used by the rule binding
+   *   for cases that reference actions in a package binding.
+   */
+  def ruleSetup(rules: Seq[(String, String, (String, String, String))], assetHelper: AssetCleaner) = {
+    val triggers = rules.map(_._2).distinct
+    val actions = rules.map(_._3).distinct
 
-        triggers.foreach { trigger =>
-            assetHelper.withCleaner(wsk.trigger, trigger) {
-                (trigger, name) => trigger.create(name)
-            }
-        }
+    triggers.foreach { trigger =>
+      assetHelper.withCleaner(wsk.trigger, trigger) { (trigger, name) =>
+        trigger.create(name)
+      }
+    }
 
-        actions.foreach {
-            case (actionName, _, file) =>
-                assetHelper.withCleaner(wsk.action, actionName) {
-                    (action, name) => action.create(name, Some(file))
-                }
-        }
-
-        rules.foreach {
-            case (ruleName, triggerName, action) =>
-                assetHelper.withCleaner(wsk.rule, ruleName) {
-                    (rule, name) => rule.create(name, triggerName, action._2)
-                }
+    actions.foreach {
+      case (actionName, _, file) =>
+        assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
+          action.create(name, Some(file))
         }
     }
 
-    /**
-     * Append the current timestamp in ms
-     */
-    def withTimestamp(text: String) = s"${text}-${System.currentTimeMillis}"
+    rules.foreach {
+      case (ruleName, triggerName, action) =>
+        assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
+          rule.create(name, triggerName, action._2)
+        }
+    }
+  }
 
-    behavior of "Whisk rules"
+  /**
+   * Append the current timestamp in ms
+   */
+  def withTimestamp(text: String) = s"${text}-${System.currentTimeMillis}"
 
-    it should "invoke the action attached on trigger fire, creating an activation for each entity including the cause" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val ruleName = withTimestamp("r1to1")
-            val triggerName = withTimestamp("t1to1")
-            val actionName = withTimestamp("a1 to 1") // spaces in name intended for greater test coverage
+  behavior of "Whisk rules"
 
-            ruleSetup(Seq(
-                (ruleName, triggerName, (actionName, actionName, defaultAction))),
-                assetHelper)
+  it should "invoke the action attached on trigger fire, creating an activation for each entity including the cause" in withAssetCleaner(
+    wskprops) { (wp, assetHelper) =>
+    val ruleName = withTimestamp("r1to1")
+    val triggerName = withTimestamp("t1to1")
+    val actionName = withTimestamp("a1 to 1") // spaces in name intended for greater test coverage
 
-            val run = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
+    ruleSetup(Seq((ruleName, triggerName, (actionName, actionName, defaultAction))), assetHelper)
 
-            withActivation(wsk.activation, run) {
-                triggerActivation =>
-                    triggerActivation.cause shouldBe None
+    val run = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
 
-                    withActivationsFromEntity(wsk.activation, ruleName, since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
-                        _.head.cause shouldBe Some(triggerActivation.activationId)
-                    }
+    withActivation(wsk.activation, run) { triggerActivation =>
+      triggerActivation.cause shouldBe None
 
-                    withActivationsFromEntity(wsk.activation, actionName, since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) { activationList =>
-                        activationList.head.response.result shouldBe Some(testResult)
-                        activationList.head.cause shouldBe None
-                    }
-            }
+      withActivationsFromEntity(
+        wsk.activation,
+        ruleName,
+        since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
+        _.head.cause shouldBe Some(triggerActivation.activationId)
+      }
+
+      withActivationsFromEntity(
+        wsk.activation,
+        actionName,
+        since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) { activationList =>
+        activationList.head.response.result shouldBe Some(testResult)
+        activationList.head.cause shouldBe None
+      }
+    }
+  }
+
+  it should "invoke the action from a package attached on trigger fire, creating an activation for each entity including the cause" in withAssetCleaner(
+    wskprops) { (wp, assetHelper) =>
+    val ruleName = withTimestamp("pr1to1")
+    val triggerName = withTimestamp("pt1to1")
+    val pkgName = withTimestamp("rule pkg") // spaces in name intended to test uri path encoding
+    val actionName = withTimestamp("a1 to 1")
+    val pkgActionName = s"$pkgName/$actionName"
+
+    assetHelper.withCleaner(wsk.pkg, pkgName) { (pkg, name) =>
+      pkg.create(name)
     }
 
-    it should "invoke the action from a package attached on trigger fire, creating an activation for each entity including the cause" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val ruleName = withTimestamp("pr1to1")
-            val triggerName = withTimestamp("pt1to1")
-            val pkgName = withTimestamp("rule pkg") // spaces in name intended to test uri path encoding
-            val actionName = withTimestamp("a1 to 1")
-            val pkgActionName = s"$pkgName/$actionName"
+    ruleSetup(Seq((ruleName, triggerName, (pkgActionName, pkgActionName, defaultAction))), assetHelper)
 
-            assetHelper.withCleaner(wsk.pkg, pkgName) {
-                (pkg, name) => pkg.create(name)
-            }
+    val now = Instant.now
+    val run = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
 
-            ruleSetup(Seq(
-                (ruleName, triggerName, (pkgActionName, pkgActionName, defaultAction))),
-                assetHelper)
+    withActivation(wsk.activation, run) { triggerActivation =>
+      triggerActivation.cause shouldBe None
 
-            val now = Instant.now
-            val run = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
+      withActivationsFromEntity(
+        wsk.activation,
+        ruleName,
+        since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
+        _.head.cause shouldBe Some(triggerActivation.activationId)
+      }
 
-            withActivation(wsk.activation, run) {
-                triggerActivation =>
-                    triggerActivation.cause shouldBe None
+      withActivationsFromEntity(
+        wsk.activation,
+        actionName,
+        since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
+        _.head.response.result shouldBe Some(testResult)
+      }
+    }
+  }
 
-                    withActivationsFromEntity(wsk.activation, ruleName, since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
-                        _.head.cause shouldBe Some(triggerActivation.activationId)
-                    }
+  it should "invoke the action from a package binding attached on trigger fire, creating an activation for each entity including the cause" in withAssetCleaner(
+    wskprops) { (wp, assetHelper) =>
+    val ruleName = withTimestamp("pr1to1")
+    val triggerName = withTimestamp("pt1to1")
+    val pkgName = withTimestamp("rule pkg") // spaces in name intended to test uri path encoding
+    val pkgBindingName = withTimestamp("rule pkg binding")
+    val actionName = withTimestamp("a1 to 1")
+    val pkgActionName = s"$pkgName/$actionName"
 
-                    withActivationsFromEntity(wsk.activation, actionName, since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
-                        _.head.response.result shouldBe Some(testResult)
-                    }
-            }
+    assetHelper.withCleaner(wsk.pkg, pkgName) { (pkg, name) =>
+      pkg.create(name)
     }
 
-    it should "invoke the action from a package binding attached on trigger fire, creating an activation for each entity including the cause" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val ruleName = withTimestamp("pr1to1")
-            val triggerName = withTimestamp("pt1to1")
-            val pkgName = withTimestamp("rule pkg") // spaces in name intended to test uri path encoding
-            val pkgBindingName = withTimestamp("rule pkg binding")
-            val actionName = withTimestamp("a1 to 1")
-            val pkgActionName = s"$pkgName/$actionName"
-
-            assetHelper.withCleaner(wsk.pkg, pkgName) {
-                (pkg, name) => pkg.create(name)
-            }
-
-            assetHelper.withCleaner(wsk.pkg, pkgBindingName) {
-                (pkg, name) => pkg.bind(pkgName, pkgBindingName)
-            }
-
-            ruleSetup(Seq(
-                (ruleName, triggerName, (pkgActionName, s"$pkgBindingName/$actionName", defaultAction))),
-                assetHelper)
-
-            val run = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
-
-            withActivation(wsk.activation, run) {
-                triggerActivation =>
-                    triggerActivation.cause shouldBe None
-
-                    withActivationsFromEntity(wsk.activation, ruleName, since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
-                        _.head.cause shouldBe Some(triggerActivation.activationId)
-                    }
-
-                    withActivationsFromEntity(wsk.activation, actionName, since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
-                        _.head.response.result shouldBe Some(testResult)
-                    }
-            }
+    assetHelper.withCleaner(wsk.pkg, pkgBindingName) { (pkg, name) =>
+      pkg.bind(pkgName, pkgBindingName)
     }
 
-    it should "not activate an action if the rule is deleted when the trigger is fired" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val ruleName = withTimestamp("ruleDelete")
-            val triggerName = withTimestamp("ruleDeleteTrigger")
-            val actionName = withTimestamp("ruleDeleteAction")
+    ruleSetup(Seq((ruleName, triggerName, (pkgActionName, s"$pkgBindingName/$actionName", defaultAction))), assetHelper)
 
-            assetHelper.withCleaner(wsk.trigger, triggerName) {
-                (trigger, name) => trigger.create(name)
-            }
-            assetHelper.withCleaner(wsk.action, actionName) {
-                (action, name) => action.create(name, Some(defaultAction))
-            }
-            assetHelper.withCleaner(wsk.rule, ruleName, false) {
-                (rule, name) => rule.create(name, triggerName, actionName)
-            }
+    val run = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
 
-            val first = wsk.trigger.fire(triggerName, Map("payload" -> "bogus".toJson))
-            wsk.rule.delete(ruleName)
-            wsk.trigger.fire(triggerName, Map("payload" -> "bogus2".toJson))
+    withActivation(wsk.activation, run) { triggerActivation =>
+      triggerActivation.cause shouldBe None
 
-            withActivation(wsk.activation, first) {
-                activation =>
-                    // tries to find 2 activations for the action, should only find 1
-                    val activations = wsk.activation.pollFor(2, Some(actionName), since = Some(activation.start.minusMillis(activationTimeSkewFactorMs)), retries = 30)
+      withActivationsFromEntity(
+        wsk.activation,
+        ruleName,
+        since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
+        _.head.cause shouldBe Some(triggerActivation.activationId)
+      }
 
-                    activations.length shouldBe 1
-            }
+      withActivationsFromEntity(
+        wsk.activation,
+        actionName,
+        since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
+        _.head.response.result shouldBe Some(testResult)
+      }
     }
+  }
 
-    it should "enable and disable a rule and check action is activated only when rule is enabled" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val ruleName = withTimestamp("ruleDisable")
-            val triggerName = withTimestamp("ruleDisableTrigger")
-            val actionName = withTimestamp("ruleDisableAction")
+  it should "not activate an action if the rule is deleted when the trigger is fired" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val ruleName = withTimestamp("ruleDelete")
+      val triggerName = withTimestamp("ruleDeleteTrigger")
+      val actionName = withTimestamp("ruleDeleteAction")
 
-            ruleSetup(Seq(
-                (ruleName, triggerName, (actionName, actionName, defaultAction))),
-                assetHelper)
+      assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
+        trigger.create(name)
+      }
+      assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
+        action.create(name, Some(defaultAction))
+      }
+      assetHelper.withCleaner(wsk.rule, ruleName, false) { (rule, name) =>
+        rule.create(name, triggerName, actionName)
+      }
 
-            val first = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
-            wsk.rule.disable(ruleName)
-            wsk.trigger.fire(triggerName, Map("payload" -> s"$testString with added words".toJson))
-            wsk.rule.enable(ruleName)
-            wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
+      val first = wsk.trigger.fire(triggerName, Map("payload" -> "bogus".toJson))
+      wsk.rule.delete(ruleName)
+      wsk.trigger.fire(triggerName, Map("payload" -> "bogus2".toJson))
 
-            withActivation(wsk.activation, first) {
-                triggerActivation =>
-                    withActivationsFromEntity(wsk.activation, actionName, N = 2, since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
-                        activations =>
-                            val results = activations.map(_.response.result)
-                            results should contain theSameElementsAs Seq(Some(testResult), Some(testResult))
-                    }
-            }
+      withActivation(wsk.activation, first) { activation =>
+        // tries to find 2 activations for the action, should only find 1
+        val activations = wsk.activation.pollFor(
+          2,
+          Some(actionName),
+          since = Some(activation.start.minusMillis(activationTimeSkewFactorMs)),
+          retries = 30)
+
+        activations.length shouldBe 1
+      }
+  }
+
+  it should "enable and disable a rule and check action is activated only when rule is enabled" in withAssetCleaner(
+    wskprops) { (wp, assetHelper) =>
+    val ruleName = withTimestamp("ruleDisable")
+    val triggerName = withTimestamp("ruleDisableTrigger")
+    val actionName = withTimestamp("ruleDisableAction")
+
+    ruleSetup(Seq((ruleName, triggerName, (actionName, actionName, defaultAction))), assetHelper)
+
+    val first = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
+    wsk.rule.disable(ruleName)
+    wsk.trigger.fire(triggerName, Map("payload" -> s"$testString with added words".toJson))
+    wsk.rule.enable(ruleName)
+    wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
+
+    withActivation(wsk.activation, first) { triggerActivation =>
+      withActivationsFromEntity(
+        wsk.activation,
+        actionName,
+        N = 2,
+        since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) { activations =>
+        val results = activations.map(_.response.result)
+        results should contain theSameElementsAs Seq(Some(testResult), Some(testResult))
+      }
     }
+  }
 
-    it should "be able to recreate a rule with the same name and match it successfully" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val ruleName = withTimestamp("ruleRecreate")
-            val triggerName1 = withTimestamp("ruleRecreateTrigger1")
-            val triggerName2 = withTimestamp("ruleRecreateTrigger2")
-            val actionName = withTimestamp("ruleRecreateAction")
+  it should "be able to recreate a rule with the same name and match it successfully" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val ruleName = withTimestamp("ruleRecreate")
+      val triggerName1 = withTimestamp("ruleRecreateTrigger1")
+      val triggerName2 = withTimestamp("ruleRecreateTrigger2")
+      val actionName = withTimestamp("ruleRecreateAction")
 
-            assetHelper.withCleaner(wsk.trigger, triggerName1) {
-                (trigger, name) => trigger.create(name)
-            }
-            assetHelper.withCleaner(wsk.action, actionName) {
-                (action, name) => action.create(name, Some(defaultAction))
-            }
-            assetHelper.withCleaner(wsk.rule, ruleName, false) {
-                (rule, name) => rule.create(name, triggerName1, actionName)
-            }
+      assetHelper.withCleaner(wsk.trigger, triggerName1) { (trigger, name) =>
+        trigger.create(name)
+      }
+      assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
+        action.create(name, Some(defaultAction))
+      }
+      assetHelper.withCleaner(wsk.rule, ruleName, false) { (rule, name) =>
+        rule.create(name, triggerName1, actionName)
+      }
 
-            wsk.rule.delete(ruleName)
+      wsk.rule.delete(ruleName)
 
-            assetHelper.withCleaner(wsk.trigger, triggerName2) {
-                (trigger, name) => trigger.create(name)
-            }
-            assetHelper.withCleaner(wsk.rule, ruleName) {
-                (rule, name) => rule.create(name, triggerName2, actionName)
-            }
+      assetHelper.withCleaner(wsk.trigger, triggerName2) { (trigger, name) =>
+        trigger.create(name)
+      }
+      assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
+        rule.create(name, triggerName2, actionName)
+      }
 
-            val first = wsk.trigger.fire(triggerName2, Map("payload" -> testString.toJson))
-            withActivation(wsk.activation, first) {
-                triggerActivation =>
-                    withActivationsFromEntity(wsk.activation, actionName, since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
-                        _.head.response.result shouldBe Some(testResult)
-                    }
-            }
-    }
+      val first = wsk.trigger.fire(triggerName2, Map("payload" -> testString.toJson))
+      withActivation(wsk.activation, first) { triggerActivation =>
+        withActivationsFromEntity(
+          wsk.activation,
+          actionName,
+          since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
+          _.head.response.result shouldBe Some(testResult)
+        }
+      }
+  }
 
-    it should "connect two triggers via rules to one action and activate it accordingly" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val triggerName1 = withTimestamp("t2to1a")
-            val triggerName2 = withTimestamp("t2to1b")
-            val actionName = withTimestamp("a2to1")
+  it should "connect two triggers via rules to one action and activate it accordingly" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val triggerName1 = withTimestamp("t2to1a")
+      val triggerName2 = withTimestamp("t2to1b")
+      val actionName = withTimestamp("a2to1")
 
-            ruleSetup(Seq(
-                ("r2to1a", triggerName1, (actionName, actionName, defaultAction)),
-                ("r2to1b", triggerName2, (actionName, actionName, defaultAction))),
-                assetHelper)
+      ruleSetup(
+        Seq(
+          ("r2to1a", triggerName1, (actionName, actionName, defaultAction)),
+          ("r2to1b", triggerName2, (actionName, actionName, defaultAction))),
+        assetHelper)
 
-            val testPayloads = Seq("got three words", "got four words, period")
+      val testPayloads = Seq("got three words", "got four words, period")
 
-            val run = wsk.trigger.fire(triggerName1, Map("payload" -> testPayloads(0).toJson))
-            wsk.trigger.fire(triggerName2, Map("payload" -> testPayloads(1).toJson))
+      val run = wsk.trigger.fire(triggerName1, Map("payload" -> testPayloads(0).toJson))
+      wsk.trigger.fire(triggerName2, Map("payload" -> testPayloads(1).toJson))
 
-            withActivation(wsk.activation, run) {
-                triggerActivation =>
-                    withActivationsFromEntity(wsk.activation, actionName, N = 2, since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
-                        activations =>
-                            val results = activations.map(_.response.result)
-                            val expectedResults = testPayloads.map { payload =>
-                                Some(JsObject("count" -> payload.split(" ").length.toJson))
-                            }
+      withActivation(wsk.activation, run) { triggerActivation =>
+        withActivationsFromEntity(
+          wsk.activation,
+          actionName,
+          N = 2,
+          since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) { activations =>
+          val results = activations.map(_.response.result)
+          val expectedResults = testPayloads.map { payload =>
+            Some(JsObject("count" -> payload.split(" ").length.toJson))
+          }
 
-                            results should contain theSameElementsAs expectedResults
-                    }
-            }
-    }
+          results should contain theSameElementsAs expectedResults
+        }
+      }
+  }
 
-    it should "connect one trigger to two different actions, invoking them both eventually" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val triggerName = withTimestamp("t1to2")
-            val actionName1 = withTimestamp("a1to2a")
-            val actionName2 = withTimestamp("a1to2b")
+  it should "connect one trigger to two different actions, invoking them both eventually" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val triggerName = withTimestamp("t1to2")
+      val actionName1 = withTimestamp("a1to2a")
+      val actionName2 = withTimestamp("a1to2b")
 
-            ruleSetup(Seq(
-                ("r1to2a", triggerName, (actionName1, actionName1, defaultAction)),
-                ("r1to2b", triggerName, (actionName2, actionName2, secondAction))),
-                assetHelper)
+      ruleSetup(
+        Seq(
+          ("r1to2a", triggerName, (actionName1, actionName1, defaultAction)),
+          ("r1to2b", triggerName, (actionName2, actionName2, secondAction))),
+        assetHelper)
 
-            val run = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
+      val run = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
 
-            withActivation(wsk.activation, run) {
-                triggerActivation =>
-                    withActivationsFromEntity(wsk.activation, actionName1, since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
-                        _.head.response.result shouldBe Some(testResult)
-                    }
-                    withActivationsFromEntity(wsk.activation, actionName2, since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
-                        _.head.logs.get.mkString(" ") should include(s"hello, $testString")
-                    }
-            }
-    }
+      withActivation(wsk.activation, run) { triggerActivation =>
+        withActivationsFromEntity(
+          wsk.activation,
+          actionName1,
+          since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
+          _.head.response.result shouldBe Some(testResult)
+        }
+        withActivationsFromEntity(
+          wsk.activation,
+          actionName2,
+          since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
+          _.head.logs.get.mkString(" ") should include(s"hello, $testString")
+        }
+      }
+  }
 
-    it should "connect two triggers to two different actions, invoking them both eventually" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val triggerName1 = withTimestamp("t1to1a")
-            val triggerName2 = withTimestamp("t1to1b")
-            val actionName1 = withTimestamp("a1to1a")
-            val actionName2 = withTimestamp("a1to1b")
+  it should "connect two triggers to two different actions, invoking them both eventually" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val triggerName1 = withTimestamp("t1to1a")
+      val triggerName2 = withTimestamp("t1to1b")
+      val actionName1 = withTimestamp("a1to1a")
+      val actionName2 = withTimestamp("a1to1b")
 
-            ruleSetup(Seq(
-                ("r2to2a", triggerName1, (actionName1, actionName1, defaultAction)),
-                ("r2to2b", triggerName1, (actionName2, actionName2, secondAction)),
-                ("r2to2c", triggerName2, (actionName1, actionName1, defaultAction)),
-                ("r2to2d", triggerName2, (actionName2, actionName2, secondAction))),
-                assetHelper)
+      ruleSetup(
+        Seq(
+          ("r2to2a", triggerName1, (actionName1, actionName1, defaultAction)),
+          ("r2to2b", triggerName1, (actionName2, actionName2, secondAction)),
+          ("r2to2c", triggerName2, (actionName1, actionName1, defaultAction)),
+          ("r2to2d", triggerName2, (actionName2, actionName2, secondAction))),
+        assetHelper)
 
-            val testPayloads = Seq("got three words", "got four words, period")
-            val run = wsk.trigger.fire(triggerName1, Map("payload" -> testPayloads(0).toJson))
-            wsk.trigger.fire(triggerName2, Map("payload" -> testPayloads(1).toJson))
+      val testPayloads = Seq("got three words", "got four words, period")
+      val run = wsk.trigger.fire(triggerName1, Map("payload" -> testPayloads(0).toJson))
+      wsk.trigger.fire(triggerName2, Map("payload" -> testPayloads(1).toJson))
 
-            withActivation(wsk.activation, run) {
-                triggerActivation =>
-                    withActivationsFromEntity(wsk.activation, actionName1, N = 2, since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
-                        activations =>
-                            val results = activations.map(_.response.result)
-                            val expectedResults = testPayloads.map { payload =>
-                                Some(JsObject("count" -> payload.split(" ").length.toJson))
-                            }
+      withActivation(wsk.activation, run) { triggerActivation =>
+        withActivationsFromEntity(
+          wsk.activation,
+          actionName1,
+          N = 2,
+          since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) { activations =>
+          val results = activations.map(_.response.result)
+          val expectedResults = testPayloads.map { payload =>
+            Some(JsObject("count" -> payload.split(" ").length.toJson))
+          }
 
-                            results should contain theSameElementsAs expectedResults
-                    }
-                    withActivationsFromEntity(wsk.activation, actionName2, N = 2, since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
-                        activations =>
-                            // drops the leftmost 39 characters (timestamp + streamname)
-                            val logs = activations.map(_.logs.get.map(_.drop(39))).flatten
-                            val expectedLogs = testPayloads.map { payload => s"hello, $payload!" }
+          results should contain theSameElementsAs expectedResults
+        }
+        withActivationsFromEntity(
+          wsk.activation,
+          actionName2,
+          N = 2,
+          since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) { activations =>
+          // drops the leftmost 39 characters (timestamp + streamname)
+          val logs = activations.map(_.logs.get.map(_.drop(39))).flatten
+          val expectedLogs = testPayloads.map { payload =>
+            s"hello, $payload!"
+          }
 
-                            logs should contain theSameElementsAs expectedLogs
-                    }
-            }
-    }
+          logs should contain theSameElementsAs expectedLogs
+        }
+      }
+  }
 
-    it should "disable a rule and check its status is displayed when listed" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val ruleName = withTimestamp("ruleDisable")
-            val ruleName2 = withTimestamp("ruleEnable")
-            val triggerName = withTimestamp("ruleDisableTrigger")
-            val actionName = withTimestamp("ruleDisableAction")
+  it should "disable a rule and check its status is displayed when listed" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val ruleName = withTimestamp("ruleDisable")
+      val ruleName2 = withTimestamp("ruleEnable")
+      val triggerName = withTimestamp("ruleDisableTrigger")
+      val actionName = withTimestamp("ruleDisableAction")
 
-            ruleSetup(Seq(
-                (ruleName, triggerName, (actionName, actionName, defaultAction)),
-                (ruleName2, triggerName, (actionName, actionName, defaultAction))),
-                assetHelper)
+      ruleSetup(
+        Seq(
+          (ruleName, triggerName, (actionName, actionName, defaultAction)),
+          (ruleName2, triggerName, (actionName, actionName, defaultAction))),
+        assetHelper)
 
-            wsk.rule.disable(ruleName)
-            val listOutput = wsk.rule.list().stdout.lines
-            listOutput.find(_.contains(ruleName2)).get should (include(ruleName2) and include("active"))
-            listOutput.find(_.contains(ruleName)).get should (include(ruleName) and include("inactive"))
-            wsk.rule.list().stdout should not include ("Unknown")
-    }
+      wsk.rule.disable(ruleName)
+      val listOutput = wsk.rule.list().stdout.lines
+      listOutput.find(_.contains(ruleName2)).get should (include(ruleName2) and include("active"))
+      listOutput.find(_.contains(ruleName)).get should (include(ruleName) and include("inactive"))
+      wsk.rule.list().stdout should not include ("Unknown")
+  }
 
 }

--- a/tests/src/test/scala/system/basic/WskSequenceTests.scala
+++ b/tests/src/test/scala/system/basic/WskSequenceTests.scala
@@ -49,484 +49,498 @@ import whisk.http.Messages.sequenceIsTooLong
  */
 
 @RunWith(classOf[JUnitRunner])
-class WskSequenceTests
-    extends TestHelpers
-    with ScalatestRouteTest
-    with WskTestHelpers
-    with StreamLogging {
+class WskSequenceTests extends TestHelpers with ScalatestRouteTest with WskTestHelpers with StreamLogging {
 
-    implicit val wskprops = WskProps()
-    val wsk = new Wsk
-    val allowedActionDuration = 120 seconds
-    val shortDuration = 10 seconds
+  implicit val wskprops = WskProps()
+  val wsk = new Wsk
+  val allowedActionDuration = 120 seconds
+  val shortDuration = 10 seconds
 
-    val whiskConfig = new WhiskConfig(Map(WhiskConfig.actionSequenceMaxLimit -> null))
-    assert(whiskConfig.isValid)
+  val whiskConfig = new WhiskConfig(Map(WhiskConfig.actionSequenceMaxLimit -> null))
+  assert(whiskConfig.isValid)
 
-    behavior of "Wsk Sequence"
+  behavior of "Wsk Sequence"
 
-    it should "invoke a sequence with normal payload and payload with error field" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "sequence"
-            val actions = Seq("split", "sort", "head", "cat")
-            for (actionName <- actions) {
-                val file = TestUtils.getTestActionFilename(s"$actionName.js")
-                assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
-                    action.create(name = actionName, artifact = Some(file), timeout = Some(allowedActionDuration))
-                }
-            }
-
-            println(s"Sequence $actions")
-            assetHelper.withCleaner(wsk.action, name) {
-                val sequence = actions.mkString(",")
-                (action, _) => action.create(name, Some(sequence), kind = Some("sequence"), timeout = Some(allowedActionDuration))
-            }
-
-            val now = "it is now " + new Date()
-            val args = Array("what time is it?", now)
-            val run = wsk.action.invoke(name, Map("payload" -> args.mkString("\n").toJson))
-            withActivation(wsk.activation, run, totalWait = 4 * allowedActionDuration) {
-                activation =>
-                    checkSequenceLogsAndAnnotations(activation, 4) // 4 activations in this sequence
-                    activation.cause shouldBe None // topmost sequence
-                    val result = activation.response.result.get
-                    result.fields.get("payload") shouldBe defined
-                    result.fields.get("length") should not be defined
-                    result.fields.get("lines") shouldBe Some(JsArray(Vector(now.toJson)))
-            }
-
-            // update action sequence and run it with normal payload
-            val newSequence = Seq("split", "sort").mkString(",")
-            println(s"Update sequence to $newSequence")
-            wsk.action.create(name, Some(newSequence), kind = Some("sequence"), timeout = Some(allowedActionDuration), update = true)
-            val secondrun = wsk.action.invoke(name, Map("payload" -> args.mkString("\n").toJson))
-            withActivation(wsk.activation, secondrun, totalWait = 2 * allowedActionDuration) {
-                activation =>
-                    checkSequenceLogsAndAnnotations(activation, 2) // 2 activations in this sequence
-                    val result = activation.response.result.get
-                    result.fields.get("length") shouldBe Some(2.toJson)
-                    result.fields.get("lines") shouldBe Some(args.sortWith(_.compareTo(_) < 0).toArray.toJson)
-            }
-
-            println("Run sequence with error in payload")
-            // run sequence with error in the payload
-            // sequence should run with no problems, error should be ignored in this test case
-            // result of sequence should be identical to previous invocation above
-            val payload = Map("error" -> JsString("irrelevant error string"), "payload" -> args.mkString("\n").toJson)
-            val thirdrun = wsk.action.invoke(name, payload)
-            withActivation(wsk.activation, thirdrun, totalWait = 2 * allowedActionDuration) {
-                activation =>
-                    checkSequenceLogsAndAnnotations(activation, 2) // 2 activations in this sequence
-                    val result = activation.response.result.get
-                    result.fields.get("length") shouldBe Some(2.toJson)
-                    result.fields.get("lines") shouldBe Some(args.sortWith(_.compareTo(_) < 0).toArray.toJson)
-            }
-    }
-
-    it should "invoke a sequence with an enclosing sequence action" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val inner_name = "inner_sequence"
-            val outer_name = "outer_sequence"
-            val inner_actions = Seq("sort", "head")
-            val actions = Seq("split") ++ inner_actions ++ Seq("cat")
-            // create atomic actions
-            for (actionName <- actions) {
-                val file = TestUtils.getTestActionFilename(s"$actionName.js")
-                assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
-                    action.create(name = actionName, artifact = Some(file), timeout = Some(allowedActionDuration))
-                }
-            }
-
-            // create inner sequence
-            assetHelper.withCleaner(wsk.action, inner_name) {
-                val inner_sequence = inner_actions.mkString(",")
-                (action, _) => action.create(inner_name, Some(inner_sequence), kind = Some("sequence"))
-            }
-
-            // create outer sequence
-            assetHelper.withCleaner(wsk.action, outer_name) {
-                val outer_sequence = Seq("split", "inner_sequence", "cat").mkString(",")
-                (action, _) => action.create(outer_name, Some(outer_sequence), kind = Some("sequence"))
-            }
-
-            val now = "it is now " + new Date()
-            val args = Array("what time is it?", now)
-            val run = wsk.action.invoke(outer_name, Map("payload" -> args.mkString("\n").toJson))
-            withActivation(wsk.activation, run, totalWait = 4 * allowedActionDuration) {
-                activation =>
-                    checkSequenceLogsAndAnnotations(activation, 3) // 3 activations in this sequence
-                    activation.cause shouldBe None // topmost sequence
-                    val result = activation.response.result.get
-                    result.fields.get("payload") shouldBe defined
-                    result.fields.get("length") should not be defined
-                    result.fields.get("lines") shouldBe Some(JsArray(Vector(now.toJson)))
-            }
-    }
-
-    /**
-     * s -> echo, x, echo
-     * x -> echo
-     *
-     * update x -> <limit-1> echo -- should work
-     * run s -> should stop after <limit> echo
-     *
-     * This confirms that a dynamic check on the sequence length holds within the system limit.
-     * This is different from creating a long sequence up front which will report a length error at create time.
-     */
-    it should "replace atomic component in a sequence that is too long and report invoke error" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val xName = "xSequence"
-            val sName = "sSequence"
-            val echo = "echo"
-
-            // create echo action
-            val file = TestUtils.getTestActionFilename(s"$echo.js")
-            assetHelper.withCleaner(wsk.action, echo) { (action, actionName) =>
-                action.create(name = actionName, artifact = Some(file), timeout = Some(allowedActionDuration))
-            }
-            // create x
-            assetHelper.withCleaner(wsk.action, xName) {
-                (action, seqName) => action.create(seqName, Some(echo), kind = Some("sequence"))
-            }
-            // create s
-            assetHelper.withCleaner(wsk.action, sName) {
-                (action, seqName) => action.create(seqName, Some(s"$echo,$xName,$echo"), kind = Some("sequence"))
-            }
-
-            // invoke s
-            val now = "it is now " + new Date()
-            val args = Array("what time is it?", now)
-            val argsJson = args.mkString("\n").toJson
-            val run = wsk.action.invoke(sName, Map("payload" -> argsJson))
-            println(s"RUN: ${run.stdout}")
-            withActivation(wsk.activation, run, totalWait = 2 * allowedActionDuration) {
-                activation =>
-                    checkSequenceLogsAndAnnotations(activation, 3) // 3 activations in this sequence
-                    val result = activation.response.result.get
-                    result.fields.get("payload") shouldBe Some(argsJson)
-            }
-            // update x with limit echo
-            val limit = whiskConfig.actionSequenceLimit.toInt
-            val manyEcho = for (i <- 1 to limit) yield echo
-
-            wsk.action.create(xName, Some(manyEcho.mkString(",")), kind = Some("sequence"), update = true)
-
-            val updateRun = wsk.action.invoke(sName, Map("payload" -> argsJson))
-            withActivation(wsk.activation, updateRun, totalWait = 2 * allowedActionDuration) {
-                activation =>
-                    activation.response.status shouldBe ("application error")
-                    checkSequenceLogsAndAnnotations(activation, 2)
-                    val result = activation.response.result.get
-                    result.fields.get("error") shouldBe Some(JsString(sequenceIsTooLong))
-                    // check that inner sequence had only (limit - 1) activations
-                    val innerSeq = activation.logs.get(1) // the id of the inner sequence activation
-                    val getInnerSeq = wsk.activation.get(Some(innerSeq))
-                    withActivation(wsk.activation, getInnerSeq, totalWait = allowedActionDuration) {
-                        innerSeqActivation =>
-                            innerSeqActivation.logs.get.size shouldBe (limit - 1)
-                            innerSeqActivation.cause shouldBe Some(activation.activationId)
-                    }
-            }
-    }
-
-    it should "create and run a sequence in a package with parameters" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val sName = "sSequence"
-
-            // create a package
-            val pkgName = "echopackage"
-            val pkgStr = "LonelyPackage"
-            assetHelper.withCleaner(wsk.pkg, pkgName) {
-                (pkg, name) => pkg.create(name, Map("payload" -> JsString(pkgStr)))
-            }
-            val helloName = "hello"
-            val helloWithPkg = s"$pkgName/$helloName"
-
-            // create hello action in package
-            val file = TestUtils.getTestActionFilename(s"$helloName.js")
-            val actionStr = "AtomicAction"
-            assetHelper.withCleaner(wsk.action, helloWithPkg) { (action, actionName) =>
-                action.create(name = actionName, artifact = Some(file), timeout = Some(allowedActionDuration), parameters = Map("payload" -> JsString(actionStr)))
-            }
-            // create s
-            assetHelper.withCleaner(wsk.action, sName) {
-                (action, seqName) => action.create(seqName, Some(helloWithPkg), kind = Some("sequence"))
-            }
-            val run = wsk.action.invoke(sName)
-            // action params trump package params
-            checkLogsAtomicAction(0, run, new Regex(actionStr))
-            // run with some parameters
-            val sequenceStr = "AlmightySequence"
-            val sequenceParamRun = wsk.action.invoke(sName, parameters = Map("payload" -> JsString(sequenceStr)))
-            // sequence param should be passed to the first atomic action and trump the action params
-            checkLogsAtomicAction(0, sequenceParamRun, new Regex(sequenceStr))
-            // update action and remove the params by sending an unused param that overrides previous params
-            wsk.action.create(name = helloWithPkg, artifact = Some(file), timeout = Some(allowedActionDuration), parameters = Map("param" -> JsString("irrelevant")), update = true)
-            val sequenceParamSecondRun = wsk.action.invoke(sName, parameters = Map("payload" -> JsString(sequenceStr)))
-            // sequence param should be passed to the first atomic action and trump the package params
-            checkLogsAtomicAction(0, sequenceParamSecondRun, new Regex(sequenceStr))
-            val pkgParamRun = wsk.action.invoke(sName)
-            // no sequence params, no atomic action params used, the pkg params should show up
-            checkLogsAtomicAction(0, pkgParamRun, new Regex(pkgStr))
-    }
-
-    it should "run a sequence with an action in a package binding with parameters" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val packageName = "package1"
-            val bindName = "package2"
-            val actionName = "print"
-            val packageActionName = packageName + "/" + actionName
-            val bindActionName = bindName + "/" + actionName
-            val packageParams = Map("key1a" -> "value1a".toJson, "key1b" -> "value1b".toJson)
-            val bindParams = Map("key2a" -> "value2a".toJson, "key1b" -> "value2b".toJson)
-            val actionParams = Map("key0" -> "value0".toJson)
-            val file = TestUtils.getTestActionFilename("printParams.js")
-            assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, _) =>
-                pkg.create(packageName, packageParams)
-            }
-            assetHelper.withCleaner(wsk.action, packageActionName) { (action, _) =>
-                action.create(packageActionName, Some(file), parameters = actionParams)
-            }
-            assetHelper.withCleaner(wsk.pkg, bindName) { (pkg, _) =>
-                pkg.bind(packageName, bindName, bindParams)
-            }
-            // sequence
-            val sName = "sequenceWithBindingParams"
-            assetHelper.withCleaner(wsk.action, sName) {
-                (action, seqName) => action.create(seqName, Some(bindActionName), kind = Some("sequence"))
-            }
-            // Check that inherited parameters are passed to the action.
-            val now = new Date().toString()
-            val run = wsk.action.invoke(sName, Map("payload" -> now.toJson))
-            // action params trump package params
-            checkLogsAtomicAction(0, run, new Regex(String.format(".*key0: value0.*key1a: value1a.*key1b: value2b.*key2a: value2a.*payload: %s", now)))
-    }
-
-    /**
-     * s -> apperror, echo
-     * only apperror should run
-     */
-    it should "stop execution of a sequence (with no payload) on error" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val sName = "sSequence"
-            val apperror = "applicationError"
-            val echo = "echo"
-
-            // create actions
-            val actions = Seq(apperror, echo)
-            for (actionName <- actions) {
-                val file = TestUtils.getTestActionFilename(s"$actionName.js")
-                assetHelper.withCleaner(wsk.action, actionName) { (action, actionName) =>
-                    action.create(name = actionName, artifact = Some(file), timeout = Some(allowedActionDuration))
-                }
-            }
-            // create sequence s
-            assetHelper.withCleaner(wsk.action, sName) {
-                (action, seqName) => action.create(seqName, artifact = Some(actions.mkString(",")), kind = Some("sequence"))
-            }
-            // run sequence s with no payload
-            val run = wsk.action.invoke(sName)
-            withActivation(wsk.activation, run, totalWait = 2 * allowedActionDuration) {
-                activation =>
-                    checkSequenceLogsAndAnnotations(activation, 1) // only the first action should have run
-                    activation.response.success shouldBe (false)
-                    // the status should be error
-                    activation.response.status shouldBe ("application error")
-                    val result = activation.response.result.get
-                    // the result of the activation should be the application error
-                    result shouldBe (JsObject("error" -> JsString("This error thrown on purpose by the action.")))
-            }
-    }
-
-    /**
-     * s -> echo, initforever
-     * should run both, but error
-     */
-    it should "propagate execution error (timeout) from atomic action to sequence" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val sName = "sSequence"
-            val initforever = "initforever"
-            val echo = "echo"
-
-            // create actions
-            val actions = Seq(echo, initforever)
-            // timeouts for the action; make the one for initforever short
-            val timeout = Map(echo -> allowedActionDuration, initforever -> shortDuration)
-            for (actionName <- actions) {
-                val file = TestUtils.getTestActionFilename(s"$actionName.js")
-                assetHelper.withCleaner(wsk.action, actionName) { (action, actionName) =>
-                    action.create(name = actionName, artifact = Some(file), timeout = Some(timeout(actionName)))
-                }
-            }
-            // create sequence s
-            assetHelper.withCleaner(wsk.action, sName) {
-                (action, seqName) => action.create(seqName, artifact = Some(actions.mkString(",")), kind = Some("sequence"))
-            }
-            // run sequence s with no payload
-            val run = wsk.action.invoke(sName)
-            withActivation(wsk.activation, run, totalWait = 2 * allowedActionDuration) {
-                activation =>
-                    checkSequenceLogsAndAnnotations(activation, 2) // 2 actions
-                    activation.response.success shouldBe (false)
-                    // the status should be error
-                    //activation.response.status shouldBe("application error")
-                    val result = activation.response.result.get
-                    // the result of the activation should be timeout
-                    result shouldBe (JsObject("error" -> JsString("The action exceeded its time limits of 10000 milliseconds during initialization.")))
-            }
-    }
-
-    /**
-     * s -> echo, sleep
-     * sleep sleeps for 90s, timeout set at 120s
-     * should run both, the blocking call should be transformed into a non-blocking call, but finish executing
-     */
-    it should "execute a sequence in blocking fashion and finish execution even if longer than blocking response timeout" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val sName = "sSequence"
-            val sleep = "timeout"
-            val echo = "echo"
-
-            // create actions
-            val actions = Seq(echo, sleep)
-            for (actionName <- actions) {
-                val file = TestUtils.getTestActionFilename(s"$actionName.js")
-                assetHelper.withCleaner(wsk.action, actionName) { (action, actionName) =>
-                    action.create(name = actionName, artifact = Some(file), timeout = Some(allowedActionDuration))
-                }
-            }
-            // create sequence s
-            assetHelper.withCleaner(wsk.action, sName) {
-                (action, seqName) => action.create(seqName, artifact = Some(actions.mkString(",")), kind = Some("sequence"))
-            }
-            // run sequence s with sleep equal to payload
-            val payload = 65000
-            val run = wsk.action.invoke(sName, parameters = Map("payload" -> JsNumber(payload)), blocking = true, expectedExitCode = ACCEPTED)
-            withActivation(wsk.activation, run, initialWait = 5 seconds, totalWait = 3 * allowedActionDuration) {
-                activation =>
-                    checkSequenceLogsAndAnnotations(activation, 2) // 2 actions
-                    activation.response.success shouldBe (true)
-                    // the status should be error
-                    //activation.response.status shouldBe("application error")
-                    val result = activation.response.result.get
-                    // the result of the activation should be timeout
-                    result shouldBe (JsObject("msg" -> JsString(s"[OK] message terminated successfully after $payload milliseconds.")))
-            }
-    }
-
-    /**
-     * sequence s -> echo
-     * t trigger with payload
-     * rule r: t -> s
-     */
-    it should "execute a sequence that is part of a rule and pass the trigger parameters to the sequence" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val seqName = "seqRule"
-            val actionName = "echo"
-            val triggerName = "trigSeq"
-            val ruleName = "ruleSeq"
-
-            val itIsNow = "it is now " + new Date()
-            // set up all entities
-            // trigger
-            val triggerPayload: Map[String, JsValue] = Map("payload" -> JsString(itIsNow))
-            assetHelper.withCleaner(wsk.trigger, triggerName) {
-                (trigger, name) => trigger.create(name, parameters = triggerPayload)
-            }
-            // action
-            val file = TestUtils.getTestActionFilename(s"$actionName.js")
-            assetHelper.withCleaner(wsk.action, actionName) { (action, actionName) =>
-                action.create(name = actionName, artifact = Some(file), timeout = Some(allowedActionDuration))
-            }
-            // sequence
-            assetHelper.withCleaner(wsk.action, seqName) {
-                (action, seqName) => action.create(seqName, artifact = Some(actionName), kind = Some("sequence"))
-            }
-            // rule
-            assetHelper.withCleaner(wsk.rule, ruleName) {
-                (rule, name) => rule.create(name, triggerName, seqName)
-            }
-            // fire trigger
-            val run = wsk.trigger.fire(triggerName)
-            // check that the sequence was invoked and that the echo action produced the expected result
-            checkEchoSeqRuleResult(run, seqName, JsObject(triggerPayload))
-            // fire trigger with new payload
-            val now = "this is now: " + Instant.now
-            val newPayload = Map("payload" -> JsString(now))
-            val newRun = wsk.trigger.fire(triggerName, newPayload)
-            checkEchoSeqRuleResult(newRun, seqName, JsObject(newPayload))
-    }
-
-    /**
-     * checks the result of an echo sequence connected to a trigger through a rule
-     * @param triggerFireRun the run result of firing the trigger
-     * @param seqName the sequence name
-     * @param triggerPayload the payload used for the trigger (that should be reflected in the sequence result)
-     */
-    private def checkEchoSeqRuleResult(triggerFireRun: RunResult, seqName: String, triggerPayload: JsObject) = {
-        withActivation(wsk.activation, triggerFireRun) {
-            triggerActivation =>
-                withActivationsFromEntity(wsk.activation, seqName, since = Some(triggerActivation.start)) { activationList =>
-                    activationList.head.response.result shouldBe Some(triggerPayload)
-                    activationList.head.cause shouldBe None
-                }
+  it should "invoke a sequence with normal payload and payload with error field" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "sequence"
+      val actions = Seq("split", "sort", "head", "cat")
+      for (actionName <- actions) {
+        val file = TestUtils.getTestActionFilename(s"$actionName.js")
+        assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
+          action.create(name = actionName, artifact = Some(file), timeout = Some(allowedActionDuration))
         }
+      }
+
+      println(s"Sequence $actions")
+      assetHelper.withCleaner(wsk.action, name) {
+        val sequence = actions.mkString(",")
+        (action, _) =>
+          action.create(name, Some(sequence), kind = Some("sequence"), timeout = Some(allowedActionDuration))
+      }
+
+      val now = "it is now " + new Date()
+      val args = Array("what time is it?", now)
+      val run = wsk.action.invoke(name, Map("payload" -> args.mkString("\n").toJson))
+      withActivation(wsk.activation, run, totalWait = 4 * allowedActionDuration) { activation =>
+        checkSequenceLogsAndAnnotations(activation, 4) // 4 activations in this sequence
+        activation.cause shouldBe None // topmost sequence
+        val result = activation.response.result.get
+        result.fields.get("payload") shouldBe defined
+        result.fields.get("length") should not be defined
+        result.fields.get("lines") shouldBe Some(JsArray(Vector(now.toJson)))
+      }
+
+      // update action sequence and run it with normal payload
+      val newSequence = Seq("split", "sort").mkString(",")
+      println(s"Update sequence to $newSequence")
+      wsk.action.create(
+        name,
+        Some(newSequence),
+        kind = Some("sequence"),
+        timeout = Some(allowedActionDuration),
+        update = true)
+      val secondrun = wsk.action.invoke(name, Map("payload" -> args.mkString("\n").toJson))
+      withActivation(wsk.activation, secondrun, totalWait = 2 * allowedActionDuration) { activation =>
+        checkSequenceLogsAndAnnotations(activation, 2) // 2 activations in this sequence
+        val result = activation.response.result.get
+        result.fields.get("length") shouldBe Some(2.toJson)
+        result.fields.get("lines") shouldBe Some(args.sortWith(_.compareTo(_) < 0).toArray.toJson)
+      }
+
+      println("Run sequence with error in payload")
+      // run sequence with error in the payload
+      // sequence should run with no problems, error should be ignored in this test case
+      // result of sequence should be identical to previous invocation above
+      val payload = Map("error" -> JsString("irrelevant error string"), "payload" -> args.mkString("\n").toJson)
+      val thirdrun = wsk.action.invoke(name, payload)
+      withActivation(wsk.activation, thirdrun, totalWait = 2 * allowedActionDuration) { activation =>
+        checkSequenceLogsAndAnnotations(activation, 2) // 2 activations in this sequence
+        val result = activation.response.result.get
+        result.fields.get("length") shouldBe Some(2.toJson)
+        result.fields.get("lines") shouldBe Some(args.sortWith(_.compareTo(_) < 0).toArray.toJson)
+      }
+  }
+
+  it should "invoke a sequence with an enclosing sequence action" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val inner_name = "inner_sequence"
+    val outer_name = "outer_sequence"
+    val inner_actions = Seq("sort", "head")
+    val actions = Seq("split") ++ inner_actions ++ Seq("cat")
+    // create atomic actions
+    for (actionName <- actions) {
+      val file = TestUtils.getTestActionFilename(s"$actionName.js")
+      assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
+        action.create(name = actionName, artifact = Some(file), timeout = Some(allowedActionDuration))
+      }
     }
 
-    /**
-     * checks logs for the activation of a sequence (length/size and ids)
-     * checks that the cause field for composing atomic actions is set properly
-     * checks duration
-     * checks memory
-     */
-    private def checkSequenceLogsAndAnnotations(activation: ActivationResult, size: Int) = {
-        activation.logs shouldBe defined
-        // check that the logs are what they are supposed to be (activation ids)
-        // check that the cause field is properly set for these activations
-        activation.logs.get.size shouldBe (size) // the number of activations in this sequence
-        var totalTime: Long = 0
-        var maxMemory: Long = 0
-        for (id <- activation.logs.get) {
-            withActivation(wsk.activation, id, initialWait = 1 second, pollPeriod = 60 seconds, totalWait = allowedActionDuration) {
-                componentActivation =>
-                    componentActivation.cause shouldBe defined
-                    componentActivation.cause.get shouldBe (activation.activationId)
-                    // check causedBy
-                    val causedBy = componentActivation.getAnnotationValue("causedBy")
-                    causedBy shouldBe defined
-                    causedBy.get shouldBe (JsString("sequence"))
-                    totalTime += componentActivation.duration
-                    // extract memory
-                    val mem = extractMemoryAnnotation(componentActivation)
-                    maxMemory = maxMemory max mem
-            }
+    // create inner sequence
+    assetHelper.withCleaner(wsk.action, inner_name) {
+      val inner_sequence = inner_actions.mkString(",")
+      (action, _) =>
+        action.create(inner_name, Some(inner_sequence), kind = Some("sequence"))
+    }
+
+    // create outer sequence
+    assetHelper.withCleaner(wsk.action, outer_name) {
+      val outer_sequence = Seq("split", "inner_sequence", "cat").mkString(",")
+      (action, _) =>
+        action.create(outer_name, Some(outer_sequence), kind = Some("sequence"))
+    }
+
+    val now = "it is now " + new Date()
+    val args = Array("what time is it?", now)
+    val run = wsk.action.invoke(outer_name, Map("payload" -> args.mkString("\n").toJson))
+    withActivation(wsk.activation, run, totalWait = 4 * allowedActionDuration) { activation =>
+      checkSequenceLogsAndAnnotations(activation, 3) // 3 activations in this sequence
+      activation.cause shouldBe None // topmost sequence
+      val result = activation.response.result.get
+      result.fields.get("payload") shouldBe defined
+      result.fields.get("length") should not be defined
+      result.fields.get("lines") shouldBe Some(JsArray(Vector(now.toJson)))
+    }
+  }
+
+  /**
+   * s -> echo, x, echo
+   * x -> echo
+   *
+   * update x -> <limit-1> echo -- should work
+   * run s -> should stop after <limit> echo
+   *
+   * This confirms that a dynamic check on the sequence length holds within the system limit.
+   * This is different from creating a long sequence up front which will report a length error at create time.
+   */
+  it should "replace atomic component in a sequence that is too long and report invoke error" in withAssetCleaner(
+    wskprops) { (wp, assetHelper) =>
+    val xName = "xSequence"
+    val sName = "sSequence"
+    val echo = "echo"
+
+    // create echo action
+    val file = TestUtils.getTestActionFilename(s"$echo.js")
+    assetHelper.withCleaner(wsk.action, echo) { (action, actionName) =>
+      action.create(name = actionName, artifact = Some(file), timeout = Some(allowedActionDuration))
+    }
+    // create x
+    assetHelper.withCleaner(wsk.action, xName) { (action, seqName) =>
+      action.create(seqName, Some(echo), kind = Some("sequence"))
+    }
+    // create s
+    assetHelper.withCleaner(wsk.action, sName) { (action, seqName) =>
+      action.create(seqName, Some(s"$echo,$xName,$echo"), kind = Some("sequence"))
+    }
+
+    // invoke s
+    val now = "it is now " + new Date()
+    val args = Array("what time is it?", now)
+    val argsJson = args.mkString("\n").toJson
+    val run = wsk.action.invoke(sName, Map("payload" -> argsJson))
+    println(s"RUN: ${run.stdout}")
+    withActivation(wsk.activation, run, totalWait = 2 * allowedActionDuration) { activation =>
+      checkSequenceLogsAndAnnotations(activation, 3) // 3 activations in this sequence
+      val result = activation.response.result.get
+      result.fields.get("payload") shouldBe Some(argsJson)
+    }
+    // update x with limit echo
+    val limit = whiskConfig.actionSequenceLimit.toInt
+    val manyEcho = for (i <- 1 to limit) yield echo
+
+    wsk.action.create(xName, Some(manyEcho.mkString(",")), kind = Some("sequence"), update = true)
+
+    val updateRun = wsk.action.invoke(sName, Map("payload" -> argsJson))
+    withActivation(wsk.activation, updateRun, totalWait = 2 * allowedActionDuration) { activation =>
+      activation.response.status shouldBe ("application error")
+      checkSequenceLogsAndAnnotations(activation, 2)
+      val result = activation.response.result.get
+      result.fields.get("error") shouldBe Some(JsString(sequenceIsTooLong))
+      // check that inner sequence had only (limit - 1) activations
+      val innerSeq = activation.logs.get(1) // the id of the inner sequence activation
+      val getInnerSeq = wsk.activation.get(Some(innerSeq))
+      withActivation(wsk.activation, getInnerSeq, totalWait = allowedActionDuration) { innerSeqActivation =>
+        innerSeqActivation.logs.get.size shouldBe (limit - 1)
+        innerSeqActivation.cause shouldBe Some(activation.activationId)
+      }
+    }
+  }
+
+  it should "create and run a sequence in a package with parameters" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val sName = "sSequence"
+
+      // create a package
+      val pkgName = "echopackage"
+      val pkgStr = "LonelyPackage"
+      assetHelper.withCleaner(wsk.pkg, pkgName) { (pkg, name) =>
+        pkg.create(name, Map("payload" -> JsString(pkgStr)))
+      }
+      val helloName = "hello"
+      val helloWithPkg = s"$pkgName/$helloName"
+
+      // create hello action in package
+      val file = TestUtils.getTestActionFilename(s"$helloName.js")
+      val actionStr = "AtomicAction"
+      assetHelper.withCleaner(wsk.action, helloWithPkg) { (action, actionName) =>
+        action.create(
+          name = actionName,
+          artifact = Some(file),
+          timeout = Some(allowedActionDuration),
+          parameters = Map("payload" -> JsString(actionStr)))
+      }
+      // create s
+      assetHelper.withCleaner(wsk.action, sName) { (action, seqName) =>
+        action.create(seqName, Some(helloWithPkg), kind = Some("sequence"))
+      }
+      val run = wsk.action.invoke(sName)
+      // action params trump package params
+      checkLogsAtomicAction(0, run, new Regex(actionStr))
+      // run with some parameters
+      val sequenceStr = "AlmightySequence"
+      val sequenceParamRun = wsk.action.invoke(sName, parameters = Map("payload" -> JsString(sequenceStr)))
+      // sequence param should be passed to the first atomic action and trump the action params
+      checkLogsAtomicAction(0, sequenceParamRun, new Regex(sequenceStr))
+      // update action and remove the params by sending an unused param that overrides previous params
+      wsk.action.create(
+        name = helloWithPkg,
+        artifact = Some(file),
+        timeout = Some(allowedActionDuration),
+        parameters = Map("param" -> JsString("irrelevant")),
+        update = true)
+      val sequenceParamSecondRun = wsk.action.invoke(sName, parameters = Map("payload" -> JsString(sequenceStr)))
+      // sequence param should be passed to the first atomic action and trump the package params
+      checkLogsAtomicAction(0, sequenceParamSecondRun, new Regex(sequenceStr))
+      val pkgParamRun = wsk.action.invoke(sName)
+      // no sequence params, no atomic action params used, the pkg params should show up
+      checkLogsAtomicAction(0, pkgParamRun, new Regex(pkgStr))
+  }
+
+  it should "run a sequence with an action in a package binding with parameters" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val packageName = "package1"
+      val bindName = "package2"
+      val actionName = "print"
+      val packageActionName = packageName + "/" + actionName
+      val bindActionName = bindName + "/" + actionName
+      val packageParams = Map("key1a" -> "value1a".toJson, "key1b" -> "value1b".toJson)
+      val bindParams = Map("key2a" -> "value2a".toJson, "key1b" -> "value2b".toJson)
+      val actionParams = Map("key0" -> "value0".toJson)
+      val file = TestUtils.getTestActionFilename("printParams.js")
+      assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, _) =>
+        pkg.create(packageName, packageParams)
+      }
+      assetHelper.withCleaner(wsk.action, packageActionName) { (action, _) =>
+        action.create(packageActionName, Some(file), parameters = actionParams)
+      }
+      assetHelper.withCleaner(wsk.pkg, bindName) { (pkg, _) =>
+        pkg.bind(packageName, bindName, bindParams)
+      }
+      // sequence
+      val sName = "sequenceWithBindingParams"
+      assetHelper.withCleaner(wsk.action, sName) { (action, seqName) =>
+        action.create(seqName, Some(bindActionName), kind = Some("sequence"))
+      }
+      // Check that inherited parameters are passed to the action.
+      val now = new Date().toString()
+      val run = wsk.action.invoke(sName, Map("payload" -> now.toJson))
+      // action params trump package params
+      checkLogsAtomicAction(
+        0,
+        run,
+        new Regex(String.format(".*key0: value0.*key1a: value1a.*key1b: value2b.*key2a: value2a.*payload: %s", now)))
+  }
+
+  /**
+   * s -> apperror, echo
+   * only apperror should run
+   */
+  it should "stop execution of a sequence (with no payload) on error" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val sName = "sSequence"
+      val apperror = "applicationError"
+      val echo = "echo"
+
+      // create actions
+      val actions = Seq(apperror, echo)
+      for (actionName <- actions) {
+        val file = TestUtils.getTestActionFilename(s"$actionName.js")
+        assetHelper.withCleaner(wsk.action, actionName) { (action, actionName) =>
+          action.create(name = actionName, artifact = Some(file), timeout = Some(allowedActionDuration))
         }
-        // extract duration
-        activation.duration shouldBe (totalTime)
+      }
+      // create sequence s
+      assetHelper.withCleaner(wsk.action, sName) { (action, seqName) =>
+        action.create(seqName, artifact = Some(actions.mkString(",")), kind = Some("sequence"))
+      }
+      // run sequence s with no payload
+      val run = wsk.action.invoke(sName)
+      withActivation(wsk.activation, run, totalWait = 2 * allowedActionDuration) { activation =>
+        checkSequenceLogsAndAnnotations(activation, 1) // only the first action should have run
+        activation.response.success shouldBe (false)
+        // the status should be error
+        activation.response.status shouldBe ("application error")
+        val result = activation.response.result.get
+        // the result of the activation should be the application error
+        result shouldBe (JsObject("error" -> JsString("This error thrown on purpose by the action.")))
+      }
+  }
+
+  /**
+   * s -> echo, initforever
+   * should run both, but error
+   */
+  it should "propagate execution error (timeout) from atomic action to sequence" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val sName = "sSequence"
+      val initforever = "initforever"
+      val echo = "echo"
+
+      // create actions
+      val actions = Seq(echo, initforever)
+      // timeouts for the action; make the one for initforever short
+      val timeout = Map(echo -> allowedActionDuration, initforever -> shortDuration)
+      for (actionName <- actions) {
+        val file = TestUtils.getTestActionFilename(s"$actionName.js")
+        assetHelper.withCleaner(wsk.action, actionName) { (action, actionName) =>
+          action.create(name = actionName, artifact = Some(file), timeout = Some(timeout(actionName)))
+        }
+      }
+      // create sequence s
+      assetHelper.withCleaner(wsk.action, sName) { (action, seqName) =>
+        action.create(seqName, artifact = Some(actions.mkString(",")), kind = Some("sequence"))
+      }
+      // run sequence s with no payload
+      val run = wsk.action.invoke(sName)
+      withActivation(wsk.activation, run, totalWait = 2 * allowedActionDuration) { activation =>
+        checkSequenceLogsAndAnnotations(activation, 2) // 2 actions
+        activation.response.success shouldBe (false)
+        // the status should be error
+        //activation.response.status shouldBe("application error")
+        val result = activation.response.result.get
+        // the result of the activation should be timeout
+        result shouldBe (JsObject(
+          "error" -> JsString("The action exceeded its time limits of 10000 milliseconds during initialization.")))
+      }
+  }
+
+  /**
+   * s -> echo, sleep
+   * sleep sleeps for 90s, timeout set at 120s
+   * should run both, the blocking call should be transformed into a non-blocking call, but finish executing
+   */
+  it should "execute a sequence in blocking fashion and finish execution even if longer than blocking response timeout" in withAssetCleaner(
+    wskprops) { (wp, assetHelper) =>
+    val sName = "sSequence"
+    val sleep = "timeout"
+    val echo = "echo"
+
+    // create actions
+    val actions = Seq(echo, sleep)
+    for (actionName <- actions) {
+      val file = TestUtils.getTestActionFilename(s"$actionName.js")
+      assetHelper.withCleaner(wsk.action, actionName) { (action, actionName) =>
+        action.create(name = actionName, artifact = Some(file), timeout = Some(allowedActionDuration))
+      }
+    }
+    // create sequence s
+    assetHelper.withCleaner(wsk.action, sName) { (action, seqName) =>
+      action.create(seqName, artifact = Some(actions.mkString(",")), kind = Some("sequence"))
+    }
+    // run sequence s with sleep equal to payload
+    val payload = 65000
+    val run = wsk.action.invoke(
+      sName,
+      parameters = Map("payload" -> JsNumber(payload)),
+      blocking = true,
+      expectedExitCode = ACCEPTED)
+    withActivation(wsk.activation, run, initialWait = 5 seconds, totalWait = 3 * allowedActionDuration) { activation =>
+      checkSequenceLogsAndAnnotations(activation, 2) // 2 actions
+      activation.response.success shouldBe (true)
+      // the status should be error
+      //activation.response.status shouldBe("application error")
+      val result = activation.response.result.get
+      // the result of the activation should be timeout
+      result shouldBe (JsObject(
+        "msg" -> JsString(s"[OK] message terminated successfully after $payload milliseconds.")))
+    }
+  }
+
+  /**
+   * sequence s -> echo
+   * t trigger with payload
+   * rule r: t -> s
+   */
+  it should "execute a sequence that is part of a rule and pass the trigger parameters to the sequence" in withAssetCleaner(
+    wskprops) { (wp, assetHelper) =>
+    val seqName = "seqRule"
+    val actionName = "echo"
+    val triggerName = "trigSeq"
+    val ruleName = "ruleSeq"
+
+    val itIsNow = "it is now " + new Date()
+    // set up all entities
+    // trigger
+    val triggerPayload: Map[String, JsValue] = Map("payload" -> JsString(itIsNow))
+    assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
+      trigger.create(name, parameters = triggerPayload)
+    }
+    // action
+    val file = TestUtils.getTestActionFilename(s"$actionName.js")
+    assetHelper.withCleaner(wsk.action, actionName) { (action, actionName) =>
+      action.create(name = actionName, artifact = Some(file), timeout = Some(allowedActionDuration))
+    }
+    // sequence
+    assetHelper.withCleaner(wsk.action, seqName) { (action, seqName) =>
+      action.create(seqName, artifact = Some(actionName), kind = Some("sequence"))
+    }
+    // rule
+    assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
+      rule.create(name, triggerName, seqName)
+    }
+    // fire trigger
+    val run = wsk.trigger.fire(triggerName)
+    // check that the sequence was invoked and that the echo action produced the expected result
+    checkEchoSeqRuleResult(run, seqName, JsObject(triggerPayload))
+    // fire trigger with new payload
+    val now = "this is now: " + Instant.now
+    val newPayload = Map("payload" -> JsString(now))
+    val newRun = wsk.trigger.fire(triggerName, newPayload)
+    checkEchoSeqRuleResult(newRun, seqName, JsObject(newPayload))
+  }
+
+  /**
+   * checks the result of an echo sequence connected to a trigger through a rule
+   * @param triggerFireRun the run result of firing the trigger
+   * @param seqName the sequence name
+   * @param triggerPayload the payload used for the trigger (that should be reflected in the sequence result)
+   */
+  private def checkEchoSeqRuleResult(triggerFireRun: RunResult, seqName: String, triggerPayload: JsObject) = {
+    withActivation(wsk.activation, triggerFireRun) { triggerActivation =>
+      withActivationsFromEntity(wsk.activation, seqName, since = Some(triggerActivation.start)) { activationList =>
+        activationList.head.response.result shouldBe Some(triggerPayload)
+        activationList.head.cause shouldBe None
+      }
+    }
+  }
+
+  /**
+   * checks logs for the activation of a sequence (length/size and ids)
+   * checks that the cause field for composing atomic actions is set properly
+   * checks duration
+   * checks memory
+   */
+  private def checkSequenceLogsAndAnnotations(activation: ActivationResult, size: Int) = {
+    activation.logs shouldBe defined
+    // check that the logs are what they are supposed to be (activation ids)
+    // check that the cause field is properly set for these activations
+    activation.logs.get.size shouldBe (size) // the number of activations in this sequence
+    var totalTime: Long = 0
+    var maxMemory: Long = 0
+    for (id <- activation.logs.get) {
+      withActivation(
+        wsk.activation,
+        id,
+        initialWait = 1 second,
+        pollPeriod = 60 seconds,
+        totalWait = allowedActionDuration) { componentActivation =>
+        componentActivation.cause shouldBe defined
+        componentActivation.cause.get shouldBe (activation.activationId)
+        // check causedBy
+        val causedBy = componentActivation.getAnnotationValue("causedBy")
+        causedBy shouldBe defined
+        causedBy.get shouldBe (JsString("sequence"))
+        totalTime += componentActivation.duration
         // extract memory
-        activation.annotations shouldBe defined
-        val memory = extractMemoryAnnotation(activation)
-        memory shouldBe (maxMemory)
+        val mem = extractMemoryAnnotation(componentActivation)
+        maxMemory = maxMemory max mem
+      }
     }
+    // extract duration
+    activation.duration shouldBe (totalTime)
+    // extract memory
+    activation.annotations shouldBe defined
+    val memory = extractMemoryAnnotation(activation)
+    memory shouldBe (maxMemory)
+  }
 
-    /** checks that the logs of the idx-th atomic action from a sequence contains logsStr */
-    private def checkLogsAtomicAction(atomicActionIdx: Int, run: RunResult, regex: Regex) {
-        withActivation(wsk.activation, run, totalWait = 2 * allowedActionDuration) { activation =>
-            checkSequenceLogsAndAnnotations(activation, 1)
-            val componentId = activation.logs.get(atomicActionIdx)
-            val getComponentActivation = wsk.activation.get(Some(componentId))
-            withActivation(wsk.activation, getComponentActivation, totalWait = allowedActionDuration) { componentActivation =>
-                println(componentActivation)
-                componentActivation.logs shouldBe defined
-                val logs = componentActivation.logs.get.mkString(" ")
-                regex.findFirstIn(logs) shouldBe defined
-            }
-        }
+  /** checks that the logs of the idx-th atomic action from a sequence contains logsStr */
+  private def checkLogsAtomicAction(atomicActionIdx: Int, run: RunResult, regex: Regex) {
+    withActivation(wsk.activation, run, totalWait = 2 * allowedActionDuration) { activation =>
+      checkSequenceLogsAndAnnotations(activation, 1)
+      val componentId = activation.logs.get(atomicActionIdx)
+      val getComponentActivation = wsk.activation.get(Some(componentId))
+      withActivation(wsk.activation, getComponentActivation, totalWait = allowedActionDuration) { componentActivation =>
+        println(componentActivation)
+        componentActivation.logs shouldBe defined
+        val logs = componentActivation.logs.get.mkString(" ")
+        regex.findFirstIn(logs) shouldBe defined
+      }
     }
+  }
 
-    private def extractMemoryAnnotation(activation: ActivationResult): Long = {
-        val limits = activation.getAnnotationValue("limits")
-        limits shouldBe defined
-        limits.get.asJsObject.getFields("memory")(0).convertTo[Long]
-    }
+  private def extractMemoryAnnotation(activation: ActivationResult): Long = {
+    val limits = activation.getAnnotationValue("limits")
+    limits shouldBe defined
+    limits.get.asJsObject.getFields("memory")(0).convertTo[Long]
+  }
 }

--- a/tests/src/test/scala/system/basic/WskUnicodeJavaTests.scala
+++ b/tests/src/test/scala/system/basic/WskUnicodeJavaTests.scala
@@ -24,12 +24,9 @@ import common.JsHelpers
 import common.WskTestHelpers
 
 @RunWith(classOf[JUnitRunner])
-class WskUnicodeJavaTests
-    extends WskUnicodeTests
-    with WskTestHelpers
-    with JsHelpers {
+class WskUnicodeJavaTests extends WskUnicodeTests with WskTestHelpers with JsHelpers {
 
-    override lazy val actionKind = "java"
-    override lazy val actionSource = "unicode.jar"
+  override lazy val actionKind = "java"
+  override lazy val actionSource = "unicode.jar"
 
 }

--- a/tests/src/test/scala/system/basic/WskUnicodeNodeTests.scala
+++ b/tests/src/test/scala/system/basic/WskUnicodeNodeTests.scala
@@ -24,12 +24,9 @@ import common.JsHelpers
 import common.WskTestHelpers
 
 @RunWith(classOf[JUnitRunner])
-class WskUnicodeNodeTests
-    extends WskUnicodeTests
-    with WskTestHelpers
-    with JsHelpers {
+class WskUnicodeNodeTests extends WskUnicodeTests with WskTestHelpers with JsHelpers {
 
-    override lazy val actionKind = "nodejs:6"
-    override lazy val actionSource = "unicode.js"
+  override lazy val actionKind = "nodejs:6"
+  override lazy val actionSource = "unicode.js"
 
 }

--- a/tests/src/test/scala/system/basic/WskUnicodePython2Tests.scala
+++ b/tests/src/test/scala/system/basic/WskUnicodePython2Tests.scala
@@ -24,12 +24,9 @@ import common.JsHelpers
 import common.WskTestHelpers
 
 @RunWith(classOf[JUnitRunner])
-class WskUnicodePython2Tests
-    extends WskUnicodeTests
-    with WskTestHelpers
-    with JsHelpers {
+class WskUnicodePython2Tests extends WskUnicodeTests with WskTestHelpers with JsHelpers {
 
-    override lazy val actionKind = "python:2"
-    override lazy val actionSource = "unicode2.py"
+  override lazy val actionKind = "python:2"
+  override lazy val actionSource = "unicode2.py"
 
 }

--- a/tests/src/test/scala/system/basic/WskUnicodePython3Tests.scala
+++ b/tests/src/test/scala/system/basic/WskUnicodePython3Tests.scala
@@ -24,12 +24,9 @@ import common.JsHelpers
 import common.WskTestHelpers
 
 @RunWith(classOf[JUnitRunner])
-class WskUnicodePython3Tests
-    extends WskUnicodeTests
-    with WskTestHelpers
-    with JsHelpers {
+class WskUnicodePython3Tests extends WskUnicodeTests with WskTestHelpers with JsHelpers {
 
-    override lazy val actionKind = "python:3"
-    override lazy val actionSource = "unicode3.py"
+  override lazy val actionKind = "python:3"
+  override lazy val actionSource = "unicode3.py"
 
 }

--- a/tests/src/test/scala/system/basic/WskUnicodeSwift311Tests.scala
+++ b/tests/src/test/scala/system/basic/WskUnicodeSwift311Tests.scala
@@ -24,12 +24,9 @@ import common.JsHelpers
 import common.WskTestHelpers
 
 @RunWith(classOf[JUnitRunner])
-class WskUnicodeSwift311Tests
-    extends WskUnicodeTests
-    with WskTestHelpers
-    with JsHelpers {
+class WskUnicodeSwift311Tests extends WskUnicodeTests with WskTestHelpers with JsHelpers {
 
-    override lazy val actionKind = "swift:3.1.1"
-    override lazy val actionSource = "unicode.swift"
+  override lazy val actionKind = "swift:3.1.1"
+  override lazy val actionSource = "unicode.swift"
 
 }

--- a/tests/src/test/scala/system/basic/WskUnicodeSwift3Tests.scala
+++ b/tests/src/test/scala/system/basic/WskUnicodeSwift3Tests.scala
@@ -24,12 +24,9 @@ import common.JsHelpers
 import common.WskTestHelpers
 
 @RunWith(classOf[JUnitRunner])
-class WskUnicodeSwift3Tests
-    extends WskUnicodeTests
-    with WskTestHelpers
-    with JsHelpers {
+class WskUnicodeSwift3Tests extends WskUnicodeTests with WskTestHelpers with JsHelpers {
 
-    override lazy val actionKind = "swift:3"
-    override lazy val actionSource = "unicode.swift"
+  override lazy val actionKind = "swift:3"
+  override lazy val actionSource = "unicode.swift"
 
 }

--- a/tests/src/test/scala/system/rest/ActionSchemaTests.scala
+++ b/tests/src/test/scala/system/rest/ActionSchemaTests.scala
@@ -42,78 +42,79 @@ import spray.json.pimpString
 @RunWith(classOf[JUnitRunner])
 class ActionSchemaTests extends FlatSpec with Matchers with RestUtil with JsonSchema with WskTestHelpers {
 
-    implicit val wskprops = WskProps()
-    val wsk = new Wsk
-    val guestNamespace = wskprops.namespace
+  implicit val wskprops = WskProps()
+  val wsk = new Wsk
+  val guestNamespace = wskprops.namespace
 
-    it should "respond to GET /actions as documented in swagger" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val packageName = "samples"
-            assetHelper.withCleaner(wsk.pkg, packageName) {
-                (pkg, _) => pkg.create(packageName, shared = Some(true))
-            }
-
-            val auth = WhiskProperties.getBasicAuth
-            val response = RestAssured.
-                given().
-                config(sslconfig).
-                auth().basic(auth.fst, auth.snd).
-                get(getBaseURL() + s"/namespaces/$guestNamespace/actions/$packageName/")
-            assert(response.statusCode() == 200)
-
-            val body = Try { response.body().asString().parseJson }
-            val schema = getJsonSchema("EntityBrief").compactPrint
-
-            body match {
-                case Success(JsArray(actions)) =>
-                    // check that each collection result obeys the schema
-                    actions.foreach { a =>
-                        val aString = a.compactPrint
-                        assert(check(aString, schema))
-                    }
-
-                case Success(_) =>
-                    assert(false, "response is not an array of actions")
-
-                case _ =>
-                    assert(false, "response failed to parse: " + body)
-            }
+  it should "respond to GET /actions as documented in swagger" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val packageName = "samples"
+    assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, _) =>
+      pkg.create(packageName, shared = Some(true))
     }
 
-    it should "respond to GET /actions/samples/wordCount as documented in swagger" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val packageName = "samples"
-            val actionName = "wordCount"
-            val fullActionName = s"/$guestNamespace/$packageName/$actionName"
-            assetHelper.withCleaner(wsk.pkg, packageName) {
-                (pkg, _) => pkg.create(packageName, shared = Some(true))
-            }
+    val auth = WhiskProperties.getBasicAuth
+    val response = RestAssured
+      .given()
+      .config(sslconfig)
+      .auth()
+      .basic(auth.fst, auth.snd)
+      .get(getBaseURL() + s"/namespaces/$guestNamespace/actions/$packageName/")
+    assert(response.statusCode() == 200)
 
-            assetHelper.withCleaner(wsk.action, fullActionName) {
-                (action, _) => action.create(fullActionName, Some(TestUtils.getTestActionFilename("wc.js")))
-            }
-            val auth = WhiskProperties.getBasicAuth
-            val response = RestAssured.
-                given().
-                config(sslconfig).
-                auth().basic(auth.fst, auth.snd).
-                get(getBaseURL() + s"/namespaces/$guestNamespace/actions/$packageName/$actionName")
-            assert(response.statusCode() == 200)
+    val body = Try { response.body().asString().parseJson }
+    val schema = getJsonSchema("EntityBrief").compactPrint
 
-            val body = Try { response.body().asString().parseJson }
-            val schema = getJsonSchema("Action").compactPrint
+    body match {
+      case Success(JsArray(actions)) =>
+        // check that each collection result obeys the schema
+        actions.foreach { a =>
+          val aString = a.compactPrint
+          assert(check(aString, schema))
+        }
 
-            body match {
-                case Success(action: JsObject) =>
-                    // check that the action obeys the Action model schema
-                    val aString = action.compactPrint
-                    assert(check(aString, schema))
+      case Success(_) =>
+        assert(false, "response is not an array of actions")
 
-                case Success(_) =>
-                    assert(false, "response is not a json object")
-
-                case _ =>
-                    assert(false, "response failed to parse as JSON: " + body)
-            }
+      case _ =>
+        assert(false, "response failed to parse: " + body)
     }
+  }
+
+  it should "respond to GET /actions/samples/wordCount as documented in swagger" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val packageName = "samples"
+      val actionName = "wordCount"
+      val fullActionName = s"/$guestNamespace/$packageName/$actionName"
+      assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, _) =>
+        pkg.create(packageName, shared = Some(true))
+      }
+
+      assetHelper.withCleaner(wsk.action, fullActionName) { (action, _) =>
+        action.create(fullActionName, Some(TestUtils.getTestActionFilename("wc.js")))
+      }
+      val auth = WhiskProperties.getBasicAuth
+      val response = RestAssured
+        .given()
+        .config(sslconfig)
+        .auth()
+        .basic(auth.fst, auth.snd)
+        .get(getBaseURL() + s"/namespaces/$guestNamespace/actions/$packageName/$actionName")
+      assert(response.statusCode() == 200)
+
+      val body = Try { response.body().asString().parseJson }
+      val schema = getJsonSchema("Action").compactPrint
+
+      body match {
+        case Success(action: JsObject) =>
+          // check that the action obeys the Action model schema
+          val aString = action.compactPrint
+          assert(check(aString, schema))
+
+        case Success(_) =>
+          assert(false, "response is not a json object")
+
+        case _ =>
+          assert(false, "response failed to parse as JSON: " + body)
+      }
+  }
 }

--- a/tests/src/test/scala/system/rest/GoCLINginxTests.scala
+++ b/tests/src/test/scala/system/rest/GoCLINginxTests.scala
@@ -32,52 +32,54 @@ import DefaultJsonProtocol._
  */
 @RunWith(classOf[JUnitRunner])
 class GoCLINginxTests extends FlatSpec with Matchers with RestUtil {
-    val ProductName = "OpenWhisk_CLI"
-    val DownloadLinkGoCli = "cli/go/download"
-    val OperatingSystems = List("mac", "linux", "windows")
-    val Architectures = List("386", "amd64")
-    val ServiceURL = getServiceURL()
+  val ProductName = "OpenWhisk_CLI"
+  val DownloadLinkGoCli = "cli/go/download"
+  val OperatingSystems = List("mac", "linux", "windows")
+  val Architectures = List("386", "amd64")
+  val ServiceURL = getServiceURL()
 
-    it should s"respond to all files in root directory" in {
-        val response = RestAssured.given().config(sslconfig).get(s"$ServiceURL/$DownloadLinkGoCli")
+  it should s"respond to all files in root directory" in {
+    val response = RestAssured.given().config(sslconfig).get(s"$ServiceURL/$DownloadLinkGoCli")
+    response.statusCode should be(200)
+    val responseString = response.body.asString
+    responseString should include("""<a href="content.json">content.json</a>""")
+    val responseJSON = RestAssured.given().config(sslconfig).get(s"$ServiceURL/$DownloadLinkGoCli/content.json")
+    responseJSON.statusCode should be(200)
+    val cli = responseJSON.body.asString.parseJson.asJsObject
+      .fields("cli")
+      .convertTo[Map[String, Map[String, Map[String, String]]]]
+    cli.foreach {
+      case (os, arch) => responseString should include(s"""<a href="$os/">$os/</a>""")
+    }
+  }
+
+  it should "respond to all operating systems and architectures in HTML index" in {
+    val responseJSON = RestAssured.given().config(sslconfig).get(s"$ServiceURL/$DownloadLinkGoCli/content.json")
+    responseJSON.statusCode should be(200)
+    val cli = responseJSON.body.asString.parseJson.asJsObject
+      .fields("cli")
+      .convertTo[Map[String, Map[String, Map[String, String]]]]
+    cli.foreach {
+      case (os, arch) =>
+        val response = RestAssured.given().config(sslconfig).get(s"$ServiceURL/$DownloadLinkGoCli/$os")
         response.statusCode should be(200)
         val responseString = response.body.asString
-        responseString should include("""<a href="content.json">content.json</a>""")
-        val responseJSON = RestAssured.given().config(sslconfig).get(s"$ServiceURL/$DownloadLinkGoCli/content.json")
-        responseJSON.statusCode should be(200)
-        val cli = responseJSON.body.asString.parseJson.asJsObject.fields("cli").convertTo[Map[String, Map[String,
-          Map[String, String]]]]
-        cli.foreach {
-            case(os, arch) => responseString should include(s"""<a href="$os/">$os/</a>""")
+        arch.foreach {
+          case (arch, path) =>
+            if (arch != "default") {
+              responseString should include(s"""<a href="$arch/">$arch/</a>""")
+            }
         }
     }
+  }
 
-    it should "respond to all operating systems and architectures in HTML index" in {
-        val responseJSON = RestAssured.given().config(sslconfig).get(s"$ServiceURL/$DownloadLinkGoCli/content.json")
-        responseJSON.statusCode should be(200)
-        val cli = responseJSON.body.asString.parseJson.asJsObject.fields("cli").convertTo[Map[String, Map[String,
-          Map[String, String]]]]
-        cli.foreach {
-            case(os, arch) =>
-                val response = RestAssured.given().config(sslconfig).get(s"$ServiceURL/$DownloadLinkGoCli/$os")
-                response.statusCode should be(200)
-                val responseString = response.body.asString
-                arch.foreach {
-                    case (arch, path) =>
-                        if (arch != "default") {
-                            responseString should include(s"""<a href="$arch/">$arch/</a>""")
-                        }
-                }
-        }
+  it should "respond to the download paths in content.json" in {
+    val response = RestAssured.given().config(sslconfig).get(s"$ServiceURL/$DownloadLinkGoCli/content.json")
+    response.statusCode should be(200)
+    val cli =
+      response.body.asString.parseJson.asJsObject.fields("cli").convertTo[Map[String, Map[String, Map[String, String]]]]
+    cli.values.flatMap(_.values).flatMap(_.values).foreach { path =>
+      RestAssured.given().config(sslconfig).get(s"$ServiceURL/$DownloadLinkGoCli/$path").statusCode should be(200)
     }
-
-    it should "respond to the download paths in content.json" in {
-        val response = RestAssured.given().config(sslconfig).get(s"$ServiceURL/$DownloadLinkGoCli/content.json")
-        response.statusCode should be(200)
-        val cli = response.body.asString.parseJson.asJsObject.fields("cli").convertTo[Map[String, Map[String,
-          Map[String, String]]]]
-        cli.values.flatMap(_.values).flatMap(_.values).foreach { path =>
-            RestAssured.given().config(sslconfig).get(s"$ServiceURL/$DownloadLinkGoCli/$path").statusCode should be(200)
-        }
-    }
+  }
 }

--- a/tests/src/test/scala/system/rest/JsonSchema.scala
+++ b/tests/src/test/scala/system/rest/JsonSchema.scala
@@ -26,17 +26,17 @@ import com.fasterxml.jackson.databind.ObjectMapper
  */
 trait JsonSchema {
 
-    /**
-     * Check whether a JSON document (represented as a String) conforms to a JSON schema (also a String).
-     *
-     * @return true if the document is valid, false otherwise
-     */
-    def check(doc: String, schema: String): Boolean = {
-        val mapper = new ObjectMapper()
-        val docNode = mapper.readTree(doc)
-        val schemaNode = mapper.readTree(schema)
+  /**
+   * Check whether a JSON document (represented as a String) conforms to a JSON schema (also a String).
+   *
+   * @return true if the document is valid, false otherwise
+   */
+  def check(doc: String, schema: String): Boolean = {
+    val mapper = new ObjectMapper()
+    val docNode = mapper.readTree(doc)
+    val schemaNode = mapper.readTree(schema)
 
-        val validator = JsonSchemaFactory.byDefault().getValidator
-        validator.validate(schemaNode, docNode).isSuccess
-    }
+    val validator = JsonSchemaFactory.byDefault().getValidator
+    validator.validate(schemaNode, docNode).isSuccess
+  }
 }

--- a/tests/src/test/scala/system/rest/JsonSchemaTests.scala
+++ b/tests/src/test/scala/system/rest/JsonSchemaTests.scala
@@ -28,7 +28,7 @@ import org.scalatest.junit.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class JsonSchemaTests extends FlatSpec with Matchers with JsonSchema with RestUtil {
 
-    def TEST_SCHEMA = """{
+  def TEST_SCHEMA = """{
       "type" : "object",
       "properties" : {
         "price" : {"type" : "number"},
@@ -36,30 +36,30 @@ class JsonSchemaTests extends FlatSpec with Matchers with JsonSchema with RestUt
        }
     }"""
 
-    "JSON schema validator" should "accept a correct object" in {
-        def GOOD = """ {"name" : "Eggs", "price" : 34.99} """
-        assert(check(GOOD, TEST_SCHEMA))
-    }
-    it should "reject a bad object" in {
-        def BAD = """ {"name" : "Eggs", "price" : "Invalid"} """
-        assert(!check(BAD, TEST_SCHEMA))
-    }
+  "JSON schema validator" should "accept a correct object" in {
+    def GOOD = """ {"name" : "Eggs", "price" : 34.99} """
+    assert(check(GOOD, TEST_SCHEMA))
+  }
+  it should "reject a bad object" in {
+    def BAD = """ {"name" : "Eggs", "price" : "Invalid"} """
+    assert(!check(BAD, TEST_SCHEMA))
+  }
 
-    it should "accept a properly structured Action" in {
-        val schema = getJsonSchema("Action").compactPrint
-        def ACTION = """ {"namespace":"_",
+  it should "accept a properly structured Action" in {
+    val schema = getJsonSchema("Action").compactPrint
+    def ACTION = """ {"namespace":"_",
                        | "name":"foo",
                        | "version":"1.1.1",
                        | "publish":false,
                        | "exec":{ "code": "foo", "kind": "nodejs" },
                        | "parameters":["key1","value1"],
                        | "limits":{ "timeout":1000, "memory":200 } }""".stripMargin
-        assert(check(ACTION, schema))
-    }
+    assert(check(ACTION, schema))
+  }
 
-    it should "reject an improperly structured Action" in {
-        val schema = getJsonSchema("Action").compactPrint
-        def ACTION = """ {"sname" : "foo", "spublish" : false} """
-        assert(!check(ACTION, schema))
-    }
+  it should "reject an improperly structured Action" in {
+    val schema = getJsonSchema("Action").compactPrint
+    def ACTION = """ {"sname" : "foo", "spublish" : false} """
+    assert(!check(ACTION, schema))
+  }
 }

--- a/tests/src/test/scala/system/rest/SwaggerTests.scala
+++ b/tests/src/test/scala/system/rest/SwaggerTests.scala
@@ -32,27 +32,24 @@ import common.WhiskProperties
 @RunWith(classOf[JUnitRunner])
 class SwaggerTests extends FlatSpec with Matchers with RestUtil {
 
-    "Whisk API service" should "respond to /docs with Swagger UI" in {
-        val response = RestAssured.given().config(sslconfig).
-            get(getServiceURL() + "/api/v1/docs/index.html")
+  "Whisk API service" should "respond to /docs with Swagger UI" in {
+    val response = RestAssured.given().config(sslconfig).get(getServiceURL() + "/api/v1/docs/index.html")
 
-        response.statusCode() should be(200)
-        response.body().asString().contains("<title>Swagger UI</title>") should be(true)
-    }
+    response.statusCode() should be(200)
+    response.body().asString().contains("<title>Swagger UI</title>") should be(true)
+  }
 
-    it should "respond to /api-docs with Swagger XML" in {
-        val response = RestAssured.given().config(sslconfig).
-            get(getServiceURL() + "/api/v1/api-docs")
+  it should "respond to /api-docs with Swagger XML" in {
+    val response = RestAssured.given().config(sslconfig).get(getServiceURL() + "/api/v1/api-docs")
 
-        response.statusCode() should be(200)
-        response.body().asString().contains("\"swagger\":") should be(true)
-    }
+    response.statusCode() should be(200)
+    response.body().asString().contains("\"swagger\":") should be(true)
+  }
 
-    it should "respond to invalid URI with status code 404" in {
-        val auth = WhiskProperties.getBasicAuth
-        val response = RestAssured.given().config(sslconfig).
-            auth().basic(auth.fst, auth.snd).
-            get(getServiceURL() + "/api/v1/docs/dummy")
-        response.statusCode() should be(404)
-    }
+  it should "respond to invalid URI with status code 404" in {
+    val auth = WhiskProperties.getBasicAuth
+    val response =
+      RestAssured.given().config(sslconfig).auth().basic(auth.fst, auth.snd).get(getServiceURL() + "/api/v1/docs/dummy")
+    response.statusCode() should be(404)
+  }
 }

--- a/tests/src/test/scala/whisk/common/ConfigTests.scala
+++ b/tests/src/test/scala/whisk/common/ConfigTests.scala
@@ -25,52 +25,50 @@ import org.scalatest.junit.JUnitRunner
 import common.StreamLogging
 
 @RunWith(classOf[JUnitRunner])
-class ConfigTests
-    extends FlatSpec
-    with Matchers
-    with StreamLogging {
+class ConfigTests extends FlatSpec with Matchers with StreamLogging {
 
-    "Config" should "gets default value" in {
-        val config = new Config(Map("a" -> "A"))(Map())
-        assert(config.isValid && config("a") == "A")
-    }
+  "Config" should "gets default value" in {
+    val config = new Config(Map("a" -> "A"))(Map())
+    assert(config.isValid && config("a") == "A")
+  }
 
-    it should "get value from environemnt" in {
-        val config = new Config(Map("a" -> null, "b" -> ""))(Map("A" -> "xyz"))
-        assert(config.isValid && config("a") == "xyz" && config("b") == "")
-    }
+  it should "get value from environemnt" in {
+    val config = new Config(Map("a" -> null, "b" -> ""))(Map("A" -> "xyz"))
+    assert(config.isValid && config("a") == "xyz" && config("b") == "")
+  }
 
-    it should "not be valid when environment does not provide value" in {
-        val config = new Config(Map("a" -> null))(Map())
-        assert(!config.isValid && config("a") == null)
-    }
+  it should "not be valid when environment does not provide value" in {
+    val config = new Config(Map("a" -> null))(Map())
+    assert(!config.isValid && config("a") == null)
+  }
 
-    it should "be invalid if same property is required and optional and still not defined" in {
-        val config = new Config(Map("a" -> null), optionalProperties = Set("a"))(Map())
-        assert(!config.isValid)
-    }
+  it should "be invalid if same property is required and optional and still not defined" in {
+    val config = new Config(Map("a" -> null), optionalProperties = Set("a"))(Map())
+    assert(!config.isValid)
+  }
 
-    it should "read optional value" in {
-        val config = new Config(Map("a" -> "A", "x" -> "X"), optionalProperties = Set("b", "c", "x"))(Map("B" -> "B"))
-        assert(config.isValid)
-        assert(config("a") == "A")
-        assert(config("b") == "B")
-        assert(config("c") == "")
-        assert(config("x") == "X")
-    }
+  it should "read optional value" in {
+    val config = new Config(Map("a" -> "A", "x" -> "X"), optionalProperties = Set("b", "c", "x"))(Map("B" -> "B"))
+    assert(config.isValid)
+    assert(config("a") == "A")
+    assert(config("b") == "B")
+    assert(config("c") == "")
+    assert(config("x") == "X")
+  }
 
-    it should "override a value with optional value" in {
-        val config = new Config(Map("a" -> null, "x" -> "X"), optionalProperties = Set("b", "c", "x"))(Map("A" -> "A", "B" -> "B"))
-        assert(config.isValid && config("a") == "A" && config("b") == "B")
-        assert(config("a", "b") == "B")
-        assert(config("a", "c") == "A")
-        assert(config("c") == "")
-        assert(config("x") == "X")
-        assert(config("x", "c") == "X")
-        assert(config("x", "d") == "X")
-        assert(config("d", "x") == "X")
-        assert(config("c", "x") == "X")
-        assert(config("c", "d") == "")
-    }
+  it should "override a value with optional value" in {
+    val config =
+      new Config(Map("a" -> null, "x" -> "X"), optionalProperties = Set("b", "c", "x"))(Map("A" -> "A", "B" -> "B"))
+    assert(config.isValid && config("a") == "A" && config("b") == "B")
+    assert(config("a", "b") == "B")
+    assert(config("a", "c") == "A")
+    assert(config("c") == "")
+    assert(config("x") == "X")
+    assert(config("x", "c") == "X")
+    assert(config("x", "d") == "X")
+    assert(config("d", "x") == "X")
+    assert(config("c", "x") == "X")
+    assert(config("c", "d") == "")
+  }
 
 }

--- a/tests/src/test/scala/whisk/common/SchedulerTests.scala
+++ b/tests/src/test/scala/whisk/common/SchedulerTests.scala
@@ -35,199 +35,196 @@ import common.StreamLogging
 import common.WskActorSystem
 
 @RunWith(classOf[JUnitRunner])
-class SchedulerTests
-    extends FlatSpec
-    with Matchers
-    with WskActorSystem
-    with StreamLogging {
+class SchedulerTests extends FlatSpec with Matchers with WskActorSystem with StreamLogging {
 
-    val timeBetweenCalls = 50 milliseconds
-    val callsToProduce = 5
-    val schedulerSlack = 100 milliseconds
+  val timeBetweenCalls = 50 milliseconds
+  val callsToProduce = 5
+  val schedulerSlack = 100 milliseconds
 
-    /**
-     * Calculates the duration between two consecutive elements
-     *
-     * @param times the points in time to calculate the difference between
-     * @return duration between each element of the given sequence
-     */
-    def calculateDifferences(times: Seq[Instant]) = {
-        times sliding (2) map {
-            case Seq(a, b) => Duration.fromNanos(java.time.Duration.between(a, b).toNanos)
-        } toList
+  /**
+   * Calculates the duration between two consecutive elements
+   *
+   * @param times the points in time to calculate the difference between
+   * @return duration between each element of the given sequence
+   */
+  def calculateDifferences(times: Seq[Instant]) = {
+    times sliding (2) map {
+      case Seq(a, b) => Duration.fromNanos(java.time.Duration.between(a, b).toNanos)
+    } toList
+  }
+
+  /**
+   * Waits for the calls to be scheduled and executed. Adds one call-interval as additional slack
+   */
+  def waitForCalls(calls: Int = callsToProduce, interval: FiniteDuration = timeBetweenCalls) =
+    Thread.sleep((calls + 1) * interval toMillis)
+
+  behavior of "A WaitAtLeast Scheduler"
+
+  ignore should "be killable by sending it a poison pill" in {
+    var callCount = 0
+    val scheduled = Scheduler.scheduleWaitAtLeast(timeBetweenCalls) { () =>
+      callCount += 1
+      Future successful true
     }
 
-    /**
-     * Waits for the calls to be scheduled and executed. Adds one call-interval as additional slack
-     */
-    def waitForCalls(calls: Int = callsToProduce, interval: FiniteDuration = timeBetweenCalls) = Thread.sleep((calls + 1) * interval toMillis)
+    waitForCalls()
+    // This is equal to a scheduled ! PoisonPill
+    val shutdownTimeout = 10.seconds
+    Await.result(akka.pattern.gracefulStop(scheduled, shutdownTimeout, PoisonPill), shutdownTimeout)
 
-    behavior of "A WaitAtLeast Scheduler"
+    val countAfterKill = callCount
+    callCount should be >= callsToProduce
 
-    ignore should "be killable by sending it a poison pill" in {
-        var callCount = 0
-        val scheduled = Scheduler.scheduleWaitAtLeast(timeBetweenCalls) { () =>
-            callCount += 1
-            Future successful true
-        }
+    waitForCalls()
 
-        waitForCalls()
-        // This is equal to a scheduled ! PoisonPill
-        val shutdownTimeout = 10.seconds
-        Await.result(akka.pattern.gracefulStop(scheduled, shutdownTimeout, PoisonPill), shutdownTimeout)
+    callCount shouldBe countAfterKill
+  }
 
-        val countAfterKill = callCount
-        callCount should be >= callsToProduce
+  it should "throw an expection when passed a negative duration" in {
+    an[IllegalArgumentException] should be thrownBy Scheduler.scheduleWaitAtLeast(-100 milliseconds) { () =>
+      Future.successful(true)
+    }
+  }
 
-        waitForCalls()
+  it should "wait at least the given interval between scheduled calls" in {
+    val calls = Buffer[Instant]()
 
-        callCount shouldBe countAfterKill
+    val scheduled = Scheduler.scheduleWaitAtLeast(timeBetweenCalls) { () =>
+      calls += Instant.now
+      Future successful true
     }
 
-    it should "throw an expection when passed a negative duration" in {
-        an[IllegalArgumentException] should be thrownBy Scheduler.scheduleWaitAtLeast(-100 milliseconds) { () =>
-            Future.successful(true)
-        }
+    waitForCalls()
+    scheduled ! PoisonPill
+
+    val differences = calculateDifferences(calls)
+    withClue(s"expecting all $differences to be >= $timeBetweenCalls") {
+      differences.forall(_ >= timeBetweenCalls)
+    }
+  }
+
+  it should "stop the scheduler if an uncaught exception is thrown by the passed closure" in {
+    var callCount = 0
+    val scheduled = Scheduler.scheduleWaitAtLeast(timeBetweenCalls) { () =>
+      callCount += 1
+      throw new Exception
     }
 
-    it should "wait at least the given interval between scheduled calls" in {
-        val calls = Buffer[Instant]()
+    waitForCalls()
 
-        val scheduled = Scheduler.scheduleWaitAtLeast(timeBetweenCalls) { () =>
-            calls += Instant.now
-            Future successful true
-        }
+    callCount shouldBe 1
+  }
 
-        waitForCalls()
-        scheduled ! PoisonPill
+  it should "log scheduler halt message with tid" in {
+    implicit val transid = TransactionId.testing
+    val msg = "test threw an exception"
 
-        val differences = calculateDifferences(calls)
-        withClue(s"expecting all $differences to be >= $timeBetweenCalls") {
-            differences.forall(_ >= timeBetweenCalls)
-        }
+    stream.reset()
+    val scheduled = Scheduler.scheduleWaitAtLeast(timeBetweenCalls) { () =>
+      throw new Exception(msg)
     }
 
-    it should "stop the scheduler if an uncaught exception is thrown by the passed closure" in {
-        var callCount = 0
-        val scheduled = Scheduler.scheduleWaitAtLeast(timeBetweenCalls) { () =>
-            callCount += 1
-            throw new Exception
-        }
+    waitForCalls()
+    stream.toString.split(" ").drop(1).mkString(" ") shouldBe {
+      s"[ERROR] [#sid_1] [Scheduler] halted because $msg\n"
+    }
+  }
 
-        waitForCalls()
+  it should "not stop the scheduler if the future from the closure is failed" in {
+    var callCount = 0
 
-        callCount shouldBe 1
+    val scheduled = Scheduler.scheduleWaitAtLeast(timeBetweenCalls) { () =>
+      callCount += 1
+      Future failed new Exception
     }
 
-    it should "log scheduler halt message with tid" in {
-        implicit val transid = TransactionId.testing
-        val msg = "test threw an exception"
+    waitForCalls()
+    scheduled ! PoisonPill
 
-        stream.reset()
-        val scheduled = Scheduler.scheduleWaitAtLeast(timeBetweenCalls) { () =>
-            throw new Exception(msg)
-        }
+    callCount shouldBe callsToProduce
+  }
 
-        waitForCalls()
-        stream.toString.split(" ").drop(1).mkString(" ") shouldBe {
-            s"[ERROR] [#sid_1] [Scheduler] halted because $msg\n"
-        }
+  "A WaitAtMost Scheduler" should "wait at most the given interval between scheduled calls" in {
+    val calls = Buffer[Instant]()
+    val timeBetweenCalls = 200 milliseconds
+    val computationTime = 100 milliseconds
+
+    val scheduled = Scheduler.scheduleWaitAtMost(timeBetweenCalls) { () =>
+      calls += Instant.now
+      akka.pattern.after(computationTime, actorSystem.scheduler)(Future.successful(true))
     }
 
-    it should "not stop the scheduler if the future from the closure is failed" in {
-        var callCount = 0
+    waitForCalls(interval = timeBetweenCalls)
+    scheduled ! PoisonPill
 
-        val scheduled = Scheduler.scheduleWaitAtLeast(timeBetweenCalls) { () =>
-            callCount += 1
-            Future failed new Exception
-        }
+    val differences = calculateDifferences(calls)
+    withClue(s"expecting all $differences to be <= $timeBetweenCalls") {
+      differences should not be 'empty
+      differences.forall(_ <= timeBetweenCalls + schedulerSlack)
+    }
+  }
 
-        waitForCalls()
-        scheduled ! PoisonPill
+  it should "delay initial schedule by given duration" in {
+    val timeBetweenCalls = 200 milliseconds
+    val initialDelay = 1.second
+    var callCount = 0
 
-        callCount shouldBe callsToProduce
+    val scheduled = Scheduler.scheduleWaitAtMost(timeBetweenCalls, initialDelay) { () =>
+      callCount += 1
+      Future successful true
     }
 
-    "A WaitAtMost Scheduler" should "wait at most the given interval between scheduled calls" in {
-        val calls = Buffer[Instant]()
-        val timeBetweenCalls = 200 milliseconds
-        val computationTime = 100 milliseconds
+    try {
+      Thread.sleep(initialDelay.toMillis)
+      callCount should be <= 1
 
-        val scheduled = Scheduler.scheduleWaitAtMost(timeBetweenCalls) { () =>
-            calls += Instant.now
-            akka.pattern.after(computationTime, actorSystem.scheduler)(Future.successful(true))
-        }
+      Thread.sleep(2 * timeBetweenCalls.toMillis)
+      callCount should be > 1
+    } finally {
+      scheduled ! PoisonPill
+    }
+  }
 
-        waitForCalls(interval = timeBetweenCalls)
-        scheduled ! PoisonPill
+  it should "perform work immediately when requested" in {
+    val timeBetweenCalls = 200 milliseconds
+    val initialDelay = 1.second
+    var callCount = 0
 
-        val differences = calculateDifferences(calls)
-        withClue(s"expecting all $differences to be <= $timeBetweenCalls") {
-            differences should not be 'empty
-            differences.forall(_ <= timeBetweenCalls + schedulerSlack)
-        }
+    val scheduled = Scheduler.scheduleWaitAtMost(timeBetweenCalls, initialDelay) { () =>
+      callCount += 1
+      Future successful true
     }
 
-    it should "delay initial schedule by given duration" in {
-        val timeBetweenCalls = 200 milliseconds
-        val initialDelay = 1.second
-        var callCount = 0
+    try {
+      Thread.sleep(2 * timeBetweenCalls.toMillis)
+      callCount should be(0)
 
-        val scheduled = Scheduler.scheduleWaitAtMost(timeBetweenCalls, initialDelay) { () =>
-            callCount += 1
-            Future successful true
-        }
+      scheduled ! Scheduler.WorkOnceNow
+      Thread.sleep(timeBetweenCalls.toMillis)
+      callCount should be(1)
+    } finally {
+      scheduled ! PoisonPill
+    }
+  }
 
-        try {
-            Thread.sleep(initialDelay.toMillis)
-            callCount should be <= 1
+  it should "not wait when the closure takes longer than the interval" in {
+    val calls = Buffer[Instant]()
+    val timeBetweenCalls = 200 milliseconds
+    val computationTime = 300 milliseconds
 
-            Thread.sleep(2 * timeBetweenCalls.toMillis)
-            callCount should be > 1
-        } finally {
-            scheduled ! PoisonPill
-        }
+    val scheduled = Scheduler.scheduleWaitAtMost(timeBetweenCalls) { () =>
+      calls += Instant.now
+      akka.pattern.after(computationTime, actorSystem.scheduler)(Future.successful(true))
     }
 
-    it should "perform work immediately when requested" in {
-        val timeBetweenCalls = 200 milliseconds
-        val initialDelay = 1.second
-        var callCount = 0
+    waitForCalls(interval = timeBetweenCalls)
+    scheduled ! PoisonPill
 
-        val scheduled = Scheduler.scheduleWaitAtMost(timeBetweenCalls, initialDelay) { () =>
-            callCount += 1
-            Future successful true
-        }
-
-        try {
-            Thread.sleep(2 * timeBetweenCalls.toMillis)
-            callCount should be(0)
-
-            scheduled ! Scheduler.WorkOnceNow
-            Thread.sleep(timeBetweenCalls.toMillis)
-            callCount should be(1)
-        } finally {
-            scheduled ! PoisonPill
-        }
+    val differences = calculateDifferences(calls)
+    withClue(s"expecting all $differences to be <= $computationTime") {
+      differences should not be 'empty
+      differences.forall(_ <= computationTime + schedulerSlack)
     }
-
-    it should "not wait when the closure takes longer than the interval" in {
-        val calls = Buffer[Instant]()
-        val timeBetweenCalls = 200 milliseconds
-        val computationTime = 300 milliseconds
-
-        val scheduled = Scheduler.scheduleWaitAtMost(timeBetweenCalls) { () =>
-            calls += Instant.now
-            akka.pattern.after(computationTime, actorSystem.scheduler)(Future.successful(true))
-        }
-
-        waitForCalls(interval = timeBetweenCalls)
-        scheduled ! PoisonPill
-
-        val differences = calculateDifferences(calls)
-        withClue(s"expecting all $differences to be <= $computationTime") {
-            differences should not be 'empty
-            differences.forall(_ <= computationTime + schedulerSlack)
-        }
-    }
+  }
 }

--- a/tests/src/test/scala/whisk/core/WhiskConfigTests.scala
+++ b/tests/src/test/scala/whisk/core/WhiskConfigTests.scala
@@ -29,66 +29,63 @@ import org.scalatest.junit.JUnitRunner
 import common.StreamLogging
 
 @RunWith(classOf[JUnitRunner])
-class WhiskConfigTests
-    extends FlatSpec
-    with Matchers
-    with StreamLogging {
+class WhiskConfigTests extends FlatSpec with Matchers with StreamLogging {
 
-    behavior of "WhiskConfig"
+  behavior of "WhiskConfig"
 
-    it should "get required property" in {
-        val config = new WhiskConfig(WhiskConfig.edgeHost)
-        assert(config.isValid)
-        assert(config.edgeHost.nonEmpty)
-    }
+  it should "get required property" in {
+    val config = new WhiskConfig(WhiskConfig.edgeHost)
+    assert(config.isValid)
+    assert(config.edgeHost.nonEmpty)
+  }
 
-    it should "be valid when a prop file is provided defining required props" in {
-        val file = File.createTempFile("cxt", ".txt")
-        file.deleteOnExit()
+  it should "be valid when a prop file is provided defining required props" in {
+    val file = File.createTempFile("cxt", ".txt")
+    file.deleteOnExit()
 
-        val bw = new BufferedWriter(new FileWriter(file))
-        bw.write("a=A\n")
-        bw.close()
+    val bw = new BufferedWriter(new FileWriter(file))
+    bw.write("a=A\n")
+    bw.close()
 
-        val config = new WhiskConfig(Map("a" -> null), Set(), file)
-        assert(config.isValid && config("a") == "A")
-    }
+    val config = new WhiskConfig(Map("a" -> null), Set(), file)
+    assert(config.isValid && config("a") == "A")
+  }
 
-    it should "not be valid when a prop file is provided but does not define required props" in {
-        val file = File.createTempFile("cxt", ".txt")
-        file.deleteOnExit()
+  it should "not be valid when a prop file is provided but does not define required props" in {
+    val file = File.createTempFile("cxt", ".txt")
+    file.deleteOnExit()
 
-        val bw = new BufferedWriter(new FileWriter(file))
-        bw.write("a=A\n")
-        bw.close()
+    val bw = new BufferedWriter(new FileWriter(file))
+    bw.write("a=A\n")
+    bw.close()
 
-        val config = new WhiskConfig(Map("a" -> null, "b" -> null), Set(), file)
-        assert(!config.isValid && config("b") == null)
-    }
+    val config = new WhiskConfig(Map("a" -> null, "b" -> null), Set(), file)
+    assert(!config.isValid && config("b") == null)
+  }
 
-    it should "be valid when a prop file is provided defining required props and optional properties" in {
-        val file = File.createTempFile("cxt", ".txt")
-        file.deleteOnExit()
+  it should "be valid when a prop file is provided defining required props and optional properties" in {
+    val file = File.createTempFile("cxt", ".txt")
+    file.deleteOnExit()
 
-        val bw = new BufferedWriter(new FileWriter(file))
-        bw.write("a=A\n")
-        bw.write("b=B\n")
-        bw.write("c=C\n")
-        bw.close()
+    val bw = new BufferedWriter(new FileWriter(file))
+    bw.write("a=A\n")
+    bw.write("b=B\n")
+    bw.write("c=C\n")
+    bw.close()
 
-        val config = new WhiskConfig(Map("a" -> null, "b" -> "???"), Set("c", "d"), file, env = Map())
-        assert(config.isValid && config("a") == "A" && config("b") == "B")
-        assert(config("c") == "C")
-        assert(config("d") == "")
-        assert(config("a", "c") == "C")
-        assert(config("a", "d") == "A")
-        assert(config("d", "a") == "A")
-        assert(config("c", "a") == "A")
-    }
+    val config = new WhiskConfig(Map("a" -> null, "b" -> "???"), Set("c", "d"), file, env = Map())
+    assert(config.isValid && config("a") == "A" && config("b") == "B")
+    assert(config("c") == "C")
+    assert(config("d") == "")
+    assert(config("a", "c") == "C")
+    assert(config("a", "d") == "A")
+    assert(config("d", "a") == "A")
+    assert(config("c", "a") == "A")
+  }
 
-    it should "get property with no value from whisk.properties file" in {
-        val config = new WhiskConfig(Map(WhiskConfig.dockerRegistry -> null))
-        println(s"${WhiskConfig.dockerRegistry} is: '${config.dockerRegistry}'")
-        assert(config.isValid)
-    }
+  it should "get property with no value from whisk.properties file" in {
+    val config = new WhiskConfig(Map(WhiskConfig.dockerRegistry -> null))
+    println(s"${WhiskConfig.dockerRegistry} is: '${config.dockerRegistry}'")
+    assert(config.isValid)
+  }
 }

--- a/tests/src/test/scala/whisk/core/admin/WskAdminTests.scala
+++ b/tests/src/test/scala/whisk/core/admin/WskAdminTests.scala
@@ -33,141 +33,150 @@ import whisk.core.entity.Subject
 import common.TestUtils
 
 @RunWith(classOf[JUnitRunner])
-class WskAdminTests
-    extends TestHelpers
-    with Matchers {
+class WskAdminTests extends TestHelpers with Matchers {
 
-    behavior of "Wsk Admin CLI"
+  behavior of "Wsk Admin CLI"
 
-    it should "confirm wskadmin exists" in {
-        WskAdmin.exists
+  it should "confirm wskadmin exists" in {
+    WskAdmin.exists
+  }
+
+  it should "CRD a subject" in {
+    val wskadmin = new RunWskAdminCmd {}
+    val auth = AuthKey()
+    val subject = Subject().asString
+    try {
+      println(s"CRD subject: $subject")
+      val create = wskadmin.cli(Seq("user", "create", subject))
+      val get = wskadmin.cli(Seq("user", "get", subject))
+      create.stdout should be(get.stdout)
+
+      val authkey = get.stdout.trim
+      authkey should include(":")
+      authkey.split(":")(0).length should be(36)
+      authkey.split(":")(1).length should be >= 64
+
+      wskadmin.cli(Seq("user", "whois", authkey)).stdout.trim should be(
+        Seq(s"subject: $subject", s"namespace: $subject").mkString("\n"))
+
+      whisk.utils.retry({
+        // reverse lookup by namespace
+        wskadmin.cli(Seq("user", "list", "-k", subject)).stdout.trim should be(authkey)
+      }, 10, Some(1.second))
+
+      wskadmin.cli(Seq("user", "delete", subject)).stdout should include("Subject deleted")
+
+      // recreate with explicit
+      val newspace = s"${subject}.myspace"
+      wskadmin.cli(Seq("user", "create", subject, "-ns", newspace, "-u", auth.compact))
+
+      whisk.utils.retry({
+        // reverse lookup by namespace
+        wskadmin.cli(Seq("user", "list", "-k", newspace)).stdout.trim should be(auth.compact)
+      }, 10, Some(1.second))
+
+      wskadmin.cli(Seq("user", "get", subject, "-ns", newspace)).stdout.trim should be(auth.compact)
+
+      // delete namespace
+      wskadmin.cli(Seq("user", "delete", subject, "-ns", newspace)).stdout should include("Namespace deleted")
+    } finally {
+      wskadmin.cli(Seq("user", "delete", subject)).stdout should include("Subject deleted")
     }
+  }
 
-    it should "CRD a subject" in {
-        val wskadmin = new RunWskAdminCmd {}
-        val auth = AuthKey()
-        val subject = Subject().asString
-        try {
-            println(s"CRD subject: $subject")
-            val create = wskadmin.cli(Seq("user", "create", subject))
-            val get = wskadmin.cli(Seq("user", "get", subject))
-            create.stdout should be(get.stdout)
+  it should "verify guest account installed correctly" in {
+    val wskadmin = new RunWskAdminCmd {}
+    implicit val wskprops = WskProps()
+    val wsk = new Wsk
+    val ns = wsk.namespace.whois()
+    wskadmin.cli(Seq("user", "get", ns)).stdout.trim should be(wskprops.authKey)
+  }
 
-            val authkey = get.stdout.trim
-            authkey should include(":")
-            authkey.split(":")(0).length should be(36)
-            authkey.split(":")(1).length should be >= 64
+  it should "block and unblock a user respectively" in {
+    val wskadmin = new RunWskAdminCmd {}
+    val auth = AuthKey()
+    val subject1 = Subject().asString
+    val subject2 = Subject().asString
+    val commonNamespace = "testspace"
+    try {
+      wskadmin.cli(Seq("user", "create", subject1, "-ns", commonNamespace, "-u", auth.compact))
+      wskadmin.cli(Seq("user", "create", subject2, "-ns", commonNamespace))
 
-            wskadmin.cli(Seq("user", "whois", authkey)).stdout.trim should be(Seq(s"subject: $subject", s"namespace: $subject").mkString("\n"))
+      whisk.utils.retry({
+        // reverse lookup by namespace
+        val out = wskadmin.cli(Seq("user", "list", "-p", "2", "-k", commonNamespace)).stdout.trim
+        out should include(auth.compact)
+        out.lines should have size 2
+      }, 10, Some(1.second))
 
-            whisk.utils.retry({
-                // reverse lookup by namespace
-                wskadmin.cli(Seq("user", "list", "-k", subject)).stdout.trim should be(authkey)
-            }, 10, Some(1.second))
+      // block the user
+      wskadmin.cli(Seq("user", "block", subject1))
 
-            wskadmin.cli(Seq("user", "delete", subject)).stdout should include("Subject deleted")
+      // wait until the user can no longer be found
+      whisk.utils.retry({
+        wskadmin.cli(Seq("user", "list", "-p", "2", "-k", commonNamespace)).stdout.trim.lines should have size 1
+      }, 10, Some(1.second))
 
-            // recreate with explicit
-            val newspace = s"${subject}.myspace"
-            wskadmin.cli(Seq("user", "create", subject, "-ns", newspace, "-u", auth.compact))
+      // unblock the user
+      wskadmin.cli(Seq("user", "unblock", subject1))
 
-            whisk.utils.retry({
-                // reverse lookup by namespace
-                wskadmin.cli(Seq("user", "list", "-k", newspace)).stdout.trim should be(auth.compact)
-            }, 10, Some(1.second))
-
-            wskadmin.cli(Seq("user", "get", subject, "-ns", newspace)).stdout.trim should be(auth.compact)
-
-            // delete namespace
-            wskadmin.cli(Seq("user", "delete", subject, "-ns", newspace)).stdout should include("Namespace deleted")
-        } finally {
-            wskadmin.cli(Seq("user", "delete", subject)).stdout should include("Subject deleted")
-        }
+      // wait until the user can be found again
+      whisk.utils.retry({
+        val out = wskadmin.cli(Seq("user", "list", "-p", "2", "-k", commonNamespace)).stdout.trim
+        out should include(auth.compact)
+        out.lines should have size 2
+      }, 10, Some(1.second))
+    } finally {
+      wskadmin.cli(Seq("user", "delete", subject1)).stdout should include("Subject deleted")
+      wskadmin.cli(Seq("user", "delete", subject2)).stdout should include("Subject deleted")
     }
+  }
 
-    it should "verify guest account installed correctly" in {
-        val wskadmin = new RunWskAdminCmd {}
-        implicit val wskprops = WskProps()
-        val wsk = new Wsk
-        val ns = wsk.namespace.whois()
-        wskadmin.cli(Seq("user", "get", ns)).stdout.trim should be(wskprops.authKey)
+  it should "not allow edits on a blocked subject" in {
+    val wskadmin = new RunWskAdminCmd {}
+    val subject = Subject().asString
+    try {
+      // initially create the subject
+      wskadmin.cli(Seq("user", "create", subject))
+      // editing works
+      wskadmin.cli(Seq("user", "create", subject, "-ns", "testspace1"))
+      // block it
+      wskadmin.cli(Seq("user", "block", subject))
+      // Try to add a namespace, doesn't work
+      wskadmin.cli(Seq("user", "create", subject, "-ns", "testspace2"), expectedExitCode = TestUtils.ERROR_EXIT)
+      // Unblock the user
+      wskadmin.cli(Seq("user", "unblock", subject))
+      // Adding a namespace works
+      wskadmin.cli(Seq("user", "create", subject, "-ns", "testspace2"))
+    } finally {
+      wskadmin.cli(Seq("user", "delete", subject)).stdout should include("Subject deleted")
     }
+  }
 
-    it should "block and unblock a user respectively" in {
-        val wskadmin = new RunWskAdminCmd {}
-        val auth = AuthKey()
-        val subject1 = Subject().asString
-        val subject2 = Subject().asString
-        val commonNamespace = "testspace"
-        try {
-            wskadmin.cli(Seq("user", "create", subject1, "-ns", commonNamespace, "-u", auth.compact))
-            wskadmin.cli(Seq("user", "create", subject2, "-ns", commonNamespace))
-
-            whisk.utils.retry({
-                // reverse lookup by namespace
-                val out = wskadmin.cli(Seq("user", "list", "-p", "2", "-k", commonNamespace)).stdout.trim
-                out should include(auth.compact)
-                out.lines should have size 2
-            }, 10, Some(1.second))
-
-            // block the user
-            wskadmin.cli(Seq("user", "block", subject1))
-
-            // wait until the user can no longer be found
-            whisk.utils.retry({
-                wskadmin.cli(Seq("user", "list", "-p", "2", "-k", commonNamespace)).stdout.trim.lines should have size 1
-            }, 10, Some(1.second))
-
-            // unblock the user
-            wskadmin.cli(Seq("user", "unblock", subject1))
-
-            // wait until the user can be found again
-            whisk.utils.retry({
-                val out = wskadmin.cli(Seq("user", "list", "-p", "2", "-k", commonNamespace)).stdout.trim
-                out should include(auth.compact)
-                out.lines should have size 2
-            }, 10, Some(1.second))
-        } finally {
-            wskadmin.cli(Seq("user", "delete", subject1)).stdout should include("Subject deleted")
-            wskadmin.cli(Seq("user", "delete", subject2)).stdout should include("Subject deleted")
-        }
+  it should "adjust throttles for namespace" in {
+    val wskadmin = new RunWskAdminCmd {}
+    val subject = Subject().asString
+    try {
+      // set some limits
+      wskadmin.cli(
+        Seq(
+          "limits",
+          "set",
+          subject,
+          "--invocationsPerMinute",
+          "1",
+          "--firesPerMinute",
+          "2",
+          "--concurrentInvocations",
+          "3"))
+      // check correctly set
+      val lines = wskadmin.cli(Seq("limits", "get", subject)).stdout.lines.toSeq
+      lines should have size 3
+      lines(0) shouldBe "invocationsPerMinute = 1"
+      lines(1) shouldBe "firesPerMinute = 2"
+      lines(2) shouldBe "concurrentInvocations = 3"
+    } finally {
+      wskadmin.cli(Seq("limits", "delete", subject)).stdout should include("Limits deleted")
     }
-
-    it should "not allow edits on a blocked subject" in {
-        val wskadmin = new RunWskAdminCmd {}
-        val subject = Subject().asString
-        try {
-            // initially create the subject
-            wskadmin.cli(Seq("user", "create", subject))
-            // editing works
-            wskadmin.cli(Seq("user", "create", subject, "-ns", "testspace1"))
-            // block it
-            wskadmin.cli(Seq("user", "block", subject))
-            // Try to add a namespace, doesn't work
-            wskadmin.cli(Seq("user", "create", subject, "-ns", "testspace2"), expectedExitCode = TestUtils.ERROR_EXIT)
-            // Unblock the user
-            wskadmin.cli(Seq("user", "unblock", subject))
-            // Adding a namespace works
-            wskadmin.cli(Seq("user", "create", subject, "-ns", "testspace2"))
-        } finally {
-            wskadmin.cli(Seq("user", "delete", subject)).stdout should include("Subject deleted")
-        }
-    }
-
-    it should "adjust throttles for namespace" in {
-        val wskadmin = new RunWskAdminCmd {}
-        val subject = Subject().asString
-        try {
-            // set some limits
-            wskadmin.cli(Seq("limits", "set", subject, "--invocationsPerMinute", "1", "--firesPerMinute", "2", "--concurrentInvocations", "3"))
-            // check correctly set
-            val lines = wskadmin.cli(Seq("limits", "get", subject)).stdout.lines.toSeq
-            lines should have size 3
-            lines(0) shouldBe "invocationsPerMinute = 1"
-            lines(1) shouldBe "firesPerMinute = 2"
-            lines(2) shouldBe "concurrentInvocations = 3"
-        } finally {
-            wskadmin.cli(Seq("limits", "delete", subject)).stdout should include("Limits deleted")
-        }
-    }
+  }
 }

--- a/tests/src/test/scala/whisk/core/apigw/actions/test/ApiGwRoutemgmtActionTests.scala
+++ b/tests/src/test/scala/whisk/core/apigw/actions/test/ApiGwRoutemgmtActionTests.scala
@@ -36,20 +36,19 @@ import common.WskTestHelpers
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
-case class ApiAction(
-    name: String,
-    namespace: String,
-    backendMethod: String = "POST",
-    backendUrl: String,
-    authkey: String) {
-    def toJson(): JsObject = {
-        return JsObject(
-            "name" -> name.toJson,
-            "namespace" -> namespace.toJson,
-            "backendMethod" -> backendMethod.toJson,
-            "backendUrl" -> backendUrl.toJson,
-            "authkey" -> authkey.toJson)
-    }
+case class ApiAction(name: String,
+                     namespace: String,
+                     backendMethod: String = "POST",
+                     backendUrl: String,
+                     authkey: String) {
+  def toJson(): JsObject = {
+    return JsObject(
+      "name" -> name.toJson,
+      "namespace" -> namespace.toJson,
+      "backendMethod" -> backendMethod.toJson,
+      "backendUrl" -> backendUrl.toJson,
+      "authkey" -> authkey.toJson)
+  }
 }
 
 /**
@@ -64,284 +63,532 @@ class ApiGwRoutemgmtActionTests
     with JsHelpers
     with StreamLogging {
 
-    val systemId = "whisk.system"
-    implicit val wskprops = WskProps(authKey = WskAdmin.listKeys(systemId)(0)._1, namespace = systemId)
-    val wsk = new Wsk
+  val systemId = "whisk.system"
+  implicit val wskprops = WskProps(authKey = WskAdmin.listKeys(systemId)(0)._1, namespace = systemId)
+  val wsk = new Wsk
 
-    def getApis(
-        bpOrName: Option[String],
-        relpath: Option[String] = None,
-        operation: Option[String] = None,
-        docid: Option[String] = None,
-        accesstoken: Option[String] = Some("AnAccessToken"),
-        spaceguid: Option[String] = Some("ASpaceGuid") ): Vector[JsValue] = {
-        val parms = Map[String, JsValue]() ++
-            Map("__ow_user" -> wskprops.namespace.toJson) ++
-            { bpOrName map { b => Map("basepath" -> b.toJson) } getOrElse Map[String, JsValue]() } ++
-            { relpath map { r => Map("relpath" -> r.toJson) } getOrElse Map[String, JsValue]() } ++
-            { operation map { o => Map("operation" -> o.toJson) } getOrElse Map[String, JsValue]() } ++
-            { docid map { d => Map("docid" -> d.toJson) } getOrElse Map[String, JsValue]() } ++
-            { accesstoken map { t => Map("accesstoken" -> t.toJson) } getOrElse Map[String, JsValue]() } ++
-            { spaceguid map { s => Map("spaceguid" -> s.toJson) } getOrElse Map[String, JsValue]() }
-
-        val rr = wsk.action.invoke(
-            name = "apimgmt/getApi",
-            parameters = parms,
-            blocking = true,
-            result = true,
-            expectedExitCode = SUCCESS_EXIT)(wskprops)
-        var apiJsArray: JsArray =
-            try {
-                var apisobj = rr.stdout.parseJson.asJsObject.fields("apis")
-                apisobj.convertTo[JsArray]
-            } catch {
-                case e: Exception =>
-                    JsArray.empty
-            }
-        return apiJsArray.elements
+  def getApis(bpOrName: Option[String],
+              relpath: Option[String] = None,
+              operation: Option[String] = None,
+              docid: Option[String] = None,
+              accesstoken: Option[String] = Some("AnAccessToken"),
+              spaceguid: Option[String] = Some("ASpaceGuid")): Vector[JsValue] = {
+    val parms = Map[String, JsValue]() ++
+      Map("__ow_user" -> wskprops.namespace.toJson) ++ {
+      bpOrName map { b =>
+        Map("basepath" -> b.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      relpath map { r =>
+        Map("relpath" -> r.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      operation map { o =>
+        Map("operation" -> o.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      docid map { d =>
+        Map("docid" -> d.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      accesstoken map { t =>
+        Map("accesstoken" -> t.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      spaceguid map { s =>
+        Map("spaceguid" -> s.toJson)
+      } getOrElse Map[String, JsValue]()
     }
 
-    def createApi(
-        namespace: Option[String] = Some("_"),
-        basepath: Option[String] = Some("/"),
-        relpath: Option[String],
-        operation: Option[String],
-        apiname: Option[String],
-        action: Option[ApiAction],
-        swagger: Option[String] = None,
-        accesstoken: Option[String] = Some("AnAccessToken"),
-        spaceguid: Option[String] = Some("ASpaceGuid"),
-        expectedExitCode: Int = SUCCESS_EXIT): RunResult = {
-        val parms = Map[String, JsValue]() ++
-            { namespace map { n => Map("namespace" -> n.toJson) } getOrElse Map[String, JsValue]() } ++
-            { basepath map { b => Map("gatewayBasePath" -> b.toJson) } getOrElse Map[String, JsValue]() } ++
-            { relpath map { r => Map("gatewayPath" -> r.toJson) } getOrElse Map[String, JsValue]() } ++
-            { operation map { o => Map("gatewayMethod" -> o.toJson) } getOrElse Map[String, JsValue]() } ++
-            { apiname map { an => Map("apiName" -> an.toJson) } getOrElse Map[String, JsValue]() } ++
-            { action map { a => Map("action" -> a.toJson) } getOrElse Map[String, JsValue]() } ++
-            { swagger map { s => Map("swagger" -> s.toJson) } getOrElse Map[String, JsValue]() }
-        val parm = Map[String, JsValue]("apidoc" -> JsObject(parms)) ++
-            { namespace map { n => Map("__ow_user" -> n.toJson) } getOrElse Map[String, JsValue]() } ++
-            { accesstoken map { t => Map("accesstoken" -> t.toJson) } getOrElse Map[String, JsValue]() } ++
-            { spaceguid map { s => Map("spaceguid" -> s.toJson) } getOrElse Map[String, JsValue]() }
+    val rr = wsk.action.invoke(
+      name = "apimgmt/getApi",
+      parameters = parms,
+      blocking = true,
+      result = true,
+      expectedExitCode = SUCCESS_EXIT)(wskprops)
+    var apiJsArray: JsArray =
+      try {
+        var apisobj = rr.stdout.parseJson.asJsObject.fields("apis")
+        apisobj.convertTo[JsArray]
+      } catch {
+        case e: Exception =>
+          JsArray.empty
+      }
+    return apiJsArray.elements
+  }
 
-        val rr = wsk.action.invoke(
-            name = "apimgmt/createApi",
-            parameters = parm,
-            blocking = true,
-            result = true,
-            expectedExitCode = expectedExitCode)(wskprops)
-        return rr
+  def createApi(namespace: Option[String] = Some("_"),
+                basepath: Option[String] = Some("/"),
+                relpath: Option[String],
+                operation: Option[String],
+                apiname: Option[String],
+                action: Option[ApiAction],
+                swagger: Option[String] = None,
+                accesstoken: Option[String] = Some("AnAccessToken"),
+                spaceguid: Option[String] = Some("ASpaceGuid"),
+                expectedExitCode: Int = SUCCESS_EXIT): RunResult = {
+    val parms = Map[String, JsValue]() ++ {
+      namespace map { n =>
+        Map("namespace" -> n.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      basepath map { b =>
+        Map("gatewayBasePath" -> b.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      relpath map { r =>
+        Map("gatewayPath" -> r.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      operation map { o =>
+        Map("gatewayMethod" -> o.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      apiname map { an =>
+        Map("apiName" -> an.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      action map { a =>
+        Map("action" -> a.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      swagger map { s =>
+        Map("swagger" -> s.toJson)
+      } getOrElse Map[String, JsValue]()
+    }
+    val parm = Map[String, JsValue]("apidoc" -> JsObject(parms)) ++ {
+      namespace map { n =>
+        Map("__ow_user" -> n.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      accesstoken map { t =>
+        Map("accesstoken" -> t.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      spaceguid map { s =>
+        Map("spaceguid" -> s.toJson)
+      } getOrElse Map[String, JsValue]()
     }
 
-    def deleteApi(
-        namespace: Option[String] = Some("_"),
-        basepath: Option[String] = Some("/"),
-        relpath: Option[String] = None,
-        operation: Option[String] = None,
-        apiname: Option[String] = None,
-        accesstoken: Option[String] = Some("AnAccessToken"),
-        spaceguid: Option[String] = Some("ASpaceGuid"),
-        expectedExitCode: Int = SUCCESS_EXIT): RunResult = {
-        val parms = Map[String, JsValue]() ++
-            { namespace map { n => Map("__ow_user" -> n.toJson) } getOrElse Map[String, JsValue]() } ++
-            { basepath map { b => Map("basepath" -> b.toJson) } getOrElse Map[String, JsValue]() } ++
-            { relpath map { r => Map("relpath" -> r.toJson) } getOrElse Map[String, JsValue]() } ++
-            { operation map { o => Map("operation" -> o.toJson) } getOrElse Map[String, JsValue]() } ++
-            { apiname map { an => Map("apiname" -> an.toJson) } getOrElse Map[String, JsValue]() } ++
-            { accesstoken map { t => Map("accesstoken" -> t.toJson) } getOrElse Map[String, JsValue]() } ++
-            { spaceguid map { s => Map("spaceguid" -> s.toJson) } getOrElse Map[String, JsValue]() }
+    val rr = wsk.action.invoke(
+      name = "apimgmt/createApi",
+      parameters = parm,
+      blocking = true,
+      result = true,
+      expectedExitCode = expectedExitCode)(wskprops)
+    return rr
+  }
 
-        val rr = wsk.action.invoke(
-            name = "apimgmt/deleteApi",
-            parameters = parms,
-            blocking = true,
-            result = true,
-            expectedExitCode = expectedExitCode)(wskprops)
-        return rr
+  def deleteApi(namespace: Option[String] = Some("_"),
+                basepath: Option[String] = Some("/"),
+                relpath: Option[String] = None,
+                operation: Option[String] = None,
+                apiname: Option[String] = None,
+                accesstoken: Option[String] = Some("AnAccessToken"),
+                spaceguid: Option[String] = Some("ASpaceGuid"),
+                expectedExitCode: Int = SUCCESS_EXIT): RunResult = {
+    val parms = Map[String, JsValue]() ++ {
+      namespace map { n =>
+        Map("__ow_user" -> n.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      basepath map { b =>
+        Map("basepath" -> b.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      relpath map { r =>
+        Map("relpath" -> r.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      operation map { o =>
+        Map("operation" -> o.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      apiname map { an =>
+        Map("apiname" -> an.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      accesstoken map { t =>
+        Map("accesstoken" -> t.toJson)
+      } getOrElse Map[String, JsValue]()
+    } ++ {
+      spaceguid map { s =>
+        Map("spaceguid" -> s.toJson)
+      } getOrElse Map[String, JsValue]()
     }
 
-    def apiMatch(
-        apiarr: Vector[JsValue],
-        basepath: String = "/",
-        relpath: String = "",
-        operation: String = "",
-        apiname: String = "",
-        action: ApiAction = null): Boolean = {
-        var matches: Boolean = false
-        for (api <- apiarr) {
-            val basepathExists = JsObjectHelper(api.asJsObject).fieldPathExists("value", "apidoc", "basePath")
-            if (basepathExists) {
-                System.out.println("basePath exists")
-                val basepathMatches = (JsObjectHelper(api.asJsObject).getFieldPath("value", "apidoc", "basePath").get.convertTo[String] == basepath)
-                if (basepathMatches) {
-                    System.out.println("basePath matches: " + basepath)
-                    val apinameExists = JsObjectHelper(api.asJsObject).fieldPathExists("value", "apidoc", "info", "title")
-                    if (apinameExists) {
-                        System.out.println("api name exists")
-                        val apinameMatches = (JsObjectHelper(api.asJsObject).getFieldPath("value", "apidoc", "info", "title").get.convertTo[String] == apiname)
-                        if (apinameMatches) {
-                            System.out.println("api name matches: " + apiname)
-                            val endpointMatches = JsObjectHelper(api.asJsObject).fieldPathExists("value", "apidoc", "paths", relpath, operation)
-                            if (endpointMatches) {
-                                System.out.println("endpoint exists/matches : " + relpath + "  " + operation)
-                                val actionConfig = JsObjectHelper(api.asJsObject).getFieldPath("value", "apidoc", "paths", relpath, operation, "x-openwhisk").get.asJsObject
-                                val actionMatches = actionMatch(actionConfig, action)
-                                if (actionMatches) {
-                                    System.out.println("endpoint action matches")
-                                    matches = true;
-                                }
-                            }
-                        }
-                    }
+    val rr = wsk.action.invoke(
+      name = "apimgmt/deleteApi",
+      parameters = parms,
+      blocking = true,
+      result = true,
+      expectedExitCode = expectedExitCode)(wskprops)
+    return rr
+  }
+
+  def apiMatch(apiarr: Vector[JsValue],
+               basepath: String = "/",
+               relpath: String = "",
+               operation: String = "",
+               apiname: String = "",
+               action: ApiAction = null): Boolean = {
+    var matches: Boolean = false
+    for (api <- apiarr) {
+      val basepathExists = JsObjectHelper(api.asJsObject).fieldPathExists("value", "apidoc", "basePath")
+      if (basepathExists) {
+        System.out.println("basePath exists")
+        val basepathMatches = (JsObjectHelper(api.asJsObject)
+          .getFieldPath("value", "apidoc", "basePath")
+          .get
+          .convertTo[String] == basepath)
+        if (basepathMatches) {
+          System.out.println("basePath matches: " + basepath)
+          val apinameExists = JsObjectHelper(api.asJsObject).fieldPathExists("value", "apidoc", "info", "title")
+          if (apinameExists) {
+            System.out.println("api name exists")
+            val apinameMatches = (JsObjectHelper(api.asJsObject)
+              .getFieldPath("value", "apidoc", "info", "title")
+              .get
+              .convertTo[String] == apiname)
+            if (apinameMatches) {
+              System.out.println("api name matches: " + apiname)
+              val endpointMatches =
+                JsObjectHelper(api.asJsObject).fieldPathExists("value", "apidoc", "paths", relpath, operation)
+              if (endpointMatches) {
+                System.out.println("endpoint exists/matches : " + relpath + "  " + operation)
+                val actionConfig = JsObjectHelper(api.asJsObject)
+                  .getFieldPath("value", "apidoc", "paths", relpath, operation, "x-openwhisk")
+                  .get
+                  .asJsObject
+                val actionMatches = actionMatch(actionConfig, action)
+                if (actionMatches) {
+                  System.out.println("endpoint action matches")
+                  matches = true;
                 }
+              }
             }
+          }
         }
-        return matches
+      }
     }
+    return matches
+  }
 
-    def actionMatch(
-        jsAction: JsObject,
-        action: ApiAction): Boolean = {
-        System.out.println("actionMatch: url " + jsAction.fields("url").convertTo[String] + "; backendUrl " + action.backendUrl)
-        System.out.println("actionMatch: namespace " + jsAction.fields("namespace").convertTo[String] + "; namespace " + action.namespace)
-        System.out.println("actionMatch: action " + jsAction.fields("action").convertTo[String] + "; action " + action.name)
-        val matches = jsAction.fields("url").convertTo[String] == action.backendUrl &&
-            jsAction.fields("namespace").convertTo[String] == action.namespace &&
-            jsAction.fields("action").convertTo[String] == action.name
-        return matches
+  def actionMatch(jsAction: JsObject, action: ApiAction): Boolean = {
+    System.out.println(
+      "actionMatch: url " + jsAction.fields("url").convertTo[String] + "; backendUrl " + action.backendUrl)
+    System.out.println(
+      "actionMatch: namespace " + jsAction.fields("namespace").convertTo[String] + "; namespace " + action.namespace)
+    System.out.println("actionMatch: action " + jsAction.fields("action").convertTo[String] + "; action " + action.name)
+    val matches = jsAction.fields("url").convertTo[String] == action.backendUrl &&
+      jsAction.fields("namespace").convertTo[String] == action.namespace &&
+      jsAction.fields("action").convertTo[String] == action.name
+    return matches
+  }
+
+  behavior of "API Gateway apimgmt action parameter validation"
+
+  it should "verify successful creation of a new API" in {
+    val testName = "APIGWTEST1"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+    val actionNamespace = wskprops.namespace
+    val actionUrl = "https://some.whisk.host/api/v1/web/" + actionNamespace + "/default/" + actionName + ".json"
+    val actionAuthKey = testName + "_authkey"
+    val testaction =
+      ApiAction(name = actionName, namespace = actionNamespace, backendUrl = actionUrl, authkey = actionAuthKey)
+
+    try {
+      val createResult = createApi(
+        namespace = Some(wskprops.namespace),
+        basepath = Some(testbasepath),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        apiname = Some(testapiname),
+        action = Some(testaction))
+      JsObjectHelper(createResult.stdout.parseJson.asJsObject).fieldPathExists("apidoc") should be(true)
+      val apiVector = getApis(bpOrName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+      apiVector.size should be > 0
+      apiMatch(apiVector, testbasepath, testrelpath, testurlop, testapiname, testaction) should be(true)
+    } finally {
+      val deleteResult =
+        deleteApi(namespace = Some(wskprops.namespace), basepath = Some(testbasepath), expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    behavior of "API Gateway apimgmt action parameter validation"
+  it should "verify successful API deletion using basepath" in {
+    val testName = "APIGWTEST2"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+    val actionNamespace = wskprops.namespace
+    val actionUrl = "https://some.whisk.host/api/v1/web/" + actionNamespace + "/default/" + actionName + ".json"
+    val actionAuthKey = testName + "_authkey"
+    val testaction =
+      ApiAction(name = actionName, namespace = actionNamespace, backendUrl = actionUrl, authkey = actionAuthKey)
 
-    it should "verify successful creation of a new API" in {
-        val testName = "APIGWTEST1"
-        val testbasepath = "/" + testName + "_bp"
-        val testrelpath = "/path"
-        val testurlop = "get"
-        val testapiname = testName + " API Name"
-        val actionName = testName + "_action"
-        val actionNamespace = wskprops.namespace
-        val actionUrl = "https://some.whisk.host/api/v1/web/" + actionNamespace + "/default/" + actionName + ".json"
-        val actionAuthKey = testName + "_authkey"
-        val testaction = ApiAction(name = actionName, namespace = actionNamespace, backendUrl = actionUrl, authkey = actionAuthKey)
-
-        try {
-            val createResult = createApi(namespace = Some(wskprops.namespace), basepath = Some(testbasepath), relpath = Some(testrelpath),
-                operation = Some(testurlop), apiname = Some(testapiname), action = Some(testaction))
-            JsObjectHelper(createResult.stdout.parseJson.asJsObject).fieldPathExists("apidoc") should be(true)
-            val apiVector = getApis(bpOrName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
-            apiVector.size should be > 0
-            apiMatch(apiVector, testbasepath, testrelpath, testurlop, testapiname, testaction) should be(true)
-        } finally {
-            val deleteResult = deleteApi(namespace = Some(wskprops.namespace), basepath = Some(testbasepath), expectedExitCode = DONTCARE_EXIT)
-        }
+    try {
+      val createResult = createApi(
+        namespace = Some(wskprops.namespace),
+        basepath = Some(testbasepath),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        apiname = Some(testapiname),
+        action = Some(testaction))
+      JsObjectHelper(createResult.stdout.parseJson.asJsObject).fieldPathExists("apidoc") should be(true)
+      var apiVector = getApis(bpOrName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+      apiVector.size should be > 0
+      apiMatch(apiVector, testbasepath, testrelpath, testurlop, testapiname, testaction) should be(true)
+      val deleteResult = deleteApi(namespace = Some(wskprops.namespace), basepath = Some(testbasepath))
+      apiVector = getApis(bpOrName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+      apiMatch(apiVector, testbasepath, testrelpath, testurlop, testapiname, testaction) should be(false)
+    } finally {
+      val deleteResult =
+        deleteApi(namespace = Some(wskprops.namespace), basepath = Some(testbasepath), expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    it should "verify successful API deletion using basepath" in {
-        val testName = "APIGWTEST2"
-        val testbasepath = "/" + testName + "_bp"
-        val testrelpath = "/path"
-        val testurlop = "get"
-        val testapiname = testName + " API Name"
-        val actionName = testName + "_action"
-        val actionNamespace = wskprops.namespace
-        val actionUrl = "https://some.whisk.host/api/v1/web/" + actionNamespace + "/default/" + actionName + ".json"
-        val actionAuthKey = testName + "_authkey"
-        val testaction = ApiAction(name = actionName, namespace = actionNamespace, backendUrl = actionUrl, authkey = actionAuthKey)
+  it should "verify successful addition of new relative path to existing API" in {
+    val testName = "APIGWTEST3"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testnewurlop = "delete"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+    val actionNamespace = wskprops.namespace
+    val actionUrl = "https://some.whisk.host/api/v1/web/" + actionNamespace + "/default/" + actionName + ".json"
+    val actionAuthKey = testName + "_authkey"
+    val testaction =
+      ApiAction(name = actionName, namespace = actionNamespace, backendUrl = actionUrl, authkey = actionAuthKey)
 
-        try {
-            val createResult = createApi(namespace = Some(wskprops.namespace), basepath = Some(testbasepath), relpath = Some(testrelpath),
-                operation = Some(testurlop), apiname = Some(testapiname), action = Some(testaction))
-            JsObjectHelper(createResult.stdout.parseJson.asJsObject).fieldPathExists("apidoc") should be(true)
-            var apiVector = getApis(bpOrName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
-            apiVector.size should be > 0
-            apiMatch(apiVector, testbasepath, testrelpath, testurlop, testapiname, testaction) should be(true)
-            val deleteResult = deleteApi(namespace = Some(wskprops.namespace), basepath = Some(testbasepath))
-            apiVector = getApis(bpOrName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
-            apiMatch(apiVector, testbasepath, testrelpath, testurlop, testapiname, testaction) should be(false)
-        } finally {
-            val deleteResult = deleteApi(namespace = Some(wskprops.namespace), basepath = Some(testbasepath), expectedExitCode = DONTCARE_EXIT)
-        }
+    try {
+      var createResult = createApi(
+        namespace = Some(wskprops.namespace),
+        basepath = Some(testbasepath),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        apiname = Some(testapiname),
+        action = Some(testaction))
+      createResult = createApi(
+        namespace = Some(wskprops.namespace),
+        basepath = Some(testbasepath),
+        relpath = Some(testnewrelpath),
+        operation = Some(testnewurlop),
+        apiname = Some(testapiname),
+        action = Some(testaction))
+      JsObjectHelper(createResult.stdout.parseJson.asJsObject).fieldPathExists("apidoc") should be(true)
+      var apiVector = getApis(bpOrName = Some(testbasepath))
+      apiVector.size should be > 0
+      apiMatch(apiVector, testbasepath, testrelpath, testurlop, testapiname, testaction) should be(true)
+      apiMatch(apiVector, testbasepath, testnewrelpath, testnewurlop, testapiname, testaction) should be(true)
+    } finally {
+      val deleteResult =
+        deleteApi(namespace = Some(wskprops.namespace), basepath = Some(testbasepath), expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    it should "verify successful addition of new relative path to existing API" in {
-        val testName = "APIGWTEST3"
-        val testbasepath = "/" + testName + "_bp"
-        val testrelpath = "/path"
-        val testnewrelpath = "/path_new"
-        val testurlop = "get"
-        val testnewurlop = "delete"
-        val testapiname = testName + " API Name"
-        val actionName = testName + "_action"
-        val actionNamespace = wskprops.namespace
-        val actionUrl = "https://some.whisk.host/api/v1/web/" + actionNamespace + "/default/" + actionName + ".json"
-        val actionAuthKey = testName + "_authkey"
-        val testaction = ApiAction(name = actionName, namespace = actionNamespace, backendUrl = actionUrl, authkey = actionAuthKey)
+  it should "reject apimgmt actions that are invoked with not enough parameters" in {
+    val invalidArgs = Seq(
+      //getApi
+      ("/whisk.system/apimgmt/getApi", ANY_ERROR_EXIT, "Invalid authentication.", Seq()),
+      //deleteApi
+      (
+        "/whisk.system/apimgmt/deleteApi",
+        ANY_ERROR_EXIT,
+        "Invalid authentication.",
+        Seq("-p", "basepath", "/ApiGwRoutemgmtActionTests_bp")),
+      (
+        "/whisk.system/apimgmt/deleteApi",
+        ANY_ERROR_EXIT,
+        "basepath is required",
+        Seq("-p", "__ow_user", "_", "-p", "accesstoken", "TOKEN")),
+      (
+        "/whisk.system/apimgmt/deleteApi",
+        ANY_ERROR_EXIT,
+        "When specifying an operation, the path is required",
+        Seq(
+          "-p",
+          "__ow_user",
+          "_",
+          "-p",
+          "accesstoken",
+          "TOKEN",
+          "-p",
+          "basepath",
+          "/ApiGwRoutemgmtActionTests_bp",
+          "-p",
+          "operation",
+          "get")),
+      //createApi
+      (
+        "/whisk.system/apimgmt/createApi",
+        ANY_ERROR_EXIT,
+        "apidoc is required",
+        Seq("-p", "__ow_user", "_", "-p", "accesstoken", "TOKEN")),
+      (
+        "/whisk.system/apimgmt/createApi",
+        ANY_ERROR_EXIT,
+        "apidoc is missing the namespace field",
+        Seq("-p", "__ow_user", "_", "-p", "accesstoken", "TOKEN", "-p", "apidoc", "{}")),
+      (
+        "/whisk.system/apimgmt/createApi",
+        ANY_ERROR_EXIT,
+        "apidoc is missing the gatewayBasePath field",
+        Seq("-p", "__ow_user", "_", "-p", "accesstoken", "TOKEN", "-p", "apidoc", """{"namespace":"_"}""")),
+      (
+        "/whisk.system/apimgmt/createApi",
+        ANY_ERROR_EXIT,
+        "apidoc is missing the gatewayPath field",
+        Seq(
+          "-p",
+          "__ow_user",
+          "_",
+          "-p",
+          "accesstoken",
+          "TOKEN",
+          "-p",
+          "apidoc",
+          """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp"}""")),
+      (
+        "/whisk.system/apimgmt/createApi",
+        ANY_ERROR_EXIT,
+        "apidoc is missing the gatewayMethod field",
+        Seq(
+          "-p",
+          "__ow_user",
+          "_",
+          "-p",
+          "accesstoken",
+          "TOKEN",
+          "-p",
+          "apidoc",
+          """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp"}""")),
+      (
+        "/whisk.system/apimgmt/createApi",
+        ANY_ERROR_EXIT,
+        "apidoc is missing the action field",
+        Seq(
+          "-p",
+          "__ow_user",
+          "_",
+          "-p",
+          "accesstoken",
+          "TOKEN",
+          "-p",
+          "apidoc",
+          """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get"}""")),
+      (
+        "/whisk.system/apimgmt/createApi",
+        ANY_ERROR_EXIT,
+        "action is missing the backendMethod field",
+        Seq(
+          "-p",
+          "__ow_user",
+          "_",
+          "-p",
+          "accesstoken",
+          "TOKEN",
+          "-p",
+          "apidoc",
+          """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{}}""")),
+      (
+        "/whisk.system/apimgmt/createApi",
+        ANY_ERROR_EXIT,
+        "action is missing the backendUrl field",
+        Seq(
+          "-p",
+          "__ow_user",
+          "_",
+          "-p",
+          "accesstoken",
+          "TOKEN",
+          "-p",
+          "apidoc",
+          """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post"}}""")),
+      (
+        "/whisk.system/apimgmt/createApi",
+        ANY_ERROR_EXIT,
+        "action is missing the namespace field",
+        Seq(
+          "-p",
+          "__ow_user",
+          "_",
+          "-p",
+          "accesstoken",
+          "TOKEN",
+          "-p",
+          "apidoc",
+          """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post","backendUrl":"URL"}}""")),
+      (
+        "/whisk.system/apimgmt/createApi",
+        ANY_ERROR_EXIT,
+        "action is missing the name field",
+        Seq(
+          "-p",
+          "__ow_user",
+          "_",
+          "-p",
+          "accesstoken",
+          "TOKEN",
+          "-p",
+          "apidoc",
+          """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post","backendUrl":"URL","namespace":"_"}}""")),
+      (
+        "/whisk.system/apimgmt/createApi",
+        ANY_ERROR_EXIT,
+        "action is missing the authkey field",
+        Seq(
+          "-p",
+          "__ow_user",
+          "_",
+          "-p",
+          "accesstoken",
+          "TOKEN",
+          "-p",
+          "apidoc",
+          """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post","backendUrl":"URL","namespace":"_","name":"N"}}""")),
+      (
+        "/whisk.system/apimgmt/createApi",
+        ANY_ERROR_EXIT,
+        "swagger and gatewayBasePath are mutually exclusive and cannot be specified together",
+        Seq(
+          "-p",
+          "__ow_user",
+          "_",
+          "-p",
+          "accesstoken",
+          "TOKEN",
+          "-p",
+          "apidoc",
+          """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post","backendUrl":"URL","namespace":"_","name":"N","authkey":"XXXX"},"swagger":{}}""")),
+      (
+        "/whisk.system/apimgmt/createApi",
+        ANY_ERROR_EXIT,
+        "apidoc field cannot be parsed. Ensure it is valid JSON",
+        Seq("-p", "__ow_user", "_", "-p", "accesstoken", "TOKEN", "-p", "apidoc", "{1:[}}}")))
 
-        try {
-            var createResult = createApi(namespace = Some(wskprops.namespace), basepath = Some(testbasepath), relpath = Some(testrelpath),
-                operation = Some(testurlop), apiname = Some(testapiname), action = Some(testaction))
-            createResult = createApi(namespace = Some(wskprops.namespace), basepath = Some(testbasepath), relpath = Some(testnewrelpath),
-                operation = Some(testnewurlop), apiname = Some(testapiname), action = Some(testaction))
-            JsObjectHelper(createResult.stdout.parseJson.asJsObject).fieldPathExists("apidoc") should be(true)
-            var apiVector = getApis(bpOrName = Some(testbasepath))
-            apiVector.size should be > 0
-            apiMatch(apiVector, testbasepath, testrelpath, testurlop, testapiname, testaction) should be(true)
-            apiMatch(apiVector, testbasepath, testnewrelpath, testnewurlop, testapiname, testaction) should be(true)
-        } finally {
-            val deleteResult = deleteApi(namespace = Some(wskprops.namespace), basepath = Some(testbasepath), expectedExitCode = DONTCARE_EXIT)
-        }
+    invalidArgs foreach {
+      case (action: String, exitcode: Int, errmsg: String, params: Seq[String]) =>
+        val cmd: Seq[String] = Seq(
+          "action",
+          "invoke",
+          action,
+          "-i",
+          "-b",
+          "-r",
+          "--apihost",
+          wskprops.apihost,
+          "--auth",
+          wskprops.authKey) ++ params
+        val rr = wsk.cli(cmd, expectedExitCode = exitcode)
+        rr.stderr should include regex (errmsg)
     }
-
-    it should "reject apimgmt actions that are invoked with not enough parameters" in {
-        val invalidArgs = Seq(
-            //getApi
-            ("/whisk.system/apimgmt/getApi", ANY_ERROR_EXIT, "Invalid authentication.", Seq()),
-
-            //deleteApi
-            ("/whisk.system/apimgmt/deleteApi", ANY_ERROR_EXIT, "Invalid authentication.", Seq("-p", "basepath", "/ApiGwRoutemgmtActionTests_bp")),
-            ("/whisk.system/apimgmt/deleteApi", ANY_ERROR_EXIT, "basepath is required", Seq("-p", "__ow_user", "_", "-p", "accesstoken", "TOKEN")),
-            ("/whisk.system/apimgmt/deleteApi", ANY_ERROR_EXIT, "When specifying an operation, the path is required",
-              Seq("-p", "__ow_user", "_", "-p", "accesstoken", "TOKEN", "-p", "basepath", "/ApiGwRoutemgmtActionTests_bp", "-p", "operation", "get")),
-
-            //createApi
-            ("/whisk.system/apimgmt/createApi", ANY_ERROR_EXIT, "apidoc is required", Seq("-p", "__ow_user", "_", "-p", "accesstoken", "TOKEN")),
-            ("/whisk.system/apimgmt/createApi", ANY_ERROR_EXIT, "apidoc is missing the namespace field",
-              Seq("-p", "__ow_user", "_", "-p", "accesstoken", "TOKEN", "-p", "apidoc", "{}")),
-            ("/whisk.system/apimgmt/createApi", ANY_ERROR_EXIT, "apidoc is missing the gatewayBasePath field",
-              Seq("-p", "__ow_user", "_", "-p", "accesstoken", "TOKEN", "-p", "apidoc", """{"namespace":"_"}""")),
-            ("/whisk.system/apimgmt/createApi", ANY_ERROR_EXIT, "apidoc is missing the gatewayPath field",
-              Seq("-p", "__ow_user", "_", "-p", "accesstoken", "TOKEN", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp"}""")),
-            ("/whisk.system/apimgmt/createApi", ANY_ERROR_EXIT, "apidoc is missing the gatewayMethod field",
-              Seq("-p", "__ow_user", "_", "-p", "accesstoken", "TOKEN", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp"}""")),
-            ("/whisk.system/apimgmt/createApi", ANY_ERROR_EXIT, "apidoc is missing the action field",
-              Seq("-p", "__ow_user", "_", "-p", "accesstoken", "TOKEN", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get"}""")),
-            ("/whisk.system/apimgmt/createApi", ANY_ERROR_EXIT, "action is missing the backendMethod field",
-              Seq("-p", "__ow_user", "_", "-p", "accesstoken", "TOKEN", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{}}""")),
-            ("/whisk.system/apimgmt/createApi", ANY_ERROR_EXIT, "action is missing the backendUrl field",
-              Seq("-p", "__ow_user", "_", "-p", "accesstoken", "TOKEN", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post"}}""")),
-            ("/whisk.system/apimgmt/createApi", ANY_ERROR_EXIT, "action is missing the namespace field",
-              Seq("-p", "__ow_user", "_", "-p", "accesstoken", "TOKEN", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post","backendUrl":"URL"}}""")),
-            ("/whisk.system/apimgmt/createApi", ANY_ERROR_EXIT, "action is missing the name field",
-              Seq("-p", "__ow_user", "_", "-p", "accesstoken", "TOKEN", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post","backendUrl":"URL","namespace":"_"}}""")),
-            ("/whisk.system/apimgmt/createApi", ANY_ERROR_EXIT, "action is missing the authkey field",
-              Seq("-p", "__ow_user", "_", "-p", "accesstoken", "TOKEN", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post","backendUrl":"URL","namespace":"_","name":"N"}}""")),
-            ("/whisk.system/apimgmt/createApi", ANY_ERROR_EXIT, "swagger and gatewayBasePath are mutually exclusive and cannot be specified together",
-              Seq("-p", "__ow_user", "_", "-p", "accesstoken", "TOKEN", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post","backendUrl":"URL","namespace":"_","name":"N","authkey":"XXXX"},"swagger":{}}""")),
-            ("/whisk.system/apimgmt/createApi", ANY_ERROR_EXIT, "apidoc field cannot be parsed. Ensure it is valid JSON",
-              Seq("-p", "__ow_user", "_", "-p", "accesstoken", "TOKEN", "-p", "apidoc", "{1:[}}}")))
-
-        invalidArgs foreach {
-            case (action: String, exitcode: Int, errmsg: String, params: Seq[String]) =>
-                val cmd: Seq[String] = Seq("action",
-                    "invoke",
-                    action,
-                    "-i", "-b", "-r",
-                    "--apihost", wskprops.apihost,
-                    "--auth", wskprops.authKey) ++ params
-                val rr = wsk.cli(cmd, expectedExitCode = exitcode)
-                rr.stderr should include regex (errmsg)
-        }
-    }
+  }
 }

--- a/tests/src/test/scala/whisk/core/cli/test/ApiGwTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/ApiGwTests.scala
@@ -43,189 +43,209 @@ import common.WskTestHelpers
  * Tests for testing the CLI "api" subcommand.  Most of these tests require a deployed backend.
  */
 @RunWith(classOf[JUnitRunner])
-class ApiGwTests
-    extends TestHelpers
-    with WskTestHelpers
-    with BeforeAndAfterEach
-    with BeforeAndAfterAll {
+class ApiGwTests extends TestHelpers with WskTestHelpers with BeforeAndAfterEach with BeforeAndAfterAll {
 
-    implicit val wskprops = WskProps()
-    val wsk = new Wsk
-    val clinamespace = wsk.namespace.whois()
+  implicit val wskprops = WskProps()
+  val wsk = new Wsk
+  val clinamespace = wsk.namespace.whois()
 
-    // This test suite makes enough CLI invocations in 60 seconds to trigger the OpenWhisk
-    // throttling restriction.  To avoid CLI failures due to being throttled, track the
-    // CLI invocation calls and when at the throttle limit, pause the next CLI invocation
-    // with exactly enough time to relax the throttling.
-    val maxActionsPerMin = WhiskProperties.getMaxActionInvokesPerMinute()
-    val invocationTimes = new ArrayBuffer[Instant]()
+  // This test suite makes enough CLI invocations in 60 seconds to trigger the OpenWhisk
+  // throttling restriction.  To avoid CLI failures due to being throttled, track the
+  // CLI invocation calls and when at the throttle limit, pause the next CLI invocation
+  // with exactly enough time to relax the throttling.
+  val maxActionsPerMin = WhiskProperties.getMaxActionInvokesPerMinute()
+  val invocationTimes = new ArrayBuffer[Instant]()
 
-    // Custom CLI properties file
-    val cliWskPropsFile = File.createTempFile("wskprops", ".tmp")
+  // Custom CLI properties file
+  val cliWskPropsFile = File.createTempFile("wskprops", ".tmp")
 
-    /**
-     * Expected to be called before each test.
-     * Assumes that each test will not invoke more than 5 actions and
-     * settle the throttle when there isn't enough capacity to handle the test.
-     */
-    def checkThrottle(maxInvocationsBeforeThrottle: Int = maxActionsPerMin, expectedActivationsPerTest: Int = 5) = {
-        val t = Instant.now
-        val tminus60 = t.minusSeconds(60)
-        val invocationsLast60Seconds = invocationTimes.filter(_.isAfter(tminus60)).sorted
-        val invocationCount = invocationsLast60Seconds.length
-        println(s"Action invokes within last minute: ${invocationCount}")
+  /**
+   * Expected to be called before each test.
+   * Assumes that each test will not invoke more than 5 actions and
+   * settle the throttle when there isn't enough capacity to handle the test.
+   */
+  def checkThrottle(maxInvocationsBeforeThrottle: Int = maxActionsPerMin, expectedActivationsPerTest: Int = 5) = {
+    val t = Instant.now
+    val tminus60 = t.minusSeconds(60)
+    val invocationsLast60Seconds = invocationTimes.filter(_.isAfter(tminus60)).sorted
+    val invocationCount = invocationsLast60Seconds.length
+    println(s"Action invokes within last minute: ${invocationCount}")
 
-        if (invocationCount >= maxInvocationsBeforeThrottle) {
-            // Instead of waiting a fixed 60 seconds to settle the throttle,
-            // calculate a wait time that will clear out about half of the
-            // current invocations (assuming even distribution) from the
-            // next 60 second period.
-            val oldestInvocationInLast60Seconds = invocationsLast60Seconds.head
+    if (invocationCount >= maxInvocationsBeforeThrottle) {
+      // Instead of waiting a fixed 60 seconds to settle the throttle,
+      // calculate a wait time that will clear out about half of the
+      // current invocations (assuming even distribution) from the
+      // next 60 second period.
+      val oldestInvocationInLast60Seconds = invocationsLast60Seconds.head
 
-            // Take the oldest invocation time in this 60 second period.  To clear
-            // this invocation from the next 60 second period, the wait time will be
-            // (60sec - oldest invocation's delta time away from the period end).
-            // This will clear all of the invocations from the next period at the
-            // expense of potentially waiting uncessarily long. Instead, this calculation
-            // halves the delta time as a compromise.
-            val throttleTime = 60.seconds.toMillis - ((t.toEpochMilli - oldestInvocationInLast60Seconds.toEpochMilli) / 2)
-            println(s"Waiting ${throttleTime} milliseconds to settle the throttle")
-            Thread.sleep(throttleTime)
-        }
-
-        invocationTimes += Instant.now
+      // Take the oldest invocation time in this 60 second period.  To clear
+      // this invocation from the next 60 second period, the wait time will be
+      // (60sec - oldest invocation's delta time away from the period end).
+      // This will clear all of the invocations from the next period at the
+      // expense of potentially waiting uncessarily long. Instead, this calculation
+      // halves the delta time as a compromise.
+      val throttleTime = 60.seconds.toMillis - ((t.toEpochMilli - oldestInvocationInLast60Seconds.toEpochMilli) / 2)
+      println(s"Waiting ${throttleTime} milliseconds to settle the throttle")
+      Thread.sleep(throttleTime)
     }
 
-    override def beforeEach() = {
-        //checkThrottle()
-    }
+    invocationTimes += Instant.now
+  }
 
-    /*
-     * Create a CLI properties file for use by the tests
-     */
-    override def beforeAll() = {
-        cliWskPropsFile.deleteOnExit()
-        val wskprops = WskProps(token = "SOME TOKEN")
-        wskprops.writeFile(cliWskPropsFile)
-        println(s"wsk temporary props file created here: ${cliWskPropsFile.getCanonicalPath()}")
-    }
+  override def beforeEach() = {
+    //checkThrottle()
+  }
 
-    /*
-     * Forcibly clear the throttle so that downstream tests are not affected by
-     * this test suite
-     */
-    override def afterAll() = {
-        // Check and settle the throttle so that this test won't cause issues with and follow on tests
-        checkThrottle(30)
-    }
+  /*
+   * Create a CLI properties file for use by the tests
+   */
+  override def beforeAll() = {
+    cliWskPropsFile.deleteOnExit()
+    val wskprops = WskProps(token = "SOME TOKEN")
+    wskprops.writeFile(cliWskPropsFile)
+    println(s"wsk temporary props file created here: ${cliWskPropsFile.getCanonicalPath()}")
+  }
 
-    def apiCreate(
-        basepath: Option[String] = None,
-        relpath: Option[String] = None,
-        operation: Option[String] = None,
-        action: Option[String] = None,
-        apiname: Option[String] = None,
-        swagger: Option[String] = None,
-        responsetype: Option[String] = None,
-        expectedExitCode: Int = SUCCESS_EXIT,
-        cliCfgFile: Option[String] = Some(cliWskPropsFile.getCanonicalPath()))(implicit wskpropsOverride: WskProps): RunResult = {
+  /*
+   * Forcibly clear the throttle so that downstream tests are not affected by
+   * this test suite
+   */
+  override def afterAll() = {
+    // Check and settle the throttle so that this test won't cause issues with and follow on tests
+    checkThrottle(30)
+  }
 
-        checkThrottle()
-        wsk.api.create(basepath, relpath, operation, action, apiname, swagger, responsetype, expectedExitCode, cliCfgFile)(wskpropsOverride)
-    }
+  def apiCreate(basepath: Option[String] = None,
+                relpath: Option[String] = None,
+                operation: Option[String] = None,
+                action: Option[String] = None,
+                apiname: Option[String] = None,
+                swagger: Option[String] = None,
+                responsetype: Option[String] = None,
+                expectedExitCode: Int = SUCCESS_EXIT,
+                cliCfgFile: Option[String] = Some(cliWskPropsFile.getCanonicalPath()))(
+    implicit wskpropsOverride: WskProps): RunResult = {
 
-    def apiList(
-        basepathOrApiName: Option[String] = None,
-        relpath: Option[String] = None,
-        operation: Option[String] = None,
-        limit: Option[Int] = None,
-        since: Option[Instant] = None,
-        full: Option[Boolean] = None,
-        nameSort: Option[Boolean] = None,
-        expectedExitCode: Int = SUCCESS_EXIT,
-        cliCfgFile: Option[String] = Some(cliWskPropsFile.getCanonicalPath())): RunResult = {
+    checkThrottle()
+    wsk.api.create(basepath, relpath, operation, action, apiname, swagger, responsetype, expectedExitCode, cliCfgFile)(
+      wskpropsOverride)
+  }
 
-        checkThrottle()
-        wsk.api.list(basepathOrApiName, relpath, operation, limit, since, full, nameSort, expectedExitCode, cliCfgFile)
-    }
+  def apiList(basepathOrApiName: Option[String] = None,
+              relpath: Option[String] = None,
+              operation: Option[String] = None,
+              limit: Option[Int] = None,
+              since: Option[Instant] = None,
+              full: Option[Boolean] = None,
+              nameSort: Option[Boolean] = None,
+              expectedExitCode: Int = SUCCESS_EXIT,
+              cliCfgFile: Option[String] = Some(cliWskPropsFile.getCanonicalPath())): RunResult = {
 
-    def apiGet(
-        basepathOrApiName: Option[String] = None,
-        full: Option[Boolean] = None,
-        expectedExitCode: Int = SUCCESS_EXIT,
-        cliCfgFile: Option[String] = Some(cliWskPropsFile.getCanonicalPath()),
-        format: Option[String] = None): RunResult = {
+    checkThrottle()
+    wsk.api.list(basepathOrApiName, relpath, operation, limit, since, full, nameSort, expectedExitCode, cliCfgFile)
+  }
 
-        checkThrottle()
-        wsk.api.get(basepathOrApiName, full, expectedExitCode, cliCfgFile, format)
-    }
+  def apiGet(basepathOrApiName: Option[String] = None,
+             full: Option[Boolean] = None,
+             expectedExitCode: Int = SUCCESS_EXIT,
+             cliCfgFile: Option[String] = Some(cliWskPropsFile.getCanonicalPath()),
+             format: Option[String] = None): RunResult = {
 
-    def apiDelete(
-        basepathOrApiName: String,
-        relpath: Option[String] = None,
-        operation: Option[String] = None,
-        expectedExitCode: Int = SUCCESS_EXIT,
-        cliCfgFile: Option[String] = Some(cliWskPropsFile.getCanonicalPath())): RunResult = {
+    checkThrottle()
+    wsk.api.get(basepathOrApiName, full, expectedExitCode, cliCfgFile, format)
+  }
 
-        checkThrottle()
-        wsk.api.delete(basepathOrApiName, relpath, operation, expectedExitCode, cliCfgFile)
-    }
+  def apiDelete(basepathOrApiName: String,
+                relpath: Option[String] = None,
+                operation: Option[String] = None,
+                expectedExitCode: Int = SUCCESS_EXIT,
+                cliCfgFile: Option[String] = Some(cliWskPropsFile.getCanonicalPath())): RunResult = {
 
-    behavior of "Wsk api"
+    checkThrottle()
+    wsk.api.delete(basepathOrApiName, relpath, operation, expectedExitCode, cliCfgFile)
+  }
 
-    it should "reject an api commands with an invalid path parameter" in {
-        val badpath = "badpath"
+  behavior of "Wsk api"
 
-        var rr = apiCreate(basepath = Some("/basepath"), relpath = Some(badpath), operation = Some("GET"), action = Some("action"), expectedExitCode = ANY_ERROR_EXIT)
-        rr.stderr should include(s"'${badpath}' must begin with '/'")
+  it should "reject an api commands with an invalid path parameter" in {
+    val badpath = "badpath"
 
-        rr = apiDelete(basepathOrApiName = "/basepath", relpath = Some(badpath), operation = Some("GET"), expectedExitCode = ANY_ERROR_EXIT)
-        rr.stderr should include(s"'${badpath}' must begin with '/'")
+    var rr = apiCreate(
+      basepath = Some("/basepath"),
+      relpath = Some(badpath),
+      operation = Some("GET"),
+      action = Some("action"),
+      expectedExitCode = ANY_ERROR_EXIT)
+    rr.stderr should include(s"'${badpath}' must begin with '/'")
 
-        rr = apiList(basepathOrApiName = Some("/basepath"), relpath = Some(badpath), operation = Some("GET"), expectedExitCode = ANY_ERROR_EXIT)
-        rr.stderr should include(s"'${badpath}' must begin with '/'")
-    }
+    rr = apiDelete(
+      basepathOrApiName = "/basepath",
+      relpath = Some(badpath),
+      operation = Some("GET"),
+      expectedExitCode = ANY_ERROR_EXIT)
+    rr.stderr should include(s"'${badpath}' must begin with '/'")
 
-    it should "reject an api commands with an invalid verb parameter" in {
-        val badverb = "badverb"
+    rr = apiList(
+      basepathOrApiName = Some("/basepath"),
+      relpath = Some(badpath),
+      operation = Some("GET"),
+      expectedExitCode = ANY_ERROR_EXIT)
+    rr.stderr should include(s"'${badpath}' must begin with '/'")
+  }
 
-        var rr = apiCreate(basepath = Some("/basepath"), relpath = Some("/path"), operation = Some(badverb), action = Some("action"), expectedExitCode = ANY_ERROR_EXIT)
-        rr.stderr should include(s"'${badverb}' is not a valid API verb.  Valid values are:")
+  it should "reject an api commands with an invalid verb parameter" in {
+    val badverb = "badverb"
 
-        rr = apiDelete(basepathOrApiName = "/basepath", relpath = Some("/path"), operation = Some(badverb), expectedExitCode = ANY_ERROR_EXIT)
-        rr.stderr should include(s"'${badverb}' is not a valid API verb.  Valid values are:")
+    var rr = apiCreate(
+      basepath = Some("/basepath"),
+      relpath = Some("/path"),
+      operation = Some(badverb),
+      action = Some("action"),
+      expectedExitCode = ANY_ERROR_EXIT)
+    rr.stderr should include(s"'${badverb}' is not a valid API verb.  Valid values are:")
 
-        rr = apiList(basepathOrApiName = Some("/basepath"), relpath = Some("/path"), operation = Some(badverb), expectedExitCode = ANY_ERROR_EXIT)
-        rr.stderr should include(s"'${badverb}' is not a valid API verb.  Valid values are:")
-    }
+    rr = apiDelete(
+      basepathOrApiName = "/basepath",
+      relpath = Some("/path"),
+      operation = Some(badverb),
+      expectedExitCode = ANY_ERROR_EXIT)
+    rr.stderr should include(s"'${badverb}' is not a valid API verb.  Valid values are:")
 
-    it should "reject an api create command that specifies a nonexistent configuration file" in {
-        val configfile = "/nonexistent/file"
+    rr = apiList(
+      basepathOrApiName = Some("/basepath"),
+      relpath = Some("/path"),
+      operation = Some(badverb),
+      expectedExitCode = ANY_ERROR_EXIT)
+    rr.stderr should include(s"'${badverb}' is not a valid API verb.  Valid values are:")
+  }
 
-        val rr = apiCreate(swagger = Some(configfile), expectedExitCode = ANY_ERROR_EXIT)
-        rr.stderr should include(s"Error reading swagger file '${configfile}':")
-    }
+  it should "reject an api create command that specifies a nonexistent configuration file" in {
+    val configfile = "/nonexistent/file"
 
-    it should "reject an api create command specifying a non-JSON configuration file" in {
-        val file = File.createTempFile("api.json", ".txt")
-        file.deleteOnExit()
-        val filename = file.getAbsolutePath()
+    val rr = apiCreate(swagger = Some(configfile), expectedExitCode = ANY_ERROR_EXIT)
+    rr.stderr should include(s"Error reading swagger file '${configfile}':")
+  }
 
-        val bw = new BufferedWriter(new FileWriter(file))
-        bw.write("a=A")
-        bw.close()
+  it should "reject an api create command specifying a non-JSON configuration file" in {
+    val file = File.createTempFile("api.json", ".txt")
+    file.deleteOnExit()
+    val filename = file.getAbsolutePath()
 
-        val rr = apiCreate(swagger = Some(filename), expectedExitCode = ANY_ERROR_EXIT)
-        rr.stderr should include(s"Error parsing swagger file '${filename}':")
-    }
+    val bw = new BufferedWriter(new FileWriter(file))
+    bw.write("a=A")
+    bw.close()
 
-    it should "reject an api create command specifying a non-swagger JSON configuration file" in {
-        val file = File.createTempFile("api.json", ".txt")
-        file.deleteOnExit()
-        val filename = file.getAbsolutePath()
+    val rr = apiCreate(swagger = Some(filename), expectedExitCode = ANY_ERROR_EXIT)
+    rr.stderr should include(s"Error parsing swagger file '${filename}':")
+  }
 
-        val bw = new BufferedWriter(new FileWriter(file))
-        bw.write("""|{
+  it should "reject an api create command specifying a non-swagger JSON configuration file" in {
+    val file = File.createTempFile("api.json", ".txt")
+    file.deleteOnExit()
+    val filename = file.getAbsolutePath()
+
+    val bw = new BufferedWriter(new FileWriter(file))
+    bw.write("""|{
                     |   "swagger": "2.0",
                     |   "info": {
                     |      "title": "My API",
@@ -238,706 +258,807 @@ class ApiGwTests
                     |     }
                     |   }
                     |}""".stripMargin)
-        bw.close()
+    bw.close()
 
-        val rr = apiCreate(swagger = Some(filename), expectedExitCode = ANY_ERROR_EXIT)
-        rr.stderr should include(s"Swagger file is invalid (missing basePath, info, paths, or swagger fields")
+    val rr = apiCreate(swagger = Some(filename), expectedExitCode = ANY_ERROR_EXIT)
+    rr.stderr should include(s"Swagger file is invalid (missing basePath, info, paths, or swagger fields")
+  }
+
+  it should "verify full list output" in {
+    val testName = "CLI_APIGWTEST_RO1"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+    try {
+      println("cli namespace: " + clinamespace)
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
+
+      var rr = apiCreate(
+        basepath = Some(testbasepath),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        action = Some(actionName),
+        apiname = Some(testapiname))
+      println("api create: " + rr.stdout)
+      rr.stdout should include("ok: created API")
+      rr = apiList(
+        basepathOrApiName = Some(testbasepath),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        full = Some(true))
+      println("api list: " + rr.stdout)
+      rr.stdout should include("ok: APIs")
+      rr.stdout should include regex (s"Action:\\s+/${clinamespace}/${actionName}\n")
+      rr.stdout should include regex (s"Verb:\\s+${testurlop}\n")
+      rr.stdout should include regex (s"Base path:\\s+${testbasepath}\n")
+      rr.stdout should include regex (s"Path:\\s+${testrelpath}\n")
+      rr.stdout should include regex (s"API Name:\\s+${testapiname}\n")
+      rr.stdout should include regex (s"URL:\\s+")
+      rr.stdout should include(testbasepath + testrelpath)
+    } finally {
+      wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      apiDelete(basepathOrApiName = testbasepath)
     }
+  }
 
-    it should "verify full list output" in {
-        val testName = "CLI_APIGWTEST_RO1"
-        val testbasepath = "/" + testName + "_bp"
-        val testrelpath = "/path"
-        val testnewrelpath = "/path_new"
-        val testurlop = "get"
-        val testapiname = testName + " API Name"
-        val actionName = testName + "_action"
-        try {
-            println("cli namespace: " + clinamespace)
-            // Create the action for the API.  It must be a "web-action" action.
-            val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
+  it should "verify successful creation and deletion of a new API" in {
+    val testName = "CLI_APIGWTEST1"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path/with/sub_paths/in/it"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+    try {
+      println("cli namespace: " + clinamespace)
 
-            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-            println("api create: " + rr.stdout)
-            rr.stdout should include("ok: created API")
-            rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), full = Some(true))
-            println("api list: " + rr.stdout)
-            rr.stdout should include("ok: APIs")
-            rr.stdout should include regex (s"Action:\\s+/${clinamespace}/${actionName}\n")
-            rr.stdout should include regex (s"Verb:\\s+${testurlop}\n")
-            rr.stdout should include regex (s"Base path:\\s+${testbasepath}\n")
-            rr.stdout should include regex (s"Path:\\s+${testrelpath}\n")
-            rr.stdout should include regex (s"API Name:\\s+${testapiname}\n")
-            rr.stdout should include regex (s"URL:\\s+")
-            rr.stdout should include(testbasepath + testrelpath)
-        } finally {
-            wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-            apiDelete(basepathOrApiName = testbasepath)
-        }
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
+
+      var rr = apiCreate(
+        basepath = Some(testbasepath),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        action = Some(actionName),
+        apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+      rr.stdout should include("ok: APIs")
+      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr.stdout should include(testbasepath + testrelpath)
+      rr = apiGet(basepathOrApiName = Some(testbasepath))
+      rr.stdout should include regex (s""""operationId":\\s+"getPathWithSub_pathsInIt"""")
+      val deleteresult = apiDelete(basepathOrApiName = testbasepath)
+      deleteresult.stdout should include("ok: deleted API")
+    } finally {
+      wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    it should "verify successful creation and deletion of a new API" in {
-        val testName = "CLI_APIGWTEST1"
-        val testbasepath = "/" + testName + "_bp"
-        val testrelpath = "/path/with/sub_paths/in/it"
-        val testnewrelpath = "/path_new"
-        val testurlop = "get"
-        val testapiname = testName + " API Name"
-        val actionName = testName + "_action"
-        try {
-            println("cli namespace: " + clinamespace)
+  it should "verify get API name " in {
+    val testName = "CLI_APIGWTEST3"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+    try {
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
 
-            // Create the action for the API.  It must be a "web-action" action.
-            val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
-
-            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-            rr.stdout should include("ok: created API")
-            rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
-            rr.stdout should include("ok: APIs")
-            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-            rr.stdout should include(testbasepath + testrelpath)
-            rr = apiGet(basepathOrApiName = Some(testbasepath))
-            rr.stdout should include regex (s""""operationId":\\s+"getPathWithSub_pathsInIt"""")
-            val deleteresult = apiDelete(basepathOrApiName = testbasepath)
-            deleteresult.stdout should include("ok: deleted API")
-        } finally {
-            wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-            apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-        }
+      var rr = apiCreate(
+        basepath = Some(testbasepath),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        action = Some(actionName),
+        apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      rr = apiGet(basepathOrApiName = Some(testapiname))
+      rr.stdout should include(testbasepath)
+      rr.stdout should include(s"${actionName}")
+      rr.stdout should include regex (""""cors":\s*\{\s*\n\s*"enabled":\s*true""")
+      rr.stdout should include regex (s""""target-url":\\s+.*${actionName}.json""")
+    } finally {
+      wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    it should "verify get API name " in {
-        val testName = "CLI_APIGWTEST3"
-        val testbasepath = "/" + testName + "_bp"
-        val testrelpath = "/path"
-        val testnewrelpath = "/path_new"
-        val testurlop = "get"
-        val testapiname = testName + " API Name"
-        val actionName = testName + "_action"
-        try {
-            // Create the action for the API.  It must be a "web-action" action.
-            val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
+  it should "verify delete API name " in {
+    val testName = "CLI_APIGWTEST4"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+    try {
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
 
-            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-            rr.stdout should include("ok: created API")
-            rr = apiGet(basepathOrApiName = Some(testapiname))
-            rr.stdout should include(testbasepath)
-            rr.stdout should include(s"${actionName}")
-            rr.stdout should include regex (""""cors":\s*\{\s*\n\s*"enabled":\s*true""")
-            rr.stdout should include regex (s""""target-url":\\s+.*${actionName}.json""")
-        } finally {
-            wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-            apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-        }
+      var rr = apiCreate(
+        basepath = Some(testbasepath),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        action = Some(actionName),
+        apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      rr = apiDelete(basepathOrApiName = testapiname)
+      rr.stdout should include("ok: deleted API")
+    } finally {
+      wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    it should "verify delete API name " in {
-        val testName = "CLI_APIGWTEST4"
-        val testbasepath = "/" + testName + "_bp"
-        val testrelpath = "/path"
-        val testnewrelpath = "/path_new"
-        val testurlop = "get"
-        val testapiname = testName + " API Name"
-        val actionName = testName + "_action"
-        try {
-            // Create the action for the API.  It must be a "web-action" action.
-            val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
+  it should "verify delete API basepath " in {
+    val testName = "CLI_APIGWTEST5"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+    try {
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
 
-            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-            rr.stdout should include("ok: created API")
-            rr = apiDelete(basepathOrApiName = testapiname)
-            rr.stdout should include("ok: deleted API")
-        } finally {
-            wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-            apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-        }
+      var rr = apiCreate(
+        basepath = Some(testbasepath),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        action = Some(actionName),
+        apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      rr = apiDelete(basepathOrApiName = testbasepath)
+      rr.stdout should include("ok: deleted API")
+    } finally {
+      wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    it should "verify delete API basepath " in {
-        val testName = "CLI_APIGWTEST5"
-        val testbasepath = "/" + testName + "_bp"
-        val testrelpath = "/path"
-        val testnewrelpath = "/path_new"
-        val testurlop = "get"
-        val testapiname = testName + " API Name"
-        val actionName = testName + "_action"
-        try {
-            // Create the action for the API.  It must be a "web-action" action.
-            val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
+  it should "verify adding endpoints to existing api" in {
+    val testName = "CLI_APIGWTEST6"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path2"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+    val newEndpoint = "/newEndpoint"
+    try {
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
 
-            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-            rr.stdout should include("ok: created API")
-            rr = apiDelete(basepathOrApiName = testbasepath)
-            rr.stdout should include("ok: deleted API")
-        } finally {
-            wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-            apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-        }
+      var rr = apiCreate(
+        basepath = Some(testbasepath),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        action = Some(actionName),
+        apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      rr = apiCreate(
+        basepath = Some(testbasepath),
+        relpath = Some(newEndpoint),
+        operation = Some(testurlop),
+        action = Some(actionName),
+        apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      rr = apiList(basepathOrApiName = Some(testbasepath))
+      rr.stdout should include("ok: APIs")
+      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr.stdout should include(testbasepath + testrelpath)
+      rr.stdout should include(testbasepath + newEndpoint)
+    } finally {
+      wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    it should "verify adding endpoints to existing api" in {
-        val testName = "CLI_APIGWTEST6"
-        val testbasepath = "/" + testName + "_bp"
-        val testrelpath = "/path2"
-        val testnewrelpath = "/path_new"
-        val testurlop = "get"
-        val testapiname = testName + " API Name"
-        val actionName = testName + "_action"
-        val newEndpoint = "/newEndpoint"
-        try {
-            // Create the action for the API.  It must be a "web-action" action.
-            val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
-
-            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-            rr.stdout should include("ok: created API")
-            rr = apiCreate(basepath = Some(testbasepath), relpath = Some(newEndpoint), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-            rr.stdout should include("ok: created API")
-            rr = apiList(basepathOrApiName = Some(testbasepath))
-            rr.stdout should include("ok: APIs")
-            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-            rr.stdout should include(testbasepath + testrelpath)
-            rr.stdout should include(testbasepath + newEndpoint)
-        } finally {
-            wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-            apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-        }
+  it should "verify successful creation with swagger doc as input" in {
+    // NOTE: These values must match the swagger file contents
+    val testName = "CLI_APIGWTEST7"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+    val swaggerPath = TestUtils.getTestApiGwFilename("testswaggerdoc1")
+    try {
+      var rr = apiCreate(swagger = Some(swaggerPath))
+      rr.stdout should include("ok: created API")
+      rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+      println("list stdout: " + rr.stdout)
+      println("list stderr: " + rr.stderr)
+      rr.stdout should include("ok: APIs")
+      // Actual CLI namespace will vary from local dev to automated test environments, so don't check
+      rr.stdout should include regex (s"/[@\\w._\\-]+/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr.stdout should include(testbasepath + testrelpath)
+    } finally {
+      apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    it should "verify successful creation with swagger doc as input" in {
-        // NOTE: These values must match the swagger file contents
-        val testName = "CLI_APIGWTEST7"
-        val testbasepath = "/" + testName + "_bp"
-        val testrelpath = "/path"
-        val testurlop = "get"
-        val testapiname = testName + " API Name"
-        val actionName = testName + "_action"
-        val swaggerPath = TestUtils.getTestApiGwFilename("testswaggerdoc1")
-        try {
-            var rr = apiCreate(swagger = Some(swaggerPath))
-            rr.stdout should include("ok: created API")
-            rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
-            println("list stdout: " + rr.stdout)
-            println("list stderr: " + rr.stderr)
-            rr.stdout should include("ok: APIs")
-            // Actual CLI namespace will vary from local dev to automated test environments, so don't check
-            rr.stdout should include regex (s"/[@\\w._\\-]+/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-            rr.stdout should include(testbasepath + testrelpath)
-        } finally {
-            apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-        }
+  it should "verify adding endpoints to two existing apis" in {
+    val testName = "CLI_APIGWTEST8"
+    val testbasepath = "/" + testName + "_bp"
+    val testbasepath2 = "/" + testName + "_bp2"
+    val testrelpath = "/path2"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val testapiname2 = testName + " API Name 2"
+    val actionName = testName + "_action"
+    val newEndpoint = "/newEndpoint"
+    try {
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
+
+      var rr = apiCreate(
+        basepath = Some(testbasepath),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        action = Some(actionName),
+        apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      rr = apiCreate(
+        basepath = Some(testbasepath2),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        action = Some(actionName),
+        apiname = Some(testapiname2))
+      rr.stdout should include("ok: created API")
+
+      // Update both APIs - each with a new endpoint
+      rr = apiCreate(
+        basepath = Some(testbasepath),
+        relpath = Some(newEndpoint),
+        operation = Some(testurlop),
+        action = Some(actionName))
+      rr.stdout should include("ok: created API")
+      rr = apiCreate(
+        basepath = Some(testbasepath2),
+        relpath = Some(newEndpoint),
+        operation = Some(testurlop),
+        action = Some(actionName))
+      rr.stdout should include("ok: created API")
+
+      rr = apiList(basepathOrApiName = Some(testbasepath))
+      rr.stdout should include("ok: APIs")
+      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr.stdout should include(testbasepath + testrelpath)
+      rr.stdout should include(testbasepath + newEndpoint)
+
+      rr = apiList(basepathOrApiName = Some(testbasepath2))
+      rr.stdout should include("ok: APIs")
+      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr.stdout should include(testbasepath2 + testrelpath)
+      rr.stdout should include(testbasepath2 + newEndpoint)
+    } finally {
+      wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+      apiDelete(basepathOrApiName = testbasepath2, expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    it should "verify adding endpoints to two existing apis" in {
-        val testName = "CLI_APIGWTEST8"
-        val testbasepath = "/" + testName + "_bp"
-        val testbasepath2 = "/" + testName + "_bp2"
-        val testrelpath = "/path2"
-        val testnewrelpath = "/path_new"
-        val testurlop = "get"
-        val testapiname = testName + " API Name"
-        val testapiname2 = testName + " API Name 2"
-        val actionName = testName + "_action"
-        val newEndpoint = "/newEndpoint"
-        try {
-            // Create the action for the API.  It must be a "web-action" action.
-            val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
+  it should "verify successful creation of a new API using an action name using all allowed characters" in {
+    // Be aware: full action name is close to being truncated by the 'list' command
+    // e.g. /lime@us.ibm.com/CLI_APIGWTEST9a-c@t ion  is currently at the 40 char 'list' display max
+    val testName = "CLI_APIGWTEST9"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "a-c@t ion"
+    try {
+      println("cli namespace: " + clinamespace)
 
-            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-            rr.stdout should include("ok: created API")
-            rr = apiCreate(basepath = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname2))
-            rr.stdout should include("ok: created API")
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
 
-            // Update both APIs - each with a new endpoint
-            rr = apiCreate(basepath = Some(testbasepath), relpath = Some(newEndpoint), operation = Some(testurlop), action = Some(actionName))
-            rr.stdout should include("ok: created API")
-            rr = apiCreate(basepath = Some(testbasepath2), relpath = Some(newEndpoint), operation = Some(testurlop), action = Some(actionName))
-            rr.stdout should include("ok: created API")
-
-            rr = apiList(basepathOrApiName = Some(testbasepath))
-            rr.stdout should include("ok: APIs")
-            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-            rr.stdout should include(testbasepath + testrelpath)
-            rr.stdout should include(testbasepath + newEndpoint)
-
-            rr = apiList(basepathOrApiName = Some(testbasepath2))
-            rr.stdout should include("ok: APIs")
-            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-            rr.stdout should include(testbasepath2 + testrelpath)
-            rr.stdout should include(testbasepath2 + newEndpoint)
-        } finally {
-            wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-            apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-            apiDelete(basepathOrApiName = testbasepath2, expectedExitCode = DONTCARE_EXIT)
-        }
+      var rr = apiCreate(
+        basepath = Some(testbasepath),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        action = Some(actionName),
+        apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+      rr.stdout should include("ok: APIs")
+      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr.stdout should include(testbasepath + testrelpath)
+      val deleteresult = apiDelete(basepathOrApiName = testbasepath)
+      deleteresult.stdout should include("ok: deleted API")
+    } finally {
+      wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    it should "verify successful creation of a new API using an action name using all allowed characters" in {
-        // Be aware: full action name is close to being truncated by the 'list' command
-        // e.g. /lime@us.ibm.com/CLI_APIGWTEST9a-c@t ion  is currently at the 40 char 'list' display max
-        val testName = "CLI_APIGWTEST9"
-        val testbasepath = "/" + testName + "_bp"
-        val testrelpath = "/path"
-        val testnewrelpath = "/path_new"
-        val testurlop = "get"
-        val testapiname = testName + " API Name"
-        val actionName = testName + "a-c@t ion"
-        try {
-            println("cli namespace: " + clinamespace)
-
-            // Create the action for the API.  It must be a "web-action" action.
-            val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
-
-            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-            rr.stdout should include("ok: created API")
-            rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
-            rr.stdout should include("ok: APIs")
-            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-            rr.stdout should include(testbasepath + testrelpath)
-            val deleteresult = apiDelete(basepathOrApiName = testbasepath)
-            deleteresult.stdout should include("ok: deleted API")
-        } finally {
-            wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-            apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-        }
+  it should "verify failed creation with invalid swagger doc as input" in {
+    val testName = "CLI_APIGWTEST10"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+    val swaggerPath = TestUtils.getTestApiGwFilename(s"testswaggerdocinvalid")
+    try {
+      val rr = apiCreate(swagger = Some(swaggerPath), expectedExitCode = ANY_ERROR_EXIT)
+      println("api create stdout: " + rr.stdout)
+      println("api create stderr: " + rr.stderr)
+      rr.stderr should include(s"Swagger file is invalid")
+    } finally {
+      apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    it should "verify failed creation with invalid swagger doc as input" in {
-        val testName = "CLI_APIGWTEST10"
-        val testbasepath = "/" + testName + "_bp"
-        val testrelpath = "/path"
-        val testnewrelpath = "/path_new"
-        val testurlop = "get"
-        val testapiname = testName + " API Name"
-        val actionName = testName + "_action"
-        val swaggerPath = TestUtils.getTestApiGwFilename(s"testswaggerdocinvalid")
-        try {
-            val rr = apiCreate(swagger = Some(swaggerPath), expectedExitCode = ANY_ERROR_EXIT)
-            println("api create stdout: " + rr.stdout)
-            println("api create stderr: " + rr.stderr)
-            rr.stderr should include(s"Swagger file is invalid")
-        } finally {
-            apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-        }
+  it should "verify delete basepath/path " in {
+    val testName = "CLI_APIGWTEST11"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+    try {
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
+
+      var rr = apiCreate(
+        basepath = Some(testbasepath),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        action = Some(actionName),
+        apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      var rr2 = apiCreate(
+        basepath = Some(testbasepath),
+        relpath = Some(testnewrelpath),
+        operation = Some(testurlop),
+        action = Some(actionName),
+        apiname = Some(testapiname))
+      rr2.stdout should include("ok: created API")
+      rr = apiDelete(basepathOrApiName = testbasepath, relpath = Some(testrelpath))
+      rr.stdout should include("ok: deleted " + testrelpath + " from " + testbasepath)
+      rr2 = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testnewrelpath))
+      rr2.stdout should include("ok: APIs")
+      rr2.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr2.stdout should include(testbasepath + testnewrelpath)
+    } finally {
+      wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    it should "verify delete basepath/path " in {
-        val testName = "CLI_APIGWTEST11"
-        val testbasepath = "/" + testName + "_bp"
-        val testrelpath = "/path"
-        val testnewrelpath = "/path_new"
-        val testurlop = "get"
-        val testapiname = testName + " API Name"
-        val actionName = testName + "_action"
-        try {
-            // Create the action for the API.  It must be a "web-action" action.
-            val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
+  it should "verify delete single operation from existing API basepath/path/operation(s) " in {
+    val testName = "CLI_APIGWTEST12"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path2"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testurlop2 = "post"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+    try {
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
 
-            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-            rr.stdout should include("ok: created API")
-            var rr2 = apiCreate(basepath = Some(testbasepath), relpath = Some(testnewrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-            rr2.stdout should include("ok: created API")
-            rr = apiDelete(basepathOrApiName = testbasepath, relpath = Some(testrelpath))
-            rr.stdout should include("ok: deleted " + testrelpath + " from " + testbasepath)
-            rr2 = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testnewrelpath))
-            rr2.stdout should include("ok: APIs")
-            rr2.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-            rr2.stdout should include(testbasepath + testnewrelpath)
-        } finally {
-            wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-            apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-        }
+      var rr = apiCreate(
+        basepath = Some(testbasepath),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        action = Some(actionName),
+        apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      rr = apiCreate(
+        basepath = Some(testbasepath),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop2),
+        action = Some(actionName),
+        apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      rr = apiList(basepathOrApiName = Some(testbasepath))
+      rr.stdout should include("ok: APIs")
+      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr.stdout should include(testbasepath + testrelpath)
+      rr = apiDelete(basepathOrApiName = testbasepath, relpath = Some(testrelpath), operation = Some(testurlop2))
+      rr.stdout should include("ok: deleted " + testrelpath + " " + "POST" + " from " + testbasepath)
+      rr = apiList(basepathOrApiName = Some(testbasepath))
+      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+    } finally {
+      wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    it should "verify delete single operation from existing API basepath/path/operation(s) " in {
-        val testName = "CLI_APIGWTEST12"
-        val testbasepath = "/" + testName + "_bp"
-        val testrelpath = "/path2"
-        val testnewrelpath = "/path_new"
-        val testurlop = "get"
-        val testurlop2 = "post"
-        val testapiname = testName + " API Name"
-        val actionName = testName + "_action"
-        try {
-            // Create the action for the API.  It must be a "web-action" action.
-            val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
-
-            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-            rr.stdout should include("ok: created API")
-            rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop2), action = Some(actionName), apiname = Some(testapiname))
-            rr.stdout should include("ok: created API")
-            rr = apiList(basepathOrApiName = Some(testbasepath))
-            rr.stdout should include("ok: APIs")
-            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-            rr.stdout should include(testbasepath + testrelpath)
-            rr = apiDelete(basepathOrApiName = testbasepath, relpath = Some(testrelpath), operation = Some(testurlop2))
-            rr.stdout should include("ok: deleted " + testrelpath + " " + "POST" + " from " + testbasepath)
-            rr = apiList(basepathOrApiName = Some(testbasepath))
-            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-        } finally {
-            wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-            apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-        }
+  it should "verify successful creation with complex swagger doc as input" in {
+    val testName = "CLI_APIGWTEST13"
+    val testbasepath = "/test1/v1"
+    val testrelpath = "/whisk_system/utils/echo"
+    val testrelpath2 = "/whisk_system/utils/split"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = "test1a"
+    val swaggerPath = TestUtils.getTestApiGwFilename(s"testswaggerdoc2")
+    try {
+      var rr = apiCreate(swagger = Some(swaggerPath))
+      println("api create stdout: " + rr.stdout)
+      println("api create stderror: " + rr.stderr)
+      rr.stdout should include("ok: created API")
+      rr = apiList(basepathOrApiName = Some(testbasepath))
+      rr.stdout should include("ok: APIs")
+      // Actual CLI namespace will vary from local dev to automated test environments, so don't check
+      rr.stdout should include regex (s"/[@\\w._\\-]+/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr.stdout should include(testbasepath + testrelpath)
+      rr.stdout should include(testbasepath + testrelpath2)
+    } finally {
+      apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    it should "verify successful creation with complex swagger doc as input" in {
-        val testName = "CLI_APIGWTEST13"
-        val testbasepath = "/test1/v1"
-        val testrelpath = "/whisk_system/utils/echo"
-        val testrelpath2 = "/whisk_system/utils/split"
-        val testurlop = "get"
-        val testapiname = testName + " API Name"
-        val actionName = "test1a"
-        val swaggerPath = TestUtils.getTestApiGwFilename(s"testswaggerdoc2")
-        try {
-            var rr = apiCreate(swagger = Some(swaggerPath))
-            println("api create stdout: " + rr.stdout)
-            println("api create stderror: " + rr.stderr)
-            rr.stdout should include("ok: created API")
-            rr = apiList(basepathOrApiName = Some(testbasepath))
-            rr.stdout should include("ok: APIs")
-            // Actual CLI namespace will vary from local dev to automated test environments, so don't check
-            rr.stdout should include regex (s"/[@\\w._\\-]+/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-            rr.stdout should include(testbasepath + testrelpath)
-            rr.stdout should include(testbasepath + testrelpath2)
-        } finally {
-            apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-        }
+  it should "verify successful creation and deletion with multiple base paths" in {
+    val testName = "CLI_APIGWTEST14"
+    val testbasepath = "/" + testName + "_bp"
+    val testbasepath2 = "/" + testName + "_bp2"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val testapiname2 = testName + " API Name 2"
+    val actionName = testName + "_action"
+    try {
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
+
+      var rr = apiCreate(
+        basepath = Some(testbasepath),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        action = Some(actionName),
+        apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+      rr.stdout should include("ok: APIs")
+      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr.stdout should include(testbasepath + testrelpath)
+      rr = apiCreate(
+        basepath = Some(testbasepath2),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        action = Some(actionName),
+        apiname = Some(testapiname2))
+      rr.stdout should include("ok: created API")
+      rr = apiList(basepathOrApiName = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop))
+      rr.stdout should include("ok: APIs")
+      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr.stdout should include(testbasepath2 + testrelpath)
+      rr = apiDelete(basepathOrApiName = testbasepath2)
+      rr.stdout should include("ok: deleted API")
+      rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+      rr.stdout should include("ok: APIs")
+      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr.stdout should include(testbasepath + testrelpath)
+      rr = apiDelete(basepathOrApiName = testbasepath)
+      rr.stdout should include("ok: deleted API")
+    } finally {
+      wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+      apiDelete(basepathOrApiName = testbasepath2, expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    it should "verify successful creation and deletion with multiple base paths" in {
-        val testName = "CLI_APIGWTEST14"
-        val testbasepath = "/" + testName + "_bp"
-        val testbasepath2 = "/" + testName + "_bp2"
-        val testrelpath = "/path"
-        val testnewrelpath = "/path_new"
-        val testurlop = "get"
-        val testapiname = testName + " API Name"
-        val testapiname2 = testName + " API Name 2"
-        val actionName = testName + "_action"
-        try {
-            // Create the action for the API.  It must be a "web-action" action.
-            val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
-
-            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-            rr.stdout should include("ok: created API")
-            rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
-            rr.stdout should include("ok: APIs")
-            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-            rr.stdout should include(testbasepath + testrelpath)
-            rr = apiCreate(basepath = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname2))
-            rr.stdout should include("ok: created API")
-            rr = apiList(basepathOrApiName = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop))
-            rr.stdout should include("ok: APIs")
-            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-            rr.stdout should include(testbasepath2 + testrelpath)
-            rr = apiDelete(basepathOrApiName = testbasepath2)
-            rr.stdout should include("ok: deleted API")
-            rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
-            rr.stdout should include("ok: APIs")
-            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-            rr.stdout should include(testbasepath + testrelpath)
-            rr = apiDelete(basepathOrApiName = testbasepath)
-            rr.stdout should include("ok: deleted API")
-        } finally {
-            wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-            apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-            apiDelete(basepathOrApiName = testbasepath2, expectedExitCode = DONTCARE_EXIT)
-        }
+  it should "reject an API created with a non-existent action" in {
+    val testName = "CLI_APIGWTEST15"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+    try {
+      val rr = apiCreate(
+        basepath = Some(testbasepath),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        action = Some(actionName),
+        apiname = Some(testapiname),
+        expectedExitCode = ANY_ERROR_EXIT)
+      rr.stderr should include("does not exist")
+    } finally {
+      apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    it should "reject an API created with a non-existent action" in {
-        val testName = "CLI_APIGWTEST15"
-        val testbasepath = "/" + testName + "_bp"
-        val testrelpath = "/path"
-        val testnewrelpath = "/path_new"
-        val testurlop = "get"
-        val testapiname = testName + " API Name"
-        val actionName = testName + "_action"
-        try {
-            val rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname), expectedExitCode = ANY_ERROR_EXIT)
-            rr.stderr should include("does not exist")
-        } finally {
-            apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-        }
+  it should "reject an API created with an action that is not a web action" in {
+    val testName = "CLI_APIGWTEST16"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+    try {
+      // Create the action for the API.  It must NOT be a "web-action" action for this test
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT)
+
+      val rr = apiCreate(
+        basepath = Some(testbasepath),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        action = Some(actionName),
+        apiname = Some(testapiname),
+        expectedExitCode = ANY_ERROR_EXIT)
+      rr.stderr should include("is not a web action")
+    } finally {
+      wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    it should "reject an API created with an action that is not a web action" in {
-        val testName = "CLI_APIGWTEST16"
-        val testbasepath = "/" + testName + "_bp"
-        val testrelpath = "/path"
-        val testnewrelpath = "/path_new"
-        val testurlop = "get"
-        val testapiname = testName + " API Name"
-        val actionName = testName + "_action"
-        try {
-            // Create the action for the API.  It must NOT be a "web-action" action for this test
-            val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT)
+  it should "verify API with http response type " in {
+    val testName = "CLI_APIGWTEST17"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+    val responseType = "http"
+    try {
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
 
-            val rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname), expectedExitCode = ANY_ERROR_EXIT)
-            rr.stderr should include("is not a web action")
-        } finally {
-            wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-            apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-        }
+      apiCreate(
+        basepath = Some(testbasepath),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        action = Some(actionName),
+        apiname = Some(testapiname),
+        responsetype = Some(responseType)).stdout should include("ok: created API")
+
+      val rr = apiGet(basepathOrApiName = Some(testapiname))
+      rr.stdout should include(testbasepath)
+      rr.stdout should include(s"${actionName}")
+      rr.stdout should include regex (s""""target-url":\\s+.*${actionName}.${responseType}""")
+    } finally {
+      wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    it should "verify API with http response type " in {
-        val testName = "CLI_APIGWTEST17"
-        val testbasepath = "/" + testName + "_bp"
-        val testrelpath = "/path"
-        val testnewrelpath = "/path_new"
-        val testurlop = "get"
-        val testapiname = testName + " API Name"
-        val actionName = testName + "_action"
-        val responseType = "http"
-        try {
-            // Create the action for the API.  It must be a "web-action" action.
-            val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
+  it should "reject API export when export type is invalid" in {
+    val testName = "CLI_APIGWTEST18"
+    val testbasepath = "/" + testName + "_bp"
 
-            apiCreate(
-                basepath = Some(testbasepath),
-                relpath = Some(testrelpath),
-                operation = Some(testurlop),
-                action = Some(actionName),
-                apiname = Some(testapiname),
-                responsetype = Some(responseType))
-                .stdout should include("ok: created API")
+    val rr = apiGet(basepathOrApiName = Some(testbasepath), format = Some("BadType"), expectedExitCode = ANY_ERROR_EXIT)
+    rr.stderr should include("Invalid format type")
+  }
 
-            val rr = apiGet(basepathOrApiName = Some(testapiname))
-            rr.stdout should include(testbasepath)
-            rr.stdout should include(s"${actionName}")
-            rr.stdout should include regex (s""""target-url":\\s+.*${actionName}.${responseType}""")
-        } finally {
-            wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-            apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-        }
+  it should "successfully export an API in YAML format" in {
+    val testName = "CLI_APIGWTEST19"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+    val responseType = "http"
+    try {
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
+
+      apiCreate(
+        basepath = Some(testbasepath),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        action = Some(actionName),
+        apiname = Some(testapiname),
+        responsetype = Some(responseType)).stdout should include("ok: created API")
+
+      val rr = apiGet(basepathOrApiName = Some(testapiname), format = Some("yaml"))
+      rr.stdout should include(s"basePath: ${testbasepath}")
+    } finally {
+      wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    it should "reject API export when export type is invalid" in {
-        val testName = "CLI_APIGWTEST18"
-        val testbasepath = "/" + testName + "_bp"
+  it should "successfully export an API when JSON format is explcitly specified" in {
+    val testName = "CLI_APIGWTEST20"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+    val responseType = "http"
+    try {
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
 
-        val rr = apiGet(basepathOrApiName = Some(testbasepath), format = Some("BadType"), expectedExitCode = ANY_ERROR_EXIT)
-        rr.stderr should include("Invalid format type")
+      apiCreate(
+        basepath = Some(testbasepath),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        action = Some(actionName),
+        apiname = Some(testapiname),
+        responsetype = Some(responseType)).stdout should include("ok: created API")
+
+      val rr = apiGet(basepathOrApiName = Some(testapiname), format = Some("json"))
+      rr.stdout should include(testbasepath)
+      rr.stdout should include(s"${actionName}")
+      rr.stdout should include regex (s""""target-url":\\s+.*${actionName}.${responseType}""")
+    } finally {
+      wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    it should "successfully export an API in YAML format" in {
-        val testName = "CLI_APIGWTEST19"
-        val testbasepath = "/" + testName + "_bp"
-        val testrelpath = "/path"
-        val testnewrelpath = "/path_new"
-        val testurlop = "get"
-        val testapiname = testName + " API Name"
-        val actionName = testName + "_action"
-        val responseType = "http"
-        try {
-            // Create the action for the API.  It must be a "web-action" action.
-            val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
-
-            apiCreate(
-                basepath = Some(testbasepath),
-                relpath = Some(testrelpath),
-                operation = Some(testurlop),
-                action = Some(actionName),
-                apiname = Some(testapiname),
-                responsetype = Some(responseType))
-                .stdout should include("ok: created API")
-
-            val rr = apiGet(basepathOrApiName = Some(testapiname), format = Some("yaml"))
-            rr.stdout should include(s"basePath: ${testbasepath}")
-        } finally {
-            wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-            apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-        }
+  it should "successfully create an API from a YAML formatted API configuration file" in {
+    val testName = "CLI_APIGWTEST21"
+    val testbasepath = "/bp"
+    val testrelpath = "/rp"
+    val testurlop = "get"
+    val testapiname = testbasepath
+    val actionName = "webhttpecho"
+    val swaggerPath = TestUtils.getTestApiGwFilename(s"local.api.yaml")
+    try {
+      var rr = apiCreate(swagger = Some(swaggerPath))
+      println("api create stdout: " + rr.stdout)
+      println("api create stderror: " + rr.stderr)
+      rr.stdout should include("ok: created API")
+      rr = apiList(basepathOrApiName = Some(testbasepath))
+      rr.stdout should include("ok: APIs")
+      // Actual CLI namespace will vary from local dev to automated test environments, so don't check
+      rr.stdout should include regex (s"/[@\\w._\\-]+/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr.stdout should include(testbasepath + testrelpath)
+    } finally {
+      apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    it should "successfully export an API when JSON format is explcitly specified" in {
-        val testName = "CLI_APIGWTEST20"
-        val testbasepath = "/" + testName + "_bp"
-        val testrelpath = "/path"
-        val testnewrelpath = "/path_new"
-        val testurlop = "get"
-        val testapiname = testName + " API Name"
-        val actionName = testName + "_action"
-        val responseType = "http"
-        try {
-            // Create the action for the API.  It must be a "web-action" action.
-            val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
-
-            apiCreate(
-                basepath = Some(testbasepath),
-                relpath = Some(testrelpath),
-                operation = Some(testurlop),
-                action = Some(actionName),
-                apiname = Some(testapiname),
-                responsetype = Some(responseType))
-                .stdout should include("ok: created API")
-
-            val rr = apiGet(basepathOrApiName = Some(testapiname), format = Some("json"))
-            rr.stdout should include(testbasepath)
-            rr.stdout should include(s"${actionName}")
-            rr.stdout should include regex (s""""target-url":\\s+.*${actionName}.${responseType}""")
-        } finally {
-            wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-            apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-        }
+  it should "reject creation of an API from invalid YAML formatted API configuration file" in {
+    val testName = "CLI_APIGWTEST22"
+    val testbasepath = "/" + testName + "_bp"
+    val swaggerPath = TestUtils.getTestApiGwFilename(s"local.api.bad.yaml")
+    try {
+      val rr = apiCreate(swagger = Some(swaggerPath), expectedExitCode = ANY_ERROR_EXIT)
+      println("api create stdout: " + rr.stdout)
+      println("api create stderror: " + rr.stderr)
+      rr.stderr should include("Unable to parse YAML configuration file")
+    } finally {
+      apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    it should "successfully create an API from a YAML formatted API configuration file" in {
-        val testName = "CLI_APIGWTEST21"
-        val testbasepath = "/bp"
-        val testrelpath = "/rp"
-        val testurlop = "get"
-        val testapiname = testbasepath
-        val actionName = "webhttpecho"
-        val swaggerPath = TestUtils.getTestApiGwFilename(s"local.api.yaml")
-        try {
-            var rr = apiCreate(swagger = Some(swaggerPath))
-            println("api create stdout: " + rr.stdout)
-            println("api create stderror: " + rr.stderr)
-            rr.stdout should include("ok: created API")
-            rr = apiList(basepathOrApiName = Some(testbasepath))
-            rr.stdout should include("ok: APIs")
-            // Actual CLI namespace will vary from local dev to automated test environments, so don't check
-            rr.stdout should include regex (s"/[@\\w._\\-]+/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-            rr.stdout should include(testbasepath + testrelpath)
-        } finally {
-            apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-        }
+  it should "reject deletion of a non-existent api" in {
+    val nonexistentApi = "/not-there"
+
+    val rr = apiDelete(basepathOrApiName = nonexistentApi, expectedExitCode = ANY_ERROR_EXIT)
+    rr.stderr should include(s"API '${nonexistentApi}' does not exist")
+  }
+
+  it should "successfully list an API whose endpoints are not mapped to actions" in {
+    val testName = "CLI_APIGWTEST23"
+    val testapiname = "A descriptive name"
+    val testbasepath = "/NoActions"
+    val testrelpath = "/"
+    val testops: Seq[String] = Seq("put", "delete", "get", "head", "options", "patch", "post")
+    val swaggerPath = TestUtils.getTestApiGwFilename(s"endpoints.without.action.swagger.json")
+
+    try {
+      var rr = apiCreate(swagger = Some(swaggerPath))
+      println("api create stdout: " + rr.stdout)
+      println("api create stderror: " + rr.stderr)
+      rr.stdout should include("ok: created API")
+
+      rr = apiList(basepathOrApiName = Some(testbasepath))
+      println("api list:\n" + rr.stdout)
+      testops foreach { testurlop =>
+        rr.stdout should include regex (s"\\s+${testurlop}\\s+${testapiname}\\s+")
+      }
+      rr.stdout should include(testbasepath + testrelpath)
+
+      rr = apiList(basepathOrApiName = Some(testbasepath), full = Some(true))
+      println("api full list:\n" + rr.stdout)
+      testops foreach { testurlop =>
+        rr.stdout should include regex (s"Verb:\\s+${testurlop}")
+      }
+      rr.stdout should include(testbasepath + testrelpath)
+
+    } finally {
+      apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    it should "reject creation of an API from invalid YAML formatted API configuration file" in {
-        val testName = "CLI_APIGWTEST22"
-        val testbasepath = "/" + testName + "_bp"
-        val swaggerPath = TestUtils.getTestApiGwFilename(s"local.api.bad.yaml")
-        try {
-            val rr = apiCreate(swagger = Some(swaggerPath), expectedExitCode = ANY_ERROR_EXIT)
-            println("api create stdout: " + rr.stdout)
-            println("api create stderror: " + rr.stderr)
-            rr.stderr should include("Unable to parse YAML configuration file")
-        } finally {
-            apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-        }
+  it should "reject creation of an API with invalid auth key" in {
+    val testName = "CLI_APIGWTEST24"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+
+    try {
+      // Create the action for the API.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
+
+      // Set an invalid auth key
+      val badWskProps = WskProps(authKey = "bad-auth-key")
+
+      apiCreate(
+        basepath = Some(testbasepath),
+        relpath = Some(testrelpath),
+        operation = Some(testurlop),
+        action = Some(actionName),
+        apiname = Some(testapiname),
+        expectedExitCode = ANY_ERROR_EXIT)(badWskProps).stderr should include("The supplied authentication is invalid")
+    } finally {
+      wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
     }
+  }
 
-    it should "reject deletion of a non-existent api" in {
-        val nonexistentApi = "/not-there"
+  it should "list api alphabetically by Base/Rel/Verb" in {
+    val baseName = "/BaseTestPathApiList"
+    val actionName = "actionName"
+    val file = TestUtils.getTestActionFilename(s"echo-web-http.js")
+    try {
+      // Create Action for apis
+      var action =
+        wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
+      println("action creation: " + action.stdout)
+      // Create apis
+      for (i <- 1 to 3) {
+        val base = s"$baseName$i"
+        var api = apiCreate(
+          basepath = Some(base),
+          relpath = Some("/relPath"),
+          operation = Some("GET"),
+          action = Some(actionName))
+        println("api creation: " + api.stdout)
+      }
+      val original = apiList(nameSort = Some(true)).stdout
+      val originalFull = apiList(full = Some(true), nameSort = Some(true)).stdout
+      val scalaSorted = List(s"${baseName}1" + "/", s"${baseName}2" + "/", s"${baseName}3" + "/")
+      val regex = s"${baseName}[1-3]/".r
+      val list = (regex.findAllMatchIn(original)).toList
+      val listFull = (regex.findAllMatchIn(originalFull)).toList
 
-        val rr = apiDelete(basepathOrApiName = nonexistentApi, expectedExitCode = ANY_ERROR_EXIT)
-        rr.stderr should include(s"API '${nonexistentApi}' does not exist")
+      scalaSorted.toString shouldEqual list.toString
+      scalaSorted.toString shouldEqual listFull.toString
+    } finally {
+      // Clean up Apis
+      for (i <- 1 to 3) {
+        apiDelete(basepathOrApiName = s"${baseName}$i", expectedExitCode = DONTCARE_EXIT)
+      }
+      wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
     }
-
-    it should "successfully list an API whose endpoints are not mapped to actions" in {
-        val testName = "CLI_APIGWTEST23"
-        val testapiname = "A descriptive name"
-        val testbasepath = "/NoActions"
-        val testrelpath = "/"
-        val testops: Seq[String] = Seq("put", "delete", "get", "head", "options", "patch", "post")
-        val swaggerPath = TestUtils.getTestApiGwFilename(s"endpoints.without.action.swagger.json")
-
-        try {
-            var rr = apiCreate(swagger = Some(swaggerPath))
-            println("api create stdout: " + rr.stdout)
-            println("api create stderror: " + rr.stderr)
-            rr.stdout should include("ok: created API")
-
-            rr = apiList(basepathOrApiName = Some(testbasepath))
-            println("api list:\n" + rr.stdout)
-            testops foreach { testurlop =>
-                rr.stdout should include regex (s"\\s+${testurlop}\\s+${testapiname}\\s+")
-            }
-            rr.stdout should include(testbasepath + testrelpath)
-
-            rr = apiList(basepathOrApiName = Some(testbasepath), full = Some(true))
-            println("api full list:\n" + rr.stdout)
-            testops foreach { testurlop =>
-                rr.stdout should include regex (s"Verb:\\s+${testurlop}")
-            }
-            rr.stdout should include(testbasepath + testrelpath)
-
-        } finally {
-            apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-        }
-    }
-
-    it should "reject creation of an API with invalid auth key" in {
-        val testName = "CLI_APIGWTEST24"
-        val testbasepath = "/" + testName + "_bp"
-        val testrelpath = "/path"
-        val testurlop = "get"
-        val testapiname = testName + " API Name"
-        val actionName = testName + "_action"
-
-        try {
-            // Create the action for the API.
-            val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
-
-            // Set an invalid auth key
-            val badWskProps = WskProps(authKey = "bad-auth-key")
-
-            apiCreate(
-                basepath = Some(testbasepath),
-                relpath = Some(testrelpath),
-                operation = Some(testurlop),
-                action = Some(actionName),
-                apiname = Some(testapiname),
-                expectedExitCode = ANY_ERROR_EXIT)(badWskProps)
-                .stderr should include("The supplied authentication is invalid")
-        } finally {
-            wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-            apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-        }
-    }
-
-    it should "list api alphabetically by Base/Rel/Verb" in {
-        val baseName = "/BaseTestPathApiList"
-        val actionName = "actionName"
-        val file = TestUtils.getTestActionFilename(s"echo-web-http.js")
-        try {
-            // Create Action for apis
-            var action = wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
-            println("action creation: " + action.stdout)
-            // Create apis
-            for (i <- 1 to 3) {
-                val base = s"$baseName$i"
-                var api = apiCreate(
-                    basepath = Some(base),
-                    relpath = Some("/relPath"),
-                    operation = Some("GET"),
-                    action = Some(actionName))
-                println("api creation: " + api.stdout)
-            }
-            val original = apiList(nameSort = Some(true)).stdout
-            val originalFull = apiList(full = Some(true), nameSort = Some(true)).stdout
-            val scalaSorted = List(s"${baseName}1" + "/", s"${baseName}2" + "/", s"${baseName}3" + "/")
-            val regex = s"${baseName}[1-3]/".r
-            val list = (regex.findAllMatchIn(original)).toList
-            val listFull = (regex.findAllMatchIn(originalFull)).toList
-
-            scalaSorted.toString shouldEqual list.toString
-            scalaSorted.toString shouldEqual listFull.toString
-        } finally {
-            // Clean up Apis
-            for (i <- 1 to 3) {
-                apiDelete(basepathOrApiName = s"${baseName}$i", expectedExitCode = DONTCARE_EXIT)
-            }
-            wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-        }
-    }
+  }
 }

--- a/tests/src/test/scala/whisk/core/cli/test/JsonArgsForTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/JsonArgsForTests.scala
@@ -25,210 +25,83 @@ import spray.json.JsBoolean
 
 object JsonArgsForTests {
 
-    def getInvalidJSONInput = Seq(
-        "{\"invalid1\": }",
-        "{\"invalid2\": bogus}",
-        "{\"invalid1\": \"aKey\"",
-        "invalid \"string\"",
-        "{\"invalid1\": [1, 2, \"invalid\"\"arr\"]}"
-    )
+  def getInvalidJSONInput =
+    Seq(
+      "{\"invalid1\": }",
+      "{\"invalid2\": bogus}",
+      "{\"invalid1\": \"aKey\"",
+      "invalid \"string\"",
+      "{\"invalid1\": [1, 2, \"invalid\"\"arr\"]}")
 
-    def getJSONFileOutput() = JsArray(
-        JsObject(
-            "key" -> JsString("a key"),
-            "value" -> JsString("a value")
-        ),
-        JsObject(
-            "key" -> JsString("a bool"),
-            "value" -> JsBoolean(true)
-        ),
-        JsObject(
-            "key" -> JsString("objKey"),
-            "value" -> JsObject(
-                "b" -> JsString("c")
-            )
-        ),
-        JsObject(
-            "key" -> JsString("objKey2"),
-            "value" -> JsObject(
-                "another object" -> JsObject(
-                    "some string" -> JsString("1111")
-                )
-            )
-        ),
-        JsObject(
-            "key" -> JsString("objKey3"),
-            "value" -> JsObject(
-                "json object" -> JsObject(
-                    "some int" -> JsNumber(1111)
-                )
-            )
-        ),
-        JsObject(
-            "key" -> JsString("a number arr"),
-            "value" -> JsArray(
-                JsNumber(1), JsNumber(2), JsNumber(3)
-            )
-        ),
-        JsObject(
-            "key" -> JsString("a string arr"),
-            "value" -> JsArray(
-                JsString("1"), JsString("2"), JsString("3")
-            )
-        ),
-        JsObject(
-            "key" -> JsString("a bool arr"),
-            "value" -> JsArray(
-                JsBoolean(true), JsBoolean(false), JsBoolean(true)
-            )
-        ),
-        JsObject(
-            "key" -> JsString("strThatLooksLikeJSON"),
-            "value" -> JsString("{\"someKey\": \"someValue\"}")
-        )
-    )
+  def getJSONFileOutput() =
+    JsArray(
+      JsObject("key" -> JsString("a key"), "value" -> JsString("a value")),
+      JsObject("key" -> JsString("a bool"), "value" -> JsBoolean(true)),
+      JsObject("key" -> JsString("objKey"), "value" -> JsObject("b" -> JsString("c"))),
+      JsObject(
+        "key" -> JsString("objKey2"),
+        "value" -> JsObject("another object" -> JsObject("some string" -> JsString("1111")))),
+      JsObject(
+        "key" -> JsString("objKey3"),
+        "value" -> JsObject("json object" -> JsObject("some int" -> JsNumber(1111)))),
+      JsObject("key" -> JsString("a number arr"), "value" -> JsArray(JsNumber(1), JsNumber(2), JsNumber(3))),
+      JsObject("key" -> JsString("a string arr"), "value" -> JsArray(JsString("1"), JsString("2"), JsString("3"))),
+      JsObject("key" -> JsString("a bool arr"), "value" -> JsArray(JsBoolean(true), JsBoolean(false), JsBoolean(true))),
+      JsObject("key" -> JsString("strThatLooksLikeJSON"), "value" -> JsString("{\"someKey\": \"someValue\"}")))
 
-    def getEscapedJSONTestArgInput() = Map(
-        "key1" -> JsObject(
-            "nonascii" -> JsString("日本語")
-        ),
-        "key2" -> JsObject(
-            "valid" -> JsString("J\\SO\"N")
-        ),
-        "\"key\"with\\escapes" -> JsObject(
-            "valid" -> JsString("JSON")
-        ),
-        "another\"escape\"" -> JsObject(
-            "valid" -> JsString("\\nJ\\rO\\tS\\bN\\f")
-        )
-    )
+  def getEscapedJSONTestArgInput() =
+    Map(
+      "key1" -> JsObject("nonascii" -> JsString("日本語")),
+      "key2" -> JsObject("valid" -> JsString("J\\SO\"N")),
+      "\"key\"with\\escapes" -> JsObject("valid" -> JsString("JSON")),
+      "another\"escape\"" -> JsObject("valid" -> JsString("\\nJ\\rO\\tS\\bN\\f")))
 
-    def getEscapedJSONTestArgOutput() = JsArray(
-        JsObject(
-            "key" -> JsString("key1"),
-            "value" -> JsObject(
-                "nonascii" -> JsString("日本語")
-            )
-        ),
-        JsObject(
-            "key" -> JsString("key2"),
-            "value" -> JsObject(
-                "valid" -> JsString("J\\SO\"N")
-            )
-        ),
-        JsObject(
-            "key" -> JsString("\"key\"with\\escapes"),
-            "value" -> JsObject(
-                "valid" -> JsString("JSON")
-            )
-        ),
-        JsObject(
-            "key" -> JsString("another\"escape\""),
-            "value" -> JsObject(
-                "valid" -> JsString("\\nJ\\rO\\tS\\bN\\f")
-            )
-        )
-    )
+  def getEscapedJSONTestArgOutput() =
+    JsArray(
+      JsObject("key" -> JsString("key1"), "value" -> JsObject("nonascii" -> JsString("日本語"))),
+      JsObject("key" -> JsString("key2"), "value" -> JsObject("valid" -> JsString("J\\SO\"N"))),
+      JsObject("key" -> JsString("\"key\"with\\escapes"), "value" -> JsObject("valid" -> JsString("JSON"))),
+      JsObject("key" -> JsString("another\"escape\""), "value" -> JsObject("valid" -> JsString("\\nJ\\rO\\tS\\bN\\f"))))
 
-    def getValidJSONTestArgOutput() = JsArray(
-        JsObject(
-            "key" -> JsString("number"),
-            "value" -> JsNumber(8)
-        ),
-        JsObject(
-            "key" -> JsString("bignumber"),
-            "value" -> JsNumber(12345678912.123456789012)
-        ),
-        JsObject(
-            "key" -> JsString("objArr"),
-            "value" -> JsArray(
-                JsObject(
-                    "name" -> JsString("someName"),
-                    "required" -> JsBoolean(true)
-                ),
-                JsObject(
-                    "name" -> JsString("events"),
-                    "count" -> JsNumber(10)
-                )
-            )
-        ),
-        JsObject(
-            "key" -> JsString("strArr"),
-            "value" -> JsArray(
-                JsString("44"),
-                JsString("55")
-            )
-        ),
-        JsObject(
-            "key" -> JsString("string"),
-            "value" -> JsString("This is a string")
-        ),
-        JsObject(
-            "key" -> JsString("numArr"),
-            "value" -> JsArray(
-                JsNumber(44),
-                JsNumber(55)
-            )
-        ),
-        JsObject(
-            "key" -> JsString("object"),
-            "value" -> JsObject(
-                "objString" -> JsString("aString"),
-                "objStrNum" -> JsString("123"),
-                "objNum" -> JsNumber(300),
-                "objBool" -> JsBoolean(false),
-                "objNumArr" -> JsArray(
-                    JsNumber(1),
-                    JsNumber(2)
-                ),
-                "objStrArr" -> JsArray(
-                    JsString("1"),
-                    JsString("2")
-                )
-            )
-        ),
-        JsObject(
-            "key" -> JsString("strNum"),
-            "value" -> JsString("9")
-        )
-    )
+  def getValidJSONTestArgOutput() =
+    JsArray(
+      JsObject("key" -> JsString("number"), "value" -> JsNumber(8)),
+      JsObject("key" -> JsString("bignumber"), "value" -> JsNumber(12345678912.123456789012)),
+      JsObject(
+        "key" -> JsString("objArr"),
+        "value" -> JsArray(
+          JsObject("name" -> JsString("someName"), "required" -> JsBoolean(true)),
+          JsObject("name" -> JsString("events"), "count" -> JsNumber(10)))),
+      JsObject("key" -> JsString("strArr"), "value" -> JsArray(JsString("44"), JsString("55"))),
+      JsObject("key" -> JsString("string"), "value" -> JsString("This is a string")),
+      JsObject("key" -> JsString("numArr"), "value" -> JsArray(JsNumber(44), JsNumber(55))),
+      JsObject(
+        "key" -> JsString("object"),
+        "value" -> JsObject(
+          "objString" -> JsString("aString"),
+          "objStrNum" -> JsString("123"),
+          "objNum" -> JsNumber(300),
+          "objBool" -> JsBoolean(false),
+          "objNumArr" -> JsArray(JsNumber(1), JsNumber(2)),
+          "objStrArr" -> JsArray(JsString("1"), JsString("2")))),
+      JsObject("key" -> JsString("strNum"), "value" -> JsString("9")))
 
-    def getValidJSONTestArgInput() = Map(
-        "string" -> JsString("This is a string"),
-        "strNum" -> JsString("9"),
-        "number" -> JsNumber(8),
-        "bignumber" -> JsNumber(12345678912.123456789012),
-        "numArr" -> JsArray(
-            JsNumber(44),
-            JsNumber(55)
-        ),
-        "strArr" -> JsArray(
-            JsString("44"),
-            JsString("55")
-        ),
-        "objArr" -> JsArray(
-            JsObject(
-                "name" -> JsString("someName"),
-                "required" -> JsBoolean(true)
-            ),
-            JsObject(
-                "name" -> JsString("events"),
-                "count" -> JsNumber(10)
-            )
-        ),
-        "object" -> JsObject(
-            "objString" -> JsString("aString"),
-            "objStrNum" -> JsString("123"),
-            "objNum" -> JsNumber(300),
-            "objBool" -> JsBoolean(false),
-            "objNumArr" -> JsArray(
-                JsNumber(1),
-                JsNumber(2)
-            ),
-            "objStrArr" -> JsArray(
-                JsString("1"),
-                JsString("2")
-            )
-        )
-    )
+  def getValidJSONTestArgInput() =
+    Map(
+      "string" -> JsString("This is a string"),
+      "strNum" -> JsString("9"),
+      "number" -> JsNumber(8),
+      "bignumber" -> JsNumber(12345678912.123456789012),
+      "numArr" -> JsArray(JsNumber(44), JsNumber(55)),
+      "strArr" -> JsArray(JsString("44"), JsString("55")),
+      "objArr" -> JsArray(
+        JsObject("name" -> JsString("someName"), "required" -> JsBoolean(true)),
+        JsObject("name" -> JsString("events"), "count" -> JsNumber(10))),
+      "object" -> JsObject(
+        "objString" -> JsString("aString"),
+        "objStrNum" -> JsString("123"),
+        "objNum" -> JsNumber(300),
+        "objBool" -> JsBoolean(false),
+        "objNumArr" -> JsArray(JsNumber(1), JsNumber(2)),
+        "objStrArr" -> JsArray(JsString("1"), JsString("2"))))
 }

--- a/tests/src/test/scala/whisk/core/cli/test/SequenceMigrationTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/SequenceMigrationTests.scala
@@ -43,95 +43,91 @@ import whisk.core.entity.test.ExecHelpers
  * Tests that "old-style" sequences can be invoked
  */
 @RunWith(classOf[JUnitRunner])
-class SequenceMigrationTests
-    extends TestHelpers
-    with BeforeAndAfter
-    with DbUtils
-    with ExecHelpers
-    with WskTestHelpers {
+class SequenceMigrationTests extends TestHelpers with BeforeAndAfter with DbUtils with ExecHelpers with WskTestHelpers {
 
-    implicit val wskprops = WskProps()
-    val wsk = new Wsk
-    val whiskConfig = new WhiskConfig(WhiskEntityStore.requiredProperties)
-    // handle on the entity datastore
-    val entityStore = WhiskEntityStore.datastore(whiskConfig)
-    val namespace = wsk.namespace.whois()
-    val allowedActionDuration = 120 seconds
+  implicit val wskprops = WskProps()
+  val wsk = new Wsk
+  val whiskConfig = new WhiskConfig(WhiskEntityStore.requiredProperties)
+  // handle on the entity datastore
+  val entityStore = WhiskEntityStore.datastore(whiskConfig)
+  val namespace = wsk.namespace.whois()
+  val allowedActionDuration = 120 seconds
 
-    behavior of "Sequence Migration"
+  behavior of "Sequence Migration"
 
-    it should "check default namespace '_' is preserved in WhiskAction of old style sequence" in {
-        // read json file and add the appropriate namespace
-        val seqJsonFile = "seq_type_2.json"
-        val jsonFile = TestUtils.getTestActionFilename(seqJsonFile)
-        val source = scala.io.Source.fromFile(jsonFile)
-        val jsonString = try source.mkString finally source.close()
-        val entityJson = jsonString.parseJson.asJsObject
-        // add default namespace (i.e., user) to the json object
-        val entityJsonWithNamespace = JsObject(entityJson.fields + ("namespace" -> JsString(namespace)))
-        val wskEntity = entityJsonWithNamespace.convertTo[WhiskAction]
-        wskEntity.exec match {
-            case SequenceExec(components) =>
-                // check '_' is preserved
-                components.size shouldBe 2
-                assert(components.forall { _.path.namespace.contains('_') }, "default namespace lost")
-            case _ => assert(false)
-        }
+  it should "check default namespace '_' is preserved in WhiskAction of old style sequence" in {
+    // read json file and add the appropriate namespace
+    val seqJsonFile = "seq_type_2.json"
+    val jsonFile = TestUtils.getTestActionFilename(seqJsonFile)
+    val source = scala.io.Source.fromFile(jsonFile)
+    val jsonString = try source.mkString
+    finally source.close()
+    val entityJson = jsonString.parseJson.asJsObject
+    // add default namespace (i.e., user) to the json object
+    val entityJsonWithNamespace = JsObject(entityJson.fields + ("namespace" -> JsString(namespace)))
+    val wskEntity = entityJsonWithNamespace.convertTo[WhiskAction]
+    wskEntity.exec match {
+      case SequenceExec(components) =>
+        // check '_' is preserved
+        components.size shouldBe 2
+        assert(components.forall { _.path.namespace.contains('_') }, "default namespace lost")
+      case _ => assert(false)
     }
+  }
 
-    it should "invoke an old-style (kind sequence) sequence and get the result" in {
-        val seqName = "seq_type_2"
-        testOldStyleSequence(seqName, s"$seqName.json")
-    }
+  it should "invoke an old-style (kind sequence) sequence and get the result" in {
+    val seqName = "seq_type_2"
+    testOldStyleSequence(seqName, s"$seqName.json")
+  }
 
-    it should "not display code from an old sequence on action get" in {
-        // install sequence in db
-        val seqName = "seq_type_2"
-        installActionInDb(s"$seqName.json")
-        val stdout = wsk.action.get(seqName).stdout
-        stdout.contains("code") shouldBe false
-    }
+  it should "not display code from an old sequence on action get" in {
+    // install sequence in db
+    val seqName = "seq_type_2"
+    installActionInDb(s"$seqName.json")
+    val stdout = wsk.action.get(seqName).stdout
+    stdout.contains("code") shouldBe false
+  }
 
-    /**
-     * helper function that tests old style sequence based on two actions echo and word_count
-     * @param seqName the name of the sequence
-     * @param seqFileName the name of the json file that contains the whisk action associated with the sequence
-     */
-    private def testOldStyleSequence(seqName: String, seqFileName: String) = {
-        // create entities to insert in the entity store
-        val echo = "echo.json"
-        val wc = "word_count.json"
-        val entities = Seq(echo, wc, seqFileName)
-        for (entity <- entities) {
-            installActionInDb(entity)
-        }
-        // invoke sequence
-        val now = "it is now " + new Date()
-        val run = wsk.action.invoke(seqName, Map("payload" -> now.mkString("\n").toJson))
-        withActivation(wsk.activation, run, totalWait = allowedActionDuration) {
-            activation =>
-                val result = activation.response.result.get
-                result.fields.get("count") shouldBe Some(JsNumber(now.split(" ").size))
-        }
+  /**
+   * helper function that tests old style sequence based on two actions echo and word_count
+   * @param seqName the name of the sequence
+   * @param seqFileName the name of the json file that contains the whisk action associated with the sequence
+   */
+  private def testOldStyleSequence(seqName: String, seqFileName: String) = {
+    // create entities to insert in the entity store
+    val echo = "echo.json"
+    val wc = "word_count.json"
+    val entities = Seq(echo, wc, seqFileName)
+    for (entity <- entities) {
+      installActionInDb(entity)
     }
+    // invoke sequence
+    val now = "it is now " + new Date()
+    val run = wsk.action.invoke(seqName, Map("payload" -> now.mkString("\n").toJson))
+    withActivation(wsk.activation, run, totalWait = allowedActionDuration) { activation =>
+      val result = activation.response.result.get
+      result.fields.get("count") shouldBe Some(JsNumber(now.split(" ").size))
+    }
+  }
 
-    /**
-     * helper function that takes a json file containing a whisk action (minus the namespace), adds namespace and installs in db
-     */
-    private def installActionInDb(actionJson: String) = {
-        // read json file and add the appropriate namespace
-        val jsonFile = TestUtils.getTestActionFilename(actionJson)
-        val source = scala.io.Source.fromFile(jsonFile)
-        val jsonString = try source.mkString finally source.close()
-        val entityJson = jsonString.parseJson.asJsObject
-        // add default namespace (i.e., user) to the json object
-        val entityJsonWithNamespace = JsObject(entityJson.fields + ("namespace" -> JsString(namespace)))
-        val wskEntity = entityJsonWithNamespace.convertTo[WhiskAction]
-        implicit val tid = transid() // needed for put db below
-        put(entityStore, wskEntity)
-    }
+  /**
+   * helper function that takes a json file containing a whisk action (minus the namespace), adds namespace and installs in db
+   */
+  private def installActionInDb(actionJson: String) = {
+    // read json file and add the appropriate namespace
+    val jsonFile = TestUtils.getTestActionFilename(actionJson)
+    val source = scala.io.Source.fromFile(jsonFile)
+    val jsonString = try source.mkString
+    finally source.close()
+    val entityJson = jsonString.parseJson.asJsObject
+    // add default namespace (i.e., user) to the json object
+    val entityJsonWithNamespace = JsObject(entityJson.fields + ("namespace" -> JsString(namespace)))
+    val wskEntity = entityJsonWithNamespace.convertTo[WhiskAction]
+    implicit val tid = transid() // needed for put db below
+    put(entityStore, wskEntity)
+  }
 
-    after {
-        cleanup() // cleanup entities from db
-    }
+  after {
+    cleanup() // cleanup entities from db
+  }
 }

--- a/tests/src/test/scala/whisk/core/cli/test/Swift311Tests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/Swift311Tests.scala
@@ -21,8 +21,7 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class Swift311Tests
-    extends Swift3Tests {
+class Swift311Tests extends Swift3Tests {
 
-    override lazy val runtimeContainer = "swift:3.1.1"
+  override lazy val runtimeContainer = "swift:3.1.1"
 }

--- a/tests/src/test/scala/whisk/core/cli/test/Swift3Tests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/Swift3Tests.scala
@@ -31,122 +31,116 @@ import spray.json.DefaultJsonProtocol.StringJsonFormat
 import spray.json.pimpAny
 
 @RunWith(classOf[JUnitRunner])
-class Swift3Tests
-    extends TestHelpers
-    with WskTestHelpers
-    with Matchers {
+class Swift3Tests extends TestHelpers with WskTestHelpers with Matchers {
 
-    implicit val wskprops = WskProps()
-    val wsk = new Wsk
-    val expectedDuration = 45 seconds
-    val activationPollDuration = 60 seconds
+  implicit val wskprops = WskProps()
+  val wsk = new Wsk
+  val expectedDuration = 45 seconds
+  val activationPollDuration = 60 seconds
 
-    lazy val runtimeContainer = "swift:3"
+  lazy val runtimeContainer = "swift:3"
 
-    behavior of "Swift Actions"
+  behavior of "Swift Actions"
 
-    /**
-     * Test the Swift "hello world" demo sequence
-     */
-    it should "invoke a swift 3 action" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "helloSwift"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("hello.swift")))
-            }
-
-            val start = System.currentTimeMillis()
-            withActivation(wsk.activation, wsk.action.invoke(name), totalWait = activationPollDuration) {
-                _.response.result.get.toString should include("Hello stranger!")
-            }
-
-            withActivation(wsk.activation, wsk.action.invoke(name, Map("name" -> "Sir".toJson)), totalWait = activationPollDuration) {
-                _.response.result.get.toString should include("Hello Sir!")
-            }
-
-            withClue("Test duration exceeds expectation (ms)") {
-                val duration = System.currentTimeMillis() - start
-                duration should be <= expectedDuration.toMillis
-            }
+  /**
+   * Test the Swift "hello world" demo sequence
+   */
+  it should "invoke a swift 3 action" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "helloSwift"
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, Some(TestUtils.getTestActionFilename("hello.swift")))
     }
 
-    behavior of "Swift 3 Whisk SDK tests"
-
-    it should "allow Swift actions to invoke other actions" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            // use CLI to create action from dat/actions/invokeAction.swift
-            val file = TestUtils.getTestActionFilename("invoke.swift")
-            val actionName = "invokeAction"
-            assetHelper.withCleaner(wsk.action, actionName) {
-                (action, _) => action.create(name = actionName, artifact = Some(file), kind = Some(runtimeContainer))
-            }
-
-            // invoke the action
-            val run = wsk.action.invoke(actionName)
-            withActivation(wsk.activation, run, initialWait = 5 seconds, totalWait = 60 seconds) {
-                activation =>
-                    // should be successful
-                    activation.response.success shouldBe true
-
-                    // should have a field named "activationId" which is the date action's activationId
-                    activation.response.result.get.fields("activationId").toString.length should be >= 32
-
-                // check for "date" field that comes from invoking the date action
-                //activation.response.result.get.fieldPathExists("response", "result", "date") should be(true)
-            }
+    val start = System.currentTimeMillis()
+    withActivation(wsk.activation, wsk.action.invoke(name), totalWait = activationPollDuration) {
+      _.response.result.get.toString should include("Hello stranger!")
     }
 
-    it should "allow Swift actions to invoke other actions and not block" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            // use CLI to create action from dat/actions/invokeNonBlocking.swift
-            val file = TestUtils.getTestActionFilename("invokeNonBlocking.swift")
-            val actionName = "invokeNonBlockingAction"
-            assetHelper.withCleaner(wsk.action, actionName) {
-                (action, _) => action.create(name = actionName, artifact = Some(file), kind = Some(runtimeContainer))
-            }
-
-            // invoke the action
-            val run = wsk.action.invoke(actionName)
-            withActivation(wsk.activation, run, initialWait = 5 seconds, totalWait = 60 seconds) {
-                activation =>
-                    // should not have a "response"
-                    whisk.utils.JsHelpers.fieldPathExists(activation.response.result.get, "response") shouldBe false
-
-                    // should have a field named "activationId" which is the date action's activationId
-                    activation.response.result.get.fields("activationId").toString.length should be >= 32
-            }
+    withActivation(
+      wsk.activation,
+      wsk.action.invoke(name, Map("name" -> "Sir".toJson)),
+      totalWait = activationPollDuration) {
+      _.response.result.get.toString should include("Hello Sir!")
     }
 
-    it should "allow Swift actions to trigger events" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            // create a trigger
-            val triggerName = s"TestTrigger ${System.currentTimeMillis()}"
-            assetHelper.withCleaner(wsk.trigger, triggerName) {
-                (trigger, _) => trigger.create(triggerName)
-            }
-
-            // create an action that fires the trigger
-            val file = TestUtils.getTestActionFilename("trigger.swift")
-            val actionName = "ActionThatTriggers"
-            assetHelper.withCleaner(wsk.action, actionName) {
-                (action, _) => action.create(name = actionName, artifact = Some(file), kind = Some(runtimeContainer))
-            }
-
-            // invoke the action
-            val run = wsk.action.invoke(actionName, Map("triggerName" -> triggerName.toJson))
-            withActivation(wsk.activation, run, initialWait = 5 seconds, totalWait = 60 seconds) {
-                activation =>
-                    // should be successful
-                    activation.response.success shouldBe true
-
-                    // should have a field named "activationId" which is the date action's activationId
-                    activation.response.result.get.fields("activationId").toString.length should be >= 32
-
-                    // should result in an activation for triggerName
-                    val triggerActivations = wsk.activation.pollFor(1, Some(triggerName), retries = 20)
-                    withClue(s"trigger activations for $triggerName:") {
-                        triggerActivations.length should be(1)
-                    }
-            }
+    withClue("Test duration exceeds expectation (ms)") {
+      val duration = System.currentTimeMillis() - start
+      duration should be <= expectedDuration.toMillis
     }
+  }
+
+  behavior of "Swift 3 Whisk SDK tests"
+
+  it should "allow Swift actions to invoke other actions" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    // use CLI to create action from dat/actions/invokeAction.swift
+    val file = TestUtils.getTestActionFilename("invoke.swift")
+    val actionName = "invokeAction"
+    assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
+      action.create(name = actionName, artifact = Some(file), kind = Some(runtimeContainer))
+    }
+
+    // invoke the action
+    val run = wsk.action.invoke(actionName)
+    withActivation(wsk.activation, run, initialWait = 5 seconds, totalWait = 60 seconds) { activation =>
+      // should be successful
+      activation.response.success shouldBe true
+
+      // should have a field named "activationId" which is the date action's activationId
+      activation.response.result.get.fields("activationId").toString.length should be >= 32
+
+      // check for "date" field that comes from invoking the date action
+      //activation.response.result.get.fieldPathExists("response", "result", "date") should be(true)
+    }
+  }
+
+  it should "allow Swift actions to invoke other actions and not block" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      // use CLI to create action from dat/actions/invokeNonBlocking.swift
+      val file = TestUtils.getTestActionFilename("invokeNonBlocking.swift")
+      val actionName = "invokeNonBlockingAction"
+      assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
+        action.create(name = actionName, artifact = Some(file), kind = Some(runtimeContainer))
+      }
+
+      // invoke the action
+      val run = wsk.action.invoke(actionName)
+      withActivation(wsk.activation, run, initialWait = 5 seconds, totalWait = 60 seconds) { activation =>
+        // should not have a "response"
+        whisk.utils.JsHelpers.fieldPathExists(activation.response.result.get, "response") shouldBe false
+
+        // should have a field named "activationId" which is the date action's activationId
+        activation.response.result.get.fields("activationId").toString.length should be >= 32
+      }
+  }
+
+  it should "allow Swift actions to trigger events" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    // create a trigger
+    val triggerName = s"TestTrigger ${System.currentTimeMillis()}"
+    assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
+      trigger.create(triggerName)
+    }
+
+    // create an action that fires the trigger
+    val file = TestUtils.getTestActionFilename("trigger.swift")
+    val actionName = "ActionThatTriggers"
+    assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
+      action.create(name = actionName, artifact = Some(file), kind = Some(runtimeContainer))
+    }
+
+    // invoke the action
+    val run = wsk.action.invoke(actionName, Map("triggerName" -> triggerName.toJson))
+    withActivation(wsk.activation, run, initialWait = 5 seconds, totalWait = 60 seconds) { activation =>
+      // should be successful
+      activation.response.success shouldBe true
+
+      // should have a field named "activationId" which is the date action's activationId
+      activation.response.result.get.fields("activationId").toString.length should be >= 32
+
+      // should result in an activation for triggerName
+      val triggerActivations = wsk.activation.pollFor(1, Some(triggerName), retries = 20)
+      withClue(s"trigger activations for $triggerName:") {
+        triggerActivations.length should be(1)
+      }
+    }
+  }
 }

--- a/tests/src/test/scala/whisk/core/cli/test/WskActionSequenceTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskActionSequenceTests.scala
@@ -32,55 +32,54 @@ import whisk.core.entity.EntityPath
  * Tests creation and retrieval of a sequence action
  */
 @RunWith(classOf[JUnitRunner])
-class WskActionSequenceTests
-    extends TestHelpers
-    with WskTestHelpers {
+class WskActionSequenceTests extends TestHelpers with WskTestHelpers {
 
-    implicit val wskprops = WskProps()
-    val wsk = new Wsk
-    val defaultNamespace = EntityPath.DEFAULT.asString
-    val namespace = wsk.namespace.whois()
+  implicit val wskprops = WskProps()
+  val wsk = new Wsk
+  val defaultNamespace = EntityPath.DEFAULT.asString
+  val namespace = wsk.namespace.whois()
 
-    behavior of "Wsk Action Sequence"
+  behavior of "Wsk Action Sequence"
 
-    it should "create, and get an action sequence" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "actionSeq"
-            val packageName = "samples"
-            val helloName = "hello"
-            val catName = "cat"
-            val fullHelloActionName = s"/$defaultNamespace/$packageName/$helloName"
-            val fullCatActionName = s"/$defaultNamespace/$packageName/$catName"
+  it should "create, and get an action sequence" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "actionSeq"
+    val packageName = "samples"
+    val helloName = "hello"
+    val catName = "cat"
+    val fullHelloActionName = s"/$defaultNamespace/$packageName/$helloName"
+    val fullCatActionName = s"/$defaultNamespace/$packageName/$catName"
 
-            assetHelper.withCleaner(wsk.pkg, packageName) {
-                (pkg, _) => pkg.create(packageName, shared = Some(true))(wp)
-            }
-
-            assetHelper.withCleaner(wsk.action, fullHelloActionName) {
-                val file = Some(TestUtils.getTestActionFilename("hello.js"))
-                (action, _) => action.create(fullHelloActionName, file)(wp)
-            }
-
-            assetHelper.withCleaner(wsk.action, fullCatActionName) {
-                val file = Some(TestUtils.getTestActionFilename("cat.js"))
-                (action, _) => action.create(fullCatActionName, file)(wp)
-            }
-
-            val artifacts = s"$fullHelloActionName,$fullCatActionName"
-            val kindValue = JsString("sequence")
-            val compValue = JsArray(
-                JsString(resolveDefaultNamespace(fullHelloActionName)),
-                JsString(resolveDefaultNamespace(fullCatActionName)))
-
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(artifacts), kind = Some("sequence"))
-            }
-
-            val stdout = wsk.action.get(name).stdout
-            assert(stdout.startsWith(s"ok: got action $name\n"))
-            wsk.parseJsonString(stdout).fields("exec").asJsObject.fields("components") shouldBe compValue
-            wsk.parseJsonString(stdout).fields("exec").asJsObject.fields("kind") shouldBe kindValue
+    assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, _) =>
+      pkg.create(packageName, shared = Some(true))(wp)
     }
 
-    private def resolveDefaultNamespace(actionName: String) = actionName.replace("/_/", s"/$namespace/")
+    assetHelper.withCleaner(wsk.action, fullHelloActionName) {
+      val file = Some(TestUtils.getTestActionFilename("hello.js"))
+      (action, _) =>
+        action.create(fullHelloActionName, file)(wp)
+    }
+
+    assetHelper.withCleaner(wsk.action, fullCatActionName) {
+      val file = Some(TestUtils.getTestActionFilename("cat.js"))
+      (action, _) =>
+        action.create(fullCatActionName, file)(wp)
+    }
+
+    val artifacts = s"$fullHelloActionName,$fullCatActionName"
+    val kindValue = JsString("sequence")
+    val compValue = JsArray(
+      JsString(resolveDefaultNamespace(fullHelloActionName)),
+      JsString(resolveDefaultNamespace(fullCatActionName)))
+
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, Some(artifacts), kind = Some("sequence"))
+    }
+
+    val stdout = wsk.action.get(name).stdout
+    assert(stdout.startsWith(s"ok: got action $name\n"))
+    wsk.parseJsonString(stdout).fields("exec").asJsObject.fields("components") shouldBe compValue
+    wsk.parseJsonString(stdout).fields("exec").asJsObject.fields("kind") shouldBe kindValue
+  }
+
+  private def resolveDefaultNamespace(actionName: String) = actionName.replace("/_/", s"/$namespace/")
 }

--- a/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -52,1669 +52,1552 @@ import whisk.http.Messages
  * Tests for basic CLI usage. Some of these tests require a deployed backend.
  */
 @RunWith(classOf[JUnitRunner])
-class WskBasicUsageTests
-    extends TestHelpers
-    with WskTestHelpers {
-
-    implicit val wskprops = WskProps()
-    val wsk = new Wsk
-    val defaultAction = Some(TestUtils.getTestActionFilename("hello.js"))
-
-    behavior of "Wsk CLI usage"
-
-    it should "show help and usage info" in {
-        val stdout = wsk.cli(Seq()).stdout
-        stdout should include regex ("""(?i)Usage:""")
-        stdout should include regex ("""(?i)Flags""")
-        stdout should include regex ("""(?i)Available commands""")
-        stdout should include regex ("""(?i)--help""")
-    }
-
-    it should "show help and usage info using the default language" in {
-        val env = Map("LANG" -> "de_DE")
-        // Call will fail with exit code 2 if language not supported
-        wsk.cli(Seq("-h"), env = env)
-    }
-
-    it should "show cli build version" in {
-        val stdout = wsk.cli(Seq("property", "get", "--cliversion")).stdout
-        stdout should include regex ("""(?i)whisk CLI version\s+201.*""")
-    }
-
-    it should "show api version" in {
-        val stdout = wsk.cli(Seq("property", "get", "--apiversion")).stdout
-        stdout should include regex ("""(?i)whisk API version\s+v1""")
-    }
-
-    it should "reject bad command" in {
-        val result = wsk.cli(Seq("bogus"), expectedExitCode = ERROR_EXIT)
-        result.stderr should include regex ("""(?i)Run 'wsk --help' for usage""")
-    }
-
-    it should "allow a 3 part Fully Qualified Name (FQN) without a leading '/'" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val guestNamespace = wsk.namespace.whois()
-            val packageName = "packageName3ptFQN"
-            val actionName = "actionName3ptFQN"
-            val triggerName = "triggerName3ptFQN"
-            val ruleName = "ruleName3ptFQN"
-            val fullQualifiedName = s"${guestNamespace}/${packageName}/${actionName}"
-            // Used for action and rule creation below
-            assetHelper.withCleaner(wsk.pkg, packageName) {
-                (pkg, _) => pkg.create(packageName)
-            }
-            assetHelper.withCleaner(wsk.trigger, triggerName) {
-                (trigger, _) => trigger.create(triggerName)
-            }
-            // Test action and rule creation where action name is 3 part FQN w/out leading slash
-            assetHelper.withCleaner(wsk.action, fullQualifiedName) {
-                (action, _) => action.create(fullQualifiedName, defaultAction)
-            }
-            assetHelper.withCleaner(wsk.rule, ruleName) {
-                (rule, _) =>
-                    rule.create(ruleName, trigger = triggerName, action = fullQualifiedName)
-            }
-
-            wsk.action.invoke(fullQualifiedName).stdout should include(s"ok: invoked /$fullQualifiedName")
-            wsk.action.get(fullQualifiedName).stdout should include(s"ok: got action ${packageName}/${actionName}")
-    }
-
-
-    behavior of "Wsk actions"
-
-    it should "reject creating entities with invalid names" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val names = Seq(
-                ("", ERROR_EXIT),
-                (" ", BAD_REQUEST),
-                ("hi+there", BAD_REQUEST),
-                ("$hola", BAD_REQUEST),
-                ("dora?", BAD_REQUEST),
-                ("|dora|dora?", BAD_REQUEST))
-
-            names foreach {
-                case (name, ec) =>
-                    assetHelper.withCleaner(wsk.action, name, confirmDelete = false) {
-                        (action, _) => action.create(name, defaultAction, expectedExitCode = ec)
-                    }
-            }
-    }
-
-    it should "reject create with missing file" in {
-        wsk.action.create("missingFile", Some("notfound"),
-            expectedExitCode = MISUSE_EXIT).
-            stderr should include("not a valid file")
-    }
-
-    it should "reject action update when specified file is missing" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            // Create dummy action to update
-            val name = "updateMissingFile"
-            val file = Some(TestUtils.getTestActionFilename("hello.js"))
-            assetHelper.withCleaner(wsk.action, name) { (action, name) => action.create(name, file) }
-            // Update it with a missing file
-            wsk.action.create(name, Some("notfound"), update = true, expectedExitCode = MISUSE_EXIT)
-    }
-
-    it should "reject action update for sequence with no components" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "updateMissingComponents"
-            val file = Some(TestUtils.getTestActionFilename("hello.js"))
-            assetHelper.withCleaner(wsk.action, name) { (action, name) => action.create(name, file) }
-            wsk.action.create(name, None, update = true, kind = Some("sequence"), expectedExitCode = MISUSE_EXIT)
-    }
-
-    it should "create, and get an action to verify parameter and annotation parsing" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "actionAnnotations"
-            val file = Some(TestUtils.getTestActionFilename("hello.js"))
-
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(name, file, annotations = getValidJSONTestArgInput,
-                        parameters = getValidJSONTestArgInput)
-            }
-
-            val stdout = wsk.action.get(name).stdout
-            assert(stdout.startsWith(s"ok: got action $name\n"))
-
-            val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
-            val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
-            val escapedJSONArr = getValidJSONTestArgOutput.convertTo[JsArray].elements
-
-            for (expectedItem <- escapedJSONArr) {
-                receivedParams should contain(expectedItem)
-                receivedAnnots should contain(expectedItem)
-            }
-    }
-
-    it should "create, and get an action to verify file parameter and annotation parsing" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "actionAnnotAndParamParsing"
-            val file = Some(TestUtils.getTestActionFilename("hello.js"))
-            val argInput = Some(TestUtils.getTestActionFilename("validInput1.json"))
-
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(name, file, annotationFile = argInput, parameterFile = argInput)
-            }
-
-            val stdout = wsk.action.get(name).stdout
-            assert(stdout.startsWith(s"ok: got action $name\n"))
-
-            val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
-            val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
-            val escapedJSONArr = getJSONFileOutput.convertTo[JsArray].elements
-
-            for (expectedItem <- escapedJSONArr) {
-                receivedParams should contain(expectedItem)
-                receivedAnnots should contain(expectedItem)
-            }
-    }
-
-    it should "create an action with the proper parameter and annotation escapes" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "actionEscapes"
-            val file = Some(TestUtils.getTestActionFilename("hello.js"))
-
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(name, file, parameters = getEscapedJSONTestArgInput,
-                        annotations = getEscapedJSONTestArgInput)
-            }
-
-            val stdout = wsk.action.get(name).stdout
-            assert(stdout.startsWith(s"ok: got action $name\n"))
-
-            val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
-            val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
-            val escapedJSONArr = getEscapedJSONTestArgOutput.convertTo[JsArray].elements
-
-            for (expectedItem <- escapedJSONArr) {
-                receivedParams should contain(expectedItem)
-                receivedAnnots should contain(expectedItem)
-            }
-    }
-
-    it should "invoke an action that exits during initialization and get appropriate error" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "abort init"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("initexit.js")))
-            }
-
-            withActivation(wsk.activation, wsk.action.invoke(name)) {
-                activation =>
-                    val response = activation.response
-                    response.result.get.fields("error") shouldBe Messages.abnormalInitialization.toJson
-                    response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ContainerError)
-            }
-    }
-
-    it should "invoke an action that hangs during initialization and get appropriate error" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "hang init"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(
-                        name,
-                        Some(TestUtils.getTestActionFilename("initforever.js")),
-                        timeout = Some(3 seconds))
-            }
-
-            withActivation(wsk.activation, wsk.action.invoke(name)) {
-                activation =>
-                    val response = activation.response
-                    response.result.get.fields("error") shouldBe Messages.timedoutActivation(3 seconds, true).toJson
-                    response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ApplicationError)
-            }
-    }
-
-    it should "invoke an action that exits during run and get appropriate error" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "abort run"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("runexit.js")))
-            }
-
-            withActivation(wsk.activation, wsk.action.invoke(name)) {
-                activation =>
-                    val response = activation.response
-                    response.result.get.fields("error") shouldBe Messages.abnormalRun.toJson
-                    response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ContainerError)
-            }
-    }
-
-    it should "retrieve the last activation using --last flag" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val auth: Seq[String] = Seq("--auth", wskprops.authKey)
-            val includeStr = "hello, undefined!"
-
-            assetHelper.withCleaner(wsk.action, "lastName") {
-                (action, _) => wsk.action.create("lastName", defaultAction)
-            }
-            retry({
-                val lastInvoke = wsk.action.invoke("lastName")
-                withActivation(wsk.activation, lastInvoke) { activation =>
-                    val lastFlag = Seq(
-                        (Seq("activation", "get", "publish", "--last"), activation.activationId),
-                        (Seq("activation", "get", "--last"), activation.activationId),
-                        (Seq("activation", "logs", "--last"), includeStr),
-                        (Seq("activation", "result", "--last"), includeStr))
-
-                    retry({
-                        lastFlag foreach {
-                            case (cmd, output) =>
-                                val stdout = wsk.cli(cmd ++ wskprops.overrides ++ auth, expectedExitCode = SUCCESS_EXIT).stdout
-                                stdout should include(output)
-                        }
-                    }, waitBeforeRetry = Some(500.milliseconds))
-
-                }
-            }, waitBeforeRetry = Some(1.second), N = 5)
-    }
-
-    it should "ensure keys are not omitted from activation record" in withAssetCleaner(wskprops) {
-        val name = "activationRecordTest"
-
-        (wp, assetHelper) =>
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("argCheck.js")))
-            }
-
-            val run = wsk.action.invoke(name)
-            withActivation(wsk.activation, run) {
-                activation =>
-                    activation.start should be > Instant.EPOCH
-                    activation.end should be > Instant.EPOCH
-                    activation.response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.Success)
-                    activation.response.success shouldBe true
-                    activation.response.result shouldBe Some(JsObject())
-                    activation.logs shouldBe Some(List())
-                    activation.annotations shouldBe defined
-            }
-    }
-
-    it should "write the action-path and the limits to the annotations" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "annotations"
-            val memoryLimit = 512 MB
-            val logLimit = 1 MB
-            val timeLimit = 60 seconds
-
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("helloAsync.js")), memory = Some(memoryLimit), timeout = Some(timeLimit), logsize = Some(logLimit))
-            }
-
-            val run = wsk.action.invoke(name, Map("payload" -> "this is a test".toJson))
-            withActivation(wsk.activation, run) {
-                activation =>
-                    activation.response.status shouldBe "success"
-                    val annotations = activation.annotations.get
-
-                    val limitsObj = JsObject(
-                        "key" -> JsString("limits"),
-                        "value" -> ActionLimits(TimeLimit(timeLimit), MemoryLimit(memoryLimit), LogLimit(logLimit)).toJson)
-
-                    val path = annotations.find { _.fields("key").convertTo[String] == "path" }.get
-
-                    path.fields("value").convertTo[String] should fullyMatch regex (s""".*/$name""")
-                    annotations should contain(limitsObj)
-            }
-    }
-
-    it should "report error when creating an action with unknown kind" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val rr = assetHelper.withCleaner(wsk.action, "invalid kind", confirmDelete = false) {
-                (action, name) => action.create(name, Some(TestUtils.getTestActionFilename("echo.js")), kind = Some("foobar"), expectedExitCode = BAD_REQUEST)
-            }
-            rr.stderr should include regex "kind 'foobar' not in Set"
-    }
-
-    it should "report error when creating an action with zip but without kind" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "zipWithNoKind"
-            val zippedPythonAction = Some(TestUtils.getTestActionFilename("python.zip"))
-            val createResult = assetHelper.withCleaner(wsk.action, name, confirmDelete = false) {
-                (action, _) =>
-                    action.create(name, zippedPythonAction, expectedExitCode = ANY_ERROR_EXIT)
-            }
-
-            createResult.stderr should include regex "requires specifying the action kind"
-    }
-
-    it should "create, and invoke an action that utilizes an invalid docker container with appropriate error" in withAssetCleaner(wskprops) {
-        val name = "invalidDockerContainer"
-        val containerName = s"bogus${Random.alphanumeric.take(16).mkString.toLowerCase}"
-
-        (wp, assetHelper) =>
-            assetHelper.withCleaner(wsk.action, name) {
-                // docker name is a randomly generate string
-                (action, _) => action.create(name, None, docker = Some(containerName))
-            }
-
-            val run = wsk.action.invoke(name)
-            withActivation(wsk.activation, run) {
-                activation =>
-                    activation.response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ApplicationError)
-                    activation.response.result.get.fields("error") shouldBe s"Failed to pull container image '$containerName'.".toJson
-                    activation.annotations shouldBe defined
-                    val limits = activation.annotations.get.filter(_.fields("key").convertTo[String] == "limits")
-                    withClue(limits) {
-                        limits.length should be > 0
-                        limits(0).fields("value") should not be JsNull
-                    }
-            }
-    }
-
-    it should "invoke an action using npm openwhisk" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "hello npm openwhisk"
-            assetHelper.withCleaner(wsk.action, name, confirmDelete = false) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("helloOpenwhiskPackage.js")))
-            }
-
-            val run = wsk.action.invoke(name, Map("ignore_certs" -> true.toJson, "name" -> name.toJson))
-            withActivation(wsk.activation, run) {
-                activation =>
-                    activation.response.status shouldBe "success"
-                    activation.response.result shouldBe Some(JsObject("delete" -> true.toJson))
-                    activation.logs.get.mkString(" ") should include("action list has this many actions")
-            }
-
-            wsk.action.delete(name, expectedExitCode = TestUtils.NOT_FOUND)
-    }
-
-    it should "invoke an action receiving context properties" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val namespace = wsk.namespace.whois()
-            val name = "context"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("helloContext.js")))
-            }
-
-            val start = Instant.now(Clock.systemUTC()).toEpochMilli
-            val run = wsk.action.invoke(name)
-            withActivation(wsk.activation, run) {
-                activation =>
-                    activation.response.status shouldBe "success"
-                    val fields = activation.response.result.get.convertTo[Map[String, String]]
-                    fields("api_host") shouldBe WhiskProperties.getApiHostForAction
-                    fields("api_key") shouldBe wskprops.authKey
-                    fields("namespace") shouldBe namespace
-                    fields("action_name") shouldBe s"/$namespace/$name"
-                    fields("activation_id") shouldBe activation.activationId
-                    fields("deadline").toLong should be >= start
-            }
-    }
-
-    it should "invoke an action successfully with options --blocking and --result" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "invokeResult"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("echo.js")))
-            }
-            val args = Map("hello" -> "Robert".toJson)
-            val run = wsk.action.invoke(name, args, blocking = true, result = true)
-            run.stdout.parseJson shouldBe args.toJson
-    }
-
-    it should "invoke an action that returns a result by the deadline" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "deadline"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("helloDeadline.js")), timeout = Some(3 seconds))
-            }
-
-            val run = wsk.action.invoke(name)
-            withActivation(wsk.activation, run) {
-                activation =>
-                    activation.response.status shouldBe "success"
-                    activation.response.result shouldBe Some(JsObject("timedout" -> true.toJson))
-            }
-    }
-
-    it should "invoke an action twice, where the first times out but the second does not and should succeed" in withAssetCleaner(wskprops) {
-        // this test issues two activations: the first is forced to time out and not return a result by its deadline (ie it does not resolve
-        // its promise). The invoker should reclaim its container so that a second activation of the same action (which must happen within a
-        // short period of time (seconds, not minutes) is allocated a fresh container and hence runs as expected (vs. hitting in the container
-        // cache and reusing a bad container).
-        (wp, assetHelper) =>
-            val name = "timeout"
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("helloDeadline.js")), timeout = Some(3 seconds))
-            }
-
-            val start = Instant.now(Clock.systemUTC()).toEpochMilli
-            val hungRun = wsk.action.invoke(name, Map("forceHang" -> true.toJson))
-            withActivation(wsk.activation, hungRun) {
-                activation =>
-                    // the first action must fail with a timeout error
-                    activation.response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ApplicationError)
-                    activation.response.result shouldBe Some(JsObject("error" -> Messages.timedoutActivation(3 seconds, false).toJson))
-            }
-
-            // run the action again, this time without forcing it to timeout
-            // it should succeed because it ran in a fresh container
-            val goodRun = wsk.action.invoke(name, Map("forceHang" -> false.toJson))
-            withActivation(wsk.activation, goodRun) {
-                activation =>
-                    // the first action must fail with a timeout error
-                    activation.response.status shouldBe "success"
-                    activation.response.result shouldBe Some(JsObject("timedout" -> true.toJson))
-            }
-    }
-
-    it should "ensure --web flags set the proper annotations" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "webaction"
-            val file = Some(TestUtils.getTestActionFilename("echo.js"))
-
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, file)
-            }
-
-            Seq("true", "faLse", "tRue", "nO", "yEs", "no", "raw", "NO", "Raw").
-                foreach { flag =>
-                    val webEnabled = flag.toLowerCase == "true" || flag.toLowerCase == "yes"
-                    val rawEnabled = flag.toLowerCase == "raw"
-
-                    wsk.action.create(name, file, web = Some(flag), update = true)
-
-                    val stdout = wsk.action.get(name, fieldFilter = Some("annotations")).stdout
-                    assert(stdout.startsWith(s"ok: got action $name, displaying field annotations\n"))
-                    removeCLIHeader(stdout).parseJson shouldBe JsArray(
-                        JsObject(
-                            "key" -> JsString("exec"),
-                            "value" -> JsString("nodejs:6")),
-                        JsObject(
-                            "key" -> JsString("web-export"),
-                            "value" -> JsBoolean(webEnabled || rawEnabled)),
-                        JsObject(
-                            "key" -> JsString("raw-http"),
-                            "value" -> JsBoolean(rawEnabled)),
-                        JsObject(
-                            "key" -> JsString("final"),
-                            "value" -> JsBoolean(webEnabled || rawEnabled)))
-                }
-    }
-
-    it should "ensure action update with --web flag only copies existing annotations when new annotations are not provided" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "webaction"
-            val file = Some(TestUtils.getTestActionFilename("echo.js"))
-            val createKey = "createKey"
-            val createValue = JsString("createValue")
-            val updateKey = "updateKey"
-            val updateValue = JsString("updateValue")
-            val origKey = "origKey"
-            val origValue = JsString("origValue")
-            val overwrittenValue = JsString("overwrittenValue")
-            val createAnnots = Map(createKey -> createValue, origKey -> origValue)
-            val updateAnnots = Map(updateKey -> updateValue, origKey -> overwrittenValue)
-
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, file, annotations = createAnnots)
-            }
-
-            wsk.action.create(name, file, web = Some("true"), update = true)
-
-            val existinAnnots = wsk.action.get(name, fieldFilter = Some("annotations")).stdout
-            assert(existinAnnots.startsWith(s"ok: got action $name, displaying field annotations\n"))
-            removeCLIHeader(existinAnnots).parseJson shouldBe JsArray(
-                JsObject(
-                    "key" -> JsString("web-export"),
-                    "value" -> JsBoolean(true)),
-                JsObject(
-                    "key" -> JsString(origKey),
-                    "value" -> origValue),
-                JsObject(
-                    "key" -> JsString("raw-http"),
-                    "value" -> JsBoolean(false)),
-                JsObject(
-                    "key" -> JsString("final"),
-                    "value" -> JsBoolean(true)),
-                JsObject(
-                    "key" -> JsString(createKey),
-                    "value" -> createValue),
-                JsObject(
-                    "key" -> JsString("exec"),
-                    "value" -> JsString("nodejs:6")))
-
-            wsk.action.create(name, file, web = Some("true"), update = true, annotations = updateAnnots)
-
-            val updatedAnnots = wsk.action.get(name, fieldFilter = Some("annotations")).stdout
-            assert(updatedAnnots.startsWith(s"ok: got action $name, displaying field annotations\n"))
-            removeCLIHeader(updatedAnnots).parseJson shouldBe JsArray(
-                JsObject(
-                    "key" -> JsString("web-export"),
-                    "value" -> JsBoolean(true)),
-                JsObject(
-                    "key" -> JsString(origKey),
-                    "value" -> overwrittenValue),
-                JsObject(
-                    "key" -> JsString(updateKey),
-                    "value" -> updateValue),
-                JsObject(
-                    "key" -> JsString("raw-http"),
-                    "value" -> JsBoolean(false)),
-                JsObject(
-                    "key" -> JsString("final"),
-                    "value" -> JsBoolean(true)),
-                JsObject(
-                    "key" -> JsString("exec"),
-                    "value" -> JsString("nodejs:6")))
-    }
-
-    it should "ensure action update creates an action with --web flag" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "webaction"
-            val file = Some(TestUtils.getTestActionFilename("echo.js"))
-
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, file, web = Some("true"), update = true)
-            }
-
-            val stdout = wsk.action.get(name, fieldFilter = Some("annotations")).stdout
-            assert(stdout.startsWith(s"ok: got action $name, displaying field annotations\n"))
-            removeCLIHeader(stdout).parseJson shouldBe JsArray(
-                JsObject(
-                    "key" -> JsString("web-export"),
-                    "value" -> JsBoolean(true)),
-                JsObject(
-                    "key" -> JsString("raw-http"),
-                    "value" -> JsBoolean(false)),
-                JsObject(
-                    "key" -> JsString("final"),
-                    "value" -> JsBoolean(true)),
-                JsObject(
-                    "key" -> JsString("exec"),
-                    "value" -> JsString("nodejs:6")))
-    }
-
-    it should "reject action create and update with invalid web flag input" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "webaction"
-            val file = Some(TestUtils.getTestActionFilename("echo.js"))
-            val invalidInput = "bogus"
-            val errorMsg = s"Invalid argument '$invalidInput' for --web flag. Valid input consist of 'yes', 'true', 'raw', 'false', or 'no'."
-            wsk.action.create(name, file, web = Some(invalidInput), expectedExitCode = MISUSE_EXIT).stderr should include(errorMsg)
-            wsk.action.create(name, file, web = Some(invalidInput), update = true, expectedExitCode = MISUSE_EXIT).stderr should include(errorMsg)
-    }
-
-    it should "invoke action while not encoding &, <, > characters" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "nonescape"
-            val file = Some(TestUtils.getTestActionFilename("hello.js"))
-            val nonescape = "&<>"
-            val input = Map("payload" -> nonescape.toJson)
-            val output = JsObject("payload" -> JsString(s"hello, $nonescape!"))
-
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, file)
-            }
-
-            withActivation(wsk.activation, wsk.action.invoke(name, parameters = input)) {
-                activation =>
-                    activation.response.success shouldBe true
-                    activation.response.result shouldBe Some(output)
-                    activation.logs.toList.flatten.filter(_.contains(nonescape)).length shouldBe 1
-            }
-    }
-
-    it should "get an action URL" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val actionName = "action name@_-."
-            val packageName = "package name@_-."
-            val defaultPackageName = "default"
-            val webActionName = "web action name@_-."
-            val nonExistentActionName = "non-existence action"
-            val packagedAction = s"$packageName/$actionName"
-            val packagedWebAction = s"$packageName/$webActionName"
-            val namespace = wsk.namespace.whois()
-            val encodedActionName = URLEncoder.encode(actionName, StandardCharsets.UTF_8.name).replace("+", "%20")
-            val encodedPackageName = URLEncoder.encode(packageName, StandardCharsets.UTF_8.name).replace("+", "%20")
-            val encodedWebActionName = URLEncoder.encode(webActionName, StandardCharsets.UTF_8.name).replace("+", "%20")
-            val encodedNamespace = URLEncoder.encode(namespace, StandardCharsets.UTF_8.name).replace("+", "%20")
-            val actionPath = "https://%s/api/%s/namespaces/%s/actions/%s"
-            val packagedActionPath = s"$actionPath/%s"
-            val webActionPath = "https://%s/api/%s/web/%s/%s/%s"
-
-            assetHelper.withCleaner(wsk.action, actionName) {
-                (action, _) => action.create(actionName, defaultAction)
-            }
-
-            assetHelper.withCleaner(wsk.action, webActionName) {
-                (action, _) => action.create(webActionName, defaultAction, web = Some("true"))
-            }
-
-            assetHelper.withCleaner(wsk.pkg, packageName) {
-                (pkg, _) => pkg.create(packageName)
-            }
-
-            assetHelper.withCleaner(wsk.action, packagedAction) {
-                (action, _) => action.create(packagedAction, defaultAction)
-            }
-
-            assetHelper.withCleaner(wsk.action, packagedWebAction) {
-                (action, _) => action.create(packagedWebAction, defaultAction, web = Some("true"))
-            }
-
-            wsk.action.get(actionName, url = Some(true)).
-                stdout should include(actionPath.format(wskprops.apihost, wskprops.apiversion, encodedNamespace, encodedActionName))
-
-            // Ensure url flag works when a field filter and summary flag are specified
-            wsk.action.get(actionName, url = Some(true), fieldFilter = Some("field"), summary = true).
-                stdout should include(actionPath.format(wskprops.apihost, wskprops.apiversion, encodedNamespace, encodedActionName))
-
-            wsk.action.get(webActionName, url = Some(true)).
-                stdout should include(webActionPath.format(wskprops.apihost, wskprops.apiversion, encodedNamespace, defaultPackageName, encodedWebActionName))
-
-            wsk.action.get(packagedAction, url = Some(true)).
-                stdout should include(packagedActionPath.format(wskprops.apihost, wskprops.apiversion, encodedNamespace, encodedPackageName, encodedActionName))
-
-            wsk.action.get(packagedWebAction, url = Some(true)).
-                stdout should include(webActionPath.format(wskprops.apihost, wskprops.apiversion, encodedNamespace, encodedPackageName, encodedWebActionName))
-
-            wsk.action.get(nonExistentActionName, url = Some(true), expectedExitCode = NOT_FOUND)
-    }
-    it should "limit length of HTTP request and response bodies for --verbose" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "limitVerbose"
-            val msg = "will be truncated"
-            val params = Seq("-p", "bigValue", "a" * 1000)
-
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("echo.js")))
-            }
-
-            val truncated = wsk.cli(Seq("action", "invoke", name, "-b", "-v", "--auth", wskprops.authKey) ++ params ++ wskprops.overrides).stdout
-            msg.r.findAllIn(truncated).length shouldBe 2
-
-            val notTruncated = wsk.cli(Seq("action", "invoke", name, "-b", "-d", "--auth", wskprops.authKey) ++ params ++ wskprops.overrides).stdout
-            msg.r.findAllIn(notTruncated).length shouldBe 0
-    }
-
-    it should "denote bound and finalized action parameters for action summaries" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val nameBoundParams = "actionBoundParams"
-            val nameFinalParams = "actionFinalParams"
-            val paramAnnot = "paramAnnot"
-            val paramOverlap = "paramOverlap"
-            val paramBound = "paramBound"
-            val annots = Map(
-                "parameters" -> JsArray(
-                    JsObject(
-                        "name" -> JsString(paramAnnot),
-                        "description" -> JsString("Annotated")),
-                    JsObject(
-                        "name" -> JsString(paramOverlap),
-                        "description" -> JsString("Annotated And Bound"))))
-            val annotsFinal = Map(
-                "final" -> JsBoolean(true),
-                "parameters" -> JsArray(
-                    JsObject(
-                        "name" -> JsString(paramAnnot),
-                        "description" -> JsString("Annotated Parameter description")),
-                    JsObject(
-                        "name" -> JsString(paramOverlap),
-                        "description" -> JsString("Annotated And Bound"))))
-            val paramsBound = Map(
-                paramBound -> JsString("Bound"),
-                paramOverlap -> JsString("Bound And Annotated"))
-
-            assetHelper.withCleaner(wsk.action, nameBoundParams) {
-                (action, _) =>
-                    action.create(nameBoundParams, defaultAction, annotations = annots, parameters = paramsBound)
-            }
-            assetHelper.withCleaner(wsk.action, nameFinalParams) {
-                (action, _) =>
-                    action.create(nameFinalParams, defaultAction, annotations = annotsFinal, parameters = paramsBound)
-            }
-
-            val stdoutBound = wsk.action.get(nameBoundParams, summary = true).stdout
-            val stdoutFinal = wsk.action.get(nameFinalParams, summary = true).stdout
-
-            stdoutBound should include (
-                s"(parameters: $paramAnnot, *$paramBound, *$paramOverlap)")
-            stdoutFinal should include (
-                s"(parameters: $paramAnnot, **$paramBound, **$paramOverlap)")
-    }
-
-    it should "create, and get an action summary without a description and/or defined parameters" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val actNameNoParams = "actionNoParams"
-            val actNameNoDesc = "actionNoDesc"
-            val actNameNoDescOrParams = "actionNoDescOrParams"
-            val desc = "Action description"
-            val descFromParamsResp = "Returns a result based on parameters"
-            val annotsNoParams = Map(
-                "description" -> JsString(desc)
-            )
-            val annotsNoDesc = Map(
-                "parameters" -> JsArray(
-                    JsObject(
-                        "name" -> JsString("paramName1"),
-                        "description" -> JsString("Parameter description 1")),
-                    JsObject(
-                        "name" -> JsString("paramName2"),
-                        "description" -> JsString("Parameter description 2"))))
-
-            assetHelper.withCleaner(wsk.action, actNameNoDesc) {
-                (action, _) =>
-                    action.create(actNameNoDesc, defaultAction, annotations = annotsNoDesc)
-            }
-            assetHelper.withCleaner(wsk.action, actNameNoParams) {
-                (action, _) =>
-                    action.create(actNameNoParams, defaultAction, annotations = annotsNoParams)
-            }
-            assetHelper.withCleaner(wsk.action, actNameNoDescOrParams) {
-                (action, _) =>
-                    action.create(actNameNoDescOrParams, defaultAction)
-            }
-
-            val stdoutNoDesc = wsk.action.get(actNameNoDesc, summary = true).stdout
-            val stdoutNoParams = wsk.action.get(actNameNoParams, summary = true).stdout
-            val stdoutNoDescOrParams = wsk.action.get(actNameNoDescOrParams, summary = true).stdout
-            val namespace = wsk.namespace.whois()
-
-            stdoutNoDesc should include regex (
-                s"(?i)action /${namespace}/${actNameNoDesc}: ${descFromParamsResp} paramName1 and paramName2\\s*\\(parameters: paramName1, paramName2\\)")
-            stdoutNoParams should include regex (
-                s"(?i)action /${namespace}/${actNameNoParams}: ${desc}\\s*\\(parameters: none defined\\)")
-            stdoutNoDescOrParams should include regex (
-                s"(?i)action /${namespace}/${actNameNoDescOrParams}\\s*\\(parameters: none defined\\)")
-    }
-
-    behavior of "Wsk packages"
-
-    it should "create, and delete a package" in {
-        val name = "createDeletePackage"
-        wsk.pkg.create(name).stdout should include(s"ok: created package $name")
-        wsk.pkg.delete(name).stdout should include(s"ok: deleted package $name")
-    }
-
-    it should "create, and get a package to verify parameter and annotation parsing" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "packageAnnotAndParamParsing"
-
-            assetHelper.withCleaner(wsk.pkg, name) {
-                (pkg, _) =>
-                    pkg.create(name, annotations = getValidJSONTestArgInput, parameters = getValidJSONTestArgInput)
-            }
-
-            val stdout = wsk.pkg.get(name).stdout
-            assert(stdout.startsWith(s"ok: got package $name\n"))
-
-            val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
-            val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
-            val escapedJSONArr = getValidJSONTestArgOutput.convertTo[JsArray].elements
-
-            for (expectedItem <- escapedJSONArr) {
-                receivedParams should contain(expectedItem)
-                receivedAnnots should contain(expectedItem)
-            }
-    }
-
-    it should "create, and get a package to verify file parameter and annotation parsing" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "packageAnnotAndParamFileParsing"
-            val file = Some(TestUtils.getTestActionFilename("hello.js"))
-            val argInput = Some(TestUtils.getTestActionFilename("validInput1.json"))
-
-            assetHelper.withCleaner(wsk.pkg, name) {
-                (pkg, _) =>
-                    pkg.create(name, annotationFile = argInput, parameterFile = argInput)
-            }
-
-            val stdout = wsk.pkg.get(name).stdout
-            assert(stdout.startsWith(s"ok: got package $name\n"))
-
-            val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
-            val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
-            val escapedJSONArr = getJSONFileOutput.convertTo[JsArray].elements
-
-            for (expectedItem <- escapedJSONArr) {
-                receivedParams should contain(expectedItem)
-                receivedAnnots should contain(expectedItem)
-            }
-    }
-
-    it should "create a package with the proper parameter and annotation escapes" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "packageEscapses"
-
-            assetHelper.withCleaner(wsk.pkg, name) {
-                (pkg, _) =>
-                    pkg.create(name, parameters = getEscapedJSONTestArgInput,
-                        annotations = getEscapedJSONTestArgInput)
-            }
-
-            val stdout = wsk.pkg.get(name).stdout
-            assert(stdout.startsWith(s"ok: got package $name\n"))
-
-            val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
-            val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
-            val escapedJSONArr = getEscapedJSONTestArgOutput.convertTo[JsArray].elements
-
-            for (expectedItem <- escapedJSONArr) {
-                receivedParams should contain(expectedItem)
-                receivedAnnots should contain(expectedItem)
-            }
-    }
-
-    it should "report conformance error accessing action as package" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "aAsP"
-            val file = Some(TestUtils.getTestActionFilename("hello.js"))
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, file)
-            }
-
-            wsk.pkg.get(name, expectedExitCode = CONFLICT).
-                stderr should include(Messages.conformanceMessage)
-
-            wsk.pkg.bind(name, "bogus", expectedExitCode = CONFLICT).
-                stderr should include(Messages.requestedBindingIsNotValid)
-
-            wsk.pkg.bind("bogus", "alsobogus", expectedExitCode = BAD_REQUEST).
-                stderr should include(Messages.bindingDoesNotExist)
-
-    }
-
-    it should "create, and get a package summary without a description and/or parameters" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val pkgNoDesc = "pkgNoDesc"
-            val pkgNoParams = "pkgNoParams"
-            val pkgNoDescOrParams = "pkgNoDescOrParams"
-            val pkgDesc = "Package description"
-            val descFromParams = "Returns a result based on parameters"
-            val namespace = wsk.namespace.whois()
-            val qualpkgNoDesc = s"/${namespace}/${pkgNoDesc}"
-            val qualpkgNoParams = s"/${namespace}/${pkgNoParams}"
-            val qualpkgNoDescOrParams = s"/${namespace}/${pkgNoDescOrParams}"
-
-            val pkgAnnotsNoParams = Map(
-                "description" -> JsString(pkgDesc)
-            )
-            val pkgAnnotsNoDesc = Map(
-                "parameters" -> JsArray(
-                    JsObject(
-                        "name" -> JsString("paramName1"),
-                        "description" -> JsString("Parameter description 1")),
-                    JsObject(
-                        "name" -> JsString("paramName2"),
-                        "description" -> JsString("Parameter description 2"))))
-
-            assetHelper.withCleaner(wsk.pkg, pkgNoDesc) {
-                (pkg, _) =>
-                    pkg.create(pkgNoDesc, annotations = pkgAnnotsNoDesc)
-            }
-            assetHelper.withCleaner(wsk.pkg, pkgNoParams) {
-                (pkg, _) =>
-                    pkg.create(pkgNoParams, annotations = pkgAnnotsNoParams)
-            }
-            assetHelper.withCleaner(wsk.pkg, pkgNoDescOrParams) {
-                (pkg, _) =>
-                    pkg.create(pkgNoDescOrParams)
-            }
-
-            val stdoutNoDescPkg = wsk.pkg.get(pkgNoDesc, summary = true).stdout
-            val stdoutNoParamsPkg = wsk.pkg.get(pkgNoParams, summary = true).stdout
-            val stdoutNoDescOrParams = wsk.pkg.get(pkgNoDescOrParams, summary = true).stdout
-
-            stdoutNoDescPkg should include regex (
-                s"(?i)package ${qualpkgNoDesc}: ${descFromParams} paramName1 and paramName2\\s*\\(parameters: paramName1, paramName2\\)")
-            stdoutNoParamsPkg should include regex (
-                s"(?i)package ${qualpkgNoParams}: ${pkgDesc}\\s*\\(parameters: none defined\\)")
-            stdoutNoDescOrParams should include regex (
-                s"(?i)package ${qualpkgNoDescOrParams}\\s*\\(parameters: none defined\\)")
-    }
-
-    it should "denote bound package parameters for package summaries" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val pkgBoundParams = "pkgBoundParams"
-            val pkgParamAnnot = "pkgParamAnnot"
-            val pkgParamOverlap = "pkgParamOverlap"
-            val pkgParamBound = "pkgParamBound"
-            val pkgAnnots = Map(
-                "parameters" -> JsArray(
-                    JsObject(
-                        "name" -> JsString(pkgParamAnnot),
-                        "description" -> JsString("Annotated")),
-                    JsObject(
-                        "name" -> JsString(pkgParamOverlap),
-                        "description" -> JsString("Annotated And Bound"))))
-            val pkgParamsBound = Map(
-                pkgParamBound -> JsString("Bound"),
-                pkgParamOverlap -> JsString("Bound And Annotated"))
-
-            assetHelper.withCleaner(wsk.pkg, pkgBoundParams) {
-                (pkg, _) =>
-                    pkg.create(pkgBoundParams, annotations = pkgAnnots, parameters = pkgParamsBound)
-            }
-
-            val pkgStdoutBound = wsk.pkg.get(pkgBoundParams, summary = true).stdout
-
-            pkgStdoutBound should include (s"(parameters: $pkgParamAnnot, *$pkgParamBound, *$pkgParamOverlap)")
-    }
-
-    behavior of "Wsk triggers"
-
-    it should "create, and get a trigger to verify parameter and annotation parsing" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "triggerAnnotAndParamParsing"
-
-            assetHelper.withCleaner(wsk.trigger, name) {
-                (trigger, _) =>
-                    trigger.create(name, annotations = getValidJSONTestArgInput, parameters = getValidJSONTestArgInput)
-            }
-
-            val stdout = wsk.trigger.get(name).stdout
-            assert(stdout.startsWith(s"ok: got trigger $name\n"))
-
-            val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
-            val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
-            val escapedJSONArr = getValidJSONTestArgOutput.convertTo[JsArray].elements
-
-            for (expectedItem <- escapedJSONArr) {
-                receivedParams should contain(expectedItem)
-                receivedAnnots should contain(expectedItem)
-            }
-    }
-
-    it should "create, and get a trigger to verify file parameter and annotation parsing" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "triggerAnnotAndParamFileParsing"
-            val file = Some(TestUtils.getTestActionFilename("hello.js"))
-            val argInput = Some(TestUtils.getTestActionFilename("validInput1.json"))
-
-            assetHelper.withCleaner(wsk.trigger, name) {
-                (trigger, _) =>
-                    trigger.create(name, annotationFile = argInput, parameterFile = argInput)
-            }
-
-            val stdout = wsk.trigger.get(name).stdout
-            assert(stdout.startsWith(s"ok: got trigger $name\n"))
-
-            val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
-            val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
-            val escapedJSONArr = getJSONFileOutput.convertTo[JsArray].elements
-
-            for (expectedItem <- escapedJSONArr) {
-                receivedParams should contain(expectedItem)
-                receivedAnnots should contain(expectedItem)
-            }
-    }
-
-    it should "display a trigger summary when --summary flag is used with 'wsk trigger get'" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val triggerName = "mySummaryTrigger"
-            assetHelper.withCleaner(wsk.trigger, triggerName, confirmDelete = false) {
-                (trigger, name) => trigger.create(name)
-            }
-
-            // Summary namespace should match one of the allowable namespaces (typically 'guest')
-            val ns = wsk.namespace.whois()
-            val stdout = wsk.trigger.get(triggerName, summary = true).stdout
-            stdout should include regex (s"(?i)trigger\\s+/$ns/$triggerName")
-    }
-
-    it should "create a trigger with the proper parameter and annotation escapes" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "triggerEscapes"
-
-            assetHelper.withCleaner(wsk.trigger, name) {
-                (trigger, _) =>
-                    trigger.create(name, parameters = getEscapedJSONTestArgInput,
-                        annotations = getEscapedJSONTestArgInput)
-            }
-
-            val stdout = wsk.trigger.get(name).stdout
-            assert(stdout.startsWith(s"ok: got trigger $name\n"))
-
-            val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
-            val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
-            val escapedJSONArr = getEscapedJSONTestArgOutput.convertTo[JsArray].elements
-
-            for (expectedItem <- escapedJSONArr) {
-                receivedParams should contain(expectedItem)
-                receivedAnnots should contain(expectedItem)
-            }
-    }
-
-    it should "not create a trigger when feed fails to initialize" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            assetHelper.withCleaner(wsk.trigger, "badfeed", confirmDelete = false) {
-                (trigger, name) =>
-                    trigger.create(name, feed = Some(s"bogus"), expectedExitCode = ANY_ERROR_EXIT).
-                        exitCode should equal(NOT_FOUND)
-                    trigger.get(name, expectedExitCode = NOT_FOUND)
-
-                    trigger.create(name, feed = Some(s"bogus/feed"), expectedExitCode = ANY_ERROR_EXIT).
-                        exitCode should equal(NOT_FOUND)
-                    trigger.get(name, expectedExitCode = NOT_FOUND)
-            }
-    }
-
-    it should "denote bound trigger parameters for trigger summaries" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val trgBoundParams = "trgBoundParams"
-            val trgParamAnnot = "trgParamAnnot"
-            val trgParamOverlap = "trgParamOverlap"
-            val trgParamBound = "trgParamBound"
-            val trgAnnots = Map(
-                "parameters" -> JsArray(
-                    JsObject(
-                        "name" -> JsString(trgParamAnnot),
-                        "description" -> JsString("Annotated")),
-                    JsObject(
-                        "name" -> JsString(trgParamOverlap),
-                        "description" -> JsString("Annotated And Bound"))))
-            val trgParamsBound = Map(
-                trgParamBound -> JsString("Bound"),
-                trgParamOverlap -> JsString("Bound And Annotated"))
-
-            assetHelper.withCleaner(wsk.trigger, trgBoundParams) {
-                (trigger, _) =>
-                    trigger.create(trgBoundParams, annotations = trgAnnots, parameters = trgParamsBound)
-            }
-
-            val trgStdoutBound = wsk.trigger.get(trgBoundParams, summary = true).stdout
-
-            trgStdoutBound should include (s"(parameters: $trgParamAnnot, *$trgParamBound, *$trgParamOverlap)")
-    }
-
-    it should "create, and get a trigger summary without a description and/or parameters" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val trgNoDesc = "trgNoDesc"
-            val trgNoParams = "trgNoParams"
-            val trgNoDescOrParams = "trgNoDescOrParams"
-            val trgDesc = "Package description"
-            val descFromParams = "Returns a result based on parameters"
-            val namespace = wsk.namespace.whois()
-            val qualtrgNoDesc = s"/${namespace}/${trgNoDesc}"
-            val qualtrgNoParams = s"/${namespace}/${trgNoParams}"
-            val qualtrgNoDescOrParams = s"/${namespace}/${trgNoDescOrParams}"
-
-            val trgAnnotsNoParams = Map(
-                "description" -> JsString(trgDesc)
-            )
-            val trgAnnotsNoDesc = Map(
-                "parameters" -> JsArray(
-                    JsObject(
-                        "name" -> JsString("paramName1"),
-                        "description" -> JsString("Parameter description 1")),
-                    JsObject(
-                        "name" -> JsString("paramName2"),
-                        "description" -> JsString("Parameter description 2"))))
-
-            assetHelper.withCleaner(wsk.trigger, trgNoDesc) {
-                (trigger, _) =>
-                    trigger.create(trgNoDesc, annotations = trgAnnotsNoDesc)
-            }
-            assetHelper.withCleaner(wsk.trigger, trgNoParams) {
-                (trigger, _) =>
-                    trigger.create(trgNoParams, annotations = trgAnnotsNoParams)
-            }
-            assetHelper.withCleaner(wsk.trigger, trgNoDescOrParams) {
-                (trigger, _) =>
-                    trigger.create(trgNoDescOrParams)
-            }
-
-            val stdoutNoDescPkg = wsk.trigger.get(trgNoDesc, summary = true).stdout
-            val stdoutNoParamsPkg = wsk.trigger.get(trgNoParams, summary = true).stdout
-            val stdoutNoDescOrParams = wsk.trigger.get(trgNoDescOrParams, summary = true).stdout
-
-            stdoutNoDescPkg should include regex (
-                s"(?i)trigger ${qualtrgNoDesc}: ${descFromParams} paramName1 and paramName2\\s*\\(parameters: paramName1, paramName2\\)")
-            stdoutNoParamsPkg should include regex (
-                s"(?i)trigger ${qualtrgNoParams}: ${trgDesc}\\s*\\(parameters: none defined\\)")
-            stdoutNoDescOrParams should include regex (
-                s"(?i)trigger ${qualtrgNoDescOrParams}\\s*\\(parameters: none defined\\)")
-    }
-
-    behavior of "Wsk entity list formatting"
-
-    it should "create, and list a package with a long name" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "x" * 70
-            assetHelper.withCleaner(wsk.pkg, name) {
-                (pkg, _) =>
-                    pkg.create(name)
-            }
-            retry({
-                wsk.pkg.list().stdout should include(s"$name private")
-            }, 5, Some(1 second))
-    }
-
-    it should "create, and list an action with a long name" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "x" * 70
-            val file = Some(TestUtils.getTestActionFilename("hello.js"))
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(name, file)
-            }
-            retry({
-                wsk.action.list().stdout should include(s"$name private nodejs")
-            }, 5, Some(1 second))
-    }
-
-    it should "create, and list a trigger with a long name" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "x" * 70
-            assetHelper.withCleaner(wsk.trigger, name) {
-                (trigger, _) =>
-                    trigger.create(name)
-            }
-            retry({
-                wsk.trigger.list().stdout should include(s"$name private")
-            }, 5, Some(1 second))
-    }
-
-    it should "create, and list a rule with a long name" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val ruleName = "x" * 70
-            val triggerName = "listRulesTrigger"
-            val actionName = "listRulesAction";
-            assetHelper.withCleaner(wsk.trigger, triggerName) {
-                (trigger, name) => trigger.create(name)
-            }
-            assetHelper.withCleaner(wsk.action, actionName) {
-                (action, name) => action.create(name, defaultAction)
-            }
-            assetHelper.withCleaner(wsk.rule, ruleName) {
-                (rule, name) =>
-                    rule.create(name, trigger = triggerName, action = actionName)
-            }
-            retry({
-                wsk.rule.list().stdout should include(s"$ruleName private")
-            }, 5, Some(1 second))
-    }
-
-    it should "return a list of alphabetized actions" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            // Declare 4 actions, create them out of alphabetical order
-            val actionName = "actionAlphaTest"
-            for (i <- 1 to 3) {
-                val name = s"$actionName$i"
-                assetHelper.withCleaner(wsk.action, name) {
-                    (action, name) =>
-                        action.create(name, defaultAction)
-                }
-            }
-            retry({
-                val original = wsk.action.list(nameSort = Some(true)).stdout
-                // Create list with action names in correct order
-                val scalaSorted = List(s"${actionName}1", s"${actionName}2", s"${actionName}3")
-                // Filter out everything not previously created
-                val regex = s"${actionName}[1-3]".r
-                // Retrieve action names into list as found in original
-                val list  = (regex.findAllMatchIn(original)).toList
-                scalaSorted.toString shouldEqual list.toString
-            }, 5, Some(1 second))
-    }
-
-    it should "return an alphabetized list with default package actions on top" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            // Declare 4 actions, create them out of alphabetical order
-            val actionName = "actionPackageAlphaTest"
-            val packageName = "packageAlphaTest"
-            assetHelper.withCleaner(wsk.action, actionName) {
-                (action, actionName) =>
-                    action.create(actionName, defaultAction)
-            }
-            assetHelper.withCleaner(wsk.pkg, packageName) {
-                (pkg, packageName) =>
-                    pkg.create(packageName)
-            }
-            for (i <- 1 to 3) {
-                val name = s"${packageName}/${actionName}$i"
-                assetHelper.withCleaner(wsk.action, name) {
-                    (action, name) =>
-                        action.create(name, defaultAction)
-                }
-            }
-            retry({
-                val original = wsk.action.list(nameSort = Some(true)).stdout
-                // Create list with action names in correct order
-                val scalaSorted = List(s"$actionName", s"${packageName}/${actionName}1", s"${packageName}/${actionName}2", s"${packageName}/${actionName}3")
-                // Filter out everything not previously created
-                val regexNoPackage = s"$actionName".r
-                val regexWithPackage = s"${packageName}/${actionName}[1-3]".r
-                // Retrieve action names into list as found in original
-                val list = regexNoPackage.findFirstIn(original).get :: (regexWithPackage.findAllMatchIn(original)).toList
-                scalaSorted.toString shouldEqual list.toString
-            }, 5, Some(1 second))
-    }
-
-    it should "return a list of alphabetized packages" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            // Declare 3 packages, create them out of alphabetical order
-            val packageName = "pkgAlphaTest"
-            for (i <- 1 to 3) {
-                val name = s"$packageName$i"
-                assetHelper.withCleaner(wsk.pkg, name) {
-                    (pkg, name) =>
-                        pkg.create(name)
-                }
-            }
-            retry({
-                val original = wsk.pkg.list(nameSort = Some(true)).stdout
-                // Create list with package names in correct order
-                val scalaSorted = List(s"${packageName}1", s"${packageName}2", s"${packageName}3")
-                // Filter out everything not previously created
-                val regex = s"${packageName}[1-3]".r
-                // Retrieve package names into list as found in original
-                val list  = (regex.findAllMatchIn(original)).toList
-                scalaSorted.toString shouldEqual list.toString
-            }, 5, Some(1 second))
-    }
-
-    it should "return a list of alphabetized triggers" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            // Declare 4 triggers, create them out of alphabetical order
-            val triggerName = "triggerAlphaTest"
-            for (i <- 1 to 3) {
-                val name = s"$triggerName$i"
-                assetHelper.withCleaner(wsk.trigger, name) {
-                    (trigger, name) =>
-                        trigger.create(name)
-                }
-            }
-            retry({
-                val original = wsk.trigger.list(nameSort = Some(true)).stdout
-                // Create list with trigger names in correct order
-                val scalaSorted = List(s"${triggerName}1", s"${triggerName}2", s"${triggerName}3")
-                // Filter out everything not previously created
-                val regex = s"${triggerName}[1-3]".r
-                // Retrieve trigger names into list as found in original
-                val list  = (regex.findAllMatchIn(original)).toList
-                scalaSorted.toString shouldEqual list.toString
-            }, 5, Some(1 second))
-    }
-
-    it should "return a list of alphabetized rules" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            // Declare a trigger and an action for the purposes of creating rules
-            val triggerName = "listRulesTrigger"
-            val actionName = "listRulesAction"
-
-            assetHelper.withCleaner(wsk.trigger, triggerName) {
-                (trigger, name) => trigger.create(name)
-            }
-            assetHelper.withCleaner(wsk.action, actionName) {
-                (action, name) => action.create(name, defaultAction)
-            }
-            // Declare 3 rules, create them out of alphabetical order
-            val ruleName = "ruleAlphaTest"
-            for (i <- 1 to 3) {
-                val name = s"$ruleName$i"
-                assetHelper.withCleaner(wsk.rule, name) {
-                    (rule, name) =>
-                        rule.create(name, trigger = triggerName, action = actionName)
-                }
-            }
-            retry({
-                val original = wsk.rule.list(nameSort = Some(true)).stdout
-                // Create list with rule names in correct order
-                val scalaSorted = List(s"${ruleName}1", s"${ruleName}2", s"${ruleName}3")
-                // Filter out everything not previously created
-                val regex = s"${ruleName}[1-3]".r
-                // Retrieve rule names into list as found in original
-                val list  = (regex.findAllMatchIn(original)).toList
-                scalaSorted.toString shouldEqual list.toString
-            })
-    }
-
-    behavior of "Wsk params and annotations"
-
-    it should "reject commands that are executed with invalid JSON for annotations and parameters" in {
-        val invalidJSONInputs = getInvalidJSONInput
-        val invalidJSONFiles = Seq(
-            TestUtils.getTestActionFilename("malformed.js"),
-            TestUtils.getTestActionFilename("invalidInput1.json"),
-            TestUtils.getTestActionFilename("invalidInput2.json"),
-            TestUtils.getTestActionFilename("invalidInput3.json"),
-            TestUtils.getTestActionFilename("invalidInput4.json"))
-        val paramCmds = Seq(
-            Seq("action", "create", "actionName", TestUtils.getTestActionFilename("hello.js")),
-            Seq("action", "update", "actionName", TestUtils.getTestActionFilename("hello.js")),
-            Seq("action", "invoke", "actionName"),
-            Seq("package", "create", "packageName"),
-            Seq("package", "update", "packageName"),
-            Seq("package", "bind", "packageName", "boundPackageName"),
-            Seq("trigger", "create", "triggerName"),
-            Seq("trigger", "update", "triggerName"),
-            Seq("trigger", "fire", "triggerName"))
-        val annotCmds = Seq(
-            Seq("action", "create", "actionName", TestUtils.getTestActionFilename("hello.js")),
-            Seq("action", "update", "actionName", TestUtils.getTestActionFilename("hello.js")),
-            Seq("package", "create", "packageName"),
-            Seq("package", "update", "packageName"),
-            Seq("package", "bind", "packageName", "boundPackageName"),
-            Seq("trigger", "create", "triggerName"),
-            Seq("trigger", "update", "triggerName"))
-
-        for (cmd <- paramCmds) {
-            for (invalid <- invalidJSONInputs) {
-                wsk.cli(cmd ++ Seq("-p", "key", invalid) ++ wskprops.overrides, expectedExitCode = ERROR_EXIT)
-                    .stderr should include("Invalid parameter argument")
-            }
-
-            for (invalid <- invalidJSONFiles) {
-                wsk.cli(cmd ++ Seq("-P", invalid) ++ wskprops.overrides, expectedExitCode = ERROR_EXIT)
-                    .stderr should include("Invalid parameter argument")
-
-            }
-        }
-
-        for (cmd <- annotCmds) {
-            for (invalid <- invalidJSONInputs) {
-                wsk.cli(cmd ++ Seq("-a", "key", invalid) ++ wskprops.overrides, expectedExitCode = ERROR_EXIT)
-                    .stderr should include("Invalid annotation argument")
-            }
-
-            for (invalid <- invalidJSONFiles) {
-                wsk.cli(cmd ++ Seq("-A", invalid) ++ wskprops.overrides, expectedExitCode = ERROR_EXIT)
-                    .stderr should include("Invalid annotation argument")
-            }
+class WskBasicUsageTests extends TestHelpers with WskTestHelpers {
+
+  implicit val wskprops = WskProps()
+  val wsk = new Wsk
+  val defaultAction = Some(TestUtils.getTestActionFilename("hello.js"))
+
+  behavior of "Wsk CLI usage"
+
+  it should "show help and usage info" in {
+    val stdout = wsk.cli(Seq()).stdout
+    stdout should include regex ("""(?i)Usage:""")
+    stdout should include regex ("""(?i)Flags""")
+    stdout should include regex ("""(?i)Available commands""")
+    stdout should include regex ("""(?i)--help""")
+  }
+
+  it should "show help and usage info using the default language" in {
+    val env = Map("LANG" -> "de_DE")
+    // Call will fail with exit code 2 if language not supported
+    wsk.cli(Seq("-h"), env = env)
+  }
+
+  it should "show cli build version" in {
+    val stdout = wsk.cli(Seq("property", "get", "--cliversion")).stdout
+    stdout should include regex ("""(?i)whisk CLI version\s+201.*""")
+  }
+
+  it should "show api version" in {
+    val stdout = wsk.cli(Seq("property", "get", "--apiversion")).stdout
+    stdout should include regex ("""(?i)whisk API version\s+v1""")
+  }
+
+  it should "reject bad command" in {
+    val result = wsk.cli(Seq("bogus"), expectedExitCode = ERROR_EXIT)
+    result.stderr should include regex ("""(?i)Run 'wsk --help' for usage""")
+  }
+
+  it should "allow a 3 part Fully Qualified Name (FQN) without a leading '/'" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val guestNamespace = wsk.namespace.whois()
+      val packageName = "packageName3ptFQN"
+      val actionName = "actionName3ptFQN"
+      val triggerName = "triggerName3ptFQN"
+      val ruleName = "ruleName3ptFQN"
+      val fullQualifiedName = s"${guestNamespace}/${packageName}/${actionName}"
+      // Used for action and rule creation below
+      assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, _) =>
+        pkg.create(packageName)
+      }
+      assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
+        trigger.create(triggerName)
+      }
+      // Test action and rule creation where action name is 3 part FQN w/out leading slash
+      assetHelper.withCleaner(wsk.action, fullQualifiedName) { (action, _) =>
+        action.create(fullQualifiedName, defaultAction)
+      }
+      assetHelper.withCleaner(wsk.rule, ruleName) { (rule, _) =>
+        rule.create(ruleName, trigger = triggerName, action = fullQualifiedName)
+      }
+
+      wsk.action.invoke(fullQualifiedName).stdout should include(s"ok: invoked /$fullQualifiedName")
+      wsk.action.get(fullQualifiedName).stdout should include(s"ok: got action ${packageName}/${actionName}")
+  }
+
+  behavior of "Wsk actions"
+
+  it should "reject creating entities with invalid names" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val names = Seq(
+      ("", ERROR_EXIT),
+      (" ", BAD_REQUEST),
+      ("hi+there", BAD_REQUEST),
+      ("$hola", BAD_REQUEST),
+      ("dora?", BAD_REQUEST),
+      ("|dora|dora?", BAD_REQUEST))
+
+    names foreach {
+      case (name, ec) =>
+        assetHelper.withCleaner(wsk.action, name, confirmDelete = false) { (action, _) =>
+          action.create(name, defaultAction, expectedExitCode = ec)
         }
     }
+  }
 
-    it should "reject commands that are executed with a missing or invalid parameter or annotation file" in {
-        val emptyFile = TestUtils.getTestActionFilename("emtpy.js")
-        val missingFile = "notafile"
-        val emptyFileMsg = s"File '$emptyFile' is not a valid file or it does not exist"
-        val missingFileMsg = s"File '$missingFile' is not a valid file or it does not exist"
-        val invalidArgs = Seq(
-            (Seq("action", "create", "actionName", TestUtils.getTestActionFilename("hello.js"), "-P", emptyFile),
-                emptyFileMsg),
-            (Seq("action", "update", "actionName", TestUtils.getTestActionFilename("hello.js"), "-P", emptyFile),
-                emptyFileMsg),
-            (Seq("action", "invoke", "actionName", "-P", emptyFile), emptyFileMsg),
-            (Seq("action", "create", "actionName", "-P", emptyFile), emptyFileMsg),
-            (Seq("action", "update", "actionName", "-P", emptyFile), emptyFileMsg),
-            (Seq("action", "invoke", "actionName", "-P", emptyFile), emptyFileMsg),
-            (Seq("package", "create", "packageName", "-P", emptyFile), emptyFileMsg),
-            (Seq("package", "update", "packageName", "-P", emptyFile), emptyFileMsg),
-            (Seq("package", "bind", "packageName", "boundPackageName", "-P", emptyFile), emptyFileMsg),
-            (Seq("package", "create", "packageName", "-P", emptyFile), emptyFileMsg),
-            (Seq("package", "update", "packageName", "-P", emptyFile), emptyFileMsg),
-            (Seq("package", "bind", "packageName", "boundPackageName", "-P", emptyFile), emptyFileMsg),
-            (Seq("trigger", "create", "triggerName", "-P", emptyFile), emptyFileMsg),
-            (Seq("trigger", "update", "triggerName", "-P", emptyFile), emptyFileMsg),
-            (Seq("trigger", "fire", "triggerName", "-P", emptyFile), emptyFileMsg),
-            (Seq("trigger", "create", "triggerName", "-P", emptyFile), emptyFileMsg),
-            (Seq("trigger", "update", "triggerName", "-P", emptyFile), emptyFileMsg),
-            (Seq("trigger", "fire", "triggerName", "-P", emptyFile), emptyFileMsg),
-            (Seq("action", "create", "actionName", TestUtils.getTestActionFilename("hello.js"), "-A", missingFile),
-                missingFileMsg),
-            (Seq("action", "update", "actionName", TestUtils.getTestActionFilename("hello.js"), "-A", missingFile),
-                missingFileMsg),
-            (Seq("action", "invoke", "actionName", "-A", missingFile), missingFileMsg),
-            (Seq("action", "create", "actionName", "-A", missingFile), missingFileMsg),
-            (Seq("action", "update", "actionName", "-A", missingFile), missingFileMsg),
-            (Seq("action", "invoke", "actionName", "-A", missingFile), missingFileMsg),
-            (Seq("package", "create", "packageName", "-A", missingFile), missingFileMsg),
-            (Seq("package", "update", "packageName", "-A", missingFile), missingFileMsg),
-            (Seq("package", "bind", "packageName", "boundPackageName", "-A", missingFile), missingFileMsg),
-            (Seq("package", "create", "packageName", "-A", missingFile), missingFileMsg),
-            (Seq("package", "update", "packageName", "-A", missingFile), missingFileMsg),
-            (Seq("package", "bind", "packageName", "boundPackageName", "-A", missingFile), missingFileMsg),
-            (Seq("trigger", "create", "triggerName", "-A", missingFile), missingFileMsg),
-            (Seq("trigger", "update", "triggerName", "-A", missingFile), missingFileMsg),
-            (Seq("trigger", "fire", "triggerName", "-A", missingFile), missingFileMsg),
-            (Seq("trigger", "create", "triggerName", "-A", missingFile), missingFileMsg),
-            (Seq("trigger", "update", "triggerName", "-A", missingFile), missingFileMsg),
-            (Seq("trigger", "fire", "triggerName", "-A", missingFile), missingFileMsg))
+  it should "reject create with missing file" in {
+    wsk.action.create("missingFile", Some("notfound"), expectedExitCode = MISUSE_EXIT).stderr should include(
+      "not a valid file")
+  }
 
-        invalidArgs foreach {
-            case (cmd, err) =>
-                val stderr = wsk.cli(cmd, expectedExitCode = MISUSE_EXIT).stderr
-                stderr should include(err)
-                stderr should include("Run 'wsk --help' for usage.")
+  it should "reject action update when specified file is missing" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    // Create dummy action to update
+    val name = "updateMissingFile"
+    val file = Some(TestUtils.getTestActionFilename("hello.js"))
+    assetHelper.withCleaner(wsk.action, name) { (action, name) =>
+      action.create(name, file)
+    }
+    // Update it with a missing file
+    wsk.action.create(name, Some("notfound"), update = true, expectedExitCode = MISUSE_EXIT)
+  }
+
+  it should "reject action update for sequence with no components" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "updateMissingComponents"
+    val file = Some(TestUtils.getTestActionFilename("hello.js"))
+    assetHelper.withCleaner(wsk.action, name) { (action, name) =>
+      action.create(name, file)
+    }
+    wsk.action.create(name, None, update = true, kind = Some("sequence"), expectedExitCode = MISUSE_EXIT)
+  }
+
+  it should "create, and get an action to verify parameter and annotation parsing" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "actionAnnotations"
+      val file = Some(TestUtils.getTestActionFilename("hello.js"))
+
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, file, annotations = getValidJSONTestArgInput, parameters = getValidJSONTestArgInput)
+      }
+
+      val stdout = wsk.action.get(name).stdout
+      assert(stdout.startsWith(s"ok: got action $name\n"))
+
+      val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
+      val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
+      val escapedJSONArr = getValidJSONTestArgOutput.convertTo[JsArray].elements
+
+      for (expectedItem <- escapedJSONArr) {
+        receivedParams should contain(expectedItem)
+        receivedAnnots should contain(expectedItem)
+      }
+  }
+
+  it should "create, and get an action to verify file parameter and annotation parsing" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "actionAnnotAndParamParsing"
+      val file = Some(TestUtils.getTestActionFilename("hello.js"))
+      val argInput = Some(TestUtils.getTestActionFilename("validInput1.json"))
+
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, file, annotationFile = argInput, parameterFile = argInput)
+      }
+
+      val stdout = wsk.action.get(name).stdout
+      assert(stdout.startsWith(s"ok: got action $name\n"))
+
+      val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
+      val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
+      val escapedJSONArr = getJSONFileOutput.convertTo[JsArray].elements
+
+      for (expectedItem <- escapedJSONArr) {
+        receivedParams should contain(expectedItem)
+        receivedAnnots should contain(expectedItem)
+      }
+  }
+
+  it should "create an action with the proper parameter and annotation escapes" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "actionEscapes"
+      val file = Some(TestUtils.getTestActionFilename("hello.js"))
+
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, file, parameters = getEscapedJSONTestArgInput, annotations = getEscapedJSONTestArgInput)
+      }
+
+      val stdout = wsk.action.get(name).stdout
+      assert(stdout.startsWith(s"ok: got action $name\n"))
+
+      val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
+      val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
+      val escapedJSONArr = getEscapedJSONTestArgOutput.convertTo[JsArray].elements
+
+      for (expectedItem <- escapedJSONArr) {
+        receivedParams should contain(expectedItem)
+        receivedAnnots should contain(expectedItem)
+      }
+  }
+
+  it should "invoke an action that exits during initialization and get appropriate error" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "abort init"
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, Some(TestUtils.getTestActionFilename("initexit.js")))
+      }
+
+      withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
+        val response = activation.response
+        response.result.get.fields("error") shouldBe Messages.abnormalInitialization.toJson
+        response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ContainerError)
+      }
+  }
+
+  it should "invoke an action that hangs during initialization and get appropriate error" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "hang init"
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, Some(TestUtils.getTestActionFilename("initforever.js")), timeout = Some(3 seconds))
+      }
+
+      withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
+        val response = activation.response
+        response.result.get.fields("error") shouldBe Messages.timedoutActivation(3 seconds, true).toJson
+        response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ApplicationError)
+      }
+  }
+
+  it should "invoke an action that exits during run and get appropriate error" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "abort run"
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, Some(TestUtils.getTestActionFilename("runexit.js")))
+      }
+
+      withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
+        val response = activation.response
+        response.result.get.fields("error") shouldBe Messages.abnormalRun.toJson
+        response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ContainerError)
+      }
+  }
+
+  it should "retrieve the last activation using --last flag" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val auth: Seq[String] = Seq("--auth", wskprops.authKey)
+    val includeStr = "hello, undefined!"
+
+    assetHelper.withCleaner(wsk.action, "lastName") { (action, _) =>
+      wsk.action.create("lastName", defaultAction)
+    }
+    retry(
+      {
+        val lastInvoke = wsk.action.invoke("lastName")
+        withActivation(wsk.activation, lastInvoke) {
+          activation =>
+            val lastFlag = Seq(
+              (Seq("activation", "get", "publish", "--last"), activation.activationId),
+              (Seq("activation", "get", "--last"), activation.activationId),
+              (Seq("activation", "logs", "--last"), includeStr),
+              (Seq("activation", "result", "--last"), includeStr))
+
+            retry({
+              lastFlag foreach {
+                case (cmd, output) =>
+                  val stdout = wsk.cli(cmd ++ wskprops.overrides ++ auth, expectedExitCode = SUCCESS_EXIT).stdout
+                  stdout should include(output)
+              }
+            }, waitBeforeRetry = Some(500.milliseconds))
+
         }
+      },
+      waitBeforeRetry = Some(1.second),
+      N = 5)
+  }
+
+  it should "ensure keys are not omitted from activation record" in withAssetCleaner(wskprops) {
+    val name = "activationRecordTest"
+
+    (wp, assetHelper) =>
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, Some(TestUtils.getTestActionFilename("argCheck.js")))
+      }
+
+      val run = wsk.action.invoke(name)
+      withActivation(wsk.activation, run) { activation =>
+        activation.start should be > Instant.EPOCH
+        activation.end should be > Instant.EPOCH
+        activation.response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.Success)
+        activation.response.success shouldBe true
+        activation.response.result shouldBe Some(JsObject())
+        activation.logs shouldBe Some(List())
+        activation.annotations shouldBe defined
+      }
+  }
+
+  it should "write the action-path and the limits to the annotations" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "annotations"
+      val memoryLimit = 512 MB
+      val logLimit = 1 MB
+      val timeLimit = 60 seconds
+
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(
+          name,
+          Some(TestUtils.getTestActionFilename("helloAsync.js")),
+          memory = Some(memoryLimit),
+          timeout = Some(timeLimit),
+          logsize = Some(logLimit))
+      }
+
+      val run = wsk.action.invoke(name, Map("payload" -> "this is a test".toJson))
+      withActivation(wsk.activation, run) { activation =>
+        activation.response.status shouldBe "success"
+        val annotations = activation.annotations.get
+
+        val limitsObj = JsObject(
+          "key" -> JsString("limits"),
+          "value" -> ActionLimits(TimeLimit(timeLimit), MemoryLimit(memoryLimit), LogLimit(logLimit)).toJson)
+
+        val path = annotations.find { _.fields("key").convertTo[String] == "path" }.get
+
+        path.fields("value").convertTo[String] should fullyMatch regex (s""".*/$name""")
+        annotations should contain(limitsObj)
+      }
+  }
+
+  it should "report error when creating an action with unknown kind" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val rr = assetHelper.withCleaner(wsk.action, "invalid kind", confirmDelete = false) { (action, name) =>
+        action.create(
+          name,
+          Some(TestUtils.getTestActionFilename("echo.js")),
+          kind = Some("foobar"),
+          expectedExitCode = BAD_REQUEST)
+      }
+      rr.stderr should include regex "kind 'foobar' not in Set"
+  }
+
+  it should "report error when creating an action with zip but without kind" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "zipWithNoKind"
+      val zippedPythonAction = Some(TestUtils.getTestActionFilename("python.zip"))
+      val createResult = assetHelper.withCleaner(wsk.action, name, confirmDelete = false) { (action, _) =>
+        action.create(name, zippedPythonAction, expectedExitCode = ANY_ERROR_EXIT)
+      }
+
+      createResult.stderr should include regex "requires specifying the action kind"
+  }
+
+  it should "create, and invoke an action that utilizes an invalid docker container with appropriate error" in withAssetCleaner(
+    wskprops) {
+    val name = "invalidDockerContainer"
+    val containerName = s"bogus${Random.alphanumeric.take(16).mkString.toLowerCase}"
+
+    (wp, assetHelper) =>
+      assetHelper.withCleaner(wsk.action, name) {
+        // docker name is a randomly generate string
+        (action, _) =>
+          action.create(name, None, docker = Some(containerName))
+      }
+
+      val run = wsk.action.invoke(name)
+      withActivation(wsk.activation, run) { activation =>
+        activation.response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ApplicationError)
+        activation.response.result.get
+          .fields("error") shouldBe s"Failed to pull container image '$containerName'.".toJson
+        activation.annotations shouldBe defined
+        val limits = activation.annotations.get.filter(_.fields("key").convertTo[String] == "limits")
+        withClue(limits) {
+          limits.length should be > 0
+          limits(0).fields("value") should not be JsNull
+        }
+      }
+  }
+
+  it should "invoke an action using npm openwhisk" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "hello npm openwhisk"
+    assetHelper.withCleaner(wsk.action, name, confirmDelete = false) { (action, _) =>
+      action.create(name, Some(TestUtils.getTestActionFilename("helloOpenwhiskPackage.js")))
     }
 
-    it should "reject commands that are executed with not enough param or annot arguments" in {
-        val invalidParamMsg = "Arguments for '-p' must be a key/value pair"
-        val invalidAnnotMsg = "Arguments for '-a' must be a key/value pair"
-        val invalidParamFileMsg = "An argument must be provided for '-P'"
-        val invalidAnnotFileMsg = "An argument must be provided for '-A'"
-        val invalidArgs = Seq(
-            (Seq("action", "create", "actionName", "-p"), invalidParamMsg),
-            (Seq("action", "create", "actionName", "-p", "key"), invalidParamMsg),
-            (Seq("action", "create", "actionName", "-P"), invalidParamFileMsg),
-            (Seq("action", "update", "actionName", "-p"), invalidParamMsg),
-            (Seq("action", "update", "actionName", "-p", "key"), invalidParamMsg),
-            (Seq("action", "update", "actionName", "-P"), invalidParamFileMsg),
-            (Seq("action", "invoke", "actionName", "-p"), invalidParamMsg),
-            (Seq("action", "invoke", "actionName", "-p", "key"), invalidParamMsg),
-            (Seq("action", "invoke", "actionName", "-P"), invalidParamFileMsg),
-            (Seq("action", "create", "actionName", "-a"), invalidAnnotMsg),
-            (Seq("action", "create", "actionName", "-a", "key"), invalidAnnotMsg),
-            (Seq("action", "create", "actionName", "-A"), invalidAnnotFileMsg),
-            (Seq("action", "update", "actionName", "-a"), invalidAnnotMsg),
-            (Seq("action", "update", "actionName", "-a", "key"), invalidAnnotMsg),
-            (Seq("action", "update", "actionName", "-A"), invalidAnnotFileMsg),
-            (Seq("action", "invoke", "actionName", "-a"), invalidAnnotMsg),
-            (Seq("action", "invoke", "actionName", "-a", "key"), invalidAnnotMsg),
-            (Seq("action", "invoke", "actionName", "-A"), invalidAnnotFileMsg),
-            (Seq("package", "create", "packageName", "-p"), invalidParamMsg),
-            (Seq("package", "create", "packageName", "-p", "key"), invalidParamMsg),
-            (Seq("package", "create", "packageName", "-P"), invalidParamFileMsg),
-            (Seq("package", "update", "packageName", "-p"), invalidParamMsg),
-            (Seq("package", "update", "packageName", "-p", "key"), invalidParamMsg),
-            (Seq("package", "update", "packageName", "-P"), invalidParamFileMsg),
-            (Seq("package", "bind", "packageName", "boundPackageName", "-p"), invalidParamMsg),
-            (Seq("package", "bind", "packageName", "boundPackageName", "-p", "key"), invalidParamMsg),
-            (Seq("package", "bind", "packageName", "boundPackageName", "-P"), invalidParamFileMsg),
-            (Seq("package", "create", "packageName", "-a"), invalidAnnotMsg),
-            (Seq("package", "create", "packageName", "-a", "key"), invalidAnnotMsg),
-            (Seq("package", "create", "packageName", "-A"), invalidAnnotFileMsg),
-            (Seq("package", "update", "packageName", "-a"), invalidAnnotMsg),
-            (Seq("package", "update", "packageName", "-a", "key"), invalidAnnotMsg),
-            (Seq("package", "update", "packageName", "-A"), invalidAnnotFileMsg),
-            (Seq("package", "bind", "packageName", "boundPackageName", "-a"), invalidAnnotMsg),
-            (Seq("package", "bind", "packageName", "boundPackageName", "-a", "key"), invalidAnnotMsg),
-            (Seq("package", "bind", "packageName", "boundPackageName", "-A"), invalidAnnotFileMsg),
-            (Seq("trigger", "create", "triggerName", "-p"), invalidParamMsg),
-            (Seq("trigger", "create", "triggerName", "-p", "key"), invalidParamMsg),
-            (Seq("trigger", "create", "triggerName", "-P"), invalidParamFileMsg),
-            (Seq("trigger", "update", "triggerName", "-p"), invalidParamMsg),
-            (Seq("trigger", "update", "triggerName", "-p", "key"), invalidParamMsg),
-            (Seq("trigger", "update", "triggerName", "-P"), invalidParamFileMsg),
-            (Seq("trigger", "fire", "triggerName", "-p"), invalidParamMsg),
-            (Seq("trigger", "fire", "triggerName", "-p", "key"), invalidParamMsg),
-            (Seq("trigger", "fire", "triggerName", "-P"), invalidParamFileMsg),
-            (Seq("trigger", "create", "triggerName", "-a"), invalidAnnotMsg),
-            (Seq("trigger", "create", "triggerName", "-a", "key"), invalidAnnotMsg),
-            (Seq("trigger", "create", "triggerName", "-A"), invalidAnnotFileMsg),
-            (Seq("trigger", "update", "triggerName", "-a"), invalidAnnotMsg),
-            (Seq("trigger", "update", "triggerName", "-a", "key"), invalidAnnotMsg),
-            (Seq("trigger", "update", "triggerName", "-A"), invalidAnnotFileMsg),
-            (Seq("trigger", "fire", "triggerName", "-a"), invalidAnnotMsg),
-            (Seq("trigger", "fire", "triggerName", "-a", "key"), invalidAnnotMsg),
-            (Seq("trigger", "fire", "triggerName", "-A"), invalidAnnotFileMsg))
-
-        invalidArgs foreach {
-            case (cmd, err) =>
-                val stderr = wsk.cli(cmd, expectedExitCode = ERROR_EXIT).stderr
-                stderr should include(err)
-                stderr should include("Run 'wsk --help' for usage.")
-        }
+    val run = wsk.action.invoke(name, Map("ignore_certs" -> true.toJson, "name" -> name.toJson))
+    withActivation(wsk.activation, run) { activation =>
+      activation.response.status shouldBe "success"
+      activation.response.result shouldBe Some(JsObject("delete" -> true.toJson))
+      activation.logs.get.mkString(" ") should include("action list has this many actions")
     }
 
-    behavior of "Wsk invalid argument handling"
+    wsk.action.delete(name, expectedExitCode = TestUtils.NOT_FOUND)
+  }
 
-    it should "reject commands that are executed with invalid arguments" in {
-        val invalidArgsMsg = "error: Invalid argument(s)"
-        val tooFewArgsMsg = invalidArgsMsg + "."
-        val tooManyArgsMsg = invalidArgsMsg + ": "
-        val actionNameActionReqMsg = "An action name and code artifact are required."
-        val actionNameReqMsg = "An action name is required."
-        val actionOptMsg = "A code artifact is optional."
-        val packageNameReqMsg = "A package name is required."
-        val packageNameBindingReqMsg = "A package name and binding name are required."
-        val ruleNameReqMsg = "A rule name is required."
-        val ruleTriggerActionReqMsg = "A rule, trigger and action name are required."
-        val activationIdReq = "An activation ID is required."
-        val triggerNameReqMsg = "A trigger name is required."
-        val optNamespaceMsg = "An optional namespace is the only valid argument."
-        val optPayloadMsg = "A payload is optional."
-        val noArgsReqMsg = "No arguments are required."
-        val invalidArg = "invalidArg"
-        val apiCreateReqMsg = "Specify a swagger file or specify an API base path with an API path, an API verb, and an action name."
-        val apiGetReqMsg = "An API base path or API name is required."
-        val apiDeleteReqMsg = "An API base path or API name is required.  An optional API relative path and operation may also be provided."
-        val apiListReqMsg = "Optional parameters are: API base path (or API name), API relative path and operation."
-        val invalidShared = s"Cannot use value '$invalidArg' for shared"
-        val entityNameMsg = s"An entity name, '$invalidArg', was provided instead of a namespace. Valid namespaces are of the following format: /NAMESPACE."
-        val invalidArgs = Seq(
-            (Seq("api", "create"), s"${tooFewArgsMsg} ${apiCreateReqMsg}"),
-            (Seq("api", "create", "/basepath", "/path", "GET", "action", invalidArg), s"${tooManyArgsMsg}${invalidArg}. ${apiCreateReqMsg}"),
-            (Seq("api", "get"), s"${tooFewArgsMsg} ${apiGetReqMsg}"),
-            (Seq("api", "get", "/basepath", invalidArg), s"${tooManyArgsMsg}${invalidArg}. ${apiGetReqMsg}"),
-            (Seq("api", "delete"), s"${tooFewArgsMsg} ${apiDeleteReqMsg}"),
-            (Seq("api", "delete", "/basepath", "/path", "GET", invalidArg), s"${tooManyArgsMsg}${invalidArg}. ${apiDeleteReqMsg}"),
-            (Seq("api", "list", "/basepath", "/path", "GET", invalidArg), s"${tooManyArgsMsg}${invalidArg}. ${apiListReqMsg}"),
-            (Seq("action", "create"), s"${tooFewArgsMsg} ${actionNameActionReqMsg}"),
-            (Seq("action", "create", "someAction"), s"${tooFewArgsMsg} ${actionNameActionReqMsg}"),
-            (Seq("action", "create", "actionName", "artifactName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
-            (Seq("action", "update"), s"${tooFewArgsMsg} ${actionNameReqMsg} ${actionOptMsg}"),
-            (Seq("action", "update", "actionName", "artifactName", invalidArg),
-                s"${tooManyArgsMsg}${invalidArg}. ${actionNameReqMsg} ${actionOptMsg}"),
-            (Seq("action", "delete"), s"${tooFewArgsMsg} ${actionNameReqMsg}"),
-            (Seq("action", "delete", "actionName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
-            (Seq("action", "get"), s"${tooFewArgsMsg} ${actionNameReqMsg}"),
-            (Seq("action", "get", "actionName", "namespace", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
-            (Seq("action", "list", "namespace", invalidArg), s"${tooManyArgsMsg}${invalidArg}. ${optNamespaceMsg}"),
-            (Seq("action", "invoke"), s"${tooFewArgsMsg} ${actionNameReqMsg}"),
-            (Seq("action", "invoke", "actionName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
-            (Seq("activation", "list", "namespace", invalidArg),
-                s"${tooManyArgsMsg}${invalidArg}. ${optNamespaceMsg}"),
-            (Seq("activation", "get"), s"${tooFewArgsMsg} ${activationIdReq}"),
-            (Seq("activation", "get", "activationID", "namespace", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
-            (Seq("activation", "logs"), s"${tooFewArgsMsg} ${activationIdReq}"),
-            (Seq("activation", "logs", "activationID", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
-            (Seq("activation", "result"), s"${tooFewArgsMsg} ${activationIdReq}"),
-            (Seq("activation", "result", "activationID", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
-            (Seq("activation", "poll", "activationID", invalidArg),
-                s"${tooManyArgsMsg}${invalidArg}. ${optNamespaceMsg}"),
-            (Seq("namespace", "list", invalidArg), s"${tooManyArgsMsg}${invalidArg}. ${noArgsReqMsg}"),
-            (Seq("namespace", "get", "namespace", invalidArg),
-                s"${tooManyArgsMsg}${invalidArg}. ${optNamespaceMsg}"),
-            (Seq("package", "create"), s"${tooFewArgsMsg} ${packageNameReqMsg}"),
-            (Seq("package", "create", "packageName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
-            (Seq("package", "create", "packageName", "--shared", invalidArg), invalidShared),
-            (Seq("package", "update"), s"${tooFewArgsMsg} ${packageNameReqMsg}"),
-            (Seq("package", "update", "packageName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
-            (Seq("package", "update", "packageName", "--shared", invalidArg), invalidShared),
-            (Seq("package", "get"), s"${tooFewArgsMsg} ${packageNameReqMsg}"),
-            (Seq("package", "get", "packageName", "namespace", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
-            (Seq("package", "bind"), s"${tooFewArgsMsg} ${packageNameBindingReqMsg}"),
-            (Seq("package", "bind", "packageName"), s"${tooFewArgsMsg} ${packageNameBindingReqMsg}"),
-            (Seq("package", "bind", "packageName", "bindingName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
-            (Seq("package", "list", "namespace", invalidArg),
-                s"${tooManyArgsMsg}${invalidArg}. ${optNamespaceMsg}"),
-            (Seq("package", "list", invalidArg), entityNameMsg),
-            (Seq("package", "delete"), s"${tooFewArgsMsg} ${packageNameReqMsg}"),
-            (Seq("package", "delete", "namespace", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
-            (Seq("package", "refresh", "namespace", invalidArg),
-                s"${tooManyArgsMsg}${invalidArg}. ${optNamespaceMsg}"),
-            (Seq("package", "refresh", invalidArg), entityNameMsg),
-            (Seq("rule", "enable"), s"${tooFewArgsMsg} ${ruleNameReqMsg}"),
-            (Seq("rule", "enable", "ruleName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
-            (Seq("rule", "disable"), s"${tooFewArgsMsg} ${ruleNameReqMsg}"),
-            (Seq("rule", "disable", "ruleName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
-            (Seq("rule", "status"), s"${tooFewArgsMsg} ${ruleNameReqMsg}"),
-            (Seq("rule", "status", "ruleName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
-            (Seq("rule", "create"), s"${tooFewArgsMsg} ${ruleTriggerActionReqMsg}"),
-            (Seq("rule", "create", "ruleName"), s"${tooFewArgsMsg} ${ruleTriggerActionReqMsg}"),
-            (Seq("rule", "create", "ruleName", "triggerName"), s"${tooFewArgsMsg} ${ruleTriggerActionReqMsg}"),
-            (Seq("rule", "create", "ruleName", "triggerName", "actionName", invalidArg),
-                s"${tooManyArgsMsg}${invalidArg}."),
-            (Seq("rule", "update"), s"${tooFewArgsMsg} ${ruleTriggerActionReqMsg}"),
-            (Seq("rule", "update", "ruleName"), s"${tooFewArgsMsg} ${ruleTriggerActionReqMsg}"),
-            (Seq("rule", "update", "ruleName", "triggerName"), s"${tooFewArgsMsg} ${ruleTriggerActionReqMsg}"),
-            (Seq("rule", "update", "ruleName", "triggerName", "actionName", invalidArg),
-                s"${tooManyArgsMsg}${invalidArg}."),
-            (Seq("rule", "get"), s"${tooFewArgsMsg} ${ruleNameReqMsg}"),
-            (Seq("rule", "get", "ruleName", "namespace", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
-            (Seq("rule", "delete"), s"${tooFewArgsMsg} ${ruleNameReqMsg}"),
-            (Seq("rule", "delete", "ruleName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
-            (Seq("rule", "list", "namespace", invalidArg), s"${tooManyArgsMsg}${invalidArg}. ${optNamespaceMsg}"),
-            (Seq("rule", "list", invalidArg), entityNameMsg),
-            (Seq("trigger", "fire"), s"${tooFewArgsMsg} ${triggerNameReqMsg} ${optPayloadMsg}"),
-            (Seq("trigger", "fire", "triggerName", "triggerPayload", invalidArg),
-                s"${tooManyArgsMsg}${invalidArg}. ${triggerNameReqMsg} ${optPayloadMsg}"),
-            (Seq("trigger", "create"), s"${tooFewArgsMsg} ${triggerNameReqMsg}"),
-            (Seq("trigger", "create", "triggerName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
-            (Seq("trigger", "update"), s"${tooFewArgsMsg} ${triggerNameReqMsg}"),
-            (Seq("trigger", "update", "triggerName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
-            (Seq("trigger", "get"), s"${tooFewArgsMsg} ${triggerNameReqMsg}"),
-            (Seq("trigger", "get", "triggerName", "namespace", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
-            (Seq("trigger", "delete"), s"${tooFewArgsMsg} ${triggerNameReqMsg}"),
-            (Seq("trigger", "delete", "triggerName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
-            (Seq("trigger", "list", "namespace", invalidArg), s"${tooManyArgsMsg}${invalidArg}. ${optNamespaceMsg}"),
-            (Seq("trigger", "list", invalidArg), entityNameMsg))
-
-        invalidArgs foreach {
-            case (cmd, err) =>
-                withClue(cmd) {
-                    val rr = wsk.cli(cmd ++ wskprops.overrides, expectedExitCode = ANY_ERROR_EXIT)
-                    rr.exitCode should (be(ERROR_EXIT) or be(MISUSE_EXIT))
-                    rr.stderr should include(err)
-                    rr.stderr should include("Run 'wsk --help' for usage.")
-                }
-        }
+  it should "invoke an action receiving context properties" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val namespace = wsk.namespace.whois()
+    val name = "context"
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, Some(TestUtils.getTestActionFilename("helloContext.js")))
     }
 
-    behavior of "Wsk action parameters"
+    val start = Instant.now(Clock.systemUTC()).toEpochMilli
+    val run = wsk.action.invoke(name)
+    withActivation(wsk.activation, run) { activation =>
+      activation.response.status shouldBe "success"
+      val fields = activation.response.result.get.convertTo[Map[String, String]]
+      fields("api_host") shouldBe WhiskProperties.getApiHostForAction
+      fields("api_key") shouldBe wskprops.authKey
+      fields("namespace") shouldBe namespace
+      fields("action_name") shouldBe s"/$namespace/$name"
+      fields("activation_id") shouldBe activation.activationId
+      fields("deadline").toLong should be >= start
+    }
+  }
 
-    it should "create an action with different permutations of limits" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val file = Some(TestUtils.getTestActionFilename("hello.js"))
+  it should "invoke an action successfully with options --blocking and --result" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "invokeResult"
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, Some(TestUtils.getTestActionFilename("echo.js")))
+      }
+      val args = Map("hello" -> "Robert".toJson)
+      val run = wsk.action.invoke(name, args, blocking = true, result = true)
+      run.stdout.parseJson shouldBe args.toJson
+  }
 
-            def testLimit(timeout: Option[Duration] = None, memory: Option[ByteSize] = None, logs: Option[ByteSize] = None, ec: Int = SUCCESS_EXIT) = {
-                // Limits to assert, standard values if CLI omits certain values
-                val limits = JsObject(
-                    "timeout" -> timeout.getOrElse(STD_DURATION).toMillis.toJson,
-                    "memory" -> memory.getOrElse(STD_MEMORY).toMB.toInt.toJson,
-                    "logs" -> logs.getOrElse(STD_LOGSIZE).toMB.toInt.toJson)
+  it should "invoke an action that returns a result by the deadline" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "deadline"
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, Some(TestUtils.getTestActionFilename("helloDeadline.js")), timeout = Some(3 seconds))
+      }
 
-                val name = "ActionLimitTests" + Instant.now.toEpochMilli
-                val createResult = assetHelper.withCleaner(wsk.action, name, confirmDelete = (ec == SUCCESS_EXIT)) {
-                    (action, _) =>
-                        val result = action.create(name, file, logsize = logs, memory = memory, timeout = timeout, expectedExitCode = DONTCARE_EXIT)
-                        withClue(s"create failed for parameters: timeout = $timeout, memory = $memory, logsize = $logs:") {
-                            result.exitCode should be(ec)
-                        }
-                        result
-                }
+      val run = wsk.action.invoke(name)
+      withActivation(wsk.activation, run) { activation =>
+        activation.response.status shouldBe "success"
+        activation.response.result shouldBe Some(JsObject("timedout" -> true.toJson))
+      }
+  }
 
-                if (ec == SUCCESS_EXIT) {
-                    val JsObject(parsedAction) = wsk.action.get(name).stdout.split("\n").tail.mkString.parseJson.asJsObject
-                    parsedAction("limits") shouldBe limits
-                } else {
-                    createResult.stderr should include("allowed threshold")
-                }
+  it should "invoke an action twice, where the first times out but the second does not and should succeed" in withAssetCleaner(
+    wskprops) {
+    // this test issues two activations: the first is forced to time out and not return a result by its deadline (ie it does not resolve
+    // its promise). The invoker should reclaim its container so that a second activation of the same action (which must happen within a
+    // short period of time (seconds, not minutes) is allocated a fresh container and hence runs as expected (vs. hitting in the container
+    // cache and reusing a bad container).
+    (wp, assetHelper) =>
+      val name = "timeout"
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, Some(TestUtils.getTestActionFilename("helloDeadline.js")), timeout = Some(3 seconds))
+      }
+
+      val start = Instant.now(Clock.systemUTC()).toEpochMilli
+      val hungRun = wsk.action.invoke(name, Map("forceHang" -> true.toJson))
+      withActivation(wsk.activation, hungRun) { activation =>
+        // the first action must fail with a timeout error
+        activation.response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ApplicationError)
+        activation.response.result shouldBe Some(
+          JsObject("error" -> Messages.timedoutActivation(3 seconds, false).toJson))
+      }
+
+      // run the action again, this time without forcing it to timeout
+      // it should succeed because it ran in a fresh container
+      val goodRun = wsk.action.invoke(name, Map("forceHang" -> false.toJson))
+      withActivation(wsk.activation, goodRun) { activation =>
+        // the first action must fail with a timeout error
+        activation.response.status shouldBe "success"
+        activation.response.result shouldBe Some(JsObject("timedout" -> true.toJson))
+      }
+  }
+
+  it should "ensure --web flags set the proper annotations" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "webaction"
+    val file = Some(TestUtils.getTestActionFilename("echo.js"))
+
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, file)
+    }
+
+    Seq("true", "faLse", "tRue", "nO", "yEs", "no", "raw", "NO", "Raw").foreach { flag =>
+      val webEnabled = flag.toLowerCase == "true" || flag.toLowerCase == "yes"
+      val rawEnabled = flag.toLowerCase == "raw"
+
+      wsk.action.create(name, file, web = Some(flag), update = true)
+
+      val stdout = wsk.action.get(name, fieldFilter = Some("annotations")).stdout
+      assert(stdout.startsWith(s"ok: got action $name, displaying field annotations\n"))
+      removeCLIHeader(stdout).parseJson shouldBe JsArray(
+        JsObject("key" -> JsString("exec"), "value" -> JsString("nodejs:6")),
+        JsObject("key" -> JsString("web-export"), "value" -> JsBoolean(webEnabled || rawEnabled)),
+        JsObject("key" -> JsString("raw-http"), "value" -> JsBoolean(rawEnabled)),
+        JsObject("key" -> JsString("final"), "value" -> JsBoolean(webEnabled || rawEnabled)))
+    }
+  }
+
+  it should "ensure action update with --web flag only copies existing annotations when new annotations are not provided" in withAssetCleaner(
+    wskprops) { (wp, assetHelper) =>
+    val name = "webaction"
+    val file = Some(TestUtils.getTestActionFilename("echo.js"))
+    val createKey = "createKey"
+    val createValue = JsString("createValue")
+    val updateKey = "updateKey"
+    val updateValue = JsString("updateValue")
+    val origKey = "origKey"
+    val origValue = JsString("origValue")
+    val overwrittenValue = JsString("overwrittenValue")
+    val createAnnots = Map(createKey -> createValue, origKey -> origValue)
+    val updateAnnots = Map(updateKey -> updateValue, origKey -> overwrittenValue)
+
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, file, annotations = createAnnots)
+    }
+
+    wsk.action.create(name, file, web = Some("true"), update = true)
+
+    val existinAnnots = wsk.action.get(name, fieldFilter = Some("annotations")).stdout
+    assert(existinAnnots.startsWith(s"ok: got action $name, displaying field annotations\n"))
+    removeCLIHeader(existinAnnots).parseJson shouldBe JsArray(
+      JsObject("key" -> JsString("web-export"), "value" -> JsBoolean(true)),
+      JsObject("key" -> JsString(origKey), "value" -> origValue),
+      JsObject("key" -> JsString("raw-http"), "value" -> JsBoolean(false)),
+      JsObject("key" -> JsString("final"), "value" -> JsBoolean(true)),
+      JsObject("key" -> JsString(createKey), "value" -> createValue),
+      JsObject("key" -> JsString("exec"), "value" -> JsString("nodejs:6")))
+
+    wsk.action.create(name, file, web = Some("true"), update = true, annotations = updateAnnots)
+
+    val updatedAnnots = wsk.action.get(name, fieldFilter = Some("annotations")).stdout
+    assert(updatedAnnots.startsWith(s"ok: got action $name, displaying field annotations\n"))
+    removeCLIHeader(updatedAnnots).parseJson shouldBe JsArray(
+      JsObject("key" -> JsString("web-export"), "value" -> JsBoolean(true)),
+      JsObject("key" -> JsString(origKey), "value" -> overwrittenValue),
+      JsObject("key" -> JsString(updateKey), "value" -> updateValue),
+      JsObject("key" -> JsString("raw-http"), "value" -> JsBoolean(false)),
+      JsObject("key" -> JsString("final"), "value" -> JsBoolean(true)),
+      JsObject("key" -> JsString("exec"), "value" -> JsString("nodejs:6")))
+  }
+
+  it should "ensure action update creates an action with --web flag" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "webaction"
+      val file = Some(TestUtils.getTestActionFilename("echo.js"))
+
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, file, web = Some("true"), update = true)
+      }
+
+      val stdout = wsk.action.get(name, fieldFilter = Some("annotations")).stdout
+      assert(stdout.startsWith(s"ok: got action $name, displaying field annotations\n"))
+      removeCLIHeader(stdout).parseJson shouldBe JsArray(
+        JsObject("key" -> JsString("web-export"), "value" -> JsBoolean(true)),
+        JsObject("key" -> JsString("raw-http"), "value" -> JsBoolean(false)),
+        JsObject("key" -> JsString("final"), "value" -> JsBoolean(true)),
+        JsObject("key" -> JsString("exec"), "value" -> JsString("nodejs:6")))
+  }
+
+  it should "reject action create and update with invalid web flag input" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "webaction"
+      val file = Some(TestUtils.getTestActionFilename("echo.js"))
+      val invalidInput = "bogus"
+      val errorMsg =
+        s"Invalid argument '$invalidInput' for --web flag. Valid input consist of 'yes', 'true', 'raw', 'false', or 'no'."
+      wsk.action.create(name, file, web = Some(invalidInput), expectedExitCode = MISUSE_EXIT).stderr should include(
+        errorMsg)
+      wsk.action
+        .create(name, file, web = Some(invalidInput), update = true, expectedExitCode = MISUSE_EXIT)
+        .stderr should include(errorMsg)
+  }
+
+  it should "invoke action while not encoding &, <, > characters" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "nonescape"
+    val file = Some(TestUtils.getTestActionFilename("hello.js"))
+    val nonescape = "&<>"
+    val input = Map("payload" -> nonescape.toJson)
+    val output = JsObject("payload" -> JsString(s"hello, $nonescape!"))
+
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, file)
+    }
+
+    withActivation(wsk.activation, wsk.action.invoke(name, parameters = input)) { activation =>
+      activation.response.success shouldBe true
+      activation.response.result shouldBe Some(output)
+      activation.logs.toList.flatten.filter(_.contains(nonescape)).length shouldBe 1
+    }
+  }
+
+  it should "get an action URL" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val actionName = "action name@_-."
+    val packageName = "package name@_-."
+    val defaultPackageName = "default"
+    val webActionName = "web action name@_-."
+    val nonExistentActionName = "non-existence action"
+    val packagedAction = s"$packageName/$actionName"
+    val packagedWebAction = s"$packageName/$webActionName"
+    val namespace = wsk.namespace.whois()
+    val encodedActionName = URLEncoder.encode(actionName, StandardCharsets.UTF_8.name).replace("+", "%20")
+    val encodedPackageName = URLEncoder.encode(packageName, StandardCharsets.UTF_8.name).replace("+", "%20")
+    val encodedWebActionName = URLEncoder.encode(webActionName, StandardCharsets.UTF_8.name).replace("+", "%20")
+    val encodedNamespace = URLEncoder.encode(namespace, StandardCharsets.UTF_8.name).replace("+", "%20")
+    val actionPath = "https://%s/api/%s/namespaces/%s/actions/%s"
+    val packagedActionPath = s"$actionPath/%s"
+    val webActionPath = "https://%s/api/%s/web/%s/%s/%s"
+
+    assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
+      action.create(actionName, defaultAction)
+    }
+
+    assetHelper.withCleaner(wsk.action, webActionName) { (action, _) =>
+      action.create(webActionName, defaultAction, web = Some("true"))
+    }
+
+    assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, _) =>
+      pkg.create(packageName)
+    }
+
+    assetHelper.withCleaner(wsk.action, packagedAction) { (action, _) =>
+      action.create(packagedAction, defaultAction)
+    }
+
+    assetHelper.withCleaner(wsk.action, packagedWebAction) { (action, _) =>
+      action.create(packagedWebAction, defaultAction, web = Some("true"))
+    }
+
+    wsk.action.get(actionName, url = Some(true)).stdout should include(
+      actionPath.format(wskprops.apihost, wskprops.apiversion, encodedNamespace, encodedActionName))
+
+    // Ensure url flag works when a field filter and summary flag are specified
+    wsk.action.get(actionName, url = Some(true), fieldFilter = Some("field"), summary = true).stdout should include(
+      actionPath.format(wskprops.apihost, wskprops.apiversion, encodedNamespace, encodedActionName))
+
+    wsk.action.get(webActionName, url = Some(true)).stdout should include(
+      webActionPath
+        .format(wskprops.apihost, wskprops.apiversion, encodedNamespace, defaultPackageName, encodedWebActionName))
+
+    wsk.action.get(packagedAction, url = Some(true)).stdout should include(
+      packagedActionPath
+        .format(wskprops.apihost, wskprops.apiversion, encodedNamespace, encodedPackageName, encodedActionName))
+
+    wsk.action.get(packagedWebAction, url = Some(true)).stdout should include(
+      webActionPath
+        .format(wskprops.apihost, wskprops.apiversion, encodedNamespace, encodedPackageName, encodedWebActionName))
+
+    wsk.action.get(nonExistentActionName, url = Some(true), expectedExitCode = NOT_FOUND)
+  }
+  it should "limit length of HTTP request and response bodies for --verbose" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "limitVerbose"
+      val msg = "will be truncated"
+      val params = Seq("-p", "bigValue", "a" * 1000)
+
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, Some(TestUtils.getTestActionFilename("echo.js")))
+      }
+
+      val truncated = wsk
+        .cli(Seq("action", "invoke", name, "-b", "-v", "--auth", wskprops.authKey) ++ params ++ wskprops.overrides)
+        .stdout
+      msg.r.findAllIn(truncated).length shouldBe 2
+
+      val notTruncated = wsk
+        .cli(Seq("action", "invoke", name, "-b", "-d", "--auth", wskprops.authKey) ++ params ++ wskprops.overrides)
+        .stdout
+      msg.r.findAllIn(notTruncated).length shouldBe 0
+  }
+
+  it should "denote bound and finalized action parameters for action summaries" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val nameBoundParams = "actionBoundParams"
+      val nameFinalParams = "actionFinalParams"
+      val paramAnnot = "paramAnnot"
+      val paramOverlap = "paramOverlap"
+      val paramBound = "paramBound"
+      val annots = Map(
+        "parameters" -> JsArray(
+          JsObject("name" -> JsString(paramAnnot), "description" -> JsString("Annotated")),
+          JsObject("name" -> JsString(paramOverlap), "description" -> JsString("Annotated And Bound"))))
+      val annotsFinal = Map(
+        "final" -> JsBoolean(true),
+        "parameters" -> JsArray(
+          JsObject("name" -> JsString(paramAnnot), "description" -> JsString("Annotated Parameter description")),
+          JsObject("name" -> JsString(paramOverlap), "description" -> JsString("Annotated And Bound"))))
+      val paramsBound = Map(paramBound -> JsString("Bound"), paramOverlap -> JsString("Bound And Annotated"))
+
+      assetHelper.withCleaner(wsk.action, nameBoundParams) { (action, _) =>
+        action.create(nameBoundParams, defaultAction, annotations = annots, parameters = paramsBound)
+      }
+      assetHelper.withCleaner(wsk.action, nameFinalParams) { (action, _) =>
+        action.create(nameFinalParams, defaultAction, annotations = annotsFinal, parameters = paramsBound)
+      }
+
+      val stdoutBound = wsk.action.get(nameBoundParams, summary = true).stdout
+      val stdoutFinal = wsk.action.get(nameFinalParams, summary = true).stdout
+
+      stdoutBound should include(s"(parameters: $paramAnnot, *$paramBound, *$paramOverlap)")
+      stdoutFinal should include(s"(parameters: $paramAnnot, **$paramBound, **$paramOverlap)")
+  }
+
+  it should "create, and get an action summary without a description and/or defined parameters" in withAssetCleaner(
+    wskprops) { (wp, assetHelper) =>
+    val actNameNoParams = "actionNoParams"
+    val actNameNoDesc = "actionNoDesc"
+    val actNameNoDescOrParams = "actionNoDescOrParams"
+    val desc = "Action description"
+    val descFromParamsResp = "Returns a result based on parameters"
+    val annotsNoParams = Map("description" -> JsString(desc))
+    val annotsNoDesc = Map(
+      "parameters" -> JsArray(
+        JsObject("name" -> JsString("paramName1"), "description" -> JsString("Parameter description 1")),
+        JsObject("name" -> JsString("paramName2"), "description" -> JsString("Parameter description 2"))))
+
+    assetHelper.withCleaner(wsk.action, actNameNoDesc) { (action, _) =>
+      action.create(actNameNoDesc, defaultAction, annotations = annotsNoDesc)
+    }
+    assetHelper.withCleaner(wsk.action, actNameNoParams) { (action, _) =>
+      action.create(actNameNoParams, defaultAction, annotations = annotsNoParams)
+    }
+    assetHelper.withCleaner(wsk.action, actNameNoDescOrParams) { (action, _) =>
+      action.create(actNameNoDescOrParams, defaultAction)
+    }
+
+    val stdoutNoDesc = wsk.action.get(actNameNoDesc, summary = true).stdout
+    val stdoutNoParams = wsk.action.get(actNameNoParams, summary = true).stdout
+    val stdoutNoDescOrParams = wsk.action.get(actNameNoDescOrParams, summary = true).stdout
+    val namespace = wsk.namespace.whois()
+
+    stdoutNoDesc should include regex (s"(?i)action /${namespace}/${actNameNoDesc}: ${descFromParamsResp} paramName1 and paramName2\\s*\\(parameters: paramName1, paramName2\\)")
+    stdoutNoParams should include regex (s"(?i)action /${namespace}/${actNameNoParams}: ${desc}\\s*\\(parameters: none defined\\)")
+    stdoutNoDescOrParams should include regex (s"(?i)action /${namespace}/${actNameNoDescOrParams}\\s*\\(parameters: none defined\\)")
+  }
+
+  behavior of "Wsk packages"
+
+  it should "create, and delete a package" in {
+    val name = "createDeletePackage"
+    wsk.pkg.create(name).stdout should include(s"ok: created package $name")
+    wsk.pkg.delete(name).stdout should include(s"ok: deleted package $name")
+  }
+
+  it should "create, and get a package to verify parameter and annotation parsing" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "packageAnnotAndParamParsing"
+
+      assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
+        pkg.create(name, annotations = getValidJSONTestArgInput, parameters = getValidJSONTestArgInput)
+      }
+
+      val stdout = wsk.pkg.get(name).stdout
+      assert(stdout.startsWith(s"ok: got package $name\n"))
+
+      val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
+      val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
+      val escapedJSONArr = getValidJSONTestArgOutput.convertTo[JsArray].elements
+
+      for (expectedItem <- escapedJSONArr) {
+        receivedParams should contain(expectedItem)
+        receivedAnnots should contain(expectedItem)
+      }
+  }
+
+  it should "create, and get a package to verify file parameter and annotation parsing" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "packageAnnotAndParamFileParsing"
+      val file = Some(TestUtils.getTestActionFilename("hello.js"))
+      val argInput = Some(TestUtils.getTestActionFilename("validInput1.json"))
+
+      assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
+        pkg.create(name, annotationFile = argInput, parameterFile = argInput)
+      }
+
+      val stdout = wsk.pkg.get(name).stdout
+      assert(stdout.startsWith(s"ok: got package $name\n"))
+
+      val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
+      val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
+      val escapedJSONArr = getJSONFileOutput.convertTo[JsArray].elements
+
+      for (expectedItem <- escapedJSONArr) {
+        receivedParams should contain(expectedItem)
+        receivedAnnots should contain(expectedItem)
+      }
+  }
+
+  it should "create a package with the proper parameter and annotation escapes" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "packageEscapses"
+
+      assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
+        pkg.create(name, parameters = getEscapedJSONTestArgInput, annotations = getEscapedJSONTestArgInput)
+      }
+
+      val stdout = wsk.pkg.get(name).stdout
+      assert(stdout.startsWith(s"ok: got package $name\n"))
+
+      val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
+      val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
+      val escapedJSONArr = getEscapedJSONTestArgOutput.convertTo[JsArray].elements
+
+      for (expectedItem <- escapedJSONArr) {
+        receivedParams should contain(expectedItem)
+        receivedAnnots should contain(expectedItem)
+      }
+  }
+
+  it should "report conformance error accessing action as package" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "aAsP"
+    val file = Some(TestUtils.getTestActionFilename("hello.js"))
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, file)
+    }
+
+    wsk.pkg.get(name, expectedExitCode = CONFLICT).stderr should include(Messages.conformanceMessage)
+
+    wsk.pkg.bind(name, "bogus", expectedExitCode = CONFLICT).stderr should include(Messages.requestedBindingIsNotValid)
+
+    wsk.pkg.bind("bogus", "alsobogus", expectedExitCode = BAD_REQUEST).stderr should include(
+      Messages.bindingDoesNotExist)
+
+  }
+
+  it should "create, and get a package summary without a description and/or parameters" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val pkgNoDesc = "pkgNoDesc"
+      val pkgNoParams = "pkgNoParams"
+      val pkgNoDescOrParams = "pkgNoDescOrParams"
+      val pkgDesc = "Package description"
+      val descFromParams = "Returns a result based on parameters"
+      val namespace = wsk.namespace.whois()
+      val qualpkgNoDesc = s"/${namespace}/${pkgNoDesc}"
+      val qualpkgNoParams = s"/${namespace}/${pkgNoParams}"
+      val qualpkgNoDescOrParams = s"/${namespace}/${pkgNoDescOrParams}"
+
+      val pkgAnnotsNoParams = Map("description" -> JsString(pkgDesc))
+      val pkgAnnotsNoDesc = Map(
+        "parameters" -> JsArray(
+          JsObject("name" -> JsString("paramName1"), "description" -> JsString("Parameter description 1")),
+          JsObject("name" -> JsString("paramName2"), "description" -> JsString("Parameter description 2"))))
+
+      assetHelper.withCleaner(wsk.pkg, pkgNoDesc) { (pkg, _) =>
+        pkg.create(pkgNoDesc, annotations = pkgAnnotsNoDesc)
+      }
+      assetHelper.withCleaner(wsk.pkg, pkgNoParams) { (pkg, _) =>
+        pkg.create(pkgNoParams, annotations = pkgAnnotsNoParams)
+      }
+      assetHelper.withCleaner(wsk.pkg, pkgNoDescOrParams) { (pkg, _) =>
+        pkg.create(pkgNoDescOrParams)
+      }
+
+      val stdoutNoDescPkg = wsk.pkg.get(pkgNoDesc, summary = true).stdout
+      val stdoutNoParamsPkg = wsk.pkg.get(pkgNoParams, summary = true).stdout
+      val stdoutNoDescOrParams = wsk.pkg.get(pkgNoDescOrParams, summary = true).stdout
+
+      stdoutNoDescPkg should include regex (s"(?i)package ${qualpkgNoDesc}: ${descFromParams} paramName1 and paramName2\\s*\\(parameters: paramName1, paramName2\\)")
+      stdoutNoParamsPkg should include regex (s"(?i)package ${qualpkgNoParams}: ${pkgDesc}\\s*\\(parameters: none defined\\)")
+      stdoutNoDescOrParams should include regex (s"(?i)package ${qualpkgNoDescOrParams}\\s*\\(parameters: none defined\\)")
+  }
+
+  it should "denote bound package parameters for package summaries" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val pkgBoundParams = "pkgBoundParams"
+    val pkgParamAnnot = "pkgParamAnnot"
+    val pkgParamOverlap = "pkgParamOverlap"
+    val pkgParamBound = "pkgParamBound"
+    val pkgAnnots = Map(
+      "parameters" -> JsArray(
+        JsObject("name" -> JsString(pkgParamAnnot), "description" -> JsString("Annotated")),
+        JsObject("name" -> JsString(pkgParamOverlap), "description" -> JsString("Annotated And Bound"))))
+    val pkgParamsBound = Map(pkgParamBound -> JsString("Bound"), pkgParamOverlap -> JsString("Bound And Annotated"))
+
+    assetHelper.withCleaner(wsk.pkg, pkgBoundParams) { (pkg, _) =>
+      pkg.create(pkgBoundParams, annotations = pkgAnnots, parameters = pkgParamsBound)
+    }
+
+    val pkgStdoutBound = wsk.pkg.get(pkgBoundParams, summary = true).stdout
+
+    pkgStdoutBound should include(s"(parameters: $pkgParamAnnot, *$pkgParamBound, *$pkgParamOverlap)")
+  }
+
+  behavior of "Wsk triggers"
+
+  it should "create, and get a trigger to verify parameter and annotation parsing" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "triggerAnnotAndParamParsing"
+
+      assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+        trigger.create(name, annotations = getValidJSONTestArgInput, parameters = getValidJSONTestArgInput)
+      }
+
+      val stdout = wsk.trigger.get(name).stdout
+      assert(stdout.startsWith(s"ok: got trigger $name\n"))
+
+      val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
+      val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
+      val escapedJSONArr = getValidJSONTestArgOutput.convertTo[JsArray].elements
+
+      for (expectedItem <- escapedJSONArr) {
+        receivedParams should contain(expectedItem)
+        receivedAnnots should contain(expectedItem)
+      }
+  }
+
+  it should "create, and get a trigger to verify file parameter and annotation parsing" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "triggerAnnotAndParamFileParsing"
+      val file = Some(TestUtils.getTestActionFilename("hello.js"))
+      val argInput = Some(TestUtils.getTestActionFilename("validInput1.json"))
+
+      assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+        trigger.create(name, annotationFile = argInput, parameterFile = argInput)
+      }
+
+      val stdout = wsk.trigger.get(name).stdout
+      assert(stdout.startsWith(s"ok: got trigger $name\n"))
+
+      val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
+      val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
+      val escapedJSONArr = getJSONFileOutput.convertTo[JsArray].elements
+
+      for (expectedItem <- escapedJSONArr) {
+        receivedParams should contain(expectedItem)
+        receivedAnnots should contain(expectedItem)
+      }
+  }
+
+  it should "display a trigger summary when --summary flag is used with 'wsk trigger get'" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val triggerName = "mySummaryTrigger"
+      assetHelper.withCleaner(wsk.trigger, triggerName, confirmDelete = false) { (trigger, name) =>
+        trigger.create(name)
+      }
+
+      // Summary namespace should match one of the allowable namespaces (typically 'guest')
+      val ns = wsk.namespace.whois()
+      val stdout = wsk.trigger.get(triggerName, summary = true).stdout
+      stdout should include regex (s"(?i)trigger\\s+/$ns/$triggerName")
+  }
+
+  it should "create a trigger with the proper parameter and annotation escapes" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "triggerEscapes"
+
+      assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+        trigger.create(name, parameters = getEscapedJSONTestArgInput, annotations = getEscapedJSONTestArgInput)
+      }
+
+      val stdout = wsk.trigger.get(name).stdout
+      assert(stdout.startsWith(s"ok: got trigger $name\n"))
+
+      val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
+      val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
+      val escapedJSONArr = getEscapedJSONTestArgOutput.convertTo[JsArray].elements
+
+      for (expectedItem <- escapedJSONArr) {
+        receivedParams should contain(expectedItem)
+        receivedAnnots should contain(expectedItem)
+      }
+  }
+
+  it should "not create a trigger when feed fails to initialize" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    assetHelper.withCleaner(wsk.trigger, "badfeed", confirmDelete = false) { (trigger, name) =>
+      trigger.create(name, feed = Some(s"bogus"), expectedExitCode = ANY_ERROR_EXIT).exitCode should equal(NOT_FOUND)
+      trigger.get(name, expectedExitCode = NOT_FOUND)
+
+      trigger.create(name, feed = Some(s"bogus/feed"), expectedExitCode = ANY_ERROR_EXIT).exitCode should equal(
+        NOT_FOUND)
+      trigger.get(name, expectedExitCode = NOT_FOUND)
+    }
+  }
+
+  it should "denote bound trigger parameters for trigger summaries" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val trgBoundParams = "trgBoundParams"
+    val trgParamAnnot = "trgParamAnnot"
+    val trgParamOverlap = "trgParamOverlap"
+    val trgParamBound = "trgParamBound"
+    val trgAnnots = Map(
+      "parameters" -> JsArray(
+        JsObject("name" -> JsString(trgParamAnnot), "description" -> JsString("Annotated")),
+        JsObject("name" -> JsString(trgParamOverlap), "description" -> JsString("Annotated And Bound"))))
+    val trgParamsBound = Map(trgParamBound -> JsString("Bound"), trgParamOverlap -> JsString("Bound And Annotated"))
+
+    assetHelper.withCleaner(wsk.trigger, trgBoundParams) { (trigger, _) =>
+      trigger.create(trgBoundParams, annotations = trgAnnots, parameters = trgParamsBound)
+    }
+
+    val trgStdoutBound = wsk.trigger.get(trgBoundParams, summary = true).stdout
+
+    trgStdoutBound should include(s"(parameters: $trgParamAnnot, *$trgParamBound, *$trgParamOverlap)")
+  }
+
+  it should "create, and get a trigger summary without a description and/or parameters" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val trgNoDesc = "trgNoDesc"
+      val trgNoParams = "trgNoParams"
+      val trgNoDescOrParams = "trgNoDescOrParams"
+      val trgDesc = "Package description"
+      val descFromParams = "Returns a result based on parameters"
+      val namespace = wsk.namespace.whois()
+      val qualtrgNoDesc = s"/${namespace}/${trgNoDesc}"
+      val qualtrgNoParams = s"/${namespace}/${trgNoParams}"
+      val qualtrgNoDescOrParams = s"/${namespace}/${trgNoDescOrParams}"
+
+      val trgAnnotsNoParams = Map("description" -> JsString(trgDesc))
+      val trgAnnotsNoDesc = Map(
+        "parameters" -> JsArray(
+          JsObject("name" -> JsString("paramName1"), "description" -> JsString("Parameter description 1")),
+          JsObject("name" -> JsString("paramName2"), "description" -> JsString("Parameter description 2"))))
+
+      assetHelper.withCleaner(wsk.trigger, trgNoDesc) { (trigger, _) =>
+        trigger.create(trgNoDesc, annotations = trgAnnotsNoDesc)
+      }
+      assetHelper.withCleaner(wsk.trigger, trgNoParams) { (trigger, _) =>
+        trigger.create(trgNoParams, annotations = trgAnnotsNoParams)
+      }
+      assetHelper.withCleaner(wsk.trigger, trgNoDescOrParams) { (trigger, _) =>
+        trigger.create(trgNoDescOrParams)
+      }
+
+      val stdoutNoDescPkg = wsk.trigger.get(trgNoDesc, summary = true).stdout
+      val stdoutNoParamsPkg = wsk.trigger.get(trgNoParams, summary = true).stdout
+      val stdoutNoDescOrParams = wsk.trigger.get(trgNoDescOrParams, summary = true).stdout
+
+      stdoutNoDescPkg should include regex (s"(?i)trigger ${qualtrgNoDesc}: ${descFromParams} paramName1 and paramName2\\s*\\(parameters: paramName1, paramName2\\)")
+      stdoutNoParamsPkg should include regex (s"(?i)trigger ${qualtrgNoParams}: ${trgDesc}\\s*\\(parameters: none defined\\)")
+      stdoutNoDescOrParams should include regex (s"(?i)trigger ${qualtrgNoDescOrParams}\\s*\\(parameters: none defined\\)")
+  }
+
+  behavior of "Wsk entity list formatting"
+
+  it should "create, and list a package with a long name" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "x" * 70
+    assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
+      pkg.create(name)
+    }
+    retry({
+      wsk.pkg.list().stdout should include(s"$name private")
+    }, 5, Some(1 second))
+  }
+
+  it should "create, and list an action with a long name" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "x" * 70
+    val file = Some(TestUtils.getTestActionFilename("hello.js"))
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, file)
+    }
+    retry({
+      wsk.action.list().stdout should include(s"$name private nodejs")
+    }, 5, Some(1 second))
+  }
+
+  it should "create, and list a trigger with a long name" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "x" * 70
+    assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+      trigger.create(name)
+    }
+    retry({
+      wsk.trigger.list().stdout should include(s"$name private")
+    }, 5, Some(1 second))
+  }
+
+  it should "create, and list a rule with a long name" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val ruleName = "x" * 70
+    val triggerName = "listRulesTrigger"
+    val actionName = "listRulesAction";
+    assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
+      trigger.create(name)
+    }
+    assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
+      action.create(name, defaultAction)
+    }
+    assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
+      rule.create(name, trigger = triggerName, action = actionName)
+    }
+    retry({
+      wsk.rule.list().stdout should include(s"$ruleName private")
+    }, 5, Some(1 second))
+  }
+
+  it should "return a list of alphabetized actions" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    // Declare 4 actions, create them out of alphabetical order
+    val actionName = "actionAlphaTest"
+    for (i <- 1 to 3) {
+      val name = s"$actionName$i"
+      assetHelper.withCleaner(wsk.action, name) { (action, name) =>
+        action.create(name, defaultAction)
+      }
+    }
+    retry({
+      val original = wsk.action.list(nameSort = Some(true)).stdout
+      // Create list with action names in correct order
+      val scalaSorted = List(s"${actionName}1", s"${actionName}2", s"${actionName}3")
+      // Filter out everything not previously created
+      val regex = s"${actionName}[1-3]".r
+      // Retrieve action names into list as found in original
+      val list = (regex.findAllMatchIn(original)).toList
+      scalaSorted.toString shouldEqual list.toString
+    }, 5, Some(1 second))
+  }
+
+  it should "return an alphabetized list with default package actions on top" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      // Declare 4 actions, create them out of alphabetical order
+      val actionName = "actionPackageAlphaTest"
+      val packageName = "packageAlphaTest"
+      assetHelper.withCleaner(wsk.action, actionName) { (action, actionName) =>
+        action.create(actionName, defaultAction)
+      }
+      assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, packageName) =>
+        pkg.create(packageName)
+      }
+      for (i <- 1 to 3) {
+        val name = s"${packageName}/${actionName}$i"
+        assetHelper.withCleaner(wsk.action, name) { (action, name) =>
+          action.create(name, defaultAction)
+        }
+      }
+      retry(
+        {
+          val original = wsk.action.list(nameSort = Some(true)).stdout
+          // Create list with action names in correct order
+          val scalaSorted = List(
+            s"$actionName",
+            s"${packageName}/${actionName}1",
+            s"${packageName}/${actionName}2",
+            s"${packageName}/${actionName}3")
+          // Filter out everything not previously created
+          val regexNoPackage = s"$actionName".r
+          val regexWithPackage = s"${packageName}/${actionName}[1-3]".r
+          // Retrieve action names into list as found in original
+          val list = regexNoPackage.findFirstIn(original).get :: (regexWithPackage.findAllMatchIn(original)).toList
+          scalaSorted.toString shouldEqual list.toString
+        },
+        5,
+        Some(1 second))
+  }
+
+  it should "return a list of alphabetized packages" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    // Declare 3 packages, create them out of alphabetical order
+    val packageName = "pkgAlphaTest"
+    for (i <- 1 to 3) {
+      val name = s"$packageName$i"
+      assetHelper.withCleaner(wsk.pkg, name) { (pkg, name) =>
+        pkg.create(name)
+      }
+    }
+    retry({
+      val original = wsk.pkg.list(nameSort = Some(true)).stdout
+      // Create list with package names in correct order
+      val scalaSorted = List(s"${packageName}1", s"${packageName}2", s"${packageName}3")
+      // Filter out everything not previously created
+      val regex = s"${packageName}[1-3]".r
+      // Retrieve package names into list as found in original
+      val list = (regex.findAllMatchIn(original)).toList
+      scalaSorted.toString shouldEqual list.toString
+    }, 5, Some(1 second))
+  }
+
+  it should "return a list of alphabetized triggers" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    // Declare 4 triggers, create them out of alphabetical order
+    val triggerName = "triggerAlphaTest"
+    for (i <- 1 to 3) {
+      val name = s"$triggerName$i"
+      assetHelper.withCleaner(wsk.trigger, name) { (trigger, name) =>
+        trigger.create(name)
+      }
+    }
+    retry({
+      val original = wsk.trigger.list(nameSort = Some(true)).stdout
+      // Create list with trigger names in correct order
+      val scalaSorted = List(s"${triggerName}1", s"${triggerName}2", s"${triggerName}3")
+      // Filter out everything not previously created
+      val regex = s"${triggerName}[1-3]".r
+      // Retrieve trigger names into list as found in original
+      val list = (regex.findAllMatchIn(original)).toList
+      scalaSorted.toString shouldEqual list.toString
+    }, 5, Some(1 second))
+  }
+
+  it should "return a list of alphabetized rules" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    // Declare a trigger and an action for the purposes of creating rules
+    val triggerName = "listRulesTrigger"
+    val actionName = "listRulesAction"
+
+    assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
+      trigger.create(name)
+    }
+    assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
+      action.create(name, defaultAction)
+    }
+    // Declare 3 rules, create them out of alphabetical order
+    val ruleName = "ruleAlphaTest"
+    for (i <- 1 to 3) {
+      val name = s"$ruleName$i"
+      assetHelper.withCleaner(wsk.rule, name) { (rule, name) =>
+        rule.create(name, trigger = triggerName, action = actionName)
+      }
+    }
+    retry({
+      val original = wsk.rule.list(nameSort = Some(true)).stdout
+      // Create list with rule names in correct order
+      val scalaSorted = List(s"${ruleName}1", s"${ruleName}2", s"${ruleName}3")
+      // Filter out everything not previously created
+      val regex = s"${ruleName}[1-3]".r
+      // Retrieve rule names into list as found in original
+      val list = (regex.findAllMatchIn(original)).toList
+      scalaSorted.toString shouldEqual list.toString
+    })
+  }
+
+  behavior of "Wsk params and annotations"
+
+  it should "reject commands that are executed with invalid JSON for annotations and parameters" in {
+    val invalidJSONInputs = getInvalidJSONInput
+    val invalidJSONFiles = Seq(
+      TestUtils.getTestActionFilename("malformed.js"),
+      TestUtils.getTestActionFilename("invalidInput1.json"),
+      TestUtils.getTestActionFilename("invalidInput2.json"),
+      TestUtils.getTestActionFilename("invalidInput3.json"),
+      TestUtils.getTestActionFilename("invalidInput4.json"))
+    val paramCmds = Seq(
+      Seq("action", "create", "actionName", TestUtils.getTestActionFilename("hello.js")),
+      Seq("action", "update", "actionName", TestUtils.getTestActionFilename("hello.js")),
+      Seq("action", "invoke", "actionName"),
+      Seq("package", "create", "packageName"),
+      Seq("package", "update", "packageName"),
+      Seq("package", "bind", "packageName", "boundPackageName"),
+      Seq("trigger", "create", "triggerName"),
+      Seq("trigger", "update", "triggerName"),
+      Seq("trigger", "fire", "triggerName"))
+    val annotCmds = Seq(
+      Seq("action", "create", "actionName", TestUtils.getTestActionFilename("hello.js")),
+      Seq("action", "update", "actionName", TestUtils.getTestActionFilename("hello.js")),
+      Seq("package", "create", "packageName"),
+      Seq("package", "update", "packageName"),
+      Seq("package", "bind", "packageName", "boundPackageName"),
+      Seq("trigger", "create", "triggerName"),
+      Seq("trigger", "update", "triggerName"))
+
+    for (cmd <- paramCmds) {
+      for (invalid <- invalidJSONInputs) {
+        wsk
+          .cli(cmd ++ Seq("-p", "key", invalid) ++ wskprops.overrides, expectedExitCode = ERROR_EXIT)
+          .stderr should include("Invalid parameter argument")
+      }
+
+      for (invalid <- invalidJSONFiles) {
+        wsk.cli(cmd ++ Seq("-P", invalid) ++ wskprops.overrides, expectedExitCode = ERROR_EXIT).stderr should include(
+          "Invalid parameter argument")
+
+      }
+    }
+
+    for (cmd <- annotCmds) {
+      for (invalid <- invalidJSONInputs) {
+        wsk
+          .cli(cmd ++ Seq("-a", "key", invalid) ++ wskprops.overrides, expectedExitCode = ERROR_EXIT)
+          .stderr should include("Invalid annotation argument")
+      }
+
+      for (invalid <- invalidJSONFiles) {
+        wsk.cli(cmd ++ Seq("-A", invalid) ++ wskprops.overrides, expectedExitCode = ERROR_EXIT).stderr should include(
+          "Invalid annotation argument")
+      }
+    }
+  }
+
+  it should "reject commands that are executed with a missing or invalid parameter or annotation file" in {
+    val emptyFile = TestUtils.getTestActionFilename("emtpy.js")
+    val missingFile = "notafile"
+    val emptyFileMsg = s"File '$emptyFile' is not a valid file or it does not exist"
+    val missingFileMsg = s"File '$missingFile' is not a valid file or it does not exist"
+    val invalidArgs = Seq(
+      (
+        Seq("action", "create", "actionName", TestUtils.getTestActionFilename("hello.js"), "-P", emptyFile),
+        emptyFileMsg),
+      (
+        Seq("action", "update", "actionName", TestUtils.getTestActionFilename("hello.js"), "-P", emptyFile),
+        emptyFileMsg),
+      (Seq("action", "invoke", "actionName", "-P", emptyFile), emptyFileMsg),
+      (Seq("action", "create", "actionName", "-P", emptyFile), emptyFileMsg),
+      (Seq("action", "update", "actionName", "-P", emptyFile), emptyFileMsg),
+      (Seq("action", "invoke", "actionName", "-P", emptyFile), emptyFileMsg),
+      (Seq("package", "create", "packageName", "-P", emptyFile), emptyFileMsg),
+      (Seq("package", "update", "packageName", "-P", emptyFile), emptyFileMsg),
+      (Seq("package", "bind", "packageName", "boundPackageName", "-P", emptyFile), emptyFileMsg),
+      (Seq("package", "create", "packageName", "-P", emptyFile), emptyFileMsg),
+      (Seq("package", "update", "packageName", "-P", emptyFile), emptyFileMsg),
+      (Seq("package", "bind", "packageName", "boundPackageName", "-P", emptyFile), emptyFileMsg),
+      (Seq("trigger", "create", "triggerName", "-P", emptyFile), emptyFileMsg),
+      (Seq("trigger", "update", "triggerName", "-P", emptyFile), emptyFileMsg),
+      (Seq("trigger", "fire", "triggerName", "-P", emptyFile), emptyFileMsg),
+      (Seq("trigger", "create", "triggerName", "-P", emptyFile), emptyFileMsg),
+      (Seq("trigger", "update", "triggerName", "-P", emptyFile), emptyFileMsg),
+      (Seq("trigger", "fire", "triggerName", "-P", emptyFile), emptyFileMsg),
+      (
+        Seq("action", "create", "actionName", TestUtils.getTestActionFilename("hello.js"), "-A", missingFile),
+        missingFileMsg),
+      (
+        Seq("action", "update", "actionName", TestUtils.getTestActionFilename("hello.js"), "-A", missingFile),
+        missingFileMsg),
+      (Seq("action", "invoke", "actionName", "-A", missingFile), missingFileMsg),
+      (Seq("action", "create", "actionName", "-A", missingFile), missingFileMsg),
+      (Seq("action", "update", "actionName", "-A", missingFile), missingFileMsg),
+      (Seq("action", "invoke", "actionName", "-A", missingFile), missingFileMsg),
+      (Seq("package", "create", "packageName", "-A", missingFile), missingFileMsg),
+      (Seq("package", "update", "packageName", "-A", missingFile), missingFileMsg),
+      (Seq("package", "bind", "packageName", "boundPackageName", "-A", missingFile), missingFileMsg),
+      (Seq("package", "create", "packageName", "-A", missingFile), missingFileMsg),
+      (Seq("package", "update", "packageName", "-A", missingFile), missingFileMsg),
+      (Seq("package", "bind", "packageName", "boundPackageName", "-A", missingFile), missingFileMsg),
+      (Seq("trigger", "create", "triggerName", "-A", missingFile), missingFileMsg),
+      (Seq("trigger", "update", "triggerName", "-A", missingFile), missingFileMsg),
+      (Seq("trigger", "fire", "triggerName", "-A", missingFile), missingFileMsg),
+      (Seq("trigger", "create", "triggerName", "-A", missingFile), missingFileMsg),
+      (Seq("trigger", "update", "triggerName", "-A", missingFile), missingFileMsg),
+      (Seq("trigger", "fire", "triggerName", "-A", missingFile), missingFileMsg))
+
+    invalidArgs foreach {
+      case (cmd, err) =>
+        val stderr = wsk.cli(cmd, expectedExitCode = MISUSE_EXIT).stderr
+        stderr should include(err)
+        stderr should include("Run 'wsk --help' for usage.")
+    }
+  }
+
+  it should "reject commands that are executed with not enough param or annot arguments" in {
+    val invalidParamMsg = "Arguments for '-p' must be a key/value pair"
+    val invalidAnnotMsg = "Arguments for '-a' must be a key/value pair"
+    val invalidParamFileMsg = "An argument must be provided for '-P'"
+    val invalidAnnotFileMsg = "An argument must be provided for '-A'"
+    val invalidArgs = Seq(
+      (Seq("action", "create", "actionName", "-p"), invalidParamMsg),
+      (Seq("action", "create", "actionName", "-p", "key"), invalidParamMsg),
+      (Seq("action", "create", "actionName", "-P"), invalidParamFileMsg),
+      (Seq("action", "update", "actionName", "-p"), invalidParamMsg),
+      (Seq("action", "update", "actionName", "-p", "key"), invalidParamMsg),
+      (Seq("action", "update", "actionName", "-P"), invalidParamFileMsg),
+      (Seq("action", "invoke", "actionName", "-p"), invalidParamMsg),
+      (Seq("action", "invoke", "actionName", "-p", "key"), invalidParamMsg),
+      (Seq("action", "invoke", "actionName", "-P"), invalidParamFileMsg),
+      (Seq("action", "create", "actionName", "-a"), invalidAnnotMsg),
+      (Seq("action", "create", "actionName", "-a", "key"), invalidAnnotMsg),
+      (Seq("action", "create", "actionName", "-A"), invalidAnnotFileMsg),
+      (Seq("action", "update", "actionName", "-a"), invalidAnnotMsg),
+      (Seq("action", "update", "actionName", "-a", "key"), invalidAnnotMsg),
+      (Seq("action", "update", "actionName", "-A"), invalidAnnotFileMsg),
+      (Seq("action", "invoke", "actionName", "-a"), invalidAnnotMsg),
+      (Seq("action", "invoke", "actionName", "-a", "key"), invalidAnnotMsg),
+      (Seq("action", "invoke", "actionName", "-A"), invalidAnnotFileMsg),
+      (Seq("package", "create", "packageName", "-p"), invalidParamMsg),
+      (Seq("package", "create", "packageName", "-p", "key"), invalidParamMsg),
+      (Seq("package", "create", "packageName", "-P"), invalidParamFileMsg),
+      (Seq("package", "update", "packageName", "-p"), invalidParamMsg),
+      (Seq("package", "update", "packageName", "-p", "key"), invalidParamMsg),
+      (Seq("package", "update", "packageName", "-P"), invalidParamFileMsg),
+      (Seq("package", "bind", "packageName", "boundPackageName", "-p"), invalidParamMsg),
+      (Seq("package", "bind", "packageName", "boundPackageName", "-p", "key"), invalidParamMsg),
+      (Seq("package", "bind", "packageName", "boundPackageName", "-P"), invalidParamFileMsg),
+      (Seq("package", "create", "packageName", "-a"), invalidAnnotMsg),
+      (Seq("package", "create", "packageName", "-a", "key"), invalidAnnotMsg),
+      (Seq("package", "create", "packageName", "-A"), invalidAnnotFileMsg),
+      (Seq("package", "update", "packageName", "-a"), invalidAnnotMsg),
+      (Seq("package", "update", "packageName", "-a", "key"), invalidAnnotMsg),
+      (Seq("package", "update", "packageName", "-A"), invalidAnnotFileMsg),
+      (Seq("package", "bind", "packageName", "boundPackageName", "-a"), invalidAnnotMsg),
+      (Seq("package", "bind", "packageName", "boundPackageName", "-a", "key"), invalidAnnotMsg),
+      (Seq("package", "bind", "packageName", "boundPackageName", "-A"), invalidAnnotFileMsg),
+      (Seq("trigger", "create", "triggerName", "-p"), invalidParamMsg),
+      (Seq("trigger", "create", "triggerName", "-p", "key"), invalidParamMsg),
+      (Seq("trigger", "create", "triggerName", "-P"), invalidParamFileMsg),
+      (Seq("trigger", "update", "triggerName", "-p"), invalidParamMsg),
+      (Seq("trigger", "update", "triggerName", "-p", "key"), invalidParamMsg),
+      (Seq("trigger", "update", "triggerName", "-P"), invalidParamFileMsg),
+      (Seq("trigger", "fire", "triggerName", "-p"), invalidParamMsg),
+      (Seq("trigger", "fire", "triggerName", "-p", "key"), invalidParamMsg),
+      (Seq("trigger", "fire", "triggerName", "-P"), invalidParamFileMsg),
+      (Seq("trigger", "create", "triggerName", "-a"), invalidAnnotMsg),
+      (Seq("trigger", "create", "triggerName", "-a", "key"), invalidAnnotMsg),
+      (Seq("trigger", "create", "triggerName", "-A"), invalidAnnotFileMsg),
+      (Seq("trigger", "update", "triggerName", "-a"), invalidAnnotMsg),
+      (Seq("trigger", "update", "triggerName", "-a", "key"), invalidAnnotMsg),
+      (Seq("trigger", "update", "triggerName", "-A"), invalidAnnotFileMsg),
+      (Seq("trigger", "fire", "triggerName", "-a"), invalidAnnotMsg),
+      (Seq("trigger", "fire", "triggerName", "-a", "key"), invalidAnnotMsg),
+      (Seq("trigger", "fire", "triggerName", "-A"), invalidAnnotFileMsg))
+
+    invalidArgs foreach {
+      case (cmd, err) =>
+        val stderr = wsk.cli(cmd, expectedExitCode = ERROR_EXIT).stderr
+        stderr should include(err)
+        stderr should include("Run 'wsk --help' for usage.")
+    }
+  }
+
+  behavior of "Wsk invalid argument handling"
+
+  it should "reject commands that are executed with invalid arguments" in {
+    val invalidArgsMsg = "error: Invalid argument(s)"
+    val tooFewArgsMsg = invalidArgsMsg + "."
+    val tooManyArgsMsg = invalidArgsMsg + ": "
+    val actionNameActionReqMsg = "An action name and code artifact are required."
+    val actionNameReqMsg = "An action name is required."
+    val actionOptMsg = "A code artifact is optional."
+    val packageNameReqMsg = "A package name is required."
+    val packageNameBindingReqMsg = "A package name and binding name are required."
+    val ruleNameReqMsg = "A rule name is required."
+    val ruleTriggerActionReqMsg = "A rule, trigger and action name are required."
+    val activationIdReq = "An activation ID is required."
+    val triggerNameReqMsg = "A trigger name is required."
+    val optNamespaceMsg = "An optional namespace is the only valid argument."
+    val optPayloadMsg = "A payload is optional."
+    val noArgsReqMsg = "No arguments are required."
+    val invalidArg = "invalidArg"
+    val apiCreateReqMsg =
+      "Specify a swagger file or specify an API base path with an API path, an API verb, and an action name."
+    val apiGetReqMsg = "An API base path or API name is required."
+    val apiDeleteReqMsg =
+      "An API base path or API name is required.  An optional API relative path and operation may also be provided."
+    val apiListReqMsg = "Optional parameters are: API base path (or API name), API relative path and operation."
+    val invalidShared = s"Cannot use value '$invalidArg' for shared"
+    val entityNameMsg =
+      s"An entity name, '$invalidArg', was provided instead of a namespace. Valid namespaces are of the following format: /NAMESPACE."
+    val invalidArgs = Seq(
+      (Seq("api", "create"), s"${tooFewArgsMsg} ${apiCreateReqMsg}"),
+      (
+        Seq("api", "create", "/basepath", "/path", "GET", "action", invalidArg),
+        s"${tooManyArgsMsg}${invalidArg}. ${apiCreateReqMsg}"),
+      (Seq("api", "get"), s"${tooFewArgsMsg} ${apiGetReqMsg}"),
+      (Seq("api", "get", "/basepath", invalidArg), s"${tooManyArgsMsg}${invalidArg}. ${apiGetReqMsg}"),
+      (Seq("api", "delete"), s"${tooFewArgsMsg} ${apiDeleteReqMsg}"),
+      (
+        Seq("api", "delete", "/basepath", "/path", "GET", invalidArg),
+        s"${tooManyArgsMsg}${invalidArg}. ${apiDeleteReqMsg}"),
+      (
+        Seq("api", "list", "/basepath", "/path", "GET", invalidArg),
+        s"${tooManyArgsMsg}${invalidArg}. ${apiListReqMsg}"),
+      (Seq("action", "create"), s"${tooFewArgsMsg} ${actionNameActionReqMsg}"),
+      (Seq("action", "create", "someAction"), s"${tooFewArgsMsg} ${actionNameActionReqMsg}"),
+      (Seq("action", "create", "actionName", "artifactName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
+      (Seq("action", "update"), s"${tooFewArgsMsg} ${actionNameReqMsg} ${actionOptMsg}"),
+      (
+        Seq("action", "update", "actionName", "artifactName", invalidArg),
+        s"${tooManyArgsMsg}${invalidArg}. ${actionNameReqMsg} ${actionOptMsg}"),
+      (Seq("action", "delete"), s"${tooFewArgsMsg} ${actionNameReqMsg}"),
+      (Seq("action", "delete", "actionName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
+      (Seq("action", "get"), s"${tooFewArgsMsg} ${actionNameReqMsg}"),
+      (Seq("action", "get", "actionName", "namespace", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
+      (Seq("action", "list", "namespace", invalidArg), s"${tooManyArgsMsg}${invalidArg}. ${optNamespaceMsg}"),
+      (Seq("action", "invoke"), s"${tooFewArgsMsg} ${actionNameReqMsg}"),
+      (Seq("action", "invoke", "actionName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
+      (Seq("activation", "list", "namespace", invalidArg), s"${tooManyArgsMsg}${invalidArg}. ${optNamespaceMsg}"),
+      (Seq("activation", "get"), s"${tooFewArgsMsg} ${activationIdReq}"),
+      (Seq("activation", "get", "activationID", "namespace", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
+      (Seq("activation", "logs"), s"${tooFewArgsMsg} ${activationIdReq}"),
+      (Seq("activation", "logs", "activationID", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
+      (Seq("activation", "result"), s"${tooFewArgsMsg} ${activationIdReq}"),
+      (Seq("activation", "result", "activationID", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
+      (Seq("activation", "poll", "activationID", invalidArg), s"${tooManyArgsMsg}${invalidArg}. ${optNamespaceMsg}"),
+      (Seq("namespace", "list", invalidArg), s"${tooManyArgsMsg}${invalidArg}. ${noArgsReqMsg}"),
+      (Seq("namespace", "get", "namespace", invalidArg), s"${tooManyArgsMsg}${invalidArg}. ${optNamespaceMsg}"),
+      (Seq("package", "create"), s"${tooFewArgsMsg} ${packageNameReqMsg}"),
+      (Seq("package", "create", "packageName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
+      (Seq("package", "create", "packageName", "--shared", invalidArg), invalidShared),
+      (Seq("package", "update"), s"${tooFewArgsMsg} ${packageNameReqMsg}"),
+      (Seq("package", "update", "packageName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
+      (Seq("package", "update", "packageName", "--shared", invalidArg), invalidShared),
+      (Seq("package", "get"), s"${tooFewArgsMsg} ${packageNameReqMsg}"),
+      (Seq("package", "get", "packageName", "namespace", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
+      (Seq("package", "bind"), s"${tooFewArgsMsg} ${packageNameBindingReqMsg}"),
+      (Seq("package", "bind", "packageName"), s"${tooFewArgsMsg} ${packageNameBindingReqMsg}"),
+      (Seq("package", "bind", "packageName", "bindingName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
+      (Seq("package", "list", "namespace", invalidArg), s"${tooManyArgsMsg}${invalidArg}. ${optNamespaceMsg}"),
+      (Seq("package", "list", invalidArg), entityNameMsg),
+      (Seq("package", "delete"), s"${tooFewArgsMsg} ${packageNameReqMsg}"),
+      (Seq("package", "delete", "namespace", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
+      (Seq("package", "refresh", "namespace", invalidArg), s"${tooManyArgsMsg}${invalidArg}. ${optNamespaceMsg}"),
+      (Seq("package", "refresh", invalidArg), entityNameMsg),
+      (Seq("rule", "enable"), s"${tooFewArgsMsg} ${ruleNameReqMsg}"),
+      (Seq("rule", "enable", "ruleName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
+      (Seq("rule", "disable"), s"${tooFewArgsMsg} ${ruleNameReqMsg}"),
+      (Seq("rule", "disable", "ruleName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
+      (Seq("rule", "status"), s"${tooFewArgsMsg} ${ruleNameReqMsg}"),
+      (Seq("rule", "status", "ruleName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
+      (Seq("rule", "create"), s"${tooFewArgsMsg} ${ruleTriggerActionReqMsg}"),
+      (Seq("rule", "create", "ruleName"), s"${tooFewArgsMsg} ${ruleTriggerActionReqMsg}"),
+      (Seq("rule", "create", "ruleName", "triggerName"), s"${tooFewArgsMsg} ${ruleTriggerActionReqMsg}"),
+      (Seq("rule", "create", "ruleName", "triggerName", "actionName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
+      (Seq("rule", "update"), s"${tooFewArgsMsg} ${ruleTriggerActionReqMsg}"),
+      (Seq("rule", "update", "ruleName"), s"${tooFewArgsMsg} ${ruleTriggerActionReqMsg}"),
+      (Seq("rule", "update", "ruleName", "triggerName"), s"${tooFewArgsMsg} ${ruleTriggerActionReqMsg}"),
+      (Seq("rule", "update", "ruleName", "triggerName", "actionName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
+      (Seq("rule", "get"), s"${tooFewArgsMsg} ${ruleNameReqMsg}"),
+      (Seq("rule", "get", "ruleName", "namespace", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
+      (Seq("rule", "delete"), s"${tooFewArgsMsg} ${ruleNameReqMsg}"),
+      (Seq("rule", "delete", "ruleName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
+      (Seq("rule", "list", "namespace", invalidArg), s"${tooManyArgsMsg}${invalidArg}. ${optNamespaceMsg}"),
+      (Seq("rule", "list", invalidArg), entityNameMsg),
+      (Seq("trigger", "fire"), s"${tooFewArgsMsg} ${triggerNameReqMsg} ${optPayloadMsg}"),
+      (
+        Seq("trigger", "fire", "triggerName", "triggerPayload", invalidArg),
+        s"${tooManyArgsMsg}${invalidArg}. ${triggerNameReqMsg} ${optPayloadMsg}"),
+      (Seq("trigger", "create"), s"${tooFewArgsMsg} ${triggerNameReqMsg}"),
+      (Seq("trigger", "create", "triggerName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
+      (Seq("trigger", "update"), s"${tooFewArgsMsg} ${triggerNameReqMsg}"),
+      (Seq("trigger", "update", "triggerName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
+      (Seq("trigger", "get"), s"${tooFewArgsMsg} ${triggerNameReqMsg}"),
+      (Seq("trigger", "get", "triggerName", "namespace", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
+      (Seq("trigger", "delete"), s"${tooFewArgsMsg} ${triggerNameReqMsg}"),
+      (Seq("trigger", "delete", "triggerName", invalidArg), s"${tooManyArgsMsg}${invalidArg}."),
+      (Seq("trigger", "list", "namespace", invalidArg), s"${tooManyArgsMsg}${invalidArg}. ${optNamespaceMsg}"),
+      (Seq("trigger", "list", invalidArg), entityNameMsg))
+
+    invalidArgs foreach {
+      case (cmd, err) =>
+        withClue(cmd) {
+          val rr = wsk.cli(cmd ++ wskprops.overrides, expectedExitCode = ANY_ERROR_EXIT)
+          rr.exitCode should (be(ERROR_EXIT) or be(MISUSE_EXIT))
+          rr.stderr should include(err)
+          rr.stderr should include("Run 'wsk --help' for usage.")
+        }
+    }
+  }
+
+  behavior of "Wsk action parameters"
+
+  it should "create an action with different permutations of limits" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val file = Some(TestUtils.getTestActionFilename("hello.js"))
+
+      def testLimit(timeout: Option[Duration] = None,
+                    memory: Option[ByteSize] = None,
+                    logs: Option[ByteSize] = None,
+                    ec: Int = SUCCESS_EXIT) = {
+        // Limits to assert, standard values if CLI omits certain values
+        val limits = JsObject(
+          "timeout" -> timeout.getOrElse(STD_DURATION).toMillis.toJson,
+          "memory" -> memory.getOrElse(STD_MEMORY).toMB.toInt.toJson,
+          "logs" -> logs.getOrElse(STD_LOGSIZE).toMB.toInt.toJson)
+
+        val name = "ActionLimitTests" + Instant.now.toEpochMilli
+        val createResult = assetHelper.withCleaner(wsk.action, name, confirmDelete = (ec == SUCCESS_EXIT)) {
+          (action, _) =>
+            val result = action.create(
+              name,
+              file,
+              logsize = logs,
+              memory = memory,
+              timeout = timeout,
+              expectedExitCode = DONTCARE_EXIT)
+            withClue(s"create failed for parameters: timeout = $timeout, memory = $memory, logsize = $logs:") {
+              result.exitCode should be(ec)
             }
+            result
+        }
 
-            // Assert for valid permutations that the values are set correctly
-            for {
-                time <- Seq(None, Some(MIN_DURATION), Some(MAX_DURATION))
-                mem <- Seq(None, Some(MIN_MEMORY), Some(MAX_MEMORY))
-                log <- Seq(None, Some(MIN_LOGSIZE), Some(MAX_LOGSIZE))
-            } testLimit(time, mem, log)
+        if (ec == SUCCESS_EXIT) {
+          val JsObject(parsedAction) = wsk.action.get(name).stdout.split("\n").tail.mkString.parseJson.asJsObject
+          parsedAction("limits") shouldBe limits
+        } else {
+          createResult.stderr should include("allowed threshold")
+        }
+      }
 
-            // Assert that invalid permutation are rejected
-            testLimit(Some(0.milliseconds), None, None, BAD_REQUEST)
-            testLimit(Some(100.minutes), None, None, BAD_REQUEST)
-            testLimit(None, Some(0.MB), None, BAD_REQUEST)
-            testLimit(None, Some(32768.MB), None, BAD_REQUEST)
-            testLimit(None, None, Some(32768.MB), BAD_REQUEST)
-    }
+      // Assert for valid permutations that the values are set correctly
+      for {
+        time <- Seq(None, Some(MIN_DURATION), Some(MAX_DURATION))
+        mem <- Seq(None, Some(MIN_MEMORY), Some(MAX_MEMORY))
+        log <- Seq(None, Some(MIN_LOGSIZE), Some(MAX_LOGSIZE))
+      } testLimit(time, mem, log)
+
+      // Assert that invalid permutation are rejected
+      testLimit(Some(0.milliseconds), None, None, BAD_REQUEST)
+      testLimit(Some(100.minutes), None, None, BAD_REQUEST)
+      testLimit(None, Some(0.MB), None, BAD_REQUEST)
+      testLimit(None, Some(32768.MB), None, BAD_REQUEST)
+      testLimit(None, None, Some(32768.MB), BAD_REQUEST)
+  }
 }

--- a/tests/src/test/scala/whisk/core/cli/test/WskConfigTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskConfigTests.scala
@@ -33,229 +33,287 @@ import common.WskProps
 import common.WskTestHelpers
 
 @RunWith(classOf[JUnitRunner])
-class WskConfigTests
-    extends TestHelpers
-    with WskTestHelpers {
+class WskConfigTests extends TestHelpers with WskTestHelpers {
 
-    implicit val wskprops = WskProps()
-    val wsk = new Wsk
+  implicit val wskprops = WskProps()
+  val wsk = new Wsk
 
-    behavior of "Wsk CLI config"
+  behavior of "Wsk CLI config"
 
-    it should "fail to show api build when setting apihost to bogus value" in {
-        val tmpwskprops = File.createTempFile("wskprops", ".tmp")
-        try {
-            val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
-            wsk.cli(Seq("property", "set", "-i", "--apihost", "xxxx.yyyy"), env = env)
-            val rr = wsk.cli(Seq("property", "get", "--apibuild", "-i"), env = env, expectedExitCode = ANY_ERROR_EXIT)
-            rr.stdout should include regex ("""whisk API build\s*Unknown""")
-            rr.stderr should include regex ("Unable to obtain API build information")
-        } finally {
-            tmpwskprops.delete()
-        }
+  it should "fail to show api build when setting apihost to bogus value" in {
+    val tmpwskprops = File.createTempFile("wskprops", ".tmp")
+    try {
+      val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
+      wsk.cli(Seq("property", "set", "-i", "--apihost", "xxxx.yyyy"), env = env)
+      val rr = wsk.cli(Seq("property", "get", "--apibuild", "-i"), env = env, expectedExitCode = ANY_ERROR_EXIT)
+      rr.stdout should include regex ("""whisk API build\s*Unknown""")
+      rr.stderr should include regex ("Unable to obtain API build information")
+    } finally {
+      tmpwskprops.delete()
     }
+  }
 
-    it should "validate default property values" in {
-        val tmpwskprops = File.createTempFile("wskprops", ".tmp")
+  it should "validate default property values" in {
+    val tmpwskprops = File.createTempFile("wskprops", ".tmp")
+    val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
+    val stdout = wsk
+      .cli(Seq("property", "unset", "--auth", "--cert", "--key", "--apihost", "--apiversion", "--namespace"), env = env)
+      .stdout
+    try {
+      stdout should include regex ("ok: whisk auth unset")
+      stdout should include regex ("ok: client cert unset")
+      stdout should include regex ("ok: client key unset")
+      stdout should include regex ("ok: whisk API host unset")
+      stdout should include regex ("ok: whisk API version unset")
+      stdout should include regex ("ok: whisk namespace unset")
+
+      wsk
+        .cli(Seq("property", "get", "--auth"), env = env)
+        .stdout should include regex ("""(?i)whisk auth\s*$""") // default = empty string
+      wsk
+        .cli(Seq("property", "get", "--cert"), env = env)
+        .stdout should include regex ("""(?i)client cert\s*$""") // default = empty string
+      wsk
+        .cli(Seq("property", "get", "--key"), env = env)
+        .stdout should include regex ("""(?i)client key\s*$""") // default = empty string
+      wsk
+        .cli(Seq("property", "get", "--apihost"), env = env)
+        .stdout should include regex ("""(?i)whisk API host\s*$""") // default = empty string
+      wsk
+        .cli(Seq("property", "get", "--namespace"), env = env)
+        .stdout should include regex ("""(?i)whisk namespace\s*_$""") // default = _
+    } finally {
+      tmpwskprops.delete()
+    }
+  }
+
+  it should "reject authenticated command when no auth key is given" in {
+    // override wsk props file in case it exists
+    val tmpwskprops = File.createTempFile("wskprops", ".tmp")
+    val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
+    val stderr = wsk.cli(Seq("list") ++ wskprops.overrides, env = env, expectedExitCode = MISUSE_EXIT).stderr
+    try {
+      stderr should include regex (s"usage[:.]")
+      stderr should include("--auth is required")
+    } finally {
+      tmpwskprops.delete()
+    }
+  }
+
+  it should "reject a command when the API host is not set" in {
+    val tmpwskprops = File.createTempFile("wskprops", ".tmp")
+    try {
+      val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
+      val stderr = wsk.cli(Seq("property", "get", "-i"), env = env, expectedExitCode = ERROR_EXIT).stderr
+      stderr should include("The API host is not valid: An API host must be provided.")
+    } finally {
+      tmpwskprops.delete()
+    }
+  }
+
+  it should "show api build details" in {
+    val tmpProps = File.createTempFile("wskprops", ".tmp")
+    try {
+      val env = Map("WSK_CONFIG_FILE" -> tmpProps.getAbsolutePath())
+      wsk.cli(Seq("property", "set", "-i") ++ wskprops.overrides, env = env)
+      val rr = wsk.cli(Seq("property", "get", "--apibuild", "--apibuildno", "-i"), env = env)
+      rr.stderr should not include ("https:///api/v1: http: no Host in request URL")
+      rr.stdout should not include regex("Cannot determine API build")
+      rr.stdout should include regex ("""(?i)whisk API build\s+201.*""")
+      rr.stdout should include regex ("""(?i)whisk API build number\s+.*""")
+    } finally {
+      tmpProps.delete()
+    }
+  }
+
+  it should "set apihost, auth, and namespace" in {
+    val tmpwskprops = File.createTempFile("wskprops", ".tmp")
+    try {
+      val namespace = wsk.namespace.whois()
+      val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
+      val stdout = wsk
+        .cli(
+          Seq(
+            "property",
+            "set",
+            "-i",
+            "--apihost",
+            wskprops.apihost,
+            "--auth",
+            wskprops.authKey,
+            "--namespace",
+            namespace),
+          env = env)
+        .stdout
+      stdout should include(s"ok: whisk auth set")
+      stdout should include(s"ok: whisk API host set to ${wskprops.apihost}")
+      stdout should include(s"ok: whisk namespace set to ${namespace}")
+    } finally {
+      tmpwskprops.delete()
+    }
+  }
+
+  // If client certificate verification is off, should ingore run below tests.
+  if (!WhiskProperties.getProperty("whisk.ssl.client.verification").equals("off")) {
+    it should "set valid cert key to get expected success result for client certificate verification" in {
+      val tmpwskprops = File.createTempFile("wskprops", ".tmp")
+      try {
+        val namespace = wsk.namespace.list().stdout.trim.split("\n").last
         val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
-        val stdout = wsk.cli(Seq("property", "unset", "--auth", "--cert", "--key", "--apihost", "--apiversion", "--namespace"), env = env).stdout
-        try {
-            stdout should include regex ("ok: whisk auth unset")
-            stdout should include regex ("ok: client cert unset")
-            stdout should include regex ("ok: client key unset")
-            stdout should include regex ("ok: whisk API host unset")
-            stdout should include regex ("ok: whisk API version unset")
-            stdout should include regex ("ok: whisk namespace unset")
-
-            wsk.cli(Seq("property", "get", "--auth"), env = env).
-                    stdout should include regex ("""(?i)whisk auth\s*$""") // default = empty string
-            wsk.cli(Seq("property", "get", "--cert"), env = env).
-                    stdout should include regex ("""(?i)client cert\s*$""") // default = empty string
-            wsk.cli(Seq("property", "get", "--key"), env = env).
-                    stdout should include regex ("""(?i)client key\s*$""") // default = empty string
-            wsk.cli(Seq("property", "get", "--apihost"), env = env).
-                    stdout should include regex ("""(?i)whisk API host\s*$""") // default = empty string
-            wsk.cli(Seq("property", "get", "--namespace"), env = env).
-                    stdout should include regex ("""(?i)whisk namespace\s*_$""") // default = _
-        } finally {
-            tmpwskprops.delete()
-        }
+        // Send request to https://<apihost>/api/v1/namespaces, wsk client passes client certificate to nginx, nginx will
+        // verify it by client ca's openwhisk-client-ca-cert.pem
+        val stdout = wsk
+          .cli(
+            Seq(
+              "property",
+              "set",
+              "-i",
+              "--apihost",
+              wskprops.apihost,
+              "--auth",
+              wskprops.authKey,
+              "--cert",
+              wskprops.cert,
+              "--key",
+              wskprops.key,
+              "--namespace",
+              namespace),
+            env = env)
+          .stdout
+        stdout should include(s"ok: client cert set")
+        stdout should include(s"ok: client key set")
+        stdout should include(s"ok: whisk auth set")
+        stdout should include(s"ok: whisk API host set to ${wskprops.apihost}")
+        stdout should include(s"ok: whisk namespace set to ${namespace}")
+      } finally {
+        tmpwskprops.delete()
+      }
     }
 
-    it should "reject authenticated command when no auth key is given" in {
-        // override wsk props file in case it exists
-        val tmpwskprops = File.createTempFile("wskprops", ".tmp")
+    it should "set invalid cert key to get expected exception result for client certificate verification" in {
+      val tmpwskprops = File.createTempFile("wskprops", ".tmp")
+      try {
+        val namespace = wsk.namespace.list().stdout.trim.split("\n").last
         val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
-        val stderr = wsk.cli(Seq("list") ++ wskprops.overrides, env = env, expectedExitCode = MISUSE_EXIT).stderr
-        try {
-            stderr should include regex (s"usage[:.]")
-            stderr should include("--auth is required")
-        } finally {
-            tmpwskprops.delete()
-        }
+        val thrown = the[Exception] thrownBy wsk.cli(
+          Seq(
+            "property",
+            "set",
+            "-i",
+            "--apihost",
+            wskprops.apihost,
+            "--auth",
+            wskprops.authKey,
+            "--cert",
+            "invalid-cert.pem",
+            "--key",
+            "invalid-key.pem",
+            "--namespace",
+            namespace),
+          env = env)
+        thrown.getMessage should include("cannot validate certificate")
+      } finally {
+        tmpwskprops.delete()
+      }
     }
+  }
 
-    it should "reject a command when the API host is not set" in {
-        val tmpwskprops = File.createTempFile("wskprops", ".tmp")
-        try {
-            val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
-            val stderr = wsk.cli(Seq("property", "get", "-i"), env = env, expectedExitCode = ERROR_EXIT).stderr
-            stderr should include("The API host is not valid: An API host must be provided.")
-        } finally {
-            tmpwskprops.delete()
-        }
+  it should "ensure default namespace is used when a blank namespace is set" in {
+    val tmpwskprops = File.createTempFile("wskprops", ".tmp")
+    try {
+      val writer = new BufferedWriter(new FileWriter(tmpwskprops))
+      writer.write(s"NAMESPACE=")
+      writer.close()
+      val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
+      val stdout = wsk.cli(Seq("property", "get", "-i", "--namespace"), env = env).stdout
+      stdout should include regex ("whisk namespace\\s+_")
+    } finally {
+      tmpwskprops.delete()
     }
+  }
 
-    it should "show api build details" in {
-        val tmpProps = File.createTempFile("wskprops", ".tmp")
-        try {
-            val env = Map("WSK_CONFIG_FILE" -> tmpProps.getAbsolutePath())
-            wsk.cli(Seq("property", "set", "-i") ++ wskprops.overrides, env = env)
-            val rr = wsk.cli(Seq("property", "get", "--apibuild", "--apibuildno", "-i"), env = env)
-            rr.stderr should not include ("https:///api/v1: http: no Host in request URL")
-            rr.stdout should not include regex("Cannot determine API build")
-            rr.stdout should include regex ("""(?i)whisk API build\s+201.*""")
-            rr.stdout should include regex ("""(?i)whisk API build number\s+.*""")
-        } finally {
-            tmpProps.delete()
-        }
+  it should "show api build version using property file" in {
+    val tmpwskprops = File.createTempFile("wskprops", ".tmp")
+    try {
+      val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
+      wsk.cli(Seq("property", "set", "-i") ++ wskprops.overrides, env = env)
+      val stdout = wsk.cli(Seq("property", "get", "--apibuild", "-i"), env = env).stdout
+      stdout should include regex ("""(?i)whisk API build\s+201.*""")
+    } finally {
+      tmpwskprops.delete()
     }
+  }
 
-    it should "set apihost, auth, and namespace" in {
-        val tmpwskprops = File.createTempFile("wskprops", ".tmp")
-        try {
-            val namespace = wsk.namespace.whois()
-            val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
-            val stdout = wsk.cli(Seq("property", "set", "-i",
-                "--apihost", wskprops.apihost,
-                "--auth", wskprops.authKey,
-                "--namespace", namespace),
-                env = env).stdout
-            stdout should include(s"ok: whisk auth set")
-            stdout should include(s"ok: whisk API host set to ${wskprops.apihost}")
-            stdout should include(s"ok: whisk namespace set to ${namespace}")
-        } finally {
-            tmpwskprops.delete()
-        }
+  it should "show api build using http apihost" in {
+    val tmpwskprops = File.createTempFile("wskprops", ".tmp")
+    try {
+      val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
+      val apihost = s"http://${WhiskProperties.getBaseControllerAddress()}"
+      wsk.cli(Seq("property", "set", "--apihost", apihost), env = env)
+      val rr = wsk.cli(Seq("property", "get", "--apibuild", "-i"), env = env)
+      rr.stdout should not include regex("""whisk API build\s*Unknown""")
+      rr.stderr should not include regex("Unable to obtain API build information")
+      rr.stdout should include regex ("""(?i)whisk API build\s+201.*""")
+    } finally {
+      tmpwskprops.delete()
     }
+  }
 
-    // If client certificate verification is off, should ingore run below tests.
-    if (!WhiskProperties.getProperty("whisk.ssl.client.verification").equals("off")) {
-        it should "set valid cert key to get expected success result for client certificate verification" in {
-            val tmpwskprops = File.createTempFile("wskprops", ".tmp")
-            try {
-                val namespace = wsk.namespace.list().stdout.trim.split("\n").last
-                val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
-                // Send request to https://<apihost>/api/v1/namespaces, wsk client passes client certificate to nginx, nginx will
-                // verify it by client ca's openwhisk-client-ca-cert.pem
-                val stdout = wsk.cli(Seq("property", "set", "-i", "--apihost", wskprops.apihost, "--auth", wskprops.authKey,
-                    "--cert", wskprops.cert, "--key", wskprops.key, "--namespace", namespace), env = env).stdout
-                stdout should include(s"ok: client cert set")
-                stdout should include(s"ok: client key set")
-                stdout should include(s"ok: whisk auth set")
-                stdout should include(s"ok: whisk API host set to ${wskprops.apihost}")
-                stdout should include(s"ok: whisk namespace set to ${namespace}")
-            } finally {
-                tmpwskprops.delete()
-            }
-        }
-
-        it should "set invalid cert key to get expected exception result for client certificate verification" in {
-            val tmpwskprops = File.createTempFile("wskprops", ".tmp")
-            try {
-                val namespace = wsk.namespace.list().stdout.trim.split("\n").last
-                val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
-                val thrown = the[Exception] thrownBy wsk.cli(Seq("property", "set", "-i", "--apihost", wskprops.apihost, "--auth", wskprops.authKey,
-                    "--cert", "invalid-cert.pem", "--key", "invalid-key.pem", "--namespace", namespace), env = env)
-                thrown.getMessage should include("cannot validate certificate")
-            } finally {
-                tmpwskprops.delete()
-            }
-        }
+  it should "set auth in property file" in {
+    val tmpwskprops = File.createTempFile("wskprops", ".tmp")
+    val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
+    wsk.cli(Seq("property", "set", "--auth", "testKey"), env = env)
+    try {
+      val fileContent = FileUtils.readFileToString(tmpwskprops)
+      fileContent should include("AUTH=testKey")
+    } finally {
+      tmpwskprops.delete()
     }
+  }
 
-    it should "ensure default namespace is used when a blank namespace is set" in {
-        val tmpwskprops = File.createTempFile("wskprops", ".tmp")
-        try {
-            val writer = new BufferedWriter(new FileWriter(tmpwskprops))
-            writer.write(s"NAMESPACE=")
-            writer.close()
-            val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
-            val stdout = wsk.cli(Seq("property", "get", "-i", "--namespace"), env = env).stdout
-            stdout should include regex ("whisk namespace\\s+_")
-        } finally {
-            tmpwskprops.delete()
-        }
+  it should "set multiple property values with single command" in {
+    val tmpwskprops = File.createTempFile("wskprops", ".tmp")
+    val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
+    val stdout = wsk
+      .cli(
+        Seq(
+          "property",
+          "set",
+          "--auth",
+          "testKey",
+          "--cert",
+          "cert.pem",
+          "--key",
+          "key.pem",
+          "--apihost",
+          "openwhisk.ng.bluemix.net",
+          "--apiversion",
+          "v1"),
+        env = env)
+      .stdout
+    try {
+      stdout should include regex ("ok: whisk auth set")
+      stdout should include regex ("ok: client cert set")
+      stdout should include regex ("ok: client key set")
+      stdout should include regex ("ok: whisk API host set")
+      stdout should include regex ("ok: whisk API version set")
+      val fileContent = FileUtils.readFileToString(tmpwskprops)
+      fileContent should include("AUTH=testKey")
+      fileContent should include("APIHOST=openwhisk.ng.bluemix.net")
+      fileContent should include("APIVERSION=v1")
+    } finally {
+      tmpwskprops.delete()
     }
+  }
 
-    it should "show api build version using property file" in {
-        val tmpwskprops = File.createTempFile("wskprops", ".tmp")
-        try {
-            val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
-            wsk.cli(Seq("property", "set", "-i") ++ wskprops.overrides, env = env)
-            val stdout = wsk.cli(Seq("property", "get", "--apibuild", "-i"), env = env).stdout
-            stdout should include regex ("""(?i)whisk API build\s+201.*""")
-        } finally {
-            tmpwskprops.delete()
-        }
+  it should "create a trigger using property file" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "listTriggers"
+    val tmpProps = File.createTempFile("wskprops", ".tmp")
+    val env = Map("WSK_CONFIG_FILE" -> tmpProps.getAbsolutePath())
+    wsk.cli(Seq("property", "set", "--auth", wp.authKey) ++ wskprops.overrides, env = env)
+    assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+      wsk.cli(Seq("-i", "trigger", "create", name), env = env)
     }
-
-    it should "show api build using http apihost" in {
-        val tmpwskprops = File.createTempFile("wskprops", ".tmp")
-        try {
-            val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
-            val apihost = s"http://${WhiskProperties.getBaseControllerAddress()}"
-            wsk.cli(Seq("property", "set", "--apihost", apihost), env = env)
-            val rr = wsk.cli(Seq("property", "get", "--apibuild", "-i"), env = env)
-            rr.stdout should not include regex("""whisk API build\s*Unknown""")
-            rr.stderr should not include regex("Unable to obtain API build information")
-            rr.stdout should include regex ("""(?i)whisk API build\s+201.*""")
-        } finally {
-            tmpwskprops.delete()
-        }
-    }
-
-    it should "set auth in property file" in {
-        val tmpwskprops = File.createTempFile("wskprops", ".tmp")
-        val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
-        wsk.cli(Seq("property", "set", "--auth", "testKey"), env = env)
-        try {
-            val fileContent = FileUtils.readFileToString(tmpwskprops)
-            fileContent should include("AUTH=testKey")
-        } finally {
-            tmpwskprops.delete()
-        }
-    }
-
-    it should "set multiple property values with single command" in {
-        val tmpwskprops = File.createTempFile("wskprops", ".tmp")
-        val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
-        val stdout = wsk.cli(Seq("property", "set", "--auth", "testKey", "--cert", "cert.pem", "--key", "key.pem", "--apihost", "openwhisk.ng.bluemix.net", "--apiversion", "v1"), env = env).stdout
-        try {
-            stdout should include regex ("ok: whisk auth set")
-            stdout should include regex ("ok: client cert set")
-            stdout should include regex ("ok: client key set")
-            stdout should include regex ("ok: whisk API host set")
-            stdout should include regex ("ok: whisk API version set")
-            val fileContent = FileUtils.readFileToString(tmpwskprops)
-            fileContent should include("AUTH=testKey")
-            fileContent should include("APIHOST=openwhisk.ng.bluemix.net")
-            fileContent should include("APIVERSION=v1")
-        } finally {
-            tmpwskprops.delete()
-        }
-    }
-
-    it should "create a trigger using property file" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "listTriggers"
-            val tmpProps = File.createTempFile("wskprops", ".tmp")
-            val env = Map("WSK_CONFIG_FILE" -> tmpProps.getAbsolutePath())
-            wsk.cli(Seq("property", "set", "--auth", wp.authKey) ++ wskprops.overrides, env = env)
-            assetHelper.withCleaner(wsk.trigger, name) {
-                (trigger, _) =>
-                    wsk.cli(Seq("-i", "trigger", "create", name), env = env)
-            }
-            tmpProps.delete()
-    }
+    tmpProps.delete()
+  }
 }

--- a/tests/src/test/scala/whisk/core/cli/test/WskEntitlementTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskEntitlementTests.scala
@@ -35,326 +35,315 @@ import whisk.core.entity.Subject
 import whisk.core.entity.WhiskPackage
 
 @RunWith(classOf[JUnitRunner])
-class WskEntitlementTests
-    extends TestHelpers
-    with WskTestHelpers
-    with BeforeAndAfterAll {
+class WskEntitlementTests extends TestHelpers with WskTestHelpers with BeforeAndAfterAll {
 
-    val wsk = new Wsk
-    lazy val defaultWskProps = WskProps()
-    lazy val guestWskProps = getAdditionalTestSubject(Subject().asString)
+  val wsk = new Wsk
+  lazy val defaultWskProps = WskProps()
+  lazy val guestWskProps = getAdditionalTestSubject(Subject().asString)
 
-    override def afterAll() = {
-        disposeAdditionalTestSubject(guestWskProps.namespace)
+  override def afterAll() = {
+    disposeAdditionalTestSubject(guestWskProps.namespace)
+  }
+
+  val samplePackage = "samplePackage"
+  val sampleAction = "sampleAction"
+  val fullSampleActionName = s"$samplePackage/$sampleAction"
+  val guestNamespace = guestWskProps.namespace
+
+  behavior of "Wsk Package Entitlement"
+
+  it should "not allow unauthorized subject to operate on private action" in withAssetCleaner(guestWskProps) {
+    (wp, assetHelper) =>
+      val privateAction = "privateAction"
+
+      assetHelper.withCleaner(wsk.action, privateAction) { (action, name) =>
+        action.create(name, Some(TestUtils.getTestActionFilename("hello.js")))(wp)
+      }
+
+      val fullyQualifiedActionName = s"/$guestNamespace/$privateAction"
+      wsk.action.get(fullyQualifiedActionName, expectedExitCode = FORBIDDEN)(defaultWskProps).stderr should include(
+        "not authorized")
+
+      withAssetCleaner(defaultWskProps) { (wp, assetHelper) =>
+        assetHelper.withCleaner(wsk.action, fullyQualifiedActionName, confirmDelete = false) { (action, name) =>
+          val rr = action.create(name, None, update = true, expectedExitCode = FORBIDDEN)(wp)
+          rr.stderr should include("not authorized")
+          rr
+        }
+        assetHelper.withCleaner(wsk.action, "unauthorized sequence", confirmDelete = false) { (action, name) =>
+          val rr = action.create(
+            name,
+            Some(fullyQualifiedActionName),
+            kind = Some("sequence"),
+            update = true,
+            expectedExitCode = FORBIDDEN)(wp)
+          rr.stderr should include("not authorized")
+          rr
+        }
+      }
+
+      wsk.action.delete(fullyQualifiedActionName, expectedExitCode = FORBIDDEN)(defaultWskProps).stderr should include(
+        "not authorized")
+
+      wsk.action.invoke(fullyQualifiedActionName, expectedExitCode = FORBIDDEN)(defaultWskProps).stderr should include(
+        "not authorized")
+  }
+
+  it should "reject deleting action in shared package not owned by authkey" in withAssetCleaner(guestWskProps) {
+    (wp, assetHelper) =>
+      assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
+        pkg.create(samplePackage, shared = Some(true))(wp)
+      }
+
+      assetHelper.withCleaner(wsk.action, fullSampleActionName) {
+        val file = Some(TestUtils.getTestActionFilename("empty.js"))
+        (action, _) =>
+          action.create(fullSampleActionName, file)(wp)
+      }
+
+      val fullyQualifiedActionName = s"/$guestNamespace/$fullSampleActionName"
+      wsk.action.get(fullyQualifiedActionName)(defaultWskProps)
+      wsk.action.delete(fullyQualifiedActionName, expectedExitCode = FORBIDDEN)(defaultWskProps)
+  }
+
+  it should "reject create action in shared package not owned by authkey" in withAssetCleaner(guestWskProps) {
+    (wp, assetHelper) =>
+      assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, name) =>
+        pkg.create(name, shared = Some(true))(wp)
+      }
+
+      val fullyQualifiedActionName = s"/$guestNamespace/notallowed"
+      val file = Some(TestUtils.getTestActionFilename("empty.js"))
+
+      withAssetCleaner(defaultWskProps) { (wp, assetHelper) =>
+        assetHelper.withCleaner(wsk.action, fullyQualifiedActionName, confirmDelete = false) { (action, name) =>
+          action.create(name, file, expectedExitCode = FORBIDDEN)(wp)
+        }
+      }
+  }
+
+  it should "reject update action in shared package not owned by authkey" in withAssetCleaner(guestWskProps) {
+    (wp, assetHelper) =>
+      assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
+        pkg.create(samplePackage, shared = Some(true))(wp)
+      }
+
+      assetHelper.withCleaner(wsk.action, fullSampleActionName) {
+        val file = Some(TestUtils.getTestActionFilename("empty.js"))
+        (action, _) =>
+          action.create(fullSampleActionName, file)(wp)
+      }
+
+      val fullyQualifiedActionName = s"/$guestNamespace/$fullSampleActionName"
+      wsk.action.create(fullyQualifiedActionName, None, update = true, expectedExitCode = FORBIDDEN)(defaultWskProps)
+  }
+
+  behavior of "Wsk Package Listing"
+
+  it should "list shared packages" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+    assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
+      pkg.create(samplePackage, shared = Some(true))(wp)
     }
 
-    val samplePackage = "samplePackage"
-    val sampleAction = "sampleAction"
-    val fullSampleActionName = s"$samplePackage/$sampleAction"
-    val guestNamespace = guestWskProps.namespace
+    val fullyQualifiedPackageName = s"/$guestNamespace/$samplePackage"
+    val result = wsk.pkg.list(Some(s"/$guestNamespace"))(defaultWskProps).stdout
+    result should include regex (fullyQualifiedPackageName + """\s+shared""")
+  }
 
-    behavior of "Wsk Package Entitlement"
-
-    it should "not allow unauthorized subject to operate on private action" in withAssetCleaner(guestWskProps) {
-        (wp, assetHelper) =>
-            val privateAction = "privateAction"
-
-            assetHelper.withCleaner(wsk.action, privateAction) {
-                (action, name) => action.create(name, Some(TestUtils.getTestActionFilename("hello.js")))(wp)
-            }
-
-            val fullyQualifiedActionName = s"/$guestNamespace/$privateAction"
-            wsk.action.get(fullyQualifiedActionName, expectedExitCode = FORBIDDEN)(defaultWskProps).
-                stderr should include("not authorized")
-
-            withAssetCleaner(defaultWskProps) {
-                (wp, assetHelper) =>
-                    assetHelper.withCleaner(wsk.action, fullyQualifiedActionName, confirmDelete = false) {
-                        (action, name) =>
-                            val rr = action.create(name, None, update = true, expectedExitCode = FORBIDDEN)(wp)
-                            rr.stderr should include("not authorized")
-                            rr
-                    }
-                    assetHelper.withCleaner(wsk.action, "unauthorized sequence", confirmDelete = false) {
-                        (action, name) =>
-                            val rr = action.create(name, Some(fullyQualifiedActionName), kind = Some("sequence"), update = true, expectedExitCode = FORBIDDEN)(wp)
-                            rr.stderr should include("not authorized")
-                            rr
-                    }
-            }
-
-            wsk.action.delete(fullyQualifiedActionName, expectedExitCode = FORBIDDEN)(defaultWskProps).
-                stderr should include("not authorized")
-
-            wsk.action.invoke(fullyQualifiedActionName, expectedExitCode = FORBIDDEN)(defaultWskProps).
-                stderr should include("not authorized")
+  it should "not list private packages" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+    assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
+      pkg.create(samplePackage)(wp)
     }
 
-    it should "reject deleting action in shared package not owned by authkey" in withAssetCleaner(guestWskProps) {
-        (wp, assetHelper) =>
-            assetHelper.withCleaner(wsk.pkg, samplePackage) {
-                (pkg, _) => pkg.create(samplePackage, shared = Some(true))(wp)
-            }
+    val fullyQualifiedPackageName = s"/$guestNamespace/$samplePackage"
+    val result = wsk.pkg.list(Some(s"/$guestNamespace"))(defaultWskProps).stdout
+    result should not include regex(fullyQualifiedPackageName)
+  }
 
-            assetHelper.withCleaner(wsk.action, fullSampleActionName) {
-                val file = Some(TestUtils.getTestActionFilename("empty.js"))
-                (action, _) => action.create(fullSampleActionName, file)(wp)
-            }
-
-            val fullyQualifiedActionName = s"/$guestNamespace/$fullSampleActionName"
-            wsk.action.get(fullyQualifiedActionName)(defaultWskProps)
-            wsk.action.delete(fullyQualifiedActionName, expectedExitCode = FORBIDDEN)(defaultWskProps)
+  it should "list shared package actions" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+    assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
+      pkg.create(samplePackage, shared = Some(true))(wp)
     }
 
-    it should "reject create action in shared package not owned by authkey" in withAssetCleaner(guestWskProps) {
-        (wp, assetHelper) =>
-            assetHelper.withCleaner(wsk.pkg, samplePackage) {
-                (pkg, name) => pkg.create(name, shared = Some(true))(wp)
-            }
-
-            val fullyQualifiedActionName = s"/$guestNamespace/notallowed"
-            val file = Some(TestUtils.getTestActionFilename("empty.js"))
-
-            withAssetCleaner(defaultWskProps) {
-                (wp, assetHelper) =>
-                    assetHelper.withCleaner(wsk.action, fullyQualifiedActionName, confirmDelete = false) {
-                        (action, name) => action.create(name, file, expectedExitCode = FORBIDDEN)(wp)
-                    }
-            }
+    assetHelper.withCleaner(wsk.action, fullSampleActionName) {
+      val file = Some(TestUtils.getTestActionFilename("empty.js"))
+      (action, _) =>
+        action.create(fullSampleActionName, file, kind = Some("nodejs:default"))(wp)
     }
 
-    it should "reject update action in shared package not owned by authkey" in withAssetCleaner(guestWskProps) {
-        (wp, assetHelper) =>
-            assetHelper.withCleaner(wsk.pkg, samplePackage) {
-                (pkg, _) => pkg.create(samplePackage, shared = Some(true))(wp)
-            }
+    val fullyQualifiedPackageName = s"/$guestNamespace/$samplePackage"
+    val fullyQualifiedActionName = s"/$guestNamespace/$fullSampleActionName"
+    val result = wsk.action.list(Some(fullyQualifiedPackageName))(defaultWskProps).stdout
+    result should include regex (fullyQualifiedActionName)
+  }
 
-            assetHelper.withCleaner(wsk.action, fullSampleActionName) {
-                val file = Some(TestUtils.getTestActionFilename("empty.js"))
-                (action, _) => action.create(fullSampleActionName, file)(wp)
-            }
+  behavior of "Wsk Package Binding"
 
-            val fullyQualifiedActionName = s"/$guestNamespace/$fullSampleActionName"
-            wsk.action.create(fullyQualifiedActionName, None, update = true, expectedExitCode = FORBIDDEN)(defaultWskProps)
+  it should "create a package binding" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+    assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
+      pkg.create(samplePackage, shared = Some(true))(wp)
     }
 
-    behavior of "Wsk Package Listing"
+    val name = "bindPackage"
+    val annotations = Map("a" -> "A".toJson, WhiskPackage.bindingFieldName -> "xxx".toJson)
+    val provider = s"/$guestNamespace/$samplePackage"
+    withAssetCleaner(defaultWskProps) { (wp, assetHelper) =>
+      assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
+        pkg.bind(provider, name, annotations = annotations)(wp)
+      }
 
-    it should "list shared packages" in withAssetCleaner(guestWskProps) {
-        (wp, assetHelper) =>
-            assetHelper.withCleaner(wsk.pkg, samplePackage) {
-                (pkg, _) => pkg.create(samplePackage, shared = Some(true))(wp)
-            }
+      val stdout = wsk.pkg.get(name)(defaultWskProps).stdout
+      val annotationString = wsk.parseJsonString(stdout).fields("annotations").toString
+      annotationString should include regex (""""key":"a"""")
+      annotationString should include regex (""""value":"A"""")
+      annotationString should include regex (s""""key":"${WhiskPackage.bindingFieldName}"""")
+      annotationString should not include regex(""""key":"xxx"""")
+      annotationString should include regex (s""""name":"${samplePackage}"""")
+    }
+  }
 
-            val fullyQualifiedPackageName = s"/$guestNamespace/$samplePackage"
-            val result = wsk.pkg.list(Some(s"/$guestNamespace"))(defaultWskProps).stdout
-            result should include regex (fullyQualifiedPackageName + """\s+shared""")
+  it should "not create a package binding for private package" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+    assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
+      pkg.create(samplePackage, shared = Some(false))(wp)
     }
 
-    it should "not list private packages" in withAssetCleaner(guestWskProps) {
-        (wp, assetHelper) =>
-            assetHelper.withCleaner(wsk.pkg, samplePackage) {
-                (pkg, _) => pkg.create(samplePackage)(wp)
-            }
+    val name = "bindPackage"
+    val provider = s"/$guestNamespace/$samplePackage"
+    withAssetCleaner(defaultWskProps) { (wp, assetHelper) =>
+      assetHelper.withCleaner(wsk.pkg, name, confirmDelete = false) { (pkg, _) =>
+        pkg.bind(provider, name, expectedExitCode = FORBIDDEN)(wp)
+      }
+    }
+  }
 
-            val fullyQualifiedPackageName = s"/$guestNamespace/$samplePackage"
-            val result = wsk.pkg.list(Some(s"/$guestNamespace"))(defaultWskProps).stdout
-            result should not include regex(fullyQualifiedPackageName)
+  behavior of "Wsk Package Action"
+
+  it should "get and invoke an action from package" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+    assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
+      pkg.create(samplePackage, parameters = Map("a" -> "A".toJson), shared = Some(true))(wp)
     }
 
-    it should "list shared package actions" in withAssetCleaner(guestWskProps) {
-        (wp, assetHelper) =>
-            assetHelper.withCleaner(wsk.pkg, samplePackage) {
-                (pkg, _) => pkg.create(samplePackage, shared = Some(true))(wp)
-            }
-
-            assetHelper.withCleaner(wsk.action, fullSampleActionName) {
-                val file = Some(TestUtils.getTestActionFilename("empty.js"))
-                (action, _) => action.create(fullSampleActionName, file, kind = Some("nodejs:default"))(wp)
-            }
-
-            val fullyQualifiedPackageName = s"/$guestNamespace/$samplePackage"
-            val fullyQualifiedActionName = s"/$guestNamespace/$fullSampleActionName"
-            val result = wsk.action.list(Some(fullyQualifiedPackageName))(defaultWskProps).stdout
-            result should include regex (fullyQualifiedActionName)
+    assetHelper.withCleaner(wsk.action, fullSampleActionName) {
+      val file = Some(TestUtils.getTestActionFilename("hello.js"))
+      (action, _) =>
+        action.create(fullSampleActionName, file)(wp)
     }
 
-    behavior of "Wsk Package Binding"
+    val fullyQualifiedActionName = s"/$guestNamespace/$fullSampleActionName"
+    val stdout = wsk.action.get(fullyQualifiedActionName)(defaultWskProps).stdout
+    stdout should include("name")
+    stdout should include("parameters")
+    stdout should include("limits")
+    stdout should include regex (""""key": "a"""")
+    stdout should include regex (""""value": "A"""")
 
-    it should "create a package binding" in withAssetCleaner(guestWskProps) {
-        (wp, assetHelper) =>
-            assetHelper.withCleaner(wsk.pkg, samplePackage) {
-                (pkg, _) => pkg.create(samplePackage, shared = Some(true))(wp)
-            }
+    val run = wsk.action.invoke(fullyQualifiedActionName)(defaultWskProps)
 
-            val name = "bindPackage"
-            val annotations = Map("a" -> "A".toJson, WhiskPackage.bindingFieldName -> "xxx".toJson)
-            val provider = s"/$guestNamespace/$samplePackage"
-            withAssetCleaner(defaultWskProps) {
-                (wp, assetHelper) =>
-                    assetHelper.withCleaner(wsk.pkg, name) {
-                        (pkg, _) => pkg.bind(provider, name, annotations = annotations)(wp)
-                    }
+    withActivation(wsk.activation, run)({
+      _.response.success shouldBe true
+    })(defaultWskProps)
+  }
 
-                    val stdout = wsk.pkg.get(name)(defaultWskProps).stdout
-                    val annotationString = wsk.parseJsonString(stdout).fields("annotations").toString
-                    annotationString should include regex (""""key":"a"""")
-                    annotationString should include regex (""""value":"A"""")
-                    annotationString should include regex (s""""key":"${WhiskPackage.bindingFieldName}"""")
-                    annotationString should not include regex(""""key":"xxx"""")
-                    annotationString should include regex (s""""name":"${samplePackage}"""")
-            }
+  it should "invoke an action sequence from package" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+    assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
+      pkg.create(samplePackage, parameters = Map("a" -> "A".toJson), shared = Some(true))(wp)
     }
 
-    it should "not create a package binding for private package" in withAssetCleaner(guestWskProps) {
-        (wp, assetHelper) =>
-            assetHelper.withCleaner(wsk.pkg, samplePackage) {
-                (pkg, _) => pkg.create(samplePackage, shared = Some(false))(wp)
-            }
-
-            val name = "bindPackage"
-            val provider = s"/$guestNamespace/$samplePackage"
-            withAssetCleaner(defaultWskProps) {
-                (wp, assetHelper) =>
-                    assetHelper.withCleaner(wsk.pkg, name, confirmDelete = false) {
-                        (pkg, _) => pkg.bind(provider, name, expectedExitCode = FORBIDDEN)(wp)
-                    }
-            }
+    assetHelper.withCleaner(wsk.action, fullSampleActionName) {
+      val file = Some(TestUtils.getTestActionFilename("hello.js"))
+      (action, _) =>
+        action.create(fullSampleActionName, file)(wp)
     }
 
-    behavior of "Wsk Package Action"
+    withAssetCleaner(defaultWskProps) { (wp, assetHelper) =>
+      assetHelper.withCleaner(wsk.action, "sequence") { (action, name) =>
+        val fullyQualifiedActionName = s"/$guestNamespace/$fullSampleActionName"
+        action.create(name, Some(fullyQualifiedActionName), kind = Some("sequence"), update = true)(wp)
+      }
 
-    it should "get and invoke an action from package" in withAssetCleaner(guestWskProps) {
-        (wp, assetHelper) =>
-            assetHelper.withCleaner(wsk.pkg, samplePackage) {
-                (pkg, _) => pkg.create(samplePackage, parameters = Map("a" -> "A".toJson), shared = Some(true))(wp)
-            }
+      val run = wsk.action.invoke("sequence")(defaultWskProps)
+      withActivation(wsk.activation, run)({
+        _.response.success shouldBe true
+      })(defaultWskProps)
+    }
+  }
 
-            assetHelper.withCleaner(wsk.action, fullSampleActionName) {
-                val file = Some(TestUtils.getTestActionFilename("hello.js"))
-                (action, _) => action.create(fullSampleActionName, file)(wp)
-            }
-
-            val fullyQualifiedActionName = s"/$guestNamespace/$fullSampleActionName"
-            val stdout = wsk.action.get(fullyQualifiedActionName)(defaultWskProps).stdout
-            stdout should include("name")
-            stdout should include("parameters")
-            stdout should include("limits")
-            stdout should include regex (""""key": "a"""")
-            stdout should include regex (""""value": "A"""")
-
-            val run = wsk.action.invoke(fullyQualifiedActionName)(defaultWskProps)
-
-            withActivation(wsk.activation, run)({
-                _.response.success shouldBe true
-            })(defaultWskProps)
+  it should "not allow invoke an action sequence with more than one component from package after entitlement change" in withAssetCleaner(
+    guestWskProps) { (guestwp, assetHelper) =>
+    val privateSamplePackage = samplePackage + "prv"
+    assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
+      pkg.create(samplePackage, parameters = Map("a" -> "A".toJson), shared = Some(true))(guestwp)
+      pkg.create(privateSamplePackage, parameters = Map("a" -> "A".toJson), shared = Some(true))(guestwp)
     }
 
-    it should "invoke an action sequence from package" in withAssetCleaner(guestWskProps) {
-        (wp, assetHelper) =>
-            assetHelper.withCleaner(wsk.pkg, samplePackage) {
-                (pkg, _) => pkg.create(samplePackage, parameters = Map("a" -> "A".toJson), shared = Some(true))(wp)
-            }
-
-            assetHelper.withCleaner(wsk.action, fullSampleActionName) {
-                val file = Some(TestUtils.getTestActionFilename("hello.js"))
-                (action, _) => action.create(fullSampleActionName, file)(wp)
-            }
-
-            withAssetCleaner(defaultWskProps) {
-                (wp, assetHelper) =>
-                    assetHelper.withCleaner(wsk.action, "sequence") {
-                        (action, name) =>
-                            val fullyQualifiedActionName = s"/$guestNamespace/$fullSampleActionName"
-                            action.create(name, Some(fullyQualifiedActionName), kind = Some("sequence"), update = true)(wp)
-                    }
-
-                    val run = wsk.action.invoke("sequence")(defaultWskProps)
-                    withActivation(wsk.activation, run)({
-                        _.response.success shouldBe true
-                    })(defaultWskProps)
-            }
+    assetHelper.withCleaner(wsk.action, fullSampleActionName) {
+      val file = Some(TestUtils.getTestActionFilename("hello.js"))
+      (action, _) =>
+        action.create(fullSampleActionName, file)(guestwp)
+        action.create(s"$privateSamplePackage/$sampleAction", file)(guestwp)
     }
 
-    it should "not allow invoke an action sequence with more than one component from package after entitlement change" in withAssetCleaner(guestWskProps) {
-        (guestwp, assetHelper) =>
-            val privateSamplePackage = samplePackage + "prv"
-            assetHelper.withCleaner(wsk.pkg, samplePackage) {
-                (pkg, _) =>
-                    pkg.create(samplePackage, parameters = Map("a" -> "A".toJson), shared = Some(true))(guestwp)
-                    pkg.create(privateSamplePackage, parameters = Map("a" -> "A".toJson), shared = Some(true))(guestwp)
-            }
+    withAssetCleaner(defaultWskProps) { (dwp, assetHelper) =>
+      assetHelper.withCleaner(wsk.action, "sequence") { (action, name) =>
+        val fullyQualifiedActionName = s"/$guestNamespace/$fullSampleActionName"
+        val fullyQualifiedActionName2 = s"/$guestNamespace/$privateSamplePackage/$sampleAction"
+        action.create(name, Some(s"$fullyQualifiedActionName,$fullyQualifiedActionName2"), kind = Some("sequence"))(dwp)
+      }
 
-            assetHelper.withCleaner(wsk.action, fullSampleActionName) {
-                val file = Some(TestUtils.getTestActionFilename("hello.js"))
-                (action, _) =>
-                    action.create(fullSampleActionName, file)(guestwp)
-                    action.create(s"$privateSamplePackage/$sampleAction", file)(guestwp)
-            }
+      // change package visibility
+      wsk.pkg.create(privateSamplePackage, update = true, shared = Some(false))(guestwp)
+      wsk.action.invoke("sequence", expectedExitCode = FORBIDDEN)(defaultWskProps)
+    }
+  }
 
-            withAssetCleaner(defaultWskProps) {
-                (dwp, assetHelper) =>
-                    assetHelper.withCleaner(wsk.action, "sequence") {
-                        (action, name) =>
-                            val fullyQualifiedActionName = s"/$guestNamespace/$fullSampleActionName"
-                            val fullyQualifiedActionName2 = s"/$guestNamespace/$privateSamplePackage/$sampleAction"
-                            action.create(name, Some(s"$fullyQualifiedActionName,$fullyQualifiedActionName2"),
-                                kind = Some("sequence"))(dwp)
-                    }
+  it should "invoke a packaged action not owned by the subject to get the subject's namespace" in withAssetCleaner(
+    guestWskProps) { (_, assetHelper) =>
+    val packageName = "namespacePackage"
+    val actionName = "namespaceAction"
+    val packagedActionName = s"$packageName/$actionName"
 
-                    // change package visibility
-                    wsk.pkg.create(privateSamplePackage, update = true, shared = Some(false))(guestwp)
-                    wsk.action.invoke("sequence", expectedExitCode = FORBIDDEN)(defaultWskProps)
-            }
+    assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, _) =>
+      pkg.create(packageName, shared = Some(true))(guestWskProps)
     }
 
-    it should "invoke a packaged action not owned by the subject to get the subject's namespace" in withAssetCleaner(guestWskProps) {
-        (_, assetHelper) =>
-            val packageName = "namespacePackage"
-            val actionName = "namespaceAction"
-            val packagedActionName = s"$packageName/$actionName"
-
-            assetHelper.withCleaner(wsk.pkg, packageName) {
-                (pkg, _) => pkg.create(packageName, shared = Some(true))(guestWskProps)
-            }
-
-            assetHelper.withCleaner(wsk.action, packagedActionName) {
-                val file = Some(TestUtils.getTestActionFilename("helloContext.js"))
-                (action, _) => action.create(packagedActionName, file)(guestWskProps)
-            }
-
-            val fullyQualifiedActionName = s"/$guestNamespace/$packagedActionName"
-            val run = wsk.action.invoke(fullyQualifiedActionName)(defaultWskProps)
-
-            withActivation(wsk.activation, run)({ activation =>
-                val namespace = wsk.namespace.whois()(defaultWskProps)
-                activation.response.success shouldBe true
-                activation.response.result.get.toString should include regex (s""""namespace":\\s*"$namespace"""")
-            })(defaultWskProps)
+    assetHelper.withCleaner(wsk.action, packagedActionName) {
+      val file = Some(TestUtils.getTestActionFilename("helloContext.js"))
+      (action, _) =>
+        action.create(packagedActionName, file)(guestWskProps)
     }
 
-    behavior of "Wsk Trigger Feed"
+    val fullyQualifiedActionName = s"/$guestNamespace/$packagedActionName"
+    val run = wsk.action.invoke(fullyQualifiedActionName)(defaultWskProps)
 
-    it should "not create a trigger with timeout error when feed fails to initialize" in withAssetCleaner(guestWskProps) {
-        (wp, assetHelper) =>
-            assetHelper.withCleaner(wsk.pkg, samplePackage) {
-                (pkg, _) => pkg.create(samplePackage, shared = Some(true))(wp)
-            }
+    withActivation(wsk.activation, run)({ activation =>
+      val namespace = wsk.namespace.whois()(defaultWskProps)
+      activation.response.success shouldBe true
+      activation.response.result.get.toString should include regex (s""""namespace":\\s*"$namespace"""")
+    })(defaultWskProps)
+  }
 
-            val sampleFeed = s"$samplePackage/sampleFeed"
-            assetHelper.withCleaner(wsk.action, sampleFeed) {
-                val file = Some(TestUtils.getTestActionFilename("empty.js"))
-                (action, _) => action.create(sampleFeed, file, kind = Some("nodejs:default"))(wp)
-            }
+  behavior of "Wsk Trigger Feed"
 
-            val fullyQualifiedFeedName = s"/$guestNamespace/$sampleFeed"
-            withAssetCleaner(defaultWskProps) {
-                (wp, assetHelper) =>
-                    assetHelper.withCleaner(wsk.trigger, "badfeed", confirmDelete = false) {
-                        (trigger, name) => trigger.create(name, feed = Some(fullyQualifiedFeedName), expectedExitCode = TIMEOUT)(wp)
-                    }
-                    wsk.trigger.get("badfeed", expectedExitCode = NOT_FOUND)(wp)
-            }
-    }
+  it should "not create a trigger with timeout error when feed fails to initialize" in withAssetCleaner(guestWskProps) {
+    (wp, assetHelper) =>
+      assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
+        pkg.create(samplePackage, shared = Some(true))(wp)
+      }
+
+      val sampleFeed = s"$samplePackage/sampleFeed"
+      assetHelper.withCleaner(wsk.action, sampleFeed) {
+        val file = Some(TestUtils.getTestActionFilename("empty.js"))
+        (action, _) =>
+          action.create(sampleFeed, file, kind = Some("nodejs:default"))(wp)
+      }
+
+      val fullyQualifiedFeedName = s"/$guestNamespace/$sampleFeed"
+      withAssetCleaner(defaultWskProps) { (wp, assetHelper) =>
+        assetHelper.withCleaner(wsk.trigger, "badfeed", confirmDelete = false) { (trigger, name) =>
+          trigger.create(name, feed = Some(fullyQualifiedFeedName), expectedExitCode = TIMEOUT)(wp)
+        }
+        wsk.trigger.get("badfeed", expectedExitCode = NOT_FOUND)(wp)
+      }
+  }
 
 }

--- a/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
@@ -49,295 +49,289 @@ import whisk.core.entity.Subject
  */
 @RunWith(classOf[JUnitRunner])
 class WskWebActionsTests extends TestHelpers with WskTestHelpers with RestUtil with BeforeAndAfterAll {
-    val MAX_URL_LENGTH = 8192 // 8K matching nginx default
+  val MAX_URL_LENGTH = 8192 // 8K matching nginx default
 
-    val wsk = new Wsk
-    private implicit val wskprops = WskProps()
-    val namespace = wsk.namespace.whois()
+  val wsk = new Wsk
+  private implicit val wskprops = WskProps()
+  val namespace = wsk.namespace.whois()
 
-    protected val testRoutePath: String = "/api/v1/web"
+  protected val testRoutePath: String = "/api/v1/web"
 
-    behavior of "Wsk Web Actions"
+  behavior of "Wsk Web Actions"
 
-    /**
-     * Tests web actions, plus max url limit.
-     */
-    it should "create a web action accessible via HTTPS" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "webaction"
-            val file = Some(TestUtils.getTestActionFilename("echo.js"))
-            val host = getServiceURL()
-            val requestPath = host + s"$testRoutePath/$namespace/default/$name.text/a?a="
-            val padAmount = MAX_URL_LENGTH - requestPath.length
+  /**
+   * Tests web actions, plus max url limit.
+   */
+  it should "create a web action accessible via HTTPS" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "webaction"
+    val file = Some(TestUtils.getTestActionFilename("echo.js"))
+    val host = getServiceURL()
+    val requestPath = host + s"$testRoutePath/$namespace/default/$name.text/a?a="
+    val padAmount = MAX_URL_LENGTH - requestPath.length
 
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, file, web = Some("true"))
-            }
-
-            Seq(("A", 200),
-                ("A" * padAmount, 200),
-                // ideally the bad case is just +1 but there's some differences
-                // in how characters are counted i.e., whether these count "https://:443"
-                // or not; it seems sufficient to test right around the boundary
-                ("A" * (padAmount + 100), 414))
-                .foreach {
-                    case (pad, code) =>
-                        val url = (requestPath + pad)
-                        val response = RestAssured.given().config(sslconfig).get(url)
-                        val responseCode = response.statusCode
-
-                        withClue(s"response code: $responseCode, url length: ${url.length}, pad amount: ${pad.length}, url: $url") {
-                            responseCode shouldBe code
-                            if (code == 200) {
-                                response.body.asString shouldBe pad
-                            } else {
-                                response.body.asString should include("414 Request-URI Too Large") // from nginx
-                            }
-                        }
-                }
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, file, web = Some("true"))
     }
 
-    /**
-     * Tests web action requiring authentication.
-     */
-    it should "create a web action requiring authentication accessible via HTTPS" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "webaction"
-            val file = Some(TestUtils.getTestActionFilename("echo.js"))
-            val host = getServiceURL()
-            val url = s"$host$testRoutePath/$namespace/default/$name.text/__ow_user"
+    Seq(
+      ("A", 200),
+      ("A" * padAmount, 200),
+      // ideally the bad case is just +1 but there's some differences
+      // in how characters are counted i.e., whether these count "https://:443"
+      // or not; it seems sufficient to test right around the boundary
+      ("A" * (padAmount + 100), 414))
+      .foreach {
+        case (pad, code) =>
+          val url = (requestPath + pad)
+          val response = RestAssured.given().config(sslconfig).get(url)
+          val responseCode = response.statusCode
 
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(name, file, web = Some("true"), annotations = Map("require-whisk-auth" -> true.toJson))
+          withClue(s"response code: $responseCode, url length: ${url.length}, pad amount: ${pad.length}, url: $url") {
+            responseCode shouldBe code
+            if (code == 200) {
+              response.body.asString shouldBe pad
+            } else {
+              response.body.asString should include("414 Request-URI Too Large") // from nginx
             }
+          }
+      }
+  }
 
-            val unauthorizedResponse = RestAssured.given().config(sslconfig).get(url)
-            unauthorizedResponse.statusCode shouldBe 401
+  /**
+   * Tests web action requiring authentication.
+   */
+  it should "create a web action requiring authentication accessible via HTTPS" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "webaction"
+      val file = Some(TestUtils.getTestActionFilename("echo.js"))
+      val host = getServiceURL()
+      val url = s"$host$testRoutePath/$namespace/default/$name.text/__ow_user"
 
-            val authorizedResponse = RestAssured
-                .given()
-                .config(sslconfig)
-                .auth().preemptive().basic(wskprops.authKey.split(":")(0), wskprops.authKey.split(":")(1))
-                .get(url)
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, file, web = Some("true"), annotations = Map("require-whisk-auth" -> true.toJson))
+      }
 
-            authorizedResponse.statusCode shouldBe 200
-            authorizedResponse.body.asString shouldBe namespace
+      val unauthorizedResponse = RestAssured.given().config(sslconfig).get(url)
+      unauthorizedResponse.statusCode shouldBe 401
+
+      val authorizedResponse = RestAssured
+        .given()
+        .config(sslconfig)
+        .auth()
+        .preemptive()
+        .basic(wskprops.authKey.split(":")(0), wskprops.authKey.split(":")(1))
+        .get(url)
+
+      authorizedResponse.statusCode shouldBe 200
+      authorizedResponse.body.asString shouldBe namespace
+  }
+
+  it should "ensure that CORS header is preserved for custom options" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "webaction"
+      val file = Some(TestUtils.getTestActionFilename("corsHeaderMod.js"))
+      val host = getServiceURL()
+      val url = host + s"$testRoutePath/$namespace/default/$name.http"
+
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, file, web = Some("true"), annotations = Map("web-custom-options" -> true.toJson))
+      }
+
+      val response = RestAssured.given().config(sslconfig).options(url)
+
+      response.statusCode shouldBe 200
+      response.header("Access-Control-Allow-Origin") shouldBe "Origin set from Web Action"
+      response.header("Access-Control-Allow-Methods") shouldBe "Methods set from Web Action"
+      response.header("Access-Control-Allow-Headers") shouldBe "Headers set from Web Action"
+      response.header("Location") shouldBe "openwhisk.org"
+      response.header("Set-Cookie") shouldBe "cookie-cookie-cookie"
+  }
+
+  it should "ensure that default CORS header is preserved" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "webaction"
+    val file = Some(TestUtils.getTestActionFilename("corsHeaderMod.js"))
+    val host = getServiceURL()
+    val url = host + s"$testRoutePath/$namespace/default/$name"
+
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, file, web = Some("true"))
     }
 
-    it should "ensure that CORS header is preserved for custom options" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "webaction"
-            val file = Some(TestUtils.getTestActionFilename("corsHeaderMod.js"))
-            val host = getServiceURL()
-            val url = host + s"$testRoutePath/$namespace/default/$name.http"
+    val responses = Seq(
+      RestAssured.given().config(sslconfig).options(s"$url.http"),
+      RestAssured.given().config(sslconfig).get(s"$url.json"))
 
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(name, file, web = Some("true"), annotations = Map("web-custom-options" -> true.toJson))
-            }
+    responses.foreach { response =>
+      response.statusCode shouldBe 200
+      response.header("Access-Control-Allow-Origin") shouldBe "*"
+      response.header("Access-Control-Allow-Methods") shouldBe "OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH"
+      response.header("Access-Control-Allow-Headers") shouldBe "Authorization, Content-Type"
+      response.header("Location") shouldBe null
+      response.header("Set-Cookie") shouldBe null
+    }
+  }
 
-            val response = RestAssured.given().config(sslconfig).options(url)
+  it should "invoke web action to ensure the returned body argument is correct" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "webaction"
+      val file = Some(TestUtils.getTestActionFilename("echo.js"))
+      val bodyContent = "This is the body"
+      val host = getServiceURL()
+      val url = s"$host$testRoutePath/$namespace/default/webaction.text/__ow_body"
 
-            response.statusCode shouldBe 200
-            response.header("Access-Control-Allow-Origin") shouldBe "Origin set from Web Action"
-            response.header("Access-Control-Allow-Methods") shouldBe "Methods set from Web Action"
-            response.header("Access-Control-Allow-Headers") shouldBe "Headers set from Web Action"
-            response.header("Location") shouldBe "openwhisk.org"
-            response.header("Set-Cookie") shouldBe "cookie-cookie-cookie"
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, file, web = Some("true"))
+      }
+
+      val paramRes = RestAssured.given().contentType("text/html").param("key", "value").config(sslconfig).post(url)
+      paramRes.statusCode shouldBe 200
+      new String(paramRes.body.asByteArray, StandardCharsets.UTF_8) shouldBe "key=value"
+
+      val bodyRes = RestAssured.given().contentType("text/html").body(bodyContent).config(sslconfig).post(url)
+      bodyRes.statusCode shouldBe 200
+      new String(bodyRes.body.asByteArray, StandardCharsets.UTF_8) shouldBe bodyContent
+  }
+
+  it should "reject invocation of web action with invalid accept header" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "webaction"
+      val file = Some(TestUtils.getTestActionFilename("textBody.js"))
+      val host = getServiceURL()
+      val url = host + s"$testRoutePath/$namespace/default/$name.http"
+
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, file, web = Some("true"))
+      }
+
+      val response = RestAssured.given().header("accept", "application/json").config(sslconfig).get(url)
+      response.statusCode shouldBe 406
+      response.body.asString should include("Resource representation is only available with these types:\\ntext/html")
+  }
+
+  it should "support multiple response header values" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "webaction"
+    val file = Some(TestUtils.getTestActionFilename("multipleHeaders.js"))
+    val host = getServiceURL()
+    val url = host + s"$testRoutePath/$namespace/default/$name.http"
+
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, file, web = Some("true"), annotations = Map("web-custom-options" -> true.toJson))
     }
 
-    it should "ensure that default CORS header is preserved" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "webaction"
-            val file = Some(TestUtils.getTestActionFilename("corsHeaderMod.js"))
-            val host = getServiceURL()
-            val url = host + s"$testRoutePath/$namespace/default/$name"
+    val response = RestAssured.given().config(sslconfig).options(url)
 
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, file, web = Some("true"))
-            }
+    response.statusCode shouldBe 200
+    val cookieHeaders = response.headers.getList("Set-Cookie")
+    cookieHeaders should contain allOf (
+      new Header("Set-Cookie", "a=b"),
+      new Header("Set-Cookie", "c=d")
+    )
+  }
 
-            val responses = Seq(
-                RestAssured.given().config(sslconfig).options(s"$url.http"),
-                RestAssured.given().config(sslconfig).get(s"$url.json"))
+  it should "handle http web action with base64 encoded response" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "base64Web"
+    val file = Some(TestUtils.getTestActionFilename("base64Web.js"))
+    val host = getServiceURL
+    val url = host + s"$testRoutePath/$namespace/default/$name.http"
 
-            responses.foreach { response =>
-                response.statusCode shouldBe 200
-                response.header("Access-Control-Allow-Origin") shouldBe "*"
-                response.header("Access-Control-Allow-Methods") shouldBe "OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH"
-                response.header("Access-Control-Allow-Headers") shouldBe "Authorization, Content-Type"
-                response.header("Location") shouldBe null
-                response.header("Set-Cookie") shouldBe null
-            }
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, file, web = Some("raw"))
     }
 
-    it should "invoke web action to ensure the returned body argument is correct" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "webaction"
-            val file = Some(TestUtils.getTestActionFilename("echo.js"))
-            val bodyContent = "This is the body"
-            val host = getServiceURL()
-            val url = s"$host$testRoutePath/$namespace/default/webaction.text/__ow_body"
+    val response = RestAssured.given().config(sslconfig).get(url)
 
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, file, web = Some("true"))
-            }
+    response.statusCode shouldBe 200
+    response.header("Content-type") shouldBe "application/json"
+    response.body.asString.parseJson.asJsObject shouldBe JsObject("status" -> "success".toJson)
+  }
 
-            val paramRes = RestAssured.given().contentType("text/html").param("key", "value").config(sslconfig).post(url)
-            paramRes.statusCode shouldBe 200
-            new String(paramRes.body.asByteArray, StandardCharsets.UTF_8) shouldBe "key=value"
+  it should "handle http web action with base64 encoded binary response" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "binaryWeb"
+      val file = Some(TestUtils.getTestActionFilename("pngWeb.js"))
+      val host = getServiceURL
+      val url = host + s"$testRoutePath/$namespace/default/$name.http"
+      val png = "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAGCAYAAAD68A/GAAAA/klEQVQYGWNgAAEHBxaG//+ZQMyyn581Pfas+cRQnf1LfF" +
+        "Ljf+62smUgcUbt0FA2Zh7drf/ffMy9vLn3RurrW9e5hCU11i2azfD4zu1/DHz8TAy/foUxsXBrFzHzC7r8+M9S1vn1qxQT07dDjL" +
+        "9fdemrqKxlYGT6z8AIMo6hgeUfA0PUvy9fGFh5GWK3z7vNxSWt++jX99+8SoyiGQwsW38w8PJEM7x5v5SJ8f+/xv8MDAzffv9hev" +
+        "fkWjiXBGMpMx+j2awovjcMjFztDO8+7GF49LkbZDCDeXLTWnZO7qDfn1/+5jbw/8pjYWS4wZLztXnuEuYTk2M+MzIw/AcA36Vewa" +
+        "D6fzsAAAAASUVORK5CYII="
 
-            val bodyRes = RestAssured.given().contentType("text/html").body(bodyContent).config(sslconfig).post(url)
-            bodyRes.statusCode shouldBe 200
-            new String(bodyRes.body.asByteArray, StandardCharsets.UTF_8) shouldBe bodyContent
-    }
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, file, web = Some("true"))
+      }
 
-    it should "reject invocation of web action with invalid accept header" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "webaction"
-            val file = Some(TestUtils.getTestActionFilename("textBody.js"))
-            val host = getServiceURL()
-            val url = host + s"$testRoutePath/$namespace/default/$name.http"
+      val response = RestAssured.given().config(sslconfig).get(url)
 
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, file, web = Some("true"))
-            }
+      response.statusCode shouldBe 200
+      response.header("Content-type") shouldBe "image/png"
+      response.body.asByteArray shouldBe Base64.getDecoder().decode(png)
+  }
 
-            val response = RestAssured.given().header("accept", "application/json").config(sslconfig).get(url)
-            response.statusCode shouldBe 406
-            response.body.asString should include("Resource representation is only available with these types:\\ntext/html")
-    }
+  private val subdomainRegex = Seq.fill(WhiskProperties.getPartsInVanitySubdomain)("[a-zA-Z0-9]+").mkString("-")
 
-    it should "support multiple response header values" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "webaction"
-            val file = Some(TestUtils.getTestActionFilename("multipleHeaders.js"))
-            val host = getServiceURL()
-            val url = host + s"$testRoutePath/$namespace/default/$name.http"
-
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(name, file, web = Some("true"), annotations = Map("web-custom-options" -> true.toJson))
-            }
-
-            val response = RestAssured.given().config(sslconfig).options(url)
-
-            response.statusCode shouldBe 200
-            val cookieHeaders = response.headers.getList("Set-Cookie")
-            cookieHeaders should contain allOf (
-                new Header("Set-Cookie", "a=b"),
-                new Header("Set-Cookie", "c=d")
-            )
-    }
-
-    it should "handle http web action with base64 encoded response" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "base64Web"
-            val file = Some(TestUtils.getTestActionFilename("base64Web.js"))
-            val host = getServiceURL
-            val url = host + s"$testRoutePath/$namespace/default/$name.http"
-
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(name, file, web = Some("raw"))
-            }
-
-            val response = RestAssured.given().config(sslconfig).get(url)
-
-            response.statusCode shouldBe 200
-            response.header("Content-type") shouldBe "application/json"
-            response.body.asString.parseJson.asJsObject shouldBe JsObject("status" -> "success".toJson)
-    }
-
-    it should "handle http web action with base64 encoded binary response" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "binaryWeb"
-            val file = Some(TestUtils.getTestActionFilename("pngWeb.js"))
-            val host = getServiceURL
-            val url = host + s"$testRoutePath/$namespace/default/$name.http"
-            val png = "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAGCAYAAAD68A/GAAAA/klEQVQYGWNgAAEHBxaG//+ZQMyyn581Pfas+cRQnf1LfF" +
-                "Ljf+62smUgcUbt0FA2Zh7drf/ffMy9vLn3RurrW9e5hCU11i2azfD4zu1/DHz8TAy/foUxsXBrFzHzC7r8+M9S1vn1qxQT07dDjL" +
-                "9fdemrqKxlYGT6z8AIMo6hgeUfA0PUvy9fGFh5GWK3z7vNxSWt++jX99+8SoyiGQwsW38w8PJEM7x5v5SJ8f+/xv8MDAzffv9hev" +
-                "fkWjiXBGMpMx+j2awovjcMjFztDO8+7GF49LkbZDCDeXLTWnZO7qDfn1/+5jbw/8pjYWS4wZLztXnuEuYTk2M+MzIw/AcA36Vewa" +
-                "D6fzsAAAAASUVORK5CYII="
-
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(name, file, web = Some("true"))
-            }
-
-            val response = RestAssured.given().config(sslconfig).get(url)
-
-            response.statusCode shouldBe 200
-            response.header("Content-type") shouldBe "image/png"
-            response.body.asByteArray shouldBe Base64.getDecoder().decode(png)
-    }
-
-    private val subdomainRegex = Seq.fill(WhiskProperties.getPartsInVanitySubdomain)("[a-zA-Z0-9]+").mkString("-")
-
-    private val (vanitySubdomain, vanityNamespace, makeTestSubject) = {
-        if (namespace.matches(subdomainRegex)) {
-            (namespace, namespace, false)
-        } else {
-            val s = Subject().asString.toLowerCase // this will generate two confirming parts
-            (s, s.replace("-", "_"), true)
-        }
-    }
-
-    private val wskPropsForSubdomainTest = if (makeTestSubject) {
-        getAdditionalTestSubject(vanityNamespace) // create new subject for the test
+  private val (vanitySubdomain, vanityNamespace, makeTestSubject) = {
+    if (namespace.matches(subdomainRegex)) {
+      (namespace, namespace, false)
     } else {
-        WskProps()
+      val s = Subject().asString.toLowerCase // this will generate two confirming parts
+      (s, s.replace("-", "_"), true)
     }
+  }
 
-    override def afterAll() = {
-        if (makeTestSubject) {
-            disposeAdditionalTestSubject(vanityNamespace)
-        }
+  private val wskPropsForSubdomainTest = if (makeTestSubject) {
+    getAdditionalTestSubject(vanityNamespace) // create new subject for the test
+  } else {
+    WskProps()
+  }
+
+  override def afterAll() = {
+    if (makeTestSubject) {
+      disposeAdditionalTestSubject(vanityNamespace)
     }
+  }
 
-    "test subdomain" should "have conforming parts" in {
-        vanitySubdomain should fullyMatch regex subdomainRegex.r
-        vanitySubdomain.length should be <= 63
-    }
+  "test subdomain" should "have conforming parts" in {
+    vanitySubdomain should fullyMatch regex subdomainRegex.r
+    vanitySubdomain.length should be <= 63
+  }
 
-    "vanity subdomain" should "access a web action via namespace subdomain" in withAssetCleaner(wskPropsForSubdomainTest) {
-        (wp, assetHelper) =>
-            val actionName = "webaction"
+  "vanity subdomain" should "access a web action via namespace subdomain" in withAssetCleaner(wskPropsForSubdomainTest) {
+    (wp, assetHelper) =>
+      val actionName = "webaction"
 
-            val file = Some(TestUtils.getTestActionFilename("echo.js"))
-            assetHelper.withCleaner(wsk.action, actionName) {
-                (action, _) => action.create(actionName, file, web = Some(true.toString))(wp)
-            }
+      val file = Some(TestUtils.getTestActionFilename("echo.js"))
+      assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
+        action.create(actionName, file, web = Some(true.toString))(wp)
+      }
 
-            val url = getServiceApiHost(vanitySubdomain, true) + s"/default/$actionName.text/a?a=A"
-            println(s"url: $url")
+      val url = getServiceApiHost(vanitySubdomain, true) + s"/default/$actionName.text/a?a=A"
+      println(s"url: $url")
 
-            // try the rest assured path first, failing that, try curl with explicit resolve
-            Try {
-                val response = RestAssured.given().config(sslconfig).get(url)
-                val responseCode = response.statusCode
-                responseCode shouldBe 200
-                response.body.asString shouldBe "A"
-            } match {
-                case Failure(t) =>
-                    println(s"RestAssured path failed, trying curl: $t")
-                    implicit val tid = TransactionId.testing
-                    implicit val logger = new PrintStreamLogging(Console.out)
-                    val host = getServiceApiHost(vanitySubdomain, false)
-                    // if the edge host is a name, try to resolve it, otherwise, it should be an ip address already
-                    val edgehost = WhiskProperties.getEdgeHost
-                    val ip = Try(java.net.InetAddress.getByName(edgehost).getHostAddress) getOrElse "???"
-                    println(s"edge: $edgehost, ip: $ip")
-                    val cmd = Seq("curl", "-k", url, "--resolve", s"$host:$ip")
-                    val (stdout, stderr, exitCode) = SimpleExec.syncRunCmd(cmd)
-                    withClue(s"\n$stderr\n") {
-                        stdout shouldBe "A"
-                        exitCode shouldBe 0
-                    }
+      // try the rest assured path first, failing that, try curl with explicit resolve
+      Try {
+        val response = RestAssured.given().config(sslconfig).get(url)
+        val responseCode = response.statusCode
+        responseCode shouldBe 200
+        response.body.asString shouldBe "A"
+      } match {
+        case Failure(t) =>
+          println(s"RestAssured path failed, trying curl: $t")
+          implicit val tid = TransactionId.testing
+          implicit val logger = new PrintStreamLogging(Console.out)
+          val host = getServiceApiHost(vanitySubdomain, false)
+          // if the edge host is a name, try to resolve it, otherwise, it should be an ip address already
+          val edgehost = WhiskProperties.getEdgeHost
+          val ip = Try(java.net.InetAddress.getByName(edgehost).getHostAddress) getOrElse "???"
+          println(s"edge: $edgehost, ip: $ip")
+          val cmd = Seq("curl", "-k", url, "--resolve", s"$host:$ip")
+          val (stdout, stderr, exitCode) = SimpleExec.syncRunCmd(cmd)
+          withClue(s"\n$stderr\n") {
+            stdout shouldBe "A"
+            exitCode shouldBe 0
+          }
 
-                case _ =>
-            }
-    }
+        case _ =>
+      }
+  }
 }

--- a/tests/src/test/scala/whisk/core/connector/tests/CompletionMessageTests.scala
+++ b/tests/src/test/scala/whisk/core/connector/tests/CompletionMessageTests.scala
@@ -39,45 +39,42 @@ import whisk.core.entity.size.SizeInt
 @RunWith(classOf[JUnitRunner])
 class CompletionMessageTests extends FlatSpec with Matchers {
 
-    behavior of "completion message"
+  behavior of "completion message"
 
-    val activation = WhiskActivation(
-        namespace = EntityPath("ns"),
-        name = EntityName("a"),
-        Subject(),
-        activationId = ActivationId(),
-        start = Instant.now(),
-        end = Instant.now(),
-        response = ActivationResponse.success(Some(JsObject("res" -> JsNumber(1)))),
-        annotations = Parameters("limits", ActionLimits(
-            TimeLimit(1.second),
-            MemoryLimit(128.MB),
-            LogLimit(1.MB)).toJson),
-        duration = Some(123))
+  val activation = WhiskActivation(
+    namespace = EntityPath("ns"),
+    name = EntityName("a"),
+    Subject(),
+    activationId = ActivationId(),
+    start = Instant.now(),
+    end = Instant.now(),
+    response = ActivationResponse.success(Some(JsObject("res" -> JsNumber(1)))),
+    annotations = Parameters("limits", ActionLimits(TimeLimit(1.second), MemoryLimit(128.MB), LogLimit(1.MB)).toJson),
+    duration = Some(123))
 
-    it should "serialize a left completion message" in {
-        val m = CompletionMessage(TransactionId.testing, Left(ActivationId()), InstanceId(0))
-        m.serialize shouldBe JsObject(
-            "transid" -> m.transid.toJson,
-            "response" -> m.response.left.get.toJson,
-            "invoker" -> m.invoker.toJson).compactPrint
-    }
+  it should "serialize a left completion message" in {
+    val m = CompletionMessage(TransactionId.testing, Left(ActivationId()), InstanceId(0))
+    m.serialize shouldBe JsObject(
+      "transid" -> m.transid.toJson,
+      "response" -> m.response.left.get.toJson,
+      "invoker" -> m.invoker.toJson).compactPrint
+  }
 
-    it should "serialize a right completion message" in {
-        val m = CompletionMessage(TransactionId.testing, Right(activation), InstanceId(0))
-        m.serialize shouldBe JsObject(
-            "transid" -> m.transid.toJson,
-            "response" -> m.response.right.get.toJson,
-            "invoker" -> m.invoker.toJson).compactPrint
-    }
+  it should "serialize a right completion message" in {
+    val m = CompletionMessage(TransactionId.testing, Right(activation), InstanceId(0))
+    m.serialize shouldBe JsObject(
+      "transid" -> m.transid.toJson,
+      "response" -> m.response.right.get.toJson,
+      "invoker" -> m.invoker.toJson).compactPrint
+  }
 
-    it should "deserialize a left completion message" in {
-        val m = CompletionMessage(TransactionId.testing, Left(ActivationId()), InstanceId(0))
-        CompletionMessage.parse(m.serialize) shouldBe Success(m)
-    }
+  it should "deserialize a left completion message" in {
+    val m = CompletionMessage(TransactionId.testing, Left(ActivationId()), InstanceId(0))
+    CompletionMessage.parse(m.serialize) shouldBe Success(m)
+  }
 
-    it should "deserialize a right completion message" in {
-        val m = CompletionMessage(TransactionId.testing, Right(activation), InstanceId(0))
-        CompletionMessage.parse(m.serialize) shouldBe Success(m)
-    }
+  it should "deserialize a right completion message" in {
+    val m = CompletionMessage(TransactionId.testing, Right(activation), InstanceId(0))
+    CompletionMessage.parse(m.serialize) shouldBe Success(m)
+  }
 }

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/ContainerConnectionTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/ContainerConnectionTests.scala
@@ -46,91 +46,87 @@ import whisk.core.containerpool.docker.HttpUtils
  * Unit tests for HttpUtils which communicate with containers.
  */
 @RunWith(classOf[JUnitRunner])
-class ContainerConnectionTests
-    extends FlatSpec
-    with Matchers
-    with BeforeAndAfter
-    with BeforeAndAfterAll {
+class ContainerConnectionTests extends FlatSpec with Matchers with BeforeAndAfter with BeforeAndAfterAll {
 
-    var testHang: FiniteDuration = 0.second
-    var testStatusOK: Boolean = true
-    var testResponse: String = null
+  var testHang: FiniteDuration = 0.second
+  var testStatusOK: Boolean = true
+  var testResponse: String = null
 
-    val mockServer = new LocalServerTestBase {
-        override def setUp() = {
-            super.setUp()
-            this.serverBootstrap.registerHandler("/init", new HttpRequestHandler() {
-                override def handle(request: HttpRequest, response: HttpResponse, context: HttpContext) = {
-                    if (testHang.length > 0) {
-                        Thread.sleep(testHang.toMillis)
-                    }
-                    response.setStatusCode(if (testStatusOK) 200 else 500);
-                    if (testResponse != null) {
-                        response.setEntity(new StringEntity(testResponse, StandardCharsets.UTF_8))
-                    }
-                }
-            })
+  val mockServer = new LocalServerTestBase {
+    override def setUp() = {
+      super.setUp()
+      this.serverBootstrap.registerHandler("/init", new HttpRequestHandler() {
+        override def handle(request: HttpRequest, response: HttpResponse, context: HttpContext) = {
+          if (testHang.length > 0) {
+            Thread.sleep(testHang.toMillis)
+          }
+          response.setStatusCode(if (testStatusOK) 200 else 500);
+          if (testResponse != null) {
+            response.setEntity(new StringEntity(testResponse, StandardCharsets.UTF_8))
+          }
         }
+      })
     }
+  }
 
-    mockServer.setUp()
-    val httpHost = mockServer.start()
-    val hostWithPort = s"${httpHost.getHostName}:${httpHost.getPort}"
+  mockServer.setUp()
+  val httpHost = mockServer.start()
+  val hostWithPort = s"${httpHost.getHostName}:${httpHost.getPort}"
 
-    before {
-        testHang = 0.second
-        testStatusOK = true
-        testResponse = null
-    }
+  before {
+    testHang = 0.second
+    testStatusOK = true
+    testResponse = null
+  }
 
-    override def afterAll = {
-        mockServer.shutDown()
-    }
+  override def afterAll = {
+    mockServer.shutDown()
+  }
 
-    behavior of "Container HTTP Utils"
+  behavior of "Container HTTP Utils"
 
-    it should "not wait longer than set timeout" in {
-        val timeout = 5.seconds
-        val connection = new HttpUtils(hostWithPort, timeout, 1.B)
-        testHang = timeout * 2
-        val start = Instant.now()
+  it should "not wait longer than set timeout" in {
+    val timeout = 5.seconds
+    val connection = new HttpUtils(hostWithPort, timeout, 1.B)
+    testHang = timeout * 2
+    val start = Instant.now()
+    val result = connection.post("/init", JsObject(), retry = true)
+    val end = Instant.now()
+    val waited = end.toEpochMilli - start.toEpochMilli
+    result.isLeft shouldBe true
+    waited should be > timeout.toMillis
+    waited should be < (timeout * 2).toMillis
+  }
+
+  it should "not truncate responses within limit" in {
+    val timeout = 1.minute.toMillis
+    val connection = new HttpUtils(hostWithPort, timeout.millis, 50.B)
+    Seq(true, false).foreach { code =>
+      Seq(null, "", "abc", """{"a":"B"}""", """["a", "b"]""").foreach { r =>
+        testStatusOK = code
+        testResponse = r
         val result = connection.post("/init", JsObject(), retry = true)
-        val end = Instant.now()
-        val waited = end.toEpochMilli - start.toEpochMilli
-        result.isLeft shouldBe true
-        waited should be > timeout.toMillis
-        waited should be < (timeout * 2).toMillis
-    }
-
-    it should "not truncate responses within limit" in {
-        val timeout = 1.minute.toMillis
-        val connection = new HttpUtils(hostWithPort, timeout.millis, 50.B)
-        Seq(true, false).foreach { code =>
-            Seq(null, "", "abc", """{"a":"B"}""", """["a", "b"]""").foreach { r =>
-                testStatusOK = code
-                testResponse = r
-                val result = connection.post("/init", JsObject(), retry = true)
-                result shouldBe Right {
-                    ContainerResponse(okStatus = testStatusOK, if (r != null) r else "", None)
-                }
-            }
+        result shouldBe Right {
+          ContainerResponse(okStatus = testStatusOK, if (r != null) r else "", None)
         }
+      }
     }
+  }
 
-    it should "truncate responses that exceed limit" in {
-        val timeout = 1.minute.toMillis
-        val limit = 1.B
-        val excess = limit + 1.B
-        val connection = new HttpUtils(hostWithPort, timeout.millis, limit)
-        Seq(true, false).foreach { code =>
-            Seq("abc", """{"a":"B"}""", """["a", "b"]""").foreach { r =>
-                testStatusOK = code
-                testResponse = r
-                val result = connection.post("/init", JsObject(), retry = true)
-                result shouldBe Right {
-                    ContainerResponse(okStatus = testStatusOK, r.take(limit.toBytes.toInt), Some((r.length.B, limit)))
-                }
-            }
+  it should "truncate responses that exceed limit" in {
+    val timeout = 1.minute.toMillis
+    val limit = 1.B
+    val excess = limit + 1.B
+    val connection = new HttpUtils(hostWithPort, timeout.millis, limit)
+    Seq(true, false).foreach { code =>
+      Seq("abc", """{"a":"B"}""", """["a", "b"]""").foreach { r =>
+        testStatusOK = code
+        testResponse = r
+        val result = connection.post("/init", JsObject(), retry = true)
+        result shouldBe Right {
+          ContainerResponse(okStatus = testStatusOK, r.take(limit.toBytes.toInt), Some((r.length.B, limit)))
         }
+      }
     }
+  }
 }

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerClientTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerClientTests.scala
@@ -43,134 +43,134 @@ import whisk.utils.retry
 @RunWith(classOf[JUnitRunner])
 class DockerClientTests extends FlatSpec with Matchers with StreamLogging with BeforeAndAfterEach {
 
-    override def beforeEach = stream.reset()
+  override def beforeEach = stream.reset()
 
-    implicit val transid = TransactionId.testing
-    val id = ContainerId("Id")
+  implicit val transid = TransactionId.testing
+  val id = ContainerId("Id")
 
-    def await[A](f: Future[A], timeout: FiniteDuration = 500.milliseconds) = Await.result(f, timeout)
+  def await[A](f: Future[A], timeout: FiniteDuration = 500.milliseconds) = Await.result(f, timeout)
 
-    val dockerCommand = "docker"
+  val dockerCommand = "docker"
 
-    /** Returns a DockerClient with a mocked result for 'executeProcess' */
-    def dockerClient(execResult: => Future[String]) = new DockerClient()(global) {
-        override val dockerCmd = Seq(dockerCommand)
-        override def executeProcess(args: String*)(implicit ec: ExecutionContext) = execResult
+  /** Returns a DockerClient with a mocked result for 'executeProcess' */
+  def dockerClient(execResult: => Future[String]) = new DockerClient()(global) {
+    override val dockerCmd = Seq(dockerCommand)
+    override def executeProcess(args: String*)(implicit ec: ExecutionContext) = execResult
+  }
+
+  behavior of "DockerClient"
+
+  it should "return a list of containers and pass down the correct arguments when using 'ps'" in {
+    val containers = Seq("1", "2", "3")
+    val dc = dockerClient { Future.successful(containers.mkString("\n")) }
+
+    val filters = Seq("name" -> "wsk", "label" -> "docker")
+    await(dc.ps(filters, all = true)) shouldBe containers.map(ContainerId.apply)
+
+    val firstLine = logLines.head
+    firstLine should include(s"${dockerCommand} ps")
+    firstLine should include("--quiet")
+    firstLine should include("--no-trunc")
+    firstLine should include("--all")
+    filters.foreach {
+      case (k, v) => firstLine should include(s"--filter $k=$v")
+    }
+  }
+
+  it should "throw NoSuchElementException if specified network does not exist when using 'inspectIPAddress'" in {
+    val dc = dockerClient { Future.successful("<no value>") }
+
+    a[NoSuchElementException] should be thrownBy await(dc.inspectIPAddress(id, "foo network"))
+  }
+
+  it should "collapse multiple parallel pull calls into just one" in {
+    // Delay execution of the pull command
+    val pullPromise = Promise[String]()
+    var commandsRun = 0
+    val dc = dockerClient {
+      commandsRun += 1
+      pullPromise.future
     }
 
-    behavior of "DockerClient"
+    val image = "testimage"
 
-    it should "return a list of containers and pass down the correct arguments when using 'ps'" in {
-        val containers = Seq("1", "2", "3")
-        val dc = dockerClient { Future.successful(containers.mkString("\n")) }
+    // Pull first, command should be run
+    dc.pull(image)
+    commandsRun shouldBe 1
 
-        val filters = Seq("name" -> "wsk", "label" -> "docker")
-        await(dc.ps(filters, all = true)) shouldBe containers.map(ContainerId.apply)
+    // Pull again, command should not be run
+    dc.pull(image)
+    commandsRun shouldBe 1
 
-        val firstLine = logLines.head
-        firstLine should include(s"${dockerCommand} ps")
-        firstLine should include("--quiet")
-        firstLine should include("--no-trunc")
-        firstLine should include("--all")
-        filters.foreach {
-            case (k, v) => firstLine should include(s"--filter $k=$v")
-        }
+    // Finish the pulls above
+    pullPromise.success("pulled")
+
+    retry {
+      // Pulling again should execute the command again
+      await(dc.pull(image))
+      commandsRun shouldBe 2
+    }
+  }
+
+  it should "write proper log markers on a successful command" in {
+    // a dummy string works here as we do not assert any output
+    // from the methods below
+    val stdout = "stdout"
+    val dc = dockerClient { Future.successful(stdout) }
+
+    /** Awaits the command and checks for proper logging. */
+    def runAndVerify(f: Future[_], cmd: String, args: Seq[String] = Seq.empty[String]) = {
+      val result = await(f)
+
+      logLines.head should include((Seq(dockerCommand, cmd) ++ args).mkString(" "))
+
+      val start = LogMarker.parse(logLines.head)
+      start.token shouldBe INVOKER_DOCKER_CMD(cmd)
+
+      val end = LogMarker.parse(logLines.last)
+      end.token shouldBe INVOKER_DOCKER_CMD(cmd).asFinish
+
+      stream.reset()
+      result
     }
 
-    it should "throw NoSuchElementException if specified network does not exist when using 'inspectIPAddress'" in {
-        val dc = dockerClient { Future.successful("<no value>") }
+    runAndVerify(dc.pause(id), "pause", Seq(id.asString))
+    runAndVerify(dc.unpause(id), "unpause", Seq(id.asString))
+    runAndVerify(dc.rm(id), "rm", Seq("-f", id.asString))
+    runAndVerify(dc.ps(), "ps")
 
-        a[NoSuchElementException] should be thrownBy await(dc.inspectIPAddress(id, "foo network"))
+    val network = "userland"
+    val inspectArgs = Seq("--format", s"{{.NetworkSettings.Networks.${network}.IPAddress}}", id.asString)
+    runAndVerify(dc.inspectIPAddress(id, network), "inspect", inspectArgs) shouldBe ContainerIp(stdout)
+
+    val image = "image"
+    val runArgs = Seq("--memory", "256m", "--cpushares", "1024")
+    runAndVerify(dc.run(image, runArgs), "run", Seq("-d") ++ runArgs ++ Seq(image)) shouldBe ContainerId(stdout)
+    runAndVerify(dc.pull(image), "pull", Seq(image))
+  }
+
+  it should "write proper log markers on a failing command" in {
+    val dc = dockerClient { Future.failed(new RuntimeException()) }
+
+    /** Awaits the command, asserts the exception and checks for proper logging. */
+    def runAndVerify(f: Future[_], cmd: String) = {
+      a[RuntimeException] should be thrownBy await(f)
+
+      val start = LogMarker.parse(logLines.head)
+      start.token shouldBe INVOKER_DOCKER_CMD(cmd)
+
+      val end = LogMarker.parse(logLines.last)
+      end.token shouldBe INVOKER_DOCKER_CMD(cmd).asError
+
+      stream.reset()
     }
 
-    it should "collapse multiple parallel pull calls into just one" in {
-        // Delay execution of the pull command
-        val pullPromise = Promise[String]()
-        var commandsRun = 0
-        val dc = dockerClient {
-            commandsRun += 1
-            pullPromise.future
-        }
-
-        val image = "testimage"
-
-        // Pull first, command should be run
-        dc.pull(image)
-        commandsRun shouldBe 1
-
-        // Pull again, command should not be run
-        dc.pull(image)
-        commandsRun shouldBe 1
-
-        // Finish the pulls above
-        pullPromise.success("pulled")
-
-        retry {
-            // Pulling again should execute the command again
-            await(dc.pull(image))
-            commandsRun shouldBe 2
-        }
-    }
-
-    it should "write proper log markers on a successful command" in {
-        // a dummy string works here as we do not assert any output
-        // from the methods below
-        val stdout = "stdout"
-        val dc = dockerClient { Future.successful(stdout) }
-
-        /** Awaits the command and checks for proper logging. */
-        def runAndVerify(f: Future[_], cmd: String, args: Seq[String] = Seq.empty[String]) = {
-            val result = await(f)
-
-            logLines.head should include((Seq(dockerCommand, cmd) ++ args).mkString(" "))
-
-            val start = LogMarker.parse(logLines.head)
-            start.token shouldBe INVOKER_DOCKER_CMD(cmd)
-
-            val end = LogMarker.parse(logLines.last)
-            end.token shouldBe INVOKER_DOCKER_CMD(cmd).asFinish
-
-            stream.reset()
-            result
-        }
-
-        runAndVerify(dc.pause(id), "pause", Seq(id.asString))
-        runAndVerify(dc.unpause(id), "unpause", Seq(id.asString))
-        runAndVerify(dc.rm(id), "rm", Seq("-f", id.asString))
-        runAndVerify(dc.ps(), "ps")
-
-        val network = "userland"
-        val inspectArgs = Seq("--format", s"{{.NetworkSettings.Networks.${network}.IPAddress}}", id.asString)
-        runAndVerify(dc.inspectIPAddress(id, network), "inspect", inspectArgs) shouldBe ContainerIp(stdout)
-
-        val image = "image"
-        val runArgs = Seq("--memory", "256m", "--cpushares", "1024")
-        runAndVerify(dc.run(image, runArgs), "run", Seq("-d") ++ runArgs ++ Seq(image)) shouldBe ContainerId(stdout)
-        runAndVerify(dc.pull(image), "pull", Seq(image))
-    }
-
-    it should "write proper log markers on a failing command" in {
-        val dc = dockerClient { Future.failed(new RuntimeException()) }
-
-        /** Awaits the command, asserts the exception and checks for proper logging. */
-        def runAndVerify(f: Future[_], cmd: String) = {
-            a[RuntimeException] should be thrownBy await(f)
-
-            val start = LogMarker.parse(logLines.head)
-            start.token shouldBe INVOKER_DOCKER_CMD(cmd)
-
-            val end = LogMarker.parse(logLines.last)
-            end.token shouldBe INVOKER_DOCKER_CMD(cmd).asError
-
-            stream.reset()
-        }
-
-        runAndVerify(dc.pause(id), "pause")
-        runAndVerify(dc.unpause(id), "unpause")
-        runAndVerify(dc.rm(id), "rm")
-        runAndVerify(dc.ps(), "ps")
-        runAndVerify(dc.inspectIPAddress(id, "network"), "inspect")
-        runAndVerify(dc.run("image"), "run")
-        runAndVerify(dc.pull("image"), "pull")
-    }
+    runAndVerify(dc.pause(id), "pause")
+    runAndVerify(dc.unpause(id), "unpause")
+    runAndVerify(dc.rm(id), "rm")
+    runAndVerify(dc.ps(), "ps")
+    runAndVerify(dc.inspectIPAddress(id, "network"), "inspect")
+    runAndVerify(dc.run("image"), "run")
+    runAndVerify(dc.pull("image"), "pull")
+  }
 }

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
@@ -53,602 +53,613 @@ import whisk.http.Messages
  * Unit tests for ContainerPool schedule
  */
 @RunWith(classOf[JUnitRunner])
-class DockerContainerTests extends FlatSpec
-    with Matchers
-    with MockFactory
-    with StreamLogging
-    with BeforeAndAfterEach {
+class DockerContainerTests extends FlatSpec with Matchers with MockFactory with StreamLogging with BeforeAndAfterEach {
 
-    override def beforeEach() = {
-        stream.reset()
+  override def beforeEach() = {
+    stream.reset()
+  }
+
+  /** Awaits the given future, throws the exception enclosed in Failure. */
+  def await[A](f: Future[A], timeout: FiniteDuration = 500.milliseconds) = Await.result[A](f, timeout)
+
+  val containerId = ContainerId("id")
+
+  /**
+   * Constructs a testcontainer with overridden IO methods. Results of the override can be provided
+   * as parameters.
+   */
+  def dockerContainer(id: ContainerId = containerId, ip: ContainerIp = ContainerIp("ip"))(
+    ccRes: Future[RunResult] =
+      Future.successful(RunResult(intervalOf(1.millisecond), Right(ContainerResponse(true, "", None)))),
+    retryCount: Int = 0)(implicit docker: DockerApiWithFileAccess, runc: RuncApi): DockerContainer = {
+
+    new DockerContainer(id, ip) {
+      override protected def callContainer(path: String,
+                                           body: JsObject,
+                                           timeout: FiniteDuration,
+                                           retry: Boolean = false): Future[RunResult] = {
+        ccRes
+      }
+      override protected val logsRetryCount = retryCount
+      override protected val logsRetryWait = 0.milliseconds
+    }
+  }
+
+  /** Creates an interval starting at EPOCH with the given duration. */
+  def intervalOf(duration: FiniteDuration) = Interval(Instant.EPOCH, Instant.ofEpochMilli(duration.toMillis))
+
+  behavior of "DockerContainer"
+
+  implicit val transid = TransactionId.testing
+
+  /*
+   * CONTAINER CREATION
+   */
+  it should "create a new instance" in {
+    implicit val docker = new TestDockerClient
+    implicit val runc = stub[RuncApi]
+
+    val image = "image"
+    val memory = 128.MB
+    val cpuShares = 1
+    val environment = Map("test" -> "hi")
+    val network = "testwork"
+    val name = "myContainer"
+
+    val container = DockerContainer.create(
+      transid = transid,
+      image = image,
+      memory = memory,
+      cpuShares = cpuShares,
+      environment = environment,
+      network = network,
+      name = Some(name))
+
+    await(container)
+
+    docker.pulls should have size 0
+    docker.runs should have size 1
+    docker.inspects should have size 1
+    docker.rms should have size 0
+
+    val (testImage, args) = docker.runs.head
+    testImage shouldBe "image"
+
+    // Assert fixed values are passed as well
+    args should contain allOf ("--cap-drop", "NET_RAW", "NET_ADMIN")
+    args should contain inOrder ("--ulimit", "nofile=1024:1024")
+    args should contain inOrder ("--pids-limit", "1024") // OW PR 2119
+
+    // Assert proper parameter translation
+    args should contain inOrder ("--memory", s"${memory.toMB}m")
+    args should contain inOrder ("--memory-swap", s"${memory.toMB}m")
+    args should contain inOrder ("--cpu-shares", cpuShares.toString)
+    args should contain inOrder ("--network", network)
+    args should contain inOrder ("--name", name)
+
+    // Assert proper environment passing
+    args should contain allOf ("-e", "test=hi")
+  }
+
+  it should "pull a user provided image before creating the container" in {
+    implicit val docker = new TestDockerClient
+    implicit val runc = stub[RuncApi]
+
+    val container = DockerContainer.create(transid = transid, image = "image", userProvidedImage = true)
+    await(container)
+
+    docker.pulls should have size 1
+    docker.runs should have size 1
+    docker.inspects should have size 1
+    docker.rms should have size 0
+  }
+
+  it should "remove the container if inspect fails" in {
+    implicit val docker = new TestDockerClient {
+      override def inspectIPAddress(id: ContainerId,
+                                    network: String)(implicit transid: TransactionId): Future[ContainerIp] = {
+        inspects += ((id, network))
+        Future.failed(new RuntimeException())
+      }
+    }
+    implicit val runc = stub[RuncApi]
+
+    val container = DockerContainer.create(transid = transid, image = "image")
+    a[WhiskContainerStartupError] should be thrownBy await(container)
+
+    docker.pulls should have size 0
+    docker.runs should have size 1
+    docker.inspects should have size 1
+    docker.rms should have size 1
+  }
+
+  it should "provide a proper error if run fails for blackbox containers" in {
+    implicit val docker = new TestDockerClient {
+      override def run(image: String,
+                       args: Seq[String] = Seq.empty[String])(implicit transid: TransactionId): Future[ContainerId] = {
+        runs += ((image, args))
+        Future.failed(new RuntimeException())
+      }
+    }
+    implicit val runc = stub[RuncApi]
+
+    val container = DockerContainer.create(transid = transid, image = "image", userProvidedImage = true)
+    a[WhiskContainerStartupError] should be thrownBy await(container)
+
+    docker.pulls should have size 1
+    docker.runs should have size 1
+    docker.inspects should have size 0
+    docker.rms should have size 0
+  }
+
+  it should "provide a proper error if inspect fails for blackbox containers" in {
+    implicit val docker = new TestDockerClient {
+      override def inspectIPAddress(id: ContainerId,
+                                    network: String)(implicit transid: TransactionId): Future[ContainerIp] = {
+        inspects += ((id, network))
+        Future.failed(new RuntimeException())
+      }
+    }
+    implicit val runc = stub[RuncApi]
+
+    val container = DockerContainer.create(transid = transid, image = "image", userProvidedImage = true)
+    a[WhiskContainerStartupError] should be thrownBy await(container)
+
+    docker.pulls should have size 1
+    docker.runs should have size 1
+    docker.inspects should have size 1
+    docker.rms should have size 1
+  }
+
+  it should "return a specific error if pulling a user provided image failed" in {
+    implicit val docker = new TestDockerClient {
+      override def pull(image: String)(implicit transid: TransactionId): Future[Unit] = {
+        pulls += image
+        Future.failed(new RuntimeException())
+      }
+    }
+    implicit val runc = stub[RuncApi]
+
+    val container = DockerContainer.create(transid = transid, image = "image", userProvidedImage = true)
+    a[BlackboxStartupError] should be thrownBy await(container)
+
+    docker.pulls should have size 1
+    docker.runs should have size 0
+    docker.inspects should have size 0
+    docker.rms should have size 0
+  }
+
+  /*
+   * DOCKER COMMANDS
+   */
+  it should "halt and resume container via runc" in {
+    implicit val docker = stub[DockerApiWithFileAccess]
+    implicit val runc = stub[RuncApi]
+
+    val id = ContainerId("id")
+    val container = new DockerContainer(id, ContainerIp("ip"))
+
+    container.suspend()
+    container.resume()
+
+    (runc.pause(_: ContainerId)(_: TransactionId)).verify(id, transid)
+    (runc.resume(_: ContainerId)(_: TransactionId)).verify(id, transid)
+  }
+
+  it should "destroy a container via Docker" in {
+    implicit val docker = stub[DockerApiWithFileAccess]
+    implicit val runc = stub[RuncApi]
+
+    val id = ContainerId("id")
+    val container = new DockerContainer(id, ContainerIp("ip"))
+
+    container.destroy()
+
+    (docker.rm(_: ContainerId)(_: TransactionId)).verify(id, transid)
+  }
+
+  /*
+   * INITIALIZE
+   *
+   * Only tests for quite simple cases. Disambiguation of errors is delegated to ActivationResponse
+   * and so are the tests for those.
+   */
+  it should "initialize a container" in {
+    implicit val docker = stub[DockerApiWithFileAccess]
+    implicit val runc = stub[RuncApi]
+
+    val initTimeout = 1.second
+    val interval = intervalOf(1.millisecond)
+    val container = dockerContainer() {
+      Future.successful(RunResult(interval, Right(ContainerResponse(true, "", None))))
     }
 
-    /** Awaits the given future, throws the exception enclosed in Failure. */
-    def await[A](f: Future[A], timeout: FiniteDuration = 500.milliseconds) = Await.result[A](f, timeout)
+    val initInterval = container.initialize(JsObject(), initTimeout)
+    await(initInterval, initTimeout) shouldBe interval
 
-    val containerId = ContainerId("id")
-    /**
-     * Constructs a testcontainer with overridden IO methods. Results of the override can be provided
-     * as parameters.
-     */
-    def dockerContainer(
-        id: ContainerId = containerId,
-        ip: ContainerIp = ContainerIp("ip"))(
-            ccRes: Future[RunResult] = Future.successful(RunResult(intervalOf(1.millisecond), Right(ContainerResponse(true, "", None)))),
-            retryCount: Int = 0)(
-                implicit docker: DockerApiWithFileAccess, runc: RuncApi): DockerContainer = {
+    // assert the starting log is there
+    val start = LogMarker.parse(logLines.head)
+    start.token shouldBe INVOKER_ACTIVATION_INIT
 
-        new DockerContainer(id, ip) {
-            override protected def callContainer(path: String, body: JsObject, timeout: FiniteDuration, retry: Boolean = false): Future[RunResult] = {
-                ccRes
-            }
-            override protected val logsRetryCount = retryCount
-            override protected val logsRetryWait = 0.milliseconds
-        }
+    // assert the end log is there
+    val end = LogMarker.parse(logLines.last)
+    end.token shouldBe INVOKER_ACTIVATION_INIT.asFinish
+    end.deltaToMarkerStart shouldBe Some(interval.duration.toMillis)
+  }
+
+  it should "properly deal with a timeout during initialization" in {
+    implicit val docker = stub[DockerApiWithFileAccess]
+    implicit val runc = stub[RuncApi]
+
+    val initTimeout = 1.second
+    val interval = intervalOf(initTimeout + 1.nanoseconds)
+
+    val container = dockerContainer() {
+      Future.successful(RunResult(interval, Left(Timeout())))
     }
 
-    /** Creates an interval starting at EPOCH with the given duration. */
-    def intervalOf(duration: FiniteDuration) = Interval(Instant.EPOCH, Instant.ofEpochMilli(duration.toMillis))
+    val init = container.initialize(JsObject(), initTimeout)
 
-    behavior of "DockerContainer"
+    val error = the[InitializationError] thrownBy await(init, initTimeout)
+    error.interval shouldBe interval
+    error.response.statusCode shouldBe ActivationResponse.ApplicationError
 
-    implicit val transid = TransactionId.testing
+    // assert the finish log is there
+    val end = LogMarker.parse(logLines.last)
+    end.token shouldBe INVOKER_ACTIVATION_INIT.asFinish
+  }
 
-    /*
-     * CONTAINER CREATION
-     */
-    it should "create a new instance" in {
-        implicit val docker = new TestDockerClient
-        implicit val runc = stub[RuncApi]
+  /*
+   * RUN
+   *
+   * Only tests for quite simple cases. Disambiguation of errors is delegated to ActivationResponse
+   * and so are the tests for those.
+   */
+  it should "run a container" in {
+    implicit val docker = stub[DockerApiWithFileAccess]
+    implicit val runc = stub[RuncApi]
 
-        val image = "image"
-        val memory = 128.MB
-        val cpuShares = 1
-        val environment = Map("test" -> "hi")
-        val network = "testwork"
-        val name = "myContainer"
-
-        val container = DockerContainer.create(
-            transid = transid,
-            image = image,
-            memory = memory,
-            cpuShares = cpuShares,
-            environment = environment,
-            network = network,
-            name = Some(name))
-
-        await(container)
-
-        docker.pulls should have size 0
-        docker.runs should have size 1
-        docker.inspects should have size 1
-        docker.rms should have size 0
-
-        val (testImage, args) = docker.runs.head
-        testImage shouldBe "image"
-
-        // Assert fixed values are passed as well
-        args should contain allOf ("--cap-drop", "NET_RAW", "NET_ADMIN")
-        args should contain inOrder ("--ulimit", "nofile=1024:1024")
-        args should contain inOrder ("--pids-limit", "1024") // OW PR 2119
-
-        // Assert proper parameter translation
-        args should contain inOrder ("--memory", s"${memory.toMB}m")
-        args should contain inOrder ("--memory-swap", s"${memory.toMB}m")
-        args should contain inOrder ("--cpu-shares", cpuShares.toString)
-        args should contain inOrder ("--network", network)
-        args should contain inOrder ("--name", name)
-
-        // Assert proper environment passing
-        args should contain allOf ("-e", "test=hi")
+    val interval = intervalOf(1.millisecond)
+    val result = JsObject()
+    val container = dockerContainer() {
+      Future.successful(RunResult(interval, Right(ContainerResponse(true, result.compactPrint, None))))
     }
 
-    it should "pull a user provided image before creating the container" in {
-        implicit val docker = new TestDockerClient
-        implicit val runc = stub[RuncApi]
+    val runResult = container.run(JsObject(), JsObject(), 1.second)
+    await(runResult) shouldBe (interval, ActivationResponse.success(Some(result)))
 
-        val container = DockerContainer.create(transid = transid, image = "image", userProvidedImage = true)
-        await(container)
+    // assert the starting log is there
+    val start = LogMarker.parse(logLines.head)
+    start.token shouldBe INVOKER_ACTIVATION_RUN
 
-        docker.pulls should have size 1
-        docker.runs should have size 1
-        docker.inspects should have size 1
-        docker.rms should have size 0
+    // assert the end log is there
+    val end = LogMarker.parse(logLines.last)
+    end.token shouldBe INVOKER_ACTIVATION_RUN.asFinish
+    end.deltaToMarkerStart shouldBe Some(interval.duration.toMillis)
+  }
+
+  it should "properly deal with a timeout during run" in {
+    implicit val docker = stub[DockerApiWithFileAccess]
+    implicit val runc = stub[RuncApi]
+
+    val runTimeout = 1.second
+    val interval = intervalOf(runTimeout + 1.nanoseconds)
+
+    val container = dockerContainer() {
+      Future.successful(RunResult(interval, Left(Timeout())))
     }
 
-    it should "remove the container if inspect fails" in {
-        implicit val docker = new TestDockerClient {
-            override def inspectIPAddress(id: ContainerId, network: String)(implicit transid: TransactionId): Future[ContainerIp] = {
-                inspects += ((id, network))
-                Future.failed(new RuntimeException())
-            }
-        }
-        implicit val runc = stub[RuncApi]
+    val runResult = container.run(JsObject(), JsObject(), runTimeout)
+    await(runResult) shouldBe (interval, ActivationResponse.applicationError(
+      Messages.timedoutActivation(runTimeout, false)))
 
-        val container = DockerContainer.create(transid = transid, image = "image")
-        a[WhiskContainerStartupError] should be thrownBy await(container)
+    // assert the finish log is there
+    val end = LogMarker.parse(logLines.last)
+    end.token shouldBe INVOKER_ACTIVATION_RUN.asFinish
+  }
 
-        docker.pulls should have size 0
-        docker.runs should have size 1
-        docker.inspects should have size 1
-        docker.rms should have size 1
+  /*
+   * LOGS
+   */
+  def toByteBuffer(s: String): ByteBuffer = {
+    val bb = ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8))
+    // Set position behind provided string to simulate read - this is what FileChannel.read() does
+    // Otherwise position would be 0 indicating that buffer is empty
+    bb.position(bb.capacity())
+    bb
+  }
+
+  def toRawLog(log: Seq[LogLine], appendSentinel: Boolean = true): ByteBuffer = {
+    val appendedLog = if (appendSentinel) {
+      val lastTime = log.lastOption.map { case LogLine(time, _, _) => time }.getOrElse(Instant.EPOCH.toString)
+      log :+
+        LogLine(lastTime, "stderr", s"${DockerActionLogDriver.LOG_ACTIVATION_SENTINEL}\n") :+
+        LogLine(lastTime, "stdout", s"${DockerActionLogDriver.LOG_ACTIVATION_SENTINEL}\n")
+    } else {
+      log
+    }
+    toByteBuffer(appendedLog.map(_.toJson.compactPrint).mkString("", "\n", "\n"))
+  }
+
+  it should "read a simple log with sentinel" in {
+    val expectedLogEntry = LogLine(Instant.EPOCH.toString, "stdout", "This is a log entry.\n")
+    val rawLog = toRawLog(Seq(expectedLogEntry), appendSentinel = true)
+    val readResults = mutable.Queue(rawLog)
+
+    implicit val docker = new TestDockerClient {
+      override def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
+        rawContainerLogsInvocations += ((containerId, fromPos))
+        Future.successful(readResults.dequeue())
+      }
+    }
+    implicit val runc = stub[RuncApi]
+
+    val container = dockerContainer(id = containerId)()
+    // Read with tight limit to verify that no truncation occurs
+    val processedLogs = await(container.logs(limit = expectedLogEntry.log.sizeInBytes, waitForSentinel = true))
+
+    docker.rawContainerLogsInvocations should have size 1
+    val (id, fromPos) = docker.rawContainerLogsInvocations(0)
+    id shouldBe containerId
+    fromPos shouldBe 0
+
+    processedLogs should have size 1
+    processedLogs shouldBe Vector(expectedLogEntry.toFormattedString)
+  }
+
+  it should "read a simple log without sentinel" in {
+    val expectedLogEntry = LogLine(Instant.EPOCH.toString, "stdout", "This is a log entry.\n")
+    val rawLog = toRawLog(Seq(expectedLogEntry), appendSentinel = false)
+    val readResults = mutable.Queue(rawLog)
+
+    implicit val docker = new TestDockerClient {
+      override def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
+        rawContainerLogsInvocations += ((containerId, fromPos))
+        Future.successful(readResults.dequeue())
+      }
+    }
+    implicit val runc = stub[RuncApi]
+
+    val container = dockerContainer(id = containerId)()
+    // Read without tight limit so that the full read result is processed
+    val processedLogs = await(container.logs(limit = 1.MB, waitForSentinel = false))
+
+    docker.rawContainerLogsInvocations should have size 1
+    val (id, fromPos) = docker.rawContainerLogsInvocations(0)
+    id shouldBe containerId
+    fromPos shouldBe 0
+
+    processedLogs should have size 1
+    processedLogs shouldBe Vector(expectedLogEntry.toFormattedString)
+  }
+
+  it should "fail log reading if error occurs during file reading" in {
+    implicit val docker = new TestDockerClient {
+      override def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
+        rawContainerLogsInvocations += ((containerId, fromPos))
+        Future.failed(new IOException)
+      }
+    }
+    implicit val runc = stub[RuncApi]
+
+    val container = dockerContainer()()
+    an[IOException] should be thrownBy await(container.logs(limit = 1.MB, waitForSentinel = true))
+
+    docker.rawContainerLogsInvocations should have size 1
+    val (id, fromPos) = docker.rawContainerLogsInvocations(0)
+    id shouldBe containerId
+    fromPos shouldBe 0
+
+    exactly(1, logLines) should include(s"Failed to obtain logs of ${containerId.asString}")
+  }
+
+  it should "read two consecutive logs with sentinel" in {
+    val firstLogEntry = LogLine(Instant.EPOCH.toString, "stdout", "This is the first log.\n")
+    val secondLogEntry = LogLine(Instant.EPOCH.plusSeconds(1L).toString, "stderr", "This is the second log.\n")
+    val firstRawLog = toRawLog(Seq(firstLogEntry), appendSentinel = true)
+    val secondRawLog = toRawLog(Seq(secondLogEntry), appendSentinel = true)
+    val returnValues = mutable.Queue(firstRawLog, secondRawLog)
+
+    implicit val docker = new TestDockerClient {
+      override def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
+        rawContainerLogsInvocations += ((containerId, fromPos))
+        Future.successful(returnValues.dequeue())
+      }
+    }
+    implicit val runc = stub[RuncApi]
+
+    val container = dockerContainer()()
+    // Read without tight limit so that the full read result is processed
+    val processedFirstLog = await(container.logs(limit = 1.MB, waitForSentinel = true))
+    val processedSecondLog = await(container.logs(limit = 1.MB, waitForSentinel = true))
+
+    docker.rawContainerLogsInvocations should have size 2
+    val (_, fromPos1) = docker.rawContainerLogsInvocations(0)
+    fromPos1 shouldBe 0
+    val (_, fromPos2) = docker.rawContainerLogsInvocations(1)
+    fromPos2 shouldBe firstRawLog.capacity() // second read should start behind the first line
+
+    processedFirstLog should have size 1
+    processedFirstLog shouldBe Vector(firstLogEntry.toFormattedString)
+    processedSecondLog should have size 1
+    processedSecondLog shouldBe Vector(secondLogEntry.toFormattedString)
+  }
+
+  it should "retry log reading if sentinel cannot be found in the first place" in {
+    val retries = 15
+    val expectedLog = (1 to retries).map { i =>
+      LogLine(Instant.EPOCH.plusMillis(i.toLong).toString, "stdout", s"This is log entry ${i}.\n")
+    }.toVector
+    val returnValues = mutable.Queue.empty[ByteBuffer]
+    for (i <- 0 to retries) {
+      // Sentinel only added for the last return value
+      returnValues += toRawLog(expectedLog.take(i).toSeq, appendSentinel = (i == retries))
     }
 
-    it should "provide a proper error if run fails for blackbox containers" in {
-        implicit val docker = new TestDockerClient {
-            override def run(image: String, args: Seq[String] = Seq.empty[String])(implicit transid: TransactionId): Future[ContainerId] = {
-                runs += ((image, args))
-                Future.failed(new RuntimeException())
-            }
-        }
-        implicit val runc = stub[RuncApi]
+    implicit val docker = new TestDockerClient {
+      override def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
+        rawContainerLogsInvocations += ((containerId, fromPos))
+        Future.successful(returnValues.dequeue())
+      }
+    }
+    implicit val runc = stub[RuncApi]
 
-        val container = DockerContainer.create(transid = transid, image = "image", userProvidedImage = true)
-        a[WhiskContainerStartupError] should be thrownBy await(container)
+    val container = dockerContainer()(retryCount = retries)
+    // Read without tight limit so that the full read result is processed
+    val processedLog = await(container.logs(limit = 1.MB, waitForSentinel = true))
 
-        docker.pulls should have size 1
-        docker.runs should have size 1
-        docker.inspects should have size 0
-        docker.rms should have size 0
+    docker.rawContainerLogsInvocations should have size retries + 1
+    forAll(docker.rawContainerLogsInvocations) {
+      case (_, fromPos) => fromPos shouldBe 0
     }
 
-    it should "provide a proper error if inspect fails for blackbox containers" in {
-        implicit val docker = new TestDockerClient {
-            override def inspectIPAddress(id: ContainerId, network: String)(implicit transid: TransactionId): Future[ContainerIp] = {
-                inspects += ((id, network))
-                Future.failed(new RuntimeException())
-            }
-        }
-        implicit val runc = stub[RuncApi]
+    processedLog should have size expectedLog.length
+    processedLog shouldBe expectedLog.map(_.toFormattedString)
 
-        val container = DockerContainer.create(transid = transid, image = "image", userProvidedImage = true)
-        a[WhiskContainerStartupError] should be thrownBy await(container)
+    (retries to 1).foreach { i =>
+      exactly(1, logLines) should include(s"log cursor advanced but missing sentinel, trying ${i} more times")
+    }
+  }
 
-        docker.pulls should have size 1
-        docker.runs should have size 1
-        docker.inspects should have size 1
-        docker.rms should have size 1
+  it should "provide full log if log reading retries are exhausted and no sentinel can be found" in {
+    val retries = 15
+    val expectedLog = (1 to retries).map { i =>
+      LogLine(Instant.EPOCH.plusMillis(i.toLong).toString, "stdout", s"This is log entry ${i}.\n")
+    }.toVector
+    val returnValues = mutable.Queue.empty[ByteBuffer]
+    for (i <- 0 to retries) {
+      returnValues += toRawLog(expectedLog.take(i).toSeq, appendSentinel = false)
     }
 
-    it should "return a specific error if pulling a user provided image failed" in {
-        implicit val docker = new TestDockerClient {
-            override def pull(image: String)(implicit transid: TransactionId): Future[Unit] = {
-                pulls += image
-                Future.failed(new RuntimeException())
-            }
-        }
-        implicit val runc = stub[RuncApi]
+    implicit val docker = new TestDockerClient {
+      override def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
+        rawContainerLogsInvocations += ((containerId, fromPos))
+        Future.successful(returnValues.dequeue())
+      }
+    }
+    implicit val runc = stub[RuncApi]
 
-        val container = DockerContainer.create(transid = transid, image = "image", userProvidedImage = true)
-        a[BlackboxStartupError] should be thrownBy await(container)
+    val container = dockerContainer()(retryCount = retries)
+    // Read without tight limit so that the full read result is processed
+    val processedLog = await(container.logs(limit = 1.MB, waitForSentinel = true))
 
-        docker.pulls should have size 1
-        docker.runs should have size 0
-        docker.inspects should have size 0
-        docker.rms should have size 0
+    docker.rawContainerLogsInvocations should have size retries + 1
+    forAll(docker.rawContainerLogsInvocations) {
+      case (_, fromPos) => fromPos shouldBe 0
     }
 
-    /*
-     * DOCKER COMMANDS
-     */
-    it should "halt and resume container via runc" in {
-        implicit val docker = stub[DockerApiWithFileAccess]
-        implicit val runc = stub[RuncApi]
+    processedLog should have size expectedLog.length
+    processedLog shouldBe expectedLog.map(_.toFormattedString)
 
-        val id = ContainerId("id")
-        val container = new DockerContainer(id, ContainerIp("ip"))
+    (retries to 1).foreach { i =>
+      exactly(1, logLines) should include(s"log cursor advanced but missing sentinel, trying ${i} more times")
+    }
+  }
 
-        container.suspend()
-        container.resume()
+  it should "truncate logs and advance reading position to end of current read" in {
+    val firstLogFirstEntry = LogLine(Instant.EPOCH.toString, "stdout", "This is the first line in first log.\n")
+    val firstLogSecondEntry =
+      LogLine(Instant.EPOCH.plusMillis(1L).toString, "stderr", "This is the second line in first log.\n")
 
-        (runc.pause(_: ContainerId)(_: TransactionId)).verify(id, transid)
-        (runc.resume(_: ContainerId)(_: TransactionId)).verify(id, transid)
+    val secondLogFirstEntry =
+      LogLine(Instant.EPOCH.plusMillis(2L).toString, "stdout", "This is the first line in second log.\n")
+    val secondLogSecondEntry =
+      LogLine(Instant.EPOCH.plusMillis(3L).toString, "stdout", "This is the second line in second log.\n")
+    val secondLogLimit = 4
+
+    val thirdLogFirstEntry =
+      LogLine(Instant.EPOCH.plusMillis(4L).toString, "stdout", "This is the first line in third log.\n")
+
+    val firstRawLog = toRawLog(Seq(firstLogFirstEntry, firstLogSecondEntry), appendSentinel = true)
+    val secondRawLog = toRawLog(Seq(secondLogFirstEntry, secondLogSecondEntry), appendSentinel = false)
+    val thirdRawLog = toRawLog(Seq(thirdLogFirstEntry), appendSentinel = true)
+
+    val returnValues = mutable.Queue(firstRawLog, secondRawLog, thirdRawLog)
+
+    implicit val docker = new TestDockerClient {
+      override def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
+        rawContainerLogsInvocations += ((containerId, fromPos))
+        Future.successful(returnValues.dequeue())
+      }
+    }
+    implicit val runc = stub[RuncApi]
+
+    val container = dockerContainer()()
+    val processedFirstLog = await(container.logs(limit = firstLogFirstEntry.log.sizeInBytes, waitForSentinel = true))
+    val processedSecondLog =
+      await(container.logs(limit = secondLogFirstEntry.log.take(secondLogLimit).sizeInBytes, waitForSentinel = false))
+    val processedThirdLog = await(container.logs(limit = 1.MB, waitForSentinel = true))
+
+    docker.rawContainerLogsInvocations should have size 3
+    val (_, fromPos1) = docker.rawContainerLogsInvocations(0)
+    fromPos1 shouldBe 0
+    val (_, fromPos2) = docker.rawContainerLogsInvocations(1)
+    fromPos2 shouldBe firstRawLog.capacity() // second read should start behind full content of first read
+    val (_, fromPos3) = docker.rawContainerLogsInvocations(2)
+    fromPos3 shouldBe firstRawLog.capacity() + secondRawLog
+      .capacity() // third read should start behind full content of first and second read
+
+    processedFirstLog should have size 2
+    processedFirstLog(0) shouldBe firstLogFirstEntry.toFormattedString
+    processedFirstLog(1) should startWith(Messages.truncateLogs(firstLogFirstEntry.log.sizeInBytes))
+
+    processedSecondLog should have size 2
+    processedSecondLog(0) shouldBe secondLogFirstEntry
+      .copy(log = secondLogFirstEntry.log.take(secondLogLimit))
+      .toFormattedString
+    processedSecondLog(1) should startWith(
+      Messages.truncateLogs(secondLogFirstEntry.log.take(secondLogLimit).sizeInBytes))
+
+    processedThirdLog should have size 1
+    processedThirdLog(0) shouldBe thirdLogFirstEntry.toFormattedString
+  }
+
+  class TestDockerClient extends DockerApiWithFileAccess {
+    var runs = mutable.Buffer.empty[(String, Seq[String])]
+    var inspects = mutable.Buffer.empty[(ContainerId, String)]
+    var pauses = mutable.Buffer.empty[ContainerId]
+    var unpauses = mutable.Buffer.empty[ContainerId]
+    var rms = mutable.Buffer.empty[ContainerId]
+    var pulls = mutable.Buffer.empty[String]
+    var rawContainerLogsInvocations = mutable.Buffer.empty[(ContainerId, Long)]
+
+    def run(image: String, args: Seq[String] = Seq.empty[String])(
+      implicit transid: TransactionId): Future[ContainerId] = {
+      runs += ((image, args))
+      Future.successful(ContainerId("testId"))
     }
 
-    it should "destroy a container via Docker" in {
-        implicit val docker = stub[DockerApiWithFileAccess]
-        implicit val runc = stub[RuncApi]
-
-        val id = ContainerId("id")
-        val container = new DockerContainer(id, ContainerIp("ip"))
-
-        container.destroy()
-
-        (docker.rm(_: ContainerId)(_: TransactionId)).verify(id, transid)
+    def inspectIPAddress(id: ContainerId, network: String)(implicit transid: TransactionId): Future[ContainerIp] = {
+      inspects += ((id, network))
+      Future.successful(ContainerIp("testIp"))
     }
 
-    /*
-     * INITIALIZE
-     *
-     * Only tests for quite simple cases. Disambiguation of errors is delegated to ActivationResponse
-     * and so are the tests for those.
-     */
-    it should "initialize a container" in {
-        implicit val docker = stub[DockerApiWithFileAccess]
-        implicit val runc = stub[RuncApi]
-
-        val initTimeout = 1.second
-        val interval = intervalOf(1.millisecond)
-        val container = dockerContainer() {
-            Future.successful(RunResult(interval, Right(ContainerResponse(true, "", None))))
-        }
-
-        val initInterval = container.initialize(JsObject(), initTimeout)
-        await(initInterval, initTimeout) shouldBe interval
-
-        // assert the starting log is there
-        val start = LogMarker.parse(logLines.head)
-        start.token shouldBe INVOKER_ACTIVATION_INIT
-
-        // assert the end log is there
-        val end = LogMarker.parse(logLines.last)
-        end.token shouldBe INVOKER_ACTIVATION_INIT.asFinish
-        end.deltaToMarkerStart shouldBe Some(interval.duration.toMillis)
+    def pause(id: ContainerId)(implicit transid: TransactionId): Future[Unit] = {
+      pauses += id
+      Future.successful(())
     }
 
-    it should "properly deal with a timeout during initialization" in {
-        implicit val docker = stub[DockerApiWithFileAccess]
-        implicit val runc = stub[RuncApi]
-
-        val initTimeout = 1.second
-        val interval = intervalOf(initTimeout + 1.nanoseconds)
-
-        val container = dockerContainer() {
-            Future.successful(RunResult(interval, Left(Timeout())))
-        }
-
-        val init = container.initialize(JsObject(), initTimeout)
-
-        val error = the[InitializationError] thrownBy await(init, initTimeout)
-        error.interval shouldBe interval
-        error.response.statusCode shouldBe ActivationResponse.ApplicationError
-
-        // assert the finish log is there
-        val end = LogMarker.parse(logLines.last)
-        end.token shouldBe INVOKER_ACTIVATION_INIT.asFinish
+    def unpause(id: ContainerId)(implicit transid: TransactionId): Future[Unit] = {
+      unpauses += id
+      Future.successful(())
     }
 
-    /*
-     * RUN
-     *
-     * Only tests for quite simple cases. Disambiguation of errors is delegated to ActivationResponse
-     * and so are the tests for those.
-     */
-    it should "run a container" in {
-        implicit val docker = stub[DockerApiWithFileAccess]
-        implicit val runc = stub[RuncApi]
-
-        val interval = intervalOf(1.millisecond)
-        val result = JsObject()
-        val container = dockerContainer() {
-            Future.successful(RunResult(interval, Right(ContainerResponse(true, result.compactPrint, None))))
-        }
-
-        val runResult = container.run(JsObject(), JsObject(), 1.second)
-        await(runResult) shouldBe (interval, ActivationResponse.success(Some(result)))
-
-        // assert the starting log is there
-        val start = LogMarker.parse(logLines.head)
-        start.token shouldBe INVOKER_ACTIVATION_RUN
-
-        // assert the end log is there
-        val end = LogMarker.parse(logLines.last)
-        end.token shouldBe INVOKER_ACTIVATION_RUN.asFinish
-        end.deltaToMarkerStart shouldBe Some(interval.duration.toMillis)
+    def rm(id: ContainerId)(implicit transid: TransactionId): Future[Unit] = {
+      rms += id
+      Future.successful(())
     }
 
-    it should "properly deal with a timeout during run" in {
-        implicit val docker = stub[DockerApiWithFileAccess]
-        implicit val runc = stub[RuncApi]
+    def ps(filters: Seq[(String, String)] = Seq(), all: Boolean = false)(
+      implicit transid: TransactionId): Future[Seq[ContainerId]] = ???
 
-        val runTimeout = 1.second
-        val interval = intervalOf(runTimeout + 1.nanoseconds)
-
-        val container = dockerContainer() {
-            Future.successful(RunResult(interval, Left(Timeout())))
-        }
-
-        val runResult = container.run(JsObject(), JsObject(), runTimeout)
-        await(runResult) shouldBe (interval, ActivationResponse.applicationError(Messages.timedoutActivation(runTimeout, false)))
-
-        // assert the finish log is there
-        val end = LogMarker.parse(logLines.last)
-        end.token shouldBe INVOKER_ACTIVATION_RUN.asFinish
+    def pull(image: String)(implicit transid: TransactionId): Future[Unit] = {
+      pulls += image
+      Future.successful(())
     }
 
-    /*
-     * LOGS
-     */
-    def toByteBuffer(s: String): ByteBuffer = {
-        val bb = ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8))
-        // Set position behind provided string to simulate read - this is what FileChannel.read() does
-        // Otherwise position would be 0 indicating that buffer is empty
-        bb.position(bb.capacity())
-        bb
+    def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
+      rawContainerLogsInvocations += ((containerId, fromPos))
+      Future.successful(ByteBuffer.wrap(Array[Byte]()))
     }
-
-    def toRawLog(log: Seq[LogLine], appendSentinel: Boolean = true): ByteBuffer = {
-        val appendedLog = if (appendSentinel) {
-            val lastTime = log.lastOption.map { case LogLine(time, _, _) => time }.getOrElse(Instant.EPOCH.toString)
-            log :+
-                LogLine(lastTime, "stderr", s"${DockerActionLogDriver.LOG_ACTIVATION_SENTINEL}\n") :+
-                LogLine(lastTime, "stdout", s"${DockerActionLogDriver.LOG_ACTIVATION_SENTINEL}\n")
-        } else {
-            log
-        }
-        toByteBuffer(appendedLog.map(_.toJson.compactPrint).mkString("", "\n", "\n"))
-    }
-
-    it should "read a simple log with sentinel" in {
-        val expectedLogEntry = LogLine(Instant.EPOCH.toString, "stdout", "This is a log entry.\n")
-        val rawLog = toRawLog(Seq(expectedLogEntry), appendSentinel = true)
-        val readResults = mutable.Queue(rawLog)
-
-        implicit val docker = new TestDockerClient {
-            override def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
-                rawContainerLogsInvocations += ((containerId, fromPos))
-                Future.successful(readResults.dequeue())
-            }
-        }
-        implicit val runc = stub[RuncApi]
-
-        val container = dockerContainer(id = containerId)()
-        // Read with tight limit to verify that no truncation occurs
-        val processedLogs = await(container.logs(limit = expectedLogEntry.log.sizeInBytes, waitForSentinel = true))
-
-        docker.rawContainerLogsInvocations should have size 1
-        val (id, fromPos) = docker.rawContainerLogsInvocations(0)
-        id shouldBe containerId
-        fromPos shouldBe 0
-
-        processedLogs should have size 1
-        processedLogs shouldBe Vector(expectedLogEntry.toFormattedString)
-    }
-
-    it should "read a simple log without sentinel" in {
-        val expectedLogEntry = LogLine(Instant.EPOCH.toString, "stdout", "This is a log entry.\n")
-        val rawLog = toRawLog(Seq(expectedLogEntry), appendSentinel = false)
-        val readResults = mutable.Queue(rawLog)
-
-        implicit val docker = new TestDockerClient {
-            override def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
-                rawContainerLogsInvocations += ((containerId, fromPos))
-                Future.successful(readResults.dequeue())
-            }
-        }
-        implicit val runc = stub[RuncApi]
-
-        val container = dockerContainer(id = containerId)()
-        // Read without tight limit so that the full read result is processed
-        val processedLogs = await(container.logs(limit = 1.MB, waitForSentinel = false))
-
-        docker.rawContainerLogsInvocations should have size 1
-        val (id, fromPos) = docker.rawContainerLogsInvocations(0)
-        id shouldBe containerId
-        fromPos shouldBe 0
-
-        processedLogs should have size 1
-        processedLogs shouldBe Vector(expectedLogEntry.toFormattedString)
-    }
-
-    it should "fail log reading if error occurs during file reading" in {
-        implicit val docker = new TestDockerClient {
-            override def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
-                rawContainerLogsInvocations += ((containerId, fromPos))
-                Future.failed(new IOException)
-            }
-        }
-        implicit val runc = stub[RuncApi]
-
-        val container = dockerContainer()()
-        an[IOException] should be thrownBy await(container.logs(limit = 1.MB, waitForSentinel = true))
-
-        docker.rawContainerLogsInvocations should have size 1
-        val (id, fromPos) = docker.rawContainerLogsInvocations(0)
-        id shouldBe containerId
-        fromPos shouldBe 0
-
-        exactly(1, logLines) should include(s"Failed to obtain logs of ${containerId.asString}")
-    }
-
-    it should "read two consecutive logs with sentinel" in {
-        val firstLogEntry = LogLine(Instant.EPOCH.toString, "stdout", "This is the first log.\n")
-        val secondLogEntry = LogLine(Instant.EPOCH.plusSeconds(1L).toString, "stderr", "This is the second log.\n")
-        val firstRawLog = toRawLog(Seq(firstLogEntry), appendSentinel = true)
-        val secondRawLog = toRawLog(Seq(secondLogEntry), appendSentinel = true)
-        val returnValues = mutable.Queue(firstRawLog, secondRawLog)
-
-        implicit val docker = new TestDockerClient {
-            override def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
-                rawContainerLogsInvocations += ((containerId, fromPos))
-                Future.successful(returnValues.dequeue())
-            }
-        }
-        implicit val runc = stub[RuncApi]
-
-        val container = dockerContainer()()
-        // Read without tight limit so that the full read result is processed
-        val processedFirstLog = await(container.logs(limit = 1.MB, waitForSentinel = true))
-        val processedSecondLog = await(container.logs(limit = 1.MB, waitForSentinel = true))
-
-        docker.rawContainerLogsInvocations should have size 2
-        val (_, fromPos1) = docker.rawContainerLogsInvocations(0)
-        fromPos1 shouldBe 0
-        val (_, fromPos2) = docker.rawContainerLogsInvocations(1)
-        fromPos2 shouldBe firstRawLog.capacity() // second read should start behind the first line
-
-        processedFirstLog should have size 1
-        processedFirstLog shouldBe Vector(firstLogEntry.toFormattedString)
-        processedSecondLog should have size 1
-        processedSecondLog shouldBe Vector(secondLogEntry.toFormattedString)
-    }
-
-    it should "retry log reading if sentinel cannot be found in the first place" in {
-        val retries = 15
-        val expectedLog = (1 to retries).map { i =>
-            LogLine(
-                Instant.EPOCH.plusMillis(i.toLong).toString,
-                "stdout",
-                s"This is log entry ${i}.\n")
-        }.toVector
-        val returnValues = mutable.Queue.empty[ByteBuffer]
-        for (i <- 0 to retries) {
-            // Sentinel only added for the last return value
-            returnValues += toRawLog(expectedLog.take(i).toSeq, appendSentinel = (i == retries))
-        }
-
-        implicit val docker = new TestDockerClient {
-            override def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
-                rawContainerLogsInvocations += ((containerId, fromPos))
-                Future.successful(returnValues.dequeue())
-            }
-        }
-        implicit val runc = stub[RuncApi]
-
-        val container = dockerContainer()(retryCount = retries)
-        // Read without tight limit so that the full read result is processed
-        val processedLog = await(container.logs(limit = 1.MB, waitForSentinel = true))
-
-        docker.rawContainerLogsInvocations should have size retries + 1
-        forAll(docker.rawContainerLogsInvocations) {
-            case (_, fromPos) => fromPos shouldBe 0
-        }
-
-        processedLog should have size expectedLog.length
-        processedLog shouldBe expectedLog.map(_.toFormattedString)
-
-        (retries to 1).foreach { i => exactly(1, logLines) should include(s"log cursor advanced but missing sentinel, trying ${i} more times") }
-    }
-
-    it should "provide full log if log reading retries are exhausted and no sentinel can be found" in {
-        val retries = 15
-        val expectedLog = (1 to retries).map { i =>
-            LogLine(
-                Instant.EPOCH.plusMillis(i.toLong).toString,
-                "stdout",
-                s"This is log entry ${i}.\n")
-        }.toVector
-        val returnValues = mutable.Queue.empty[ByteBuffer]
-        for (i <- 0 to retries) {
-            returnValues += toRawLog(expectedLog.take(i).toSeq, appendSentinel = false)
-        }
-
-        implicit val docker = new TestDockerClient {
-            override def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
-                rawContainerLogsInvocations += ((containerId, fromPos))
-                Future.successful(returnValues.dequeue())
-            }
-        }
-        implicit val runc = stub[RuncApi]
-
-        val container = dockerContainer()(retryCount = retries)
-        // Read without tight limit so that the full read result is processed
-        val processedLog = await(container.logs(limit = 1.MB, waitForSentinel = true))
-
-        docker.rawContainerLogsInvocations should have size retries + 1
-        forAll(docker.rawContainerLogsInvocations) {
-            case (_, fromPos) => fromPos shouldBe 0
-        }
-
-        processedLog should have size expectedLog.length
-        processedLog shouldBe expectedLog.map(_.toFormattedString)
-
-        (retries to 1).foreach { i => exactly(1, logLines) should include(s"log cursor advanced but missing sentinel, trying ${i} more times") }
-    }
-
-    it should "truncate logs and advance reading position to end of current read" in {
-        val firstLogFirstEntry = LogLine(Instant.EPOCH.toString, "stdout", "This is the first line in first log.\n")
-        val firstLogSecondEntry = LogLine(Instant.EPOCH.plusMillis(1L).toString, "stderr", "This is the second line in first log.\n")
-
-        val secondLogFirstEntry = LogLine(Instant.EPOCH.plusMillis(2L).toString, "stdout", "This is the first line in second log.\n")
-        val secondLogSecondEntry = LogLine(Instant.EPOCH.plusMillis(3L).toString, "stdout", "This is the second line in second log.\n")
-        val secondLogLimit = 4
-
-        val thirdLogFirstEntry = LogLine(Instant.EPOCH.plusMillis(4L).toString, "stdout", "This is the first line in third log.\n")
-
-        val firstRawLog = toRawLog(Seq(firstLogFirstEntry, firstLogSecondEntry), appendSentinel = true)
-        val secondRawLog = toRawLog(Seq(secondLogFirstEntry, secondLogSecondEntry), appendSentinel = false)
-        val thirdRawLog = toRawLog(Seq(thirdLogFirstEntry), appendSentinel = true)
-
-        val returnValues = mutable.Queue(firstRawLog, secondRawLog, thirdRawLog)
-
-        implicit val docker = new TestDockerClient {
-            override def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
-                rawContainerLogsInvocations += ((containerId, fromPos))
-                Future.successful(returnValues.dequeue())
-            }
-        }
-        implicit val runc = stub[RuncApi]
-
-        val container = dockerContainer()()
-        val processedFirstLog = await(container.logs(limit = firstLogFirstEntry.log.sizeInBytes, waitForSentinel = true))
-        val processedSecondLog = await(container.logs(limit = secondLogFirstEntry.log.take(secondLogLimit).sizeInBytes, waitForSentinel = false))
-        val processedThirdLog = await(container.logs(limit = 1.MB, waitForSentinel = true))
-
-        docker.rawContainerLogsInvocations should have size 3
-        val (_, fromPos1) = docker.rawContainerLogsInvocations(0)
-        fromPos1 shouldBe 0
-        val (_, fromPos2) = docker.rawContainerLogsInvocations(1)
-        fromPos2 shouldBe firstRawLog.capacity() // second read should start behind full content of first read
-        val (_, fromPos3) = docker.rawContainerLogsInvocations(2)
-        fromPos3 shouldBe firstRawLog.capacity() + secondRawLog.capacity() // third read should start behind full content of first and second read
-
-        processedFirstLog should have size 2
-        processedFirstLog(0) shouldBe firstLogFirstEntry.toFormattedString
-        processedFirstLog(1) should startWith(Messages.truncateLogs(firstLogFirstEntry.log.sizeInBytes))
-
-        processedSecondLog should have size 2
-        processedSecondLog(0) shouldBe secondLogFirstEntry.copy(log = secondLogFirstEntry.log.take(secondLogLimit)).toFormattedString
-        processedSecondLog(1) should startWith(Messages.truncateLogs(secondLogFirstEntry.log.take(secondLogLimit).sizeInBytes))
-
-        processedThirdLog should have size 1
-        processedThirdLog(0) shouldBe thirdLogFirstEntry.toFormattedString
-    }
-
-    class TestDockerClient extends DockerApiWithFileAccess {
-        var runs = mutable.Buffer.empty[(String, Seq[String])]
-        var inspects = mutable.Buffer.empty[(ContainerId, String)]
-        var pauses = mutable.Buffer.empty[ContainerId]
-        var unpauses = mutable.Buffer.empty[ContainerId]
-        var rms = mutable.Buffer.empty[ContainerId]
-        var pulls = mutable.Buffer.empty[String]
-        var rawContainerLogsInvocations = mutable.Buffer.empty[(ContainerId, Long)]
-
-        def run(image: String, args: Seq[String] = Seq.empty[String])(implicit transid: TransactionId): Future[ContainerId] = {
-            runs += ((image, args))
-            Future.successful(ContainerId("testId"))
-        }
-
-        def inspectIPAddress(id: ContainerId, network: String)(implicit transid: TransactionId): Future[ContainerIp] = {
-            inspects += ((id, network))
-            Future.successful(ContainerIp("testIp"))
-        }
-
-        def pause(id: ContainerId)(implicit transid: TransactionId): Future[Unit] = {
-            pauses += id
-            Future.successful(())
-        }
-
-        def unpause(id: ContainerId)(implicit transid: TransactionId): Future[Unit] = {
-            unpauses += id
-            Future.successful(())
-        }
-
-        def rm(id: ContainerId)(implicit transid: TransactionId): Future[Unit] = {
-            rms += id
-            Future.successful(())
-        }
-
-        def ps(filters: Seq[(String, String)] = Seq(), all: Boolean = false)(implicit transid: TransactionId): Future[Seq[ContainerId]] = ???
-
-        def pull(image: String)(implicit transid: TransactionId): Future[Unit] = {
-            pulls += image
-            Future.successful(())
-        }
-
-        def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
-            rawContainerLogsInvocations += ((containerId, fromPos))
-            Future.successful(ByteBuffer.wrap(Array[Byte]()))
-        }
-    }
+  }
 }

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/ProcessRunnerTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/ProcessRunnerTests.scala
@@ -35,26 +35,26 @@ import scala.language.reflectiveCalls // Needed to invoke run() method of struct
 @RunWith(classOf[JUnitRunner])
 class ProcessRunnerTests extends FlatSpec with Matchers {
 
-    def await[A](f: Future[A], timeout: FiniteDuration = 500.milliseconds) = Await.result(f, timeout)
+  def await[A](f: Future[A], timeout: FiniteDuration = 500.milliseconds) = Await.result(f, timeout)
 
-    val processRunner = new ProcessRunner {
-        def run(args: String*)(implicit ec: ExecutionContext) = executeProcess(args: _*)
-    }
+  val processRunner = new ProcessRunner {
+    def run(args: String*)(implicit ec: ExecutionContext) = executeProcess(args: _*)
+  }
 
-    behavior of "ProcessRunner"
+  behavior of "ProcessRunner"
 
-    it should "run an external command successfully and capture its output" in {
-        val stdout = "Output"
-        await(processRunner.run("echo", stdout)) shouldBe stdout
-    }
+  it should "run an external command successfully and capture its output" in {
+    val stdout = "Output"
+    await(processRunner.run("echo", stdout)) shouldBe stdout
+  }
 
-    it should "run an external command unsuccessfully and capture its output" in {
-        val exitCode = 1
-        val stdout = "Output"
-        val stderr = "Error"
+  it should "run an external command unsuccessfully and capture its output" in {
+    val exitCode = 1
+    val stdout = "Output"
+    val stderr = "Error"
 
-        val future = processRunner.run("/bin/sh", "-c", s"echo ${stdout}; echo ${stderr} 1>&2; exit ${exitCode}")
+    val future = processRunner.run("/bin/sh", "-c", s"echo ${stdout}; echo ${stderr} 1>&2; exit ${exitCode}")
 
-        the[ProcessRunningException] thrownBy await(future) shouldBe ProcessRunningException(exitCode, stdout, stderr)
-    }
+    the[ProcessRunningException] thrownBy await(future) shouldBe ProcessRunningException(exitCode, stdout, stderr)
+  }
 }

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerPoolTests.scala
@@ -50,226 +50,236 @@ import whisk.core.connector.MessageFeed
  * These tests test the runtime behavior of a ContainerPool actor.
  */
 @RunWith(classOf[JUnitRunner])
-class ContainerPoolTests extends TestKit(ActorSystem("ContainerPool"))
+class ContainerPoolTests
+    extends TestKit(ActorSystem("ContainerPool"))
     with ImplicitSender
     with FlatSpecLike
     with Matchers
     with BeforeAndAfterAll
     with MockFactory {
 
-    override def afterAll = TestKit.shutdownActorSystem(system)
+  override def afterAll = TestKit.shutdownActorSystem(system)
 
-    val timeout = 5.seconds
+  val timeout = 5.seconds
 
-    // Common entities to pass to the tests. We don't really care what's inside
-    // those for the behavior testing here, as none of the contents will really
-    // reach a container anyway. We merely assert that passing and extraction of
-    // the values is done properly.
-    val exec = CodeExecAsString(RuntimeManifest("actionKind", ImageName("testImage")), "testCode", None)
-    val memoryLimit = 256.MB
+  // Common entities to pass to the tests. We don't really care what's inside
+  // those for the behavior testing here, as none of the contents will really
+  // reach a container anyway. We merely assert that passing and extraction of
+  // the values is done properly.
+  val exec = CodeExecAsString(RuntimeManifest("actionKind", ImageName("testImage")), "testCode", None)
+  val memoryLimit = 256.MB
 
-    /** Creates a `Run` message */
-    def createRunMessage(action: ExecutableWhiskAction, invocationNamespace: EntityName) = {
-        val message = ActivationMessage(
-            TransactionId.testing,
-            action.fullyQualifiedName(true),
-            action.rev,
-            Identity(Subject(), invocationNamespace, AuthKey(), Set()),
-            ActivationId(),
-            invocationNamespace.toPath,
-            InstanceId(0),
-            blocking = false,
-            content = None)
-        Run(action, message)
-    }
+  /** Creates a `Run` message */
+  def createRunMessage(action: ExecutableWhiskAction, invocationNamespace: EntityName) = {
+    val message = ActivationMessage(
+      TransactionId.testing,
+      action.fullyQualifiedName(true),
+      action.rev,
+      Identity(Subject(), invocationNamespace, AuthKey(), Set()),
+      ActivationId(),
+      invocationNamespace.toPath,
+      InstanceId(0),
+      blocking = false,
+      content = None)
+    Run(action, message)
+  }
 
-    val invocationNamespace = EntityName("invocationSpace")
-    val differentInvocationNamespace = EntityName("invocationSpace2")
-    val action = ExecutableWhiskAction(EntityPath("actionSpace"), EntityName("actionName"), exec)
-    val differentAction = action.copy(name = EntityName("actionName2"))
+  val invocationNamespace = EntityName("invocationSpace")
+  val differentInvocationNamespace = EntityName("invocationSpace2")
+  val action = ExecutableWhiskAction(EntityPath("actionSpace"), EntityName("actionName"), exec)
+  val differentAction = action.copy(name = EntityName("actionName2"))
 
-    val runMessage = createRunMessage(action, invocationNamespace)
-    val runMessageDifferentNamespace = createRunMessage(action, differentInvocationNamespace)
-    val runMessageDifferentEverything = createRunMessage(differentAction, differentInvocationNamespace)
+  val runMessage = createRunMessage(action, invocationNamespace)
+  val runMessageDifferentNamespace = createRunMessage(action, differentInvocationNamespace)
+  val runMessageDifferentEverything = createRunMessage(differentAction, differentInvocationNamespace)
 
-    /** Helper to create PreWarmedData */
-    def preWarmedData(kind: String, memoryLimit: ByteSize = memoryLimit) = PreWarmedData(stub[Container], kind, memoryLimit)
+  /** Helper to create PreWarmedData */
+  def preWarmedData(kind: String, memoryLimit: ByteSize = memoryLimit) =
+    PreWarmedData(stub[Container], kind, memoryLimit)
 
-    /** Helper to create WarmedData */
-    def warmedData(action: ExecutableWhiskAction = action, namespace: String = "invocationSpace", lastUsed: Instant = Instant.now) =
-        WarmedData(stub[Container], EntityName(namespace), action, lastUsed)
+  /** Helper to create WarmedData */
+  def warmedData(action: ExecutableWhiskAction = action,
+                 namespace: String = "invocationSpace",
+                 lastUsed: Instant = Instant.now) =
+    WarmedData(stub[Container], EntityName(namespace), action, lastUsed)
 
-    /** Creates a sequence of containers and a factory returning this sequence. */
-    def testContainers(n: Int) = {
-        val containers = (0 to n).map(_ => TestProbe())
-        val queue = mutable.Queue(containers: _*)
-        val factory = (fac: ActorRefFactory) => queue.dequeue().ref
-        (containers, factory)
-    }
+  /** Creates a sequence of containers and a factory returning this sequence. */
+  def testContainers(n: Int) = {
+    val containers = (0 to n).map(_ => TestProbe())
+    val queue = mutable.Queue(containers: _*)
+    val factory = (fac: ActorRefFactory) => queue.dequeue().ref
+    (containers, factory)
+  }
 
-    behavior of "ContainerPool"
+  behavior of "ContainerPool"
 
-    /*
-     * CONTAINER SCHEDULING
-     *
-     * These tests only test the simplest approaches. Look below for full coverage tests
-     * of the respective scheduling methods.
-     */
-    it should "reuse a warm container" in within(timeout) {
-        val (containers, factory) = testContainers(2)
-        val feed = TestProbe()
-        val pool = system.actorOf(ContainerPool.props(factory, 2, 2, feed.ref))
+  /*
+   * CONTAINER SCHEDULING
+   *
+   * These tests only test the simplest approaches. Look below for full coverage tests
+   * of the respective scheduling methods.
+   */
+  it should "reuse a warm container" in within(timeout) {
+    val (containers, factory) = testContainers(2)
+    val feed = TestProbe()
+    val pool = system.actorOf(ContainerPool.props(factory, 2, 2, feed.ref))
 
-        pool ! runMessage
-        containers(0).expectMsg(runMessage)
-        containers(0).send(pool, NeedWork(warmedData()))
+    pool ! runMessage
+    containers(0).expectMsg(runMessage)
+    containers(0).send(pool, NeedWork(warmedData()))
 
-        pool ! runMessage
-        containers(0).expectMsg(runMessage)
-        containers(1).expectNoMsg(100.milliseconds)
-    }
+    pool ! runMessage
+    containers(0).expectMsg(runMessage)
+    containers(1).expectNoMsg(100.milliseconds)
+  }
 
-    it should "create a container if it cannot find a matching container" in within(timeout) {
-        val (containers, factory) = testContainers(2)
-        val feed = TestProbe()
+  it should "create a container if it cannot find a matching container" in within(timeout) {
+    val (containers, factory) = testContainers(2)
+    val feed = TestProbe()
 
-        val pool = system.actorOf(ContainerPool.props(factory, 2, 2, feed.ref))
-        pool ! runMessage
-        containers(0).expectMsg(runMessage)
-        // Note that the container doesn't respond, thus it's not free to take work
-        pool ! runMessage
-        containers(1).expectMsg(runMessage)
-    }
+    val pool = system.actorOf(ContainerPool.props(factory, 2, 2, feed.ref))
+    pool ! runMessage
+    containers(0).expectMsg(runMessage)
+    // Note that the container doesn't respond, thus it's not free to take work
+    pool ! runMessage
+    containers(1).expectMsg(runMessage)
+  }
 
-    it should "remove a container to make space in the pool if it is already full and a different action arrives" in within(timeout) {
-        val (containers, factory) = testContainers(2)
-        val feed = TestProbe()
+  it should "remove a container to make space in the pool if it is already full and a different action arrives" in within(
+    timeout) {
+    val (containers, factory) = testContainers(2)
+    val feed = TestProbe()
 
-        // a pool with only 1 slot
-        val pool = system.actorOf(ContainerPool.props(factory, 1, 1, feed.ref))
-        pool ! runMessage
-        containers(0).expectMsg(runMessage)
-        containers(0).send(pool, NeedWork(warmedData()))
-        feed.expectMsg(MessageFeed.Processed)
-        pool ! runMessageDifferentEverything
-        containers(0).expectMsg(Remove)
-        containers(1).expectMsg(runMessageDifferentEverything)
-    }
+    // a pool with only 1 slot
+    val pool = system.actorOf(ContainerPool.props(factory, 1, 1, feed.ref))
+    pool ! runMessage
+    containers(0).expectMsg(runMessage)
+    containers(0).send(pool, NeedWork(warmedData()))
+    feed.expectMsg(MessageFeed.Processed)
+    pool ! runMessageDifferentEverything
+    containers(0).expectMsg(Remove)
+    containers(1).expectMsg(runMessageDifferentEverything)
+  }
 
-    it should "cache a container if there is still space in the pool" in within(timeout) {
-        val (containers, factory) = testContainers(2)
-        val feed = TestProbe()
+  it should "cache a container if there is still space in the pool" in within(timeout) {
+    val (containers, factory) = testContainers(2)
+    val feed = TestProbe()
 
-        // a pool with only 1 active slot but 2 slots in total
-        val pool = system.actorOf(ContainerPool.props(factory, 1, 2, feed.ref))
+    // a pool with only 1 active slot but 2 slots in total
+    val pool = system.actorOf(ContainerPool.props(factory, 1, 2, feed.ref))
 
-        // Run the first container
-        pool ! runMessage
-        containers(0).expectMsg(runMessage)
-        containers(0).send(pool, NeedWork(warmedData(lastUsed = Instant.EPOCH)))
-        feed.expectMsg(MessageFeed.Processed)
+    // Run the first container
+    pool ! runMessage
+    containers(0).expectMsg(runMessage)
+    containers(0).send(pool, NeedWork(warmedData(lastUsed = Instant.EPOCH)))
+    feed.expectMsg(MessageFeed.Processed)
 
-        // Run the second container, don't remove the first one
-        pool ! runMessageDifferentEverything
-        containers(1).expectMsg(runMessageDifferentEverything)
-        containers(1).send(pool, NeedWork(warmedData(lastUsed = Instant.now)))
-        feed.expectMsg(MessageFeed.Processed)
-        pool ! runMessageDifferentNamespace
-        containers(2).expectMsg(runMessageDifferentNamespace)
+    // Run the second container, don't remove the first one
+    pool ! runMessageDifferentEverything
+    containers(1).expectMsg(runMessageDifferentEverything)
+    containers(1).send(pool, NeedWork(warmedData(lastUsed = Instant.now)))
+    feed.expectMsg(MessageFeed.Processed)
+    pool ! runMessageDifferentNamespace
+    containers(2).expectMsg(runMessageDifferentNamespace)
 
-        // 2 Slots exhausted, remove the first container to make space
-        containers(0).expectMsg(Remove)
-    }
+    // 2 Slots exhausted, remove the first container to make space
+    containers(0).expectMsg(Remove)
+  }
 
-    it should "remove a container to make space in the pool if it is already full and another action with different invocation namespace arrives" in within(timeout) {
-        val (containers, factory) = testContainers(2)
-        val feed = TestProbe()
+  it should "remove a container to make space in the pool if it is already full and another action with different invocation namespace arrives" in within(
+    timeout) {
+    val (containers, factory) = testContainers(2)
+    val feed = TestProbe()
 
-        // a pool with only 1 slot
-        val pool = system.actorOf(ContainerPool.props(factory, 1, 1, feed.ref))
-        pool ! runMessage
-        containers(0).expectMsg(runMessage)
-        containers(0).send(pool, NeedWork(warmedData()))
-        feed.expectMsg(MessageFeed.Processed)
-        pool ! runMessageDifferentNamespace
-        containers(0).expectMsg(Remove)
-        containers(1).expectMsg(runMessageDifferentNamespace)
-    }
+    // a pool with only 1 slot
+    val pool = system.actorOf(ContainerPool.props(factory, 1, 1, feed.ref))
+    pool ! runMessage
+    containers(0).expectMsg(runMessage)
+    containers(0).send(pool, NeedWork(warmedData()))
+    feed.expectMsg(MessageFeed.Processed)
+    pool ! runMessageDifferentNamespace
+    containers(0).expectMsg(Remove)
+    containers(1).expectMsg(runMessageDifferentNamespace)
+  }
 
-    /*
-     * CONTAINER PREWARMING
-     */
-    it should "create prewarmed containers on startup" in within(timeout) {
-        val (containers, factory) = testContainers(1)
-        val feed = TestProbe()
+  /*
+   * CONTAINER PREWARMING
+   */
+  it should "create prewarmed containers on startup" in within(timeout) {
+    val (containers, factory) = testContainers(1)
+    val feed = TestProbe()
 
-        val pool = system.actorOf(ContainerPool.props(factory, 0, 0, feed.ref, Some(PrewarmingConfig(1, exec, memoryLimit))))
-        containers(0).expectMsg(Start(exec, memoryLimit))
-    }
+    val pool =
+      system.actorOf(ContainerPool.props(factory, 0, 0, feed.ref, Some(PrewarmingConfig(1, exec, memoryLimit))))
+    containers(0).expectMsg(Start(exec, memoryLimit))
+  }
 
-    it should "use a prewarmed container and create a new one to fill its place" in within(timeout) {
-        val (containers, factory) = testContainers(2)
-        val feed = TestProbe()
+  it should "use a prewarmed container and create a new one to fill its place" in within(timeout) {
+    val (containers, factory) = testContainers(2)
+    val feed = TestProbe()
 
-        val pool = system.actorOf(ContainerPool.props(factory, 1, 1, feed.ref, Some(PrewarmingConfig(1, exec, memoryLimit))))
-        containers(0).expectMsg(Start(exec, memoryLimit))
-        containers(0).send(pool, NeedWork(preWarmedData(exec.kind)))
-        pool ! runMessage
-        containers(1).expectMsg(Start(exec, memoryLimit))
-    }
+    val pool =
+      system.actorOf(ContainerPool.props(factory, 1, 1, feed.ref, Some(PrewarmingConfig(1, exec, memoryLimit))))
+    containers(0).expectMsg(Start(exec, memoryLimit))
+    containers(0).send(pool, NeedWork(preWarmedData(exec.kind)))
+    pool ! runMessage
+    containers(1).expectMsg(Start(exec, memoryLimit))
+  }
 
-    it should "not use a prewarmed container if it doesn't fit the kind" in within(timeout) {
-        val (containers, factory) = testContainers(2)
-        val feed = TestProbe()
+  it should "not use a prewarmed container if it doesn't fit the kind" in within(timeout) {
+    val (containers, factory) = testContainers(2)
+    val feed = TestProbe()
 
-        val alternativeExec = CodeExecAsString(RuntimeManifest("anotherKind", ImageName("testImage")), "testCode", None)
+    val alternativeExec = CodeExecAsString(RuntimeManifest("anotherKind", ImageName("testImage")), "testCode", None)
 
-        val pool = system.actorOf(ContainerPool.props(factory, 1, 1, feed.ref, Some(PrewarmingConfig(1, alternativeExec, memoryLimit))))
-        containers(0).expectMsg(Start(alternativeExec, memoryLimit)) // container0 was prewarmed
-        containers(0).send(pool, NeedWork(preWarmedData(alternativeExec.kind)))
-        pool ! runMessage
-        containers(1).expectMsg(runMessage) // but container1 is used
-    }
+    val pool = system.actorOf(
+      ContainerPool.props(factory, 1, 1, feed.ref, Some(PrewarmingConfig(1, alternativeExec, memoryLimit))))
+    containers(0).expectMsg(Start(alternativeExec, memoryLimit)) // container0 was prewarmed
+    containers(0).send(pool, NeedWork(preWarmedData(alternativeExec.kind)))
+    pool ! runMessage
+    containers(1).expectMsg(runMessage) // but container1 is used
+  }
 
-    it should "not use a prewarmed container if it doesn't fit memory wise" in within(timeout) {
-        val (containers, factory) = testContainers(2)
-        val feed = TestProbe()
+  it should "not use a prewarmed container if it doesn't fit memory wise" in within(timeout) {
+    val (containers, factory) = testContainers(2)
+    val feed = TestProbe()
 
-        val alternativeLimit = 128.MB
+    val alternativeLimit = 128.MB
 
-        val pool = system.actorOf(ContainerPool.props(factory, 1, 1, feed.ref, Some(PrewarmingConfig(1, exec, alternativeLimit))))
-        containers(0).expectMsg(Start(exec, alternativeLimit)) // container0 was prewarmed
-        containers(0).send(pool, NeedWork(preWarmedData(exec.kind, alternativeLimit)))
-        pool ! runMessage
-        containers(1).expectMsg(runMessage) // but container1 is used
-    }
+    val pool =
+      system.actorOf(ContainerPool.props(factory, 1, 1, feed.ref, Some(PrewarmingConfig(1, exec, alternativeLimit))))
+    containers(0).expectMsg(Start(exec, alternativeLimit)) // container0 was prewarmed
+    containers(0).send(pool, NeedWork(preWarmedData(exec.kind, alternativeLimit)))
+    pool ! runMessage
+    containers(1).expectMsg(runMessage) // but container1 is used
+  }
 
-    /*
-     * CONTAINER DELETION
-     */
-    it should "not reuse a container which is scheduled for deletion" in within(timeout) {
-        val (containers, factory) = testContainers(2)
-        val feed = TestProbe()
+  /*
+   * CONTAINER DELETION
+   */
+  it should "not reuse a container which is scheduled for deletion" in within(timeout) {
+    val (containers, factory) = testContainers(2)
+    val feed = TestProbe()
 
-        val pool = system.actorOf(ContainerPool.props(factory, 2, 2, feed.ref))
+    val pool = system.actorOf(ContainerPool.props(factory, 2, 2, feed.ref))
 
-        // container0 is created and used
-        pool ! runMessage
-        containers(0).expectMsg(runMessage)
-        containers(0).send(pool, NeedWork(warmedData()))
+    // container0 is created and used
+    pool ! runMessage
+    containers(0).expectMsg(runMessage)
+    containers(0).send(pool, NeedWork(warmedData()))
 
-        // container0 is reused
-        pool ! runMessage
-        containers(0).expectMsg(runMessage)
-        containers(0).send(pool, NeedWork(warmedData()))
+    // container0 is reused
+    pool ! runMessage
+    containers(0).expectMsg(runMessage)
+    containers(0).send(pool, NeedWork(warmedData()))
 
-        // container0 is deleted
-        containers(0).send(pool, ContainerRemoved)
+    // container0 is deleted
+    containers(0).send(pool, ContainerRemoved)
 
-        // container1 is created and used
-        pool ! runMessage
-        containers(1).expectMsg(runMessage)
-    }
+    // container1 is created and used
+    pool ! runMessage
+    containers(1).expectMsg(runMessage)
+  }
 }
 
 /**
@@ -281,137 +291,129 @@ class ContainerPoolTests extends TestKit(ActorSystem("ContainerPool"))
 @RunWith(classOf[JUnitRunner])
 class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
 
-    val actionExec = CodeExecAsString(RuntimeManifest("actionKind", ImageName("testImage")), "testCode", None)
-    val standardNamespace = EntityName("standardNamespace")
-    val differentNamespace = EntityName("differentNamespace")
+  val actionExec = CodeExecAsString(RuntimeManifest("actionKind", ImageName("testImage")), "testCode", None)
+  val standardNamespace = EntityName("standardNamespace")
+  val differentNamespace = EntityName("differentNamespace")
 
-    /** Helper to create a new action from String representations */
-    def createAction(namespace: String = "actionNS", name: String = "actionName") =
-        ExecutableWhiskAction(EntityPath(namespace), EntityName(name), actionExec)
+  /** Helper to create a new action from String representations */
+  def createAction(namespace: String = "actionNS", name: String = "actionName") =
+    ExecutableWhiskAction(EntityPath(namespace), EntityName(name), actionExec)
 
-    /** Helper to create WarmedData with sensible defaults */
-    def warmedData(action: ExecutableWhiskAction = createAction(), namespace: String = standardNamespace.asString, lastUsed: Instant = Instant.now) =
-        WarmedData(stub[Container], EntityName(namespace), action, lastUsed)
+  /** Helper to create WarmedData with sensible defaults */
+  def warmedData(action: ExecutableWhiskAction = createAction(),
+                 namespace: String = standardNamespace.asString,
+                 lastUsed: Instant = Instant.now) =
+    WarmedData(stub[Container], EntityName(namespace), action, lastUsed)
 
-    /** Helper to create PreWarmedData with sensible defaults */
-    def preWarmedData(kind: String = "anyKind") = PreWarmedData(stub[Container], kind, 256.MB)
+  /** Helper to create PreWarmedData with sensible defaults */
+  def preWarmedData(kind: String = "anyKind") = PreWarmedData(stub[Container], kind, 256.MB)
 
-    /** Helper to create NoData */
-    def noData() = NoData()
+  /** Helper to create NoData */
+  def noData() = NoData()
 
-    behavior of "ContainerPool schedule()"
+  behavior of "ContainerPool schedule()"
 
-    it should "not provide a container if idle pool is empty" in {
-        ContainerPool.schedule(createAction(), standardNamespace, Map()) shouldBe None
-    }
+  it should "not provide a container if idle pool is empty" in {
+    ContainerPool.schedule(createAction(), standardNamespace, Map()) shouldBe None
+  }
 
-    it should "reuse an applicable warm container from idle pool with one container" in {
-        val data = warmedData()
-        val pool = Map('name -> data)
+  it should "reuse an applicable warm container from idle pool with one container" in {
+    val data = warmedData()
+    val pool = Map('name -> data)
 
-        // copy to make sure, referencial equality doesn't suffice
-        ContainerPool.schedule(data.action.copy(), data.invocationNamespace, pool) shouldBe Some('name, data)
-    }
+    // copy to make sure, referencial equality doesn't suffice
+    ContainerPool.schedule(data.action.copy(), data.invocationNamespace, pool) shouldBe Some('name, data)
+  }
 
-    it should "reuse an applicable warm container from idle pool with several applicable containers" in {
-        val data = warmedData()
-        val pool = Map(
-            'first -> data,
-            'second -> data)
+  it should "reuse an applicable warm container from idle pool with several applicable containers" in {
+    val data = warmedData()
+    val pool = Map('first -> data, 'second -> data)
 
-        ContainerPool.schedule(data.action.copy(), data.invocationNamespace, pool) should (be(Some('first, data)) or be(Some('second, data)))
-    }
+    ContainerPool.schedule(data.action.copy(), data.invocationNamespace, pool) should (be(Some('first, data)) or be(
+      Some('second, data)))
+  }
 
-    it should "reuse an applicable warm container from idle pool with several different containers" in {
-        val matchingData = warmedData()
-        val pool = Map(
-            'none -> noData(),
-            'pre -> preWarmedData(),
-            'warm -> matchingData)
+  it should "reuse an applicable warm container from idle pool with several different containers" in {
+    val matchingData = warmedData()
+    val pool = Map('none -> noData(), 'pre -> preWarmedData(), 'warm -> matchingData)
 
-        ContainerPool.schedule(matchingData.action.copy(), matchingData.invocationNamespace, pool) shouldBe Some('warm, matchingData)
-    }
+    ContainerPool.schedule(matchingData.action.copy(), matchingData.invocationNamespace, pool) shouldBe Some(
+      'warm,
+      matchingData)
+  }
 
-    it should "not reuse a container from idle pool with non-warm containers" in {
-        val data = warmedData()
-        // data is **not** in the pool!
-        val pool = Map(
-            'none -> noData(),
-            'pre -> preWarmedData())
+  it should "not reuse a container from idle pool with non-warm containers" in {
+    val data = warmedData()
+    // data is **not** in the pool!
+    val pool = Map('none -> noData(), 'pre -> preWarmedData())
 
-        ContainerPool.schedule(data.action.copy(), data.invocationNamespace, pool) shouldBe None
-    }
+    ContainerPool.schedule(data.action.copy(), data.invocationNamespace, pool) shouldBe None
+  }
 
-    it should "not reuse a warm container with different invocation namespace" in {
-        val data = warmedData()
-        val pool = Map('warm -> data)
-        val differentNamespace = EntityName(data.invocationNamespace.asString + "butDifferent")
+  it should "not reuse a warm container with different invocation namespace" in {
+    val data = warmedData()
+    val pool = Map('warm -> data)
+    val differentNamespace = EntityName(data.invocationNamespace.asString + "butDifferent")
 
-        data.invocationNamespace should not be differentNamespace
-        ContainerPool.schedule(data.action.copy(), differentNamespace, pool) shouldBe None
-    }
+    data.invocationNamespace should not be differentNamespace
+    ContainerPool.schedule(data.action.copy(), differentNamespace, pool) shouldBe None
+  }
 
-    it should "not reuse a warm container with different action name" in {
-        val data = warmedData()
-        val differentAction = data.action.copy(name = EntityName(data.action.name.asString + "butDifferent"))
-        val pool = Map('warm -> data)
+  it should "not reuse a warm container with different action name" in {
+    val data = warmedData()
+    val differentAction = data.action.copy(name = EntityName(data.action.name.asString + "butDifferent"))
+    val pool = Map('warm -> data)
 
-        data.action.name should not be differentAction.name
-        ContainerPool.schedule(differentAction, data.invocationNamespace, pool) shouldBe None
-    }
+    data.action.name should not be differentAction.name
+    ContainerPool.schedule(differentAction, data.invocationNamespace, pool) shouldBe None
+  }
 
-    it should "not reuse a warm container with different action version" in {
-        val data = warmedData()
-        val differentAction = data.action.copy(version = data.action.version.upMajor)
-        val pool = Map('warm -> data)
+  it should "not reuse a warm container with different action version" in {
+    val data = warmedData()
+    val differentAction = data.action.copy(version = data.action.version.upMajor)
+    val pool = Map('warm -> data)
 
-        data.action.version should not be differentAction.version
-        ContainerPool.schedule(differentAction, data.invocationNamespace, pool) shouldBe None
-    }
+    data.action.version should not be differentAction.version
+    ContainerPool.schedule(differentAction, data.invocationNamespace, pool) shouldBe None
+  }
 
-    behavior of "ContainerPool remove()"
+  behavior of "ContainerPool remove()"
 
-    it should "not provide a container if pool is empty" in {
-        ContainerPool.remove(createAction(), standardNamespace, Map()) shouldBe None
-    }
+  it should "not provide a container if pool is empty" in {
+    ContainerPool.remove(createAction(), standardNamespace, Map()) shouldBe None
+  }
 
-    it should "not provide a container from busy pool with non-warm containers" in {
-        val pool = Map(
-            'none -> noData(),
-            'pre -> preWarmedData())
-        ContainerPool.remove(createAction(), standardNamespace, pool) shouldBe None
-    }
+  it should "not provide a container from busy pool with non-warm containers" in {
+    val pool = Map('none -> noData(), 'pre -> preWarmedData())
+    ContainerPool.remove(createAction(), standardNamespace, pool) shouldBe None
+  }
 
-    it should "not provide a container from pool with one single free container with the same action and namespace" in {
-        val data = warmedData()
-        val pool = Map('warm -> data)
+  it should "not provide a container from pool with one single free container with the same action and namespace" in {
+    val data = warmedData()
+    val pool = Map('warm -> data)
 
-        // same data --> no removal
-        ContainerPool.remove(data.action, data.invocationNamespace, pool) shouldBe None
+    // same data --> no removal
+    ContainerPool.remove(data.action, data.invocationNamespace, pool) shouldBe None
 
-        // different action, same namespace --> remove
-        ContainerPool.remove(createAction(data.action.name + "butDifferent"),
-            data.invocationNamespace, pool) shouldBe Some('warm)
+    // different action, same namespace --> remove
+    ContainerPool.remove(createAction(data.action.name + "butDifferent"), data.invocationNamespace, pool) shouldBe Some(
+      'warm)
 
-        // different namespace, same action --> remove
-        ContainerPool.remove(data.action, differentNamespace, pool) shouldBe Some('warm)
+    // different namespace, same action --> remove
+    ContainerPool.remove(data.action, differentNamespace, pool) shouldBe Some('warm)
 
-        // different everything --> remove
-        ContainerPool.remove(createAction(data.action.name + "butDifferent"),
-            differentNamespace, pool) shouldBe Some('warm)
-    }
+    // different everything --> remove
+    ContainerPool.remove(createAction(data.action.name + "butDifferent"), differentNamespace, pool) shouldBe Some('warm)
+  }
 
-    it should "provide oldest container from busy pool with multiple containers" in {
-        val commonNamespace = differentNamespace.asString
-        val first = warmedData(namespace = commonNamespace, lastUsed = Instant.ofEpochMilli(1))
-        val second = warmedData(namespace = commonNamespace, lastUsed = Instant.ofEpochMilli(2))
-        val oldest = warmedData(namespace = commonNamespace, lastUsed = Instant.ofEpochMilli(0))
+  it should "provide oldest container from busy pool with multiple containers" in {
+    val commonNamespace = differentNamespace.asString
+    val first = warmedData(namespace = commonNamespace, lastUsed = Instant.ofEpochMilli(1))
+    val second = warmedData(namespace = commonNamespace, lastUsed = Instant.ofEpochMilli(2))
+    val oldest = warmedData(namespace = commonNamespace, lastUsed = Instant.ofEpochMilli(0))
 
-        val pool = Map(
-            'first -> first,
-            'second -> second,
-            'oldest -> oldest)
+    val pool = Map('first -> first, 'second -> second, 'oldest -> oldest)
 
-        ContainerPool.remove(createAction(), standardNamespace, pool) shouldBe Some('oldest)
-    }
+    ContainerPool.remove(createAction(), standardNamespace, pool) shouldBe Some('oldest)
+  }
 }

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
@@ -50,495 +50,505 @@ import whisk.core.entity.ExecManifest.ImageName
 import whisk.core.entity.size._
 
 @RunWith(classOf[JUnitRunner])
-class ContainerProxyTests extends TestKit(ActorSystem("ContainerProxys"))
+class ContainerProxyTests
+    extends TestKit(ActorSystem("ContainerProxys"))
     with ImplicitSender
     with FlatSpecLike
     with Matchers
     with BeforeAndAfterAll
     with MockFactory {
 
-    override def afterAll = TestKit.shutdownActorSystem(system)
+  override def afterAll = TestKit.shutdownActorSystem(system)
 
-    val timeout = 5.seconds
+  val timeout = 5.seconds
 
-    // Common entities to pass to the tests. We don't really care what's inside
-    // those for the behavior testing here, as none of the contents will really
-    // reach a container anyway. We merely assert that passing and extraction of
-    // the values is done properly.
-    val exec = CodeExecAsString(RuntimeManifest("actionKind", ImageName("testImage")), "testCode", None)
-    val memoryLimit = 256.MB
+  // Common entities to pass to the tests. We don't really care what's inside
+  // those for the behavior testing here, as none of the contents will really
+  // reach a container anyway. We merely assert that passing and extraction of
+  // the values is done properly.
+  val exec = CodeExecAsString(RuntimeManifest("actionKind", ImageName("testImage")), "testCode", None)
+  val memoryLimit = 256.MB
 
-    val invocationNamespace = EntityName("invocationSpace")
-    val action = ExecutableWhiskAction(EntityPath("actionSpace"), EntityName("actionName"), exec)
+  val invocationNamespace = EntityName("invocationSpace")
+  val action = ExecutableWhiskAction(EntityPath("actionSpace"), EntityName("actionName"), exec)
 
-    val message = ActivationMessage(
-        TransactionId.testing,
-        action.fullyQualifiedName(true),
-        action.rev,
-        Identity(Subject(), invocationNamespace, AuthKey(), Set()),
-        ActivationId(),
-        invocationNamespace.toPath,
-        InstanceId(0),
-        blocking = false,
-        content = None)
+  val message = ActivationMessage(
+    TransactionId.testing,
+    action.fullyQualifiedName(true),
+    action.rev,
+    Identity(Subject(), invocationNamespace, AuthKey(), Set()),
+    ActivationId(),
+    invocationNamespace.toPath,
+    InstanceId(0),
+    blocking = false,
+    content = None)
 
-    /*
-     * Helpers for assertions and actor lifecycles
-     */
-    /** Imitates a StateTimeout in the FSM */
-    def timeout(actor: ActorRef) = actor ! FSM.StateTimeout
+  /*
+   * Helpers for assertions and actor lifecycles
+   */
+  /** Imitates a StateTimeout in the FSM */
+  def timeout(actor: ActorRef) = actor ! FSM.StateTimeout
 
-    /** Registers the transition callback and expects the first message */
-    def registerCallback(c: ActorRef) = {
-        c ! SubscribeTransitionCallBack(testActor)
-        expectMsg(CurrentState(c, Uninitialized))
+  /** Registers the transition callback and expects the first message */
+  def registerCallback(c: ActorRef) = {
+    c ! SubscribeTransitionCallBack(testActor)
+    expectMsg(CurrentState(c, Uninitialized))
+  }
+
+  /** Pre-warms the given state-machine, assumes good cases */
+  def preWarm(machine: ActorRef) = {
+    machine ! Start(exec, memoryLimit)
+    expectMsg(Transition(machine, Uninitialized, Starting))
+    expectPreWarmed(exec.kind)
+    expectMsg(Transition(machine, Starting, Started))
+  }
+
+  /** Run the common action on the state-machine, assumes good cases */
+  def run(machine: ActorRef, currentState: ContainerState) = {
+    machine ! Run(action, message)
+    expectMsg(Transition(machine, currentState, Running))
+    expectWarmed(invocationNamespace.name, action)
+    expectMsg(Transition(machine, Running, Ready))
+  }
+
+  /** Expect a NeedWork message with prewarmed data */
+  def expectPreWarmed(kind: String) = expectMsgPF() {
+    case NeedWork(PreWarmedData(_, kind, memoryLimit)) => true
+  }
+
+  /** Expect a NeedWork message with warmed data */
+  def expectWarmed(namespace: String, action: ExecutableWhiskAction) = {
+    val test = EntityName(namespace)
+    expectMsgPF() {
+      case NeedWork(WarmedData(_, `test`, `action`, _)) => true
     }
+  }
 
-    /** Pre-warms the given state-machine, assumes good cases */
-    def preWarm(machine: ActorRef) = {
-        machine ! Start(exec, memoryLimit)
-        expectMsg(Transition(machine, Uninitialized, Starting))
-        expectPreWarmed(exec.kind)
-        expectMsg(Transition(machine, Starting, Started))
+  /** Expect the container to pause successfully */
+  def expectPause(machine: ActorRef) = {
+    expectMsg(Transition(machine, Ready, Pausing))
+    expectMsg(Transition(machine, Pausing, Paused))
+  }
+
+  /** Creates an inspectable version of the ack method, which records all calls in a buffer */
+  def createAcker = LoggedFunction { (_: TransactionId, _: WhiskActivation, _: Boolean, _: InstanceId) =>
+    Future.successful(())
+  }
+
+  /** Creates an inspectable factory */
+  def createFactory(response: Future[Container]) = LoggedFunction {
+    (_: TransactionId, _: String, _: ImageName, _: Boolean, _: ByteSize) =>
+      response
+  }
+
+  val store = stubFunction[TransactionId, WhiskActivation, Future[Any]]
+
+  behavior of "ContainerProxy"
+
+  /*
+   * SUCCESSFUL CASES
+   */
+  it should "create a container given a Start message" in within(timeout) {
+    val container = new TestContainer
+    val factory = createFactory(Future.successful(container))
+
+    val machine = childActorOf(ContainerProxy.props(factory, createAcker, store, InstanceId(0), pauseGrace = timeout))
+    registerCallback(machine)
+    preWarm(machine)
+
+    factory.calls should have size 1
+    val (tid, name, _, _, memory) = factory.calls(0)
+    tid shouldBe TransactionId.invokerWarmup
+    name should fullyMatch regex """wsk\d+_\d+_prewarm_actionKind"""
+    memory shouldBe memoryLimit
+  }
+
+  it should "run a container which has been started before, write an active ack, write to the store, pause and remove the container" in within(
+    timeout) {
+    val container = new TestContainer
+    val factory = createFactory(Future.successful(container))
+    val acker = createAcker
+
+    val machine = childActorOf(ContainerProxy.props(factory, acker, store, InstanceId(0), pauseGrace = timeout))
+    registerCallback(machine)
+
+    preWarm(machine)
+    run(machine, Started)
+
+    // Timeout causes the container to pause
+    timeout(machine)
+    expectPause(machine)
+
+    // Another pause causes the container to be removed
+    timeout(machine)
+    expectMsg(ContainerRemoved)
+    expectMsg(Transition(machine, Paused, Removing))
+
+    awaitAssert {
+      factory.calls should have size 1
+      container.initializeCount shouldBe 1
+      container.runCount shouldBe 1
+      container.logsCount shouldBe 1
+      container.suspendCount shouldBe 1
+      container.destroyCount shouldBe 1
+      acker.calls should have size 1
+      store.verify(message.transid, *)
     }
+  }
 
-    /** Run the common action on the state-machine, assumes good cases */
-    def run(machine: ActorRef, currentState: ContainerState) = {
-        machine ! Run(action, message)
-        expectMsg(Transition(machine, currentState, Running))
-        expectWarmed(invocationNamespace.name, action)
-        expectMsg(Transition(machine, Running, Ready))
+  it should "run an action and continue with a next run without pausing the container" in within(timeout) {
+    val container = new TestContainer
+    val factory = createFactory(Future.successful(container))
+    val acker = createAcker
+
+    val machine = childActorOf(ContainerProxy.props(factory, acker, store, InstanceId(0), pauseGrace = timeout))
+    registerCallback(machine)
+    preWarm(machine)
+
+    run(machine, Started)
+    // Note that there are no intermediate state changes
+    run(machine, Ready)
+
+    awaitAssert {
+      factory.calls should have size 1
+      container.initializeCount shouldBe 1
+      container.runCount shouldBe 2
+      container.logsCount shouldBe 2
+      container.suspendCount shouldBe 0
+      acker.calls should have size 2
+      store.verify(message.transid, *).repeat(2)
     }
+  }
 
-    /** Expect a NeedWork message with prewarmed data */
-    def expectPreWarmed(kind: String) = expectMsgPF() {
-        case NeedWork(PreWarmedData(_, kind, memoryLimit)) => true
+  it should "run an action after pausing the container" in within(timeout) {
+    val container = new TestContainer
+    val factory = createFactory(Future.successful(container))
+    val acker = createAcker
+
+    val machine = childActorOf(ContainerProxy.props(factory, acker, store, InstanceId(0), pauseGrace = timeout))
+    registerCallback(machine)
+    preWarm(machine)
+
+    run(machine, Started)
+    timeout(machine)
+    expectPause(machine)
+    run(machine, Paused)
+
+    awaitAssert {
+      factory.calls should have size 1
+      container.initializeCount shouldBe 1
+      container.runCount shouldBe 2
+      container.logsCount shouldBe 2
+      container.suspendCount shouldBe 1
+      container.resumeCount shouldBe 1
+      acker.calls should have size 2
+      store.verify(message.transid, *).repeat(2)
     }
+  }
 
-    /** Expect a NeedWork message with warmed data */
-    def expectWarmed(namespace: String, action: ExecutableWhiskAction) = {
-        val test = EntityName(namespace)
-        expectMsgPF() {
-            case NeedWork(WarmedData(_, `test`, `action`, _)) => true
-        }
+  it should "successfully run on an uninitialized container" in within(timeout) {
+    val container = new TestContainer
+    val factory = createFactory(Future.successful(container))
+    val acker = createAcker
+
+    val machine = childActorOf(ContainerProxy.props(factory, acker, store, InstanceId(0), pauseGrace = timeout))
+    registerCallback(machine)
+    run(machine, Uninitialized)
+
+    awaitAssert {
+      factory.calls should have size 1
+      container.initializeCount shouldBe 1
+      container.runCount shouldBe 1
+      container.logsCount shouldBe 1
+      acker.calls should have size 1
+      store.verify(message.transid, *).repeat(1)
     }
+  }
 
-    /** Expect the container to pause successfully */
-    def expectPause(machine: ActorRef) = {
-        expectMsg(Transition(machine, Ready, Pausing))
-        expectMsg(Transition(machine, Pausing, Paused))
+  /*
+   * ERROR CASES
+   */
+  it should "complete the transaction and abort if container creation fails" in within(timeout) {
+    val container = new TestContainer
+    val factory = createFactory(Future.failed(new Exception()))
+    val acker = createAcker
+
+    val machine = childActorOf(ContainerProxy.props(factory, acker, store, InstanceId(0), pauseGrace = timeout))
+    registerCallback(machine)
+    machine ! Run(action, message)
+    expectMsg(Transition(machine, Uninitialized, Running))
+    expectMsg(ContainerRemoved)
+
+    awaitAssert {
+      factory.calls should have size 1
+      container.initializeCount shouldBe 0
+      container.runCount shouldBe 0
+      container.logsCount shouldBe 0 // gather no logs
+      container.destroyCount shouldBe 0 // no destroying possible as no container could be obtained
+      acker.calls should have size 1
+      acker.calls(0)._2.response should be a 'whiskError
+      store.verify(message.transid, *).repeat(1)
     }
+  }
 
-    /** Creates an inspectable version of the ack method, which records all calls in a buffer */
-    def createAcker = LoggedFunction { (_: TransactionId, _: WhiskActivation, _: Boolean, _: InstanceId) => Future.successful(()) }
-
-    /** Creates an inspectable factory */
-    def createFactory(response: Future[Container]) = LoggedFunction {
-        (_: TransactionId, _: String, _: ImageName, _: Boolean, _: ByteSize) => response
+  it should "complete the transaction and destroy the container on a failed init" in within(timeout) {
+    val container = new TestContainer {
+      override def initialize(initializer: JsObject,
+                              timeout: FiniteDuration)(implicit transid: TransactionId): Future[Interval] = {
+        initializeCount += 1
+        Future.failed(InitializationError(Interval.zero, ActivationResponse.applicationError("boom")))
+      }
     }
+    val factory = createFactory(Future.successful(container))
+    val acker = createAcker
 
-    val store = stubFunction[TransactionId, WhiskActivation, Future[Any]]
+    val machine = childActorOf(ContainerProxy.props(factory, acker, store, InstanceId(0), pauseGrace = timeout))
+    registerCallback(machine)
+    machine ! Run(action, message)
+    expectMsg(Transition(machine, Uninitialized, Running))
+    expectMsg(ContainerRemoved) // The message is sent as soon as the container decides to destroy itself
+    expectMsg(Transition(machine, Running, Removing))
 
-    behavior of "ContainerProxy"
-
-    /*
-     * SUCCESSFUL CASES
-     */
-    it should "create a container given a Start message" in within(timeout) {
-        val container = new TestContainer
-        val factory = createFactory(Future.successful(container))
-
-        val machine = childActorOf(ContainerProxy.props(factory, createAcker, store, InstanceId(0), pauseGrace = timeout))
-        registerCallback(machine)
-        preWarm(machine)
-
-        factory.calls should have size 1
-        val (tid, name, _, _, memory) = factory.calls(0)
-        tid shouldBe TransactionId.invokerWarmup
-        name should fullyMatch regex """wsk\d+_\d+_prewarm_actionKind"""
-        memory shouldBe memoryLimit
+    awaitAssert {
+      factory.calls should have size 1
+      container.initializeCount shouldBe 1
+      container.runCount shouldBe 0 // should not run the action
+      container.logsCount shouldBe 1
+      container.destroyCount shouldBe 1
+      acker.calls(0)._2.response shouldBe ActivationResponse.applicationError("boom")
+      store.verify(message.transid, *).repeat(1)
     }
+  }
 
-    it should "run a container which has been started before, write an active ack, write to the store, pause and remove the container" in within(timeout) {
-        val container = new TestContainer
-        val factory = createFactory(Future.successful(container))
-        val acker = createAcker
-
-        val machine = childActorOf(ContainerProxy.props(factory, acker, store, InstanceId(0), pauseGrace = timeout))
-        registerCallback(machine)
-
-        preWarm(machine)
-        run(machine, Started)
-
-        // Timeout causes the container to pause
-        timeout(machine)
-        expectPause(machine)
-
-        // Another pause causes the container to be removed
-        timeout(machine)
-        expectMsg(ContainerRemoved)
-        expectMsg(Transition(machine, Paused, Removing))
-
-        awaitAssert {
-            factory.calls should have size 1
-            container.initializeCount shouldBe 1
-            container.runCount shouldBe 1
-            container.logsCount shouldBe 1
-            container.suspendCount shouldBe 1
-            container.destroyCount shouldBe 1
-            acker.calls should have size 1
-            store.verify(message.transid, *)
-        }
+  it should "complete the transaction and destroy the container on a failed run" in within(timeout) {
+    val container = new TestContainer {
+      override def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration)(
+        implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
+        runCount += 1
+        Future.successful((Interval.zero, ActivationResponse.applicationError("boom")))
+      }
     }
+    val factory = createFactory(Future.successful(container))
+    val acker = createAcker
 
-    it should "run an action and continue with a next run without pausing the container" in within(timeout) {
-        val container = new TestContainer
-        val factory = createFactory(Future.successful(container))
-        val acker = createAcker
+    val machine = childActorOf(ContainerProxy.props(factory, acker, store, InstanceId(0), pauseGrace = timeout))
+    registerCallback(machine)
+    machine ! Run(action, message)
+    expectMsg(Transition(machine, Uninitialized, Running))
+    expectMsg(ContainerRemoved) // The message is sent as soon as the container decides to destroy itself
+    expectMsg(Transition(machine, Running, Removing))
 
-        val machine = childActorOf(ContainerProxy.props(factory, acker, store, InstanceId(0), pauseGrace = timeout))
-        registerCallback(machine)
-        preWarm(machine)
-
-        run(machine, Started)
-        // Note that there are no intermediate state changes
-        run(machine, Ready)
-
-        awaitAssert {
-            factory.calls should have size 1
-            container.initializeCount shouldBe 1
-            container.runCount shouldBe 2
-            container.logsCount shouldBe 2
-            container.suspendCount shouldBe 0
-            acker.calls should have size 2
-            store.verify(message.transid, *).repeat(2)
-        }
+    awaitAssert {
+      factory.calls should have size 1
+      container.initializeCount shouldBe 1
+      container.runCount shouldBe 1
+      container.logsCount shouldBe 1
+      container.destroyCount shouldBe 1
+      acker.calls(0)._2.response shouldBe ActivationResponse.applicationError("boom")
+      store.verify(message.transid, *).repeat(1)
     }
+  }
 
-    it should "run an action after pausing the container" in within(timeout) {
-        val container = new TestContainer
-        val factory = createFactory(Future.successful(container))
-        val acker = createAcker
-
-        val machine = childActorOf(ContainerProxy.props(factory, acker, store, InstanceId(0), pauseGrace = timeout))
-        registerCallback(machine)
-        preWarm(machine)
-
-        run(machine, Started)
-        timeout(machine)
-        expectPause(machine)
-        run(machine, Paused)
-
-        awaitAssert {
-            factory.calls should have size 1
-            container.initializeCount shouldBe 1
-            container.runCount shouldBe 2
-            container.logsCount shouldBe 2
-            container.suspendCount shouldBe 1
-            container.resumeCount shouldBe 1
-            acker.calls should have size 2
-            store.verify(message.transid, *).repeat(2)
-        }
+  it should "resend the job to the parent if resuming a container fails" in within(timeout) {
+    val container = new TestContainer {
+      override def resume()(implicit transid: TransactionId) = {
+        resumeCount += 1
+        Future.failed(new RuntimeException())
+      }
     }
+    val factory = createFactory(Future.successful(container))
+    val acker = createAcker
 
-    it should "successfully run on an uninitialized container" in within(timeout) {
-        val container = new TestContainer
-        val factory = createFactory(Future.successful(container))
-        val acker = createAcker
+    val machine = childActorOf(ContainerProxy.props(factory, acker, store, InstanceId(0), pauseGrace = timeout))
+    registerCallback(machine)
+    run(machine, Uninitialized) // first run an activation
+    timeout(machine) // times out Ready state so container suspends
+    expectPause(machine)
 
-        val machine = childActorOf(ContainerProxy.props(factory, acker, store, InstanceId(0), pauseGrace = timeout))
-        registerCallback(machine)
-        run(machine, Uninitialized)
+    val runMessage = Run(action, message)
+    machine ! runMessage
+    expectMsg(Transition(machine, Paused, Running))
+    expectMsg(ContainerRemoved) // The message is sent as soon as the container decides to destroy itself
+    expectMsg(Transition(machine, Running, Removing))
+    expectMsg(runMessage)
 
-        awaitAssert {
-            factory.calls should have size 1
-            container.initializeCount shouldBe 1
-            container.runCount shouldBe 1
-            container.logsCount shouldBe 1
-            acker.calls should have size 1
-            store.verify(message.transid, *).repeat(1)
-        }
+    awaitAssert {
+      factory.calls should have size 1
+      container.runCount shouldBe 1
+      container.suspendCount shouldBe 1
+      container.resumeCount shouldBe 1
+      container.destroyCount shouldBe 1
     }
+  }
 
-    /*
-     * ERROR CASES
-     */
-    it should "complete the transaction and abort if container creation fails" in within(timeout) {
-        val container = new TestContainer
-        val factory = createFactory(Future.failed(new Exception()))
-        val acker = createAcker
-
-        val machine = childActorOf(ContainerProxy.props(factory, acker, store, InstanceId(0), pauseGrace = timeout))
-        registerCallback(machine)
-        machine ! Run(action, message)
-        expectMsg(Transition(machine, Uninitialized, Running))
-        expectMsg(ContainerRemoved)
-
-        awaitAssert {
-            factory.calls should have size 1
-            container.initializeCount shouldBe 0
-            container.runCount shouldBe 0
-            container.logsCount shouldBe 0 // gather no logs
-            container.destroyCount shouldBe 0 // no destroying possible as no container could be obtained
-            acker.calls should have size 1
-            acker.calls(0)._2.response should be a 'whiskError
-            store.verify(message.transid, *).repeat(1)
-        }
+  it should "remove the container if suspend fails" in within(timeout) {
+    val container = new TestContainer {
+      override def suspend()(implicit transid: TransactionId) = {
+        suspendCount += 1
+        Future.failed(new RuntimeException())
+      }
     }
+    val factory = createFactory(Future.successful(container))
+    val acker = createAcker
 
-    it should "complete the transaction and destroy the container on a failed init" in within(timeout) {
-        val container = new TestContainer {
-            override def initialize(initializer: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[Interval] = {
-                initializeCount += 1
-                Future.failed(InitializationError(Interval.zero, ActivationResponse.applicationError("boom")))
-            }
-        }
-        val factory = createFactory(Future.successful(container))
-        val acker = createAcker
+    val machine = childActorOf(ContainerProxy.props(factory, acker, store, InstanceId(0), pauseGrace = timeout))
+    registerCallback(machine)
+    run(machine, Uninitialized)
+    timeout(machine) // times out Ready state so container suspends
+    expectMsg(Transition(machine, Ready, Pausing))
+    expectMsg(ContainerRemoved) // The message is sent as soon as the container decides to destroy itself
+    expectMsg(Transition(machine, Pausing, Removing))
 
-        val machine = childActorOf(ContainerProxy.props(factory, acker, store, InstanceId(0), pauseGrace = timeout))
-        registerCallback(machine)
-        machine ! Run(action, message)
-        expectMsg(Transition(machine, Uninitialized, Running))
-        expectMsg(ContainerRemoved) // The message is sent as soon as the container decides to destroy itself
-        expectMsg(Transition(machine, Running, Removing))
-
-        awaitAssert {
-            factory.calls should have size 1
-            container.initializeCount shouldBe 1
-            container.runCount shouldBe 0 // should not run the action
-            container.logsCount shouldBe 1
-            container.destroyCount shouldBe 1
-            acker.calls(0)._2.response shouldBe ActivationResponse.applicationError("boom")
-            store.verify(message.transid, *).repeat(1)
-        }
+    awaitAssert {
+      factory.calls should have size 1
+      container.suspendCount shouldBe 1
+      container.destroyCount shouldBe 1
     }
+  }
 
-    it should "complete the transaction and destroy the container on a failed run" in within(timeout) {
-        val container = new TestContainer {
-            override def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
-                runCount += 1
-                Future.successful((Interval.zero, ActivationResponse.applicationError("boom")))
-            }
-        }
-        val factory = createFactory(Future.successful(container))
-        val acker = createAcker
-
-        val machine = childActorOf(ContainerProxy.props(factory, acker, store, InstanceId(0), pauseGrace = timeout))
-        registerCallback(machine)
-        machine ! Run(action, message)
-        expectMsg(Transition(machine, Uninitialized, Running))
-        expectMsg(ContainerRemoved) // The message is sent as soon as the container decides to destroy itself
-        expectMsg(Transition(machine, Running, Removing))
-
-        awaitAssert {
-            factory.calls should have size 1
-            container.initializeCount shouldBe 1
-            container.runCount shouldBe 1
-            container.logsCount shouldBe 1
-            container.destroyCount shouldBe 1
-            acker.calls(0)._2.response shouldBe ActivationResponse.applicationError("boom")
-            store.verify(message.transid, *).repeat(1)
-        }
+  /*
+   * DELAYED DELETION CASES
+   */
+  // this test represents a Remove message whenever you are in the "Running" state. Therefore, testing
+  // a Remove while /init should suffice to guarantee test coverage here.
+  it should "delay a deletion message until the transaction is completed successfully" in within(timeout) {
+    val initPromise = Promise[Interval]
+    val container = new TestContainer {
+      override def initialize(initializer: JsObject,
+                              timeout: FiniteDuration)(implicit transid: TransactionId): Future[Interval] = {
+        initializeCount += 1
+        initPromise.future
+      }
     }
+    val factory = createFactory(Future.successful(container))
+    val acker = createAcker
 
-    it should "resend the job to the parent if resuming a container fails" in within(timeout) {
-        val container = new TestContainer {
-            override def resume()(implicit transid: TransactionId) = {
-                resumeCount += 1
-                Future.failed(new RuntimeException())
-            }
-        }
-        val factory = createFactory(Future.successful(container))
-        val acker = createAcker
+    val machine = childActorOf(ContainerProxy.props(factory, acker, store, InstanceId(0), pauseGrace = timeout))
+    registerCallback(machine)
 
-        val machine = childActorOf(ContainerProxy.props(factory, acker, store, InstanceId(0), pauseGrace = timeout))
-        registerCallback(machine)
-        run(machine, Uninitialized) // first run an activation
-        timeout(machine) // times out Ready state so container suspends
-        expectPause(machine)
+    // Start running the action
+    machine ! Run(action, message)
+    expectMsg(Transition(machine, Uninitialized, Running))
 
-        val runMessage = Run(action, message)
-        machine ! runMessage
-        expectMsg(Transition(machine, Paused, Running))
-        expectMsg(ContainerRemoved) // The message is sent as soon as the container decides to destroy itself
-        expectMsg(Transition(machine, Running, Removing))
-        expectMsg(runMessage)
+    // Schedule the container to be removed
+    machine ! Remove
 
-        awaitAssert {
-            factory.calls should have size 1
-            container.runCount shouldBe 1
-            container.suspendCount shouldBe 1
-            container.resumeCount shouldBe 1
-            container.destroyCount shouldBe 1
-        }
+    // Finish /init, note that /run and log-collecting happens nonetheless
+    initPromise.success(Interval.zero)
+    expectWarmed(invocationNamespace.name, action)
+    expectMsg(Transition(machine, Running, Ready))
+
+    // Remove the container after the transaction finished
+    expectMsg(ContainerRemoved)
+    expectMsg(Transition(machine, Ready, Removing))
+
+    awaitAssert {
+      factory.calls should have size 1
+      container.initializeCount shouldBe 1
+      container.runCount shouldBe 1
+      container.logsCount shouldBe 1
+      container.suspendCount shouldBe 0 // skips pausing the container
+      container.destroyCount shouldBe 1
+      acker.calls should have size 1
+      store.verify(message.transid, *).repeat(1)
     }
+  }
 
-    it should "remove the container if suspend fails" in within(timeout) {
-        val container = new TestContainer {
-            override def suspend()(implicit transid: TransactionId) = {
-                suspendCount += 1
-                Future.failed(new RuntimeException())
-            }
-        }
-        val factory = createFactory(Future.successful(container))
-        val acker = createAcker
-
-        val machine = childActorOf(ContainerProxy.props(factory, acker, store, InstanceId(0), pauseGrace = timeout))
-        registerCallback(machine)
-        run(machine, Uninitialized)
-        timeout(machine) // times out Ready state so container suspends
-        expectMsg(Transition(machine, Ready, Pausing))
-        expectMsg(ContainerRemoved) // The message is sent as soon as the container decides to destroy itself
-        expectMsg(Transition(machine, Pausing, Removing))
-
-        awaitAssert {
-            factory.calls should have size 1
-            container.suspendCount shouldBe 1
-            container.destroyCount shouldBe 1
-        }
+  // this tests a Run message in the "Removing" state. The contract between the pool and state-machine
+  // is, that only one Run is to be sent until a "NeedWork" comes back. If we sent a NeedWork but no work is
+  // there, we might run into the final timeout which will schedule a removal of the container. There is a
+  // time window though, in which the pool doesn't know of that decision yet. We handle the collision by
+  // sending the Run back to the pool so it can reschedule.
+  it should "send back a Run message which got sent before the container decided to remove itself" in within(timeout) {
+    val destroyPromise = Promise[Unit]
+    val container = new TestContainer {
+      override def destroy()(implicit transid: TransactionId): Future[Unit] = {
+        destroyCount += 1
+        destroyPromise.future
+      }
     }
+    val factory = createFactory(Future.successful(container))
+    val acker = createAcker
 
-    /*
-     * DELAYED DELETION CASES
-     */
-    // this test represents a Remove message whenever you are in the "Running" state. Therefore, testing
-    // a Remove while /init should suffice to guarantee test coverage here.
-    it should "delay a deletion message until the transaction is completed successfully" in within(timeout) {
-        val initPromise = Promise[Interval]
-        val container = new TestContainer {
-            override def initialize(initializer: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[Interval] = {
-                initializeCount += 1
-                initPromise.future
-            }
-        }
-        val factory = createFactory(Future.successful(container))
-        val acker = createAcker
+    val machine = childActorOf(ContainerProxy.props(factory, acker, store, InstanceId(0), pauseGrace = timeout))
+    registerCallback(machine)
+    run(machine, Uninitialized)
+    timeout(machine)
+    expectPause(machine)
+    timeout(machine)
 
-        val machine = childActorOf(ContainerProxy.props(factory, acker, store, InstanceId(0), pauseGrace = timeout))
-        registerCallback(machine)
+    // We don't know of this timeout, so we schedule a run.
+    machine ! Run(action, message)
 
-        // Start running the action
-        machine ! Run(action, message)
-        expectMsg(Transition(machine, Uninitialized, Running))
+    // State-machine shuts down nonetheless.
+    expectMsg(ContainerRemoved)
+    expectMsg(Transition(machine, Paused, Removing))
 
-        // Schedule the container to be removed
-        machine ! Remove
+    // Pool gets the message again.
+    expectMsg(Run(action, message))
 
-        // Finish /init, note that /run and log-collecting happens nonetheless
-        initPromise.success(Interval.zero)
-        expectWarmed(invocationNamespace.name, action)
-        expectMsg(Transition(machine, Running, Ready))
-
-        // Remove the container after the transaction finished
-        expectMsg(ContainerRemoved)
-        expectMsg(Transition(machine, Ready, Removing))
-
-        awaitAssert {
-            factory.calls should have size 1
-            container.initializeCount shouldBe 1
-            container.runCount shouldBe 1
-            container.logsCount shouldBe 1
-            container.suspendCount shouldBe 0 // skips pausing the container
-            container.destroyCount shouldBe 1
-            acker.calls should have size 1
-            store.verify(message.transid, *).repeat(1)
-        }
+    awaitAssert {
+      factory.calls should have size 1
+      container.initializeCount shouldBe 1
+      container.runCount shouldBe 1
+      container.logsCount shouldBe 1
+      container.suspendCount shouldBe 1
+      container.resumeCount shouldBe 1
+      container.destroyCount shouldBe 1
+      acker.calls should have size 1
+      store.verify(message.transid, *).repeat(1)
     }
+  }
 
-    // this tests a Run message in the "Removing" state. The contract between the pool and state-machine
-    // is, that only one Run is to be sent until a "NeedWork" comes back. If we sent a NeedWork but no work is
-    // there, we might run into the final timeout which will schedule a removal of the container. There is a
-    // time window though, in which the pool doesn't know of that decision yet. We handle the collision by
-    // sending the Run back to the pool so it can reschedule.
-    it should "send back a Run message which got sent before the container decided to remove itself" in within(timeout) {
-        val destroyPromise = Promise[Unit]
-        val container = new TestContainer {
-            override def destroy()(implicit transid: TransactionId): Future[Unit] = {
-                destroyCount += 1
-                destroyPromise.future
-            }
-        }
-        val factory = createFactory(Future.successful(container))
-        val acker = createAcker
+  /**
+   * Implements all the good cases of a perfect run to facilitate error case overriding.
+   */
+  class TestContainer extends Container {
+    var suspendCount = 0
+    var resumeCount = 0
+    var destroyCount = 0
+    var initializeCount = 0
+    var runCount = 0
+    var logsCount = 0
 
-        val machine = childActorOf(ContainerProxy.props(factory, acker, store, InstanceId(0), pauseGrace = timeout))
-        registerCallback(machine)
-        run(machine, Uninitialized)
-        timeout(machine)
-        expectPause(machine)
-        timeout(machine)
-
-        // We don't know of this timeout, so we schedule a run.
-        machine ! Run(action, message)
-
-        // State-machine shuts down nonetheless.
-        expectMsg(ContainerRemoved)
-        expectMsg(Transition(machine, Paused, Removing))
-
-        // Pool gets the message again.
-        expectMsg(Run(action, message))
-
-        awaitAssert {
-            factory.calls should have size 1
-            container.initializeCount shouldBe 1
-            container.runCount shouldBe 1
-            container.logsCount shouldBe 1
-            container.suspendCount shouldBe 1
-            container.resumeCount shouldBe 1
-            container.destroyCount shouldBe 1
-            acker.calls should have size 1
-            store.verify(message.transid, *).repeat(1)
-        }
+    def suspend()(implicit transid: TransactionId): Future[Unit] = {
+      suspendCount += 1
+      Future.successful(())
     }
-
-    /**
-     * Implements all the good cases of a perfect run to facilitate error case overriding.
-     */
-    class TestContainer extends Container {
-        var suspendCount = 0
-        var resumeCount = 0
-        var destroyCount = 0
-        var initializeCount = 0
-        var runCount = 0
-        var logsCount = 0
-
-        def suspend()(implicit transid: TransactionId): Future[Unit] = {
-            suspendCount += 1
-            Future.successful(())
-        }
-        def resume()(implicit transid: TransactionId): Future[Unit] = {
-            resumeCount += 1
-            Future.successful(())
-        }
-        def destroy()(implicit transid: TransactionId): Future[Unit] = {
-            destroyCount += 1
-            Future.successful(())
-        }
-        def initialize(initializer: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[Interval] = {
-            initializeCount += 1
-            initializer shouldBe action.containerInitializer
-            timeout shouldBe action.limits.timeout.duration
-            Future.successful(Interval.zero)
-        }
-        def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
-            runCount += 1
-            environment.fields("api_key") shouldBe message.user.authkey.toJson
-            environment.fields("namespace") shouldBe invocationNamespace.toJson
-            environment.fields("action_name") shouldBe message.action.qualifiedNameWithLeadingSlash.toJson
-            environment.fields("activation_id") shouldBe message.activationId.toJson
-            val deadline = Instant.ofEpochMilli(environment.fields("deadline").convertTo[String].toLong)
-            val maxDeadline = Instant.now.plusMillis(timeout.toMillis)
-
-            // The deadline should be in the future but must be smaller than or equal
-            // a freshly computed deadline, as they get computed slightly after each other
-            deadline should (be <= maxDeadline and be >= Instant.now)
-
-            Future.successful((Interval.zero, ActivationResponse.success()))
-        }
-        def logs(limit: ByteSize, waitForSentinel: Boolean)(implicit transid: TransactionId): Future[Vector[String]] = {
-            logsCount += 1
-            Future.successful(Vector("helloTest"))
-        }
+    def resume()(implicit transid: TransactionId): Future[Unit] = {
+      resumeCount += 1
+      Future.successful(())
     }
+    def destroy()(implicit transid: TransactionId): Future[Unit] = {
+      destroyCount += 1
+      Future.successful(())
+    }
+    def initialize(initializer: JsObject, timeout: FiniteDuration)(
+      implicit transid: TransactionId): Future[Interval] = {
+      initializeCount += 1
+      initializer shouldBe action.containerInitializer
+      timeout shouldBe action.limits.timeout.duration
+      Future.successful(Interval.zero)
+    }
+    def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration)(
+      implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
+      runCount += 1
+      environment.fields("api_key") shouldBe message.user.authkey.toJson
+      environment.fields("namespace") shouldBe invocationNamespace.toJson
+      environment.fields("action_name") shouldBe message.action.qualifiedNameWithLeadingSlash.toJson
+      environment.fields("activation_id") shouldBe message.activationId.toJson
+      val deadline = Instant.ofEpochMilli(environment.fields("deadline").convertTo[String].toLong)
+      val maxDeadline = Instant.now.plusMillis(timeout.toMillis)
+
+      // The deadline should be in the future but must be smaller than or equal
+      // a freshly computed deadline, as they get computed slightly after each other
+      deadline should (be <= maxDeadline and be >= Instant.now)
+
+      Future.successful((Interval.zero, ActivationResponse.success()))
+    }
+    def logs(limit: ByteSize, waitForSentinel: Boolean)(implicit transid: TransactionId): Future[Vector[String]] = {
+      logsCount += 1
+      Future.successful(Vector("helloTest"))
+    }
+  }
 }

--- a/tests/src/test/scala/whisk/core/controller/actions/test/SequenceAccountingTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/actions/test/SequenceAccountingTests.scala
@@ -37,107 +37,101 @@ import whisk.http.Messages
 @RunWith(classOf[JUnitRunner])
 class SequenceAccountingTests extends FlatSpec with Matchers with WskActorSystem {
 
-    behavior of "sequence accounting"
+  behavior of "sequence accounting"
 
-    val okRes1 = ActivationResponse.success(Some(JsObject("res" -> JsNumber(1))))
-    val okRes2 = ActivationResponse.success(Some(JsObject("res" -> JsNumber(2))))
-    val failedRes = ActivationResponse.applicationError(JsNumber(3))
+  val okRes1 = ActivationResponse.success(Some(JsObject("res" -> JsNumber(1))))
+  val okRes2 = ActivationResponse.success(Some(JsObject("res" -> JsNumber(2))))
+  val failedRes = ActivationResponse.applicationError(JsNumber(3))
 
-    val okActivation = WhiskActivation(
-        namespace = EntityPath("ns"),
-        name = EntityName("a"),
-        Subject(),
-        activationId = ActivationId(),
-        start = Instant.now(),
-        end = Instant.now(),
-        response = okRes2,
-        annotations = Parameters("limits", ActionLimits(
-            TimeLimit(1.second),
-            MemoryLimit(128.MB),
-            LogLimit(1.MB)).toJson),
-        duration = Some(123))
+  val okActivation = WhiskActivation(
+    namespace = EntityPath("ns"),
+    name = EntityName("a"),
+    Subject(),
+    activationId = ActivationId(),
+    start = Instant.now(),
+    end = Instant.now(),
+    response = okRes2,
+    annotations = Parameters("limits", ActionLimits(TimeLimit(1.second), MemoryLimit(128.MB), LogLimit(1.MB)).toJson),
+    duration = Some(123))
 
-    val notOkActivation = WhiskActivation(
-        namespace = EntityPath("ns"),
-        name = EntityName("a"),
-        Subject(),
-        activationId = ActivationId(),
-        start = Instant.now(),
-        end = Instant.now(),
-        response = failedRes,
-        annotations = Parameters("limits", ActionLimits(
-            TimeLimit(11.second),
-            MemoryLimit(256.MB),
-            LogLimit(2.MB)).toJson),
-        duration = Some(234))
+  val notOkActivation = WhiskActivation(
+    namespace = EntityPath("ns"),
+    name = EntityName("a"),
+    Subject(),
+    activationId = ActivationId(),
+    start = Instant.now(),
+    end = Instant.now(),
+    response = failedRes,
+    annotations = Parameters("limits", ActionLimits(TimeLimit(11.second), MemoryLimit(256.MB), LogLimit(2.MB)).toJson),
+    duration = Some(234))
 
-    it should "create initial accounting object" in {
-        val s = SequenceAccounting(2, okRes1)
-        s.atomicActionCnt shouldBe 2
-        s.previousResponse.get shouldBe okRes1
-        s.logs shouldBe empty
-        s.duration shouldBe 0
-        s.maxMemory shouldBe None
-        s.shortcircuit shouldBe false
-    }
+  it should "create initial accounting object" in {
+    val s = SequenceAccounting(2, okRes1)
+    s.atomicActionCnt shouldBe 2
+    s.previousResponse.get shouldBe okRes1
+    s.logs shouldBe empty
+    s.duration shouldBe 0
+    s.maxMemory shouldBe None
+    s.shortcircuit shouldBe false
+  }
 
-    it should "resolve maybe to success and update accounting object" in {
-        val p = SequenceAccounting(2, okRes1)
-        val n1 = p.maybe(okActivation, 3, 5)
-        n1.atomicActionCnt shouldBe 3
-        n1.previousResponse.get shouldBe okRes2
-        n1.logs.length shouldBe 1
-        n1.logs(0) shouldBe okActivation.activationId
-        n1.duration shouldBe 123
-        n1.maxMemory shouldBe Some(128)
-        n1.shortcircuit shouldBe false
-    }
+  it should "resolve maybe to success and update accounting object" in {
+    val p = SequenceAccounting(2, okRes1)
+    val n1 = p.maybe(okActivation, 3, 5)
+    n1.atomicActionCnt shouldBe 3
+    n1.previousResponse.get shouldBe okRes2
+    n1.logs.length shouldBe 1
+    n1.logs(0) shouldBe okActivation.activationId
+    n1.duration shouldBe 123
+    n1.maxMemory shouldBe Some(128)
+    n1.shortcircuit shouldBe false
+  }
 
-    it should "resolve maybe and enable short circuit" in {
-        val p = SequenceAccounting(2, okRes1)
-        val n1 = p.maybe(okActivation, 3, 5)
-        val n2 = n1.maybe(notOkActivation, 4, 5)
-        n2.atomicActionCnt shouldBe 4
-        n2.previousResponse.get shouldBe failedRes
-        n2.logs.length shouldBe 2
-        n2.logs(0) shouldBe okActivation.activationId
-        n2.logs(1) shouldBe notOkActivation.activationId
-        n2.duration shouldBe (123 + 234)
-        n2.maxMemory shouldBe Some(256)
-        n2.shortcircuit shouldBe true
-    }
+  it should "resolve maybe and enable short circuit" in {
+    val p = SequenceAccounting(2, okRes1)
+    val n1 = p.maybe(okActivation, 3, 5)
+    val n2 = n1.maybe(notOkActivation, 4, 5)
+    n2.atomicActionCnt shouldBe 4
+    n2.previousResponse.get shouldBe failedRes
+    n2.logs.length shouldBe 2
+    n2.logs(0) shouldBe okActivation.activationId
+    n2.logs(1) shouldBe notOkActivation.activationId
+    n2.duration shouldBe (123 + 234)
+    n2.maxMemory shouldBe Some(256)
+    n2.shortcircuit shouldBe true
+  }
 
-    it should "record an activation that exceeds allowed limit but also short circuit" in {
-        val p = SequenceAccounting(2, okRes1)
-        val n = p.maybe(okActivation, 3, 2)
-        n.atomicActionCnt shouldBe 3
-        n.previousResponse.get shouldBe ActivationResponse.applicationError(Messages.sequenceIsTooLong)
-        n.logs.length shouldBe 1
-        n.logs(0) shouldBe okActivation.activationId
-        n.duration shouldBe 123
-        n.maxMemory shouldBe Some(128)
-        n.shortcircuit shouldBe true
-    }
+  it should "record an activation that exceeds allowed limit but also short circuit" in {
+    val p = SequenceAccounting(2, okRes1)
+    val n = p.maybe(okActivation, 3, 2)
+    n.atomicActionCnt shouldBe 3
+    n.previousResponse.get shouldBe ActivationResponse.applicationError(Messages.sequenceIsTooLong)
+    n.logs.length shouldBe 1
+    n.logs(0) shouldBe okActivation.activationId
+    n.duration shouldBe 123
+    n.maxMemory shouldBe Some(128)
+    n.shortcircuit shouldBe true
+  }
 
-    it should "set failed response and short circuit on failure" in {
-        val p = SequenceAccounting(2, okRes1)
-        val n = p.maybe(okActivation, 3, 3)
-        val f = n.fail(failedRes, None)
-        f.atomicActionCnt shouldBe 3
-        f.previousResponse.get shouldBe failedRes
-        f.logs.length shouldBe 1
-        f.logs(0) shouldBe okActivation.activationId
-        f.duration shouldBe 123
-        f.maxMemory shouldBe Some(128)
-        f.shortcircuit shouldBe true
-    }
+  it should "set failed response and short circuit on failure" in {
+    val p = SequenceAccounting(2, okRes1)
+    val n = p.maybe(okActivation, 3, 3)
+    val f = n.fail(failedRes, None)
+    f.atomicActionCnt shouldBe 3
+    f.previousResponse.get shouldBe failedRes
+    f.logs.length shouldBe 1
+    f.logs(0) shouldBe okActivation.activationId
+    f.duration shouldBe 123
+    f.maxMemory shouldBe Some(128)
+    f.shortcircuit shouldBe true
+  }
 
-    it should "resolve max memory" in {
-        SequenceAccounting.maxMemory(None, None) shouldBe None
-        SequenceAccounting.maxMemory(None, Some(1)) shouldBe Some(1)
-        SequenceAccounting.maxMemory(Some(1), None) shouldBe Some(1)
-        SequenceAccounting.maxMemory(Some(1), Some(2)) shouldBe Some(2)
-        SequenceAccounting.maxMemory(Some(2), Some(1)) shouldBe Some(2)
-        SequenceAccounting.maxMemory(Some(2), Some(2)) shouldBe Some(2)
-    }
+  it should "resolve max memory" in {
+    SequenceAccounting.maxMemory(None, None) shouldBe None
+    SequenceAccounting.maxMemory(None, Some(1)) shouldBe Some(1)
+    SequenceAccounting.maxMemory(Some(1), None) shouldBe Some(1)
+    SequenceAccounting.maxMemory(Some(1), Some(2)) shouldBe Some(2)
+    SequenceAccounting.maxMemory(Some(2), Some(1)) shouldBe Some(2)
+    SequenceAccounting.maxMemory(Some(2), Some(2)) shouldBe Some(2)
+  }
 }

--- a/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
@@ -54,746 +54,848 @@ import whisk.http.Messages
 @RunWith(classOf[JUnitRunner])
 class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
 
-    /** Actions API tests */
-    behavior of "Actions API"
+  /** Actions API tests */
+  behavior of "Actions API"
 
-    val creds = WhiskAuthHelpers.newIdentity()
-    val namespace = EntityPath(creds.subject.asString)
-    val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
-    def aname = MakeName.next("action_tests")
-    val actionLimit = Exec.sizeLimit
-    val parametersLimit = Parameters.sizeLimit
+  val creds = WhiskAuthHelpers.newIdentity()
+  val namespace = EntityPath(creds.subject.asString)
+  val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
+  def aname = MakeName.next("action_tests")
+  val actionLimit = Exec.sizeLimit
+  val parametersLimit = Parameters.sizeLimit
 
-    //// GET /actions
-    it should "list actions by default namespace" in {
-        implicit val tid = transid()
-        val actions = (1 to 2).map { i =>
-            WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
-        }.toList
-        actions foreach { put(entityStore, _) }
-        waitOnView(entityStore, WhiskAction, namespace, 2)
-        Get(s"$collectionPath") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[List[JsObject]]
-            actions.length should be(response.length)
-            actions forall { a => response contains a.summaryAsJson } should be(true)
-        }
+  //// GET /actions
+  it should "list actions by default namespace" in {
+    implicit val tid = transid()
+    val actions = (1 to 2).map { i =>
+      WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
+    }.toList
+    actions foreach { put(entityStore, _) }
+    waitOnView(entityStore, WhiskAction, namespace, 2)
+    Get(s"$collectionPath") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[List[JsObject]]
+      actions.length should be(response.length)
+      actions forall { a =>
+        response contains a.summaryAsJson
+      } should be(true)
+    }
+  }
+
+  // ?docs disabled
+  ignore should "list action by default namespace with full docs" in {
+    implicit val tid = transid()
+    val actions = (1 to 2).map { i =>
+      WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
+    }.toList
+    actions foreach { put(entityStore, _) }
+    waitOnView(entityStore, WhiskAction, namespace, 2)
+    Get(s"$collectionPath?docs=true") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[List[WhiskAction]]
+      actions.length should be(response.length)
+      actions forall { a =>
+        response contains a
+      } should be(true)
+    }
+  }
+
+  it should "list action with explicit namespace" in {
+    implicit val tid = transid()
+    val actions = (1 to 2).map { i =>
+      WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
+    }.toList
+    actions foreach { put(entityStore, _) }
+    waitOnView(entityStore, WhiskAction, namespace, 2)
+    Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[List[JsObject]]
+      actions.length should be(response.length)
+      actions forall { a =>
+        response contains a.summaryAsJson
+      } should be(true)
     }
 
-    // ?docs disabled
-    ignore should "list action by default namespace with full docs" in {
-        implicit val tid = transid()
-        val actions = (1 to 2).map { i =>
-            WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
-        }.toList
-        actions foreach { put(entityStore, _) }
-        waitOnView(entityStore, WhiskAction, namespace, 2)
-        Get(s"$collectionPath?docs=true") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[List[WhiskAction]]
-            actions.length should be(response.length)
-            actions forall { a => response contains a } should be(true)
-        }
+    // it should "reject list action with explicit namespace not owned by subject" in {
+    val auser = WhiskAuthHelpers.newIdentity()
+    Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden)
+    }
+  }
+
+  it should "list should reject request with post" in {
+    implicit val tid = transid()
+    Post(s"$collectionPath") ~> Route.seal(routes(creds)) ~> check {
+      status should be(MethodNotAllowed)
+    }
+  }
+
+  //// GET /actions/name
+  it should "get action by name in default namespace" in {
+    implicit val tid = transid()
+    val action = WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
+    put(entityStore, action)
+    Get(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response should be(action)
+    }
+  }
+
+  it should "get action by name in explicit namespace" in {
+    implicit val tid = transid()
+    val action = WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
+    put(entityStore, action)
+    Get(s"/$namespace/${collection.path}/${action.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response should be(action)
     }
 
-    it should "list action with explicit namespace" in {
-        implicit val tid = transid()
-        val actions = (1 to 2).map { i =>
-            WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
-        }.toList
-        actions foreach { put(entityStore, _) }
-        waitOnView(entityStore, WhiskAction, namespace, 2)
-        Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[List[JsObject]]
-            actions.length should be(response.length)
-            actions forall { a => response contains a.summaryAsJson } should be(true)
-        }
+    // it should "reject get action by name in explicit namespace not owned by subject" in
+    val auser = WhiskAuthHelpers.newIdentity()
+    Get(s"/$namespace/${collection.path}/${action.name}") ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden)
+    }
+  }
 
-        // it should "reject list action with explicit namespace not owned by subject" in {
-        val auser = WhiskAuthHelpers.newIdentity()
-        Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden)
-        }
+  it should "report NotFound for get non existent action" in {
+    implicit val tid = transid()
+    Get(s"$collectionPath/xyz") ~> Route.seal(routes(creds)) ~> check {
+      status should be(NotFound)
+    }
+  }
+
+  it should "report Conflict if the name was of a different type" in {
+    implicit val tid = transid()
+    val trigger = WhiskTrigger(namespace, aname)
+    put(entityStore, trigger)
+    Get(s"/$namespace/${collection.path}/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(Conflict)
+    }
+  }
+
+  it should "reject long entity names" in {
+    implicit val tid = transid()
+    val longName = "a" * (EntityName.ENTITY_NAME_MAX_LENGTH + 1)
+    Get(s"/$longName/${collection.path}/$longName") ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[String] shouldBe {
+        Messages.entityNameTooLong(
+          SizeError(namespaceDescriptionForSizeError, longName.length.B, EntityName.ENTITY_NAME_MAX_LENGTH.B))
+      }
     }
 
-    it should "list should reject request with post" in {
-        implicit val tid = transid()
-        Post(s"$collectionPath") ~> Route.seal(routes(creds)) ~> check {
-            status should be(MethodNotAllowed)
+    Seq(
+      s"/$namespace/${collection.path}/$longName",
+      s"/$namespace/${collection.path}/pkg/$longName",
+      s"/$namespace/${collection.path}/$longName/a",
+      s"/$namespace/${collection.path}/$longName/$longName").foreach { p =>
+      Get(p) ~> Route.seal(routes(creds)) ~> check {
+        status should be(BadRequest)
+        responseAs[String] shouldBe {
+          Messages.entityNameTooLong(
+            SizeError(segmentDescriptionForSizeError, longName.length.B, EntityName.ENTITY_NAME_MAX_LENGTH.B))
         }
+      }
+    }
+  }
+
+  //// DEL /actions/name
+  it should "delete action by name" in {
+    implicit val tid = transid()
+    val action = WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
+    put(entityStore, action)
+
+    // it should "reject delete action by name not owned by subject" in
+    val auser = WhiskAuthHelpers.newIdentity()
+    Get(s"/$namespace/${collection.path}/${action.name}") ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden)
     }
 
-    //// GET /actions/name
-    it should "get action by name in default namespace" in {
-        implicit val tid = transid()
-        val action = WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
-        put(entityStore, action)
-        Get(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskAction]
-            response should be(action)
-        }
+    Delete(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response should be(action)
     }
+  }
 
-    it should "get action by name in explicit namespace" in {
-        implicit val tid = transid()
-        val action = WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
-        put(entityStore, action)
-        Get(s"/$namespace/${collection.path}/${action.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskAction]
-            response should be(action)
-        }
-
-        // it should "reject get action by name in explicit namespace not owned by subject" in
-        val auser = WhiskAuthHelpers.newIdentity()
-        Get(s"/$namespace/${collection.path}/${action.name}") ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden)
-        }
+  it should "report NotFound for delete non existent action" in {
+    implicit val tid = transid()
+    Delete(s"$collectionPath/xyz") ~> Route.seal(routes(creds)) ~> check {
+      status should be(NotFound)
     }
+  }
 
-    it should "report NotFound for get non existent action" in {
-        implicit val tid = transid()
-        Get(s"$collectionPath/xyz") ~> Route.seal(routes(creds)) ~> check {
-            status should be(NotFound)
-        }
+  //// PUT /actions/name
+  it should "put should reject request missing json content" in {
+    implicit val tid = transid()
+    Put(s"$collectionPath/xxx", "") ~> Route.seal(routes(creds)) ~> check {
+      val response = responseAs[String]
+      status should be(UnsupportedMediaType)
     }
+  }
 
-    it should "report Conflict if the name was of a different type" in {
-        implicit val tid = transid()
-        val trigger = WhiskTrigger(namespace, aname)
-        put(entityStore, trigger)
-        Get(s"/$namespace/${collection.path}/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(Conflict)
-        }
+  it should "put should reject request missing property exec" in {
+    implicit val tid = transid()
+    val content = """|{"name":"name","publish":true}""".stripMargin.parseJson.asJsObject
+    Put(s"$collectionPath/xxx", content) ~> Route.seal(routes(creds)) ~> check {
+      val response = responseAs[String]
+      status should be(BadRequest)
     }
+  }
 
-    it should "reject long entity names" in {
-        implicit val tid = transid()
-        val longName = "a" * (EntityName.ENTITY_NAME_MAX_LENGTH + 1)
-        Get(s"/$longName/${collection.path}/$longName") ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[String] shouldBe {
-                Messages.entityNameTooLong(
-                    SizeError(namespaceDescriptionForSizeError, longName.length.B, EntityName.ENTITY_NAME_MAX_LENGTH.B))
-            }
-        }
-
-        Seq(s"/$namespace/${collection.path}/$longName",
-            s"/$namespace/${collection.path}/pkg/$longName",
-            s"/$namespace/${collection.path}/$longName/a",
-            s"/$namespace/${collection.path}/$longName/$longName").
-            foreach { p =>
-                Get(p) ~> Route.seal(routes(creds)) ~> check {
-                    status should be(BadRequest)
-                    responseAs[String] shouldBe {
-                        Messages.entityNameTooLong(
-                            SizeError(segmentDescriptionForSizeError, longName.length.B, EntityName.ENTITY_NAME_MAX_LENGTH.B))
-                    }
-                }
-            }
-    }
-
-    //// DEL /actions/name
-    it should "delete action by name" in {
-        implicit val tid = transid()
-        val action = WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
-        put(entityStore, action)
-
-        // it should "reject delete action by name not owned by subject" in
-        val auser = WhiskAuthHelpers.newIdentity()
-        Get(s"/$namespace/${collection.path}/${action.name}") ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden)
-        }
-
-        Delete(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskAction]
-            response should be(action)
-        }
-    }
-
-    it should "report NotFound for delete non existent action" in {
-        implicit val tid = transid()
-        Delete(s"$collectionPath/xyz") ~> Route.seal(routes(creds)) ~> check {
-            status should be(NotFound)
-        }
-    }
-
-    //// PUT /actions/name
-    it should "put should reject request missing json content" in {
-        implicit val tid = transid()
-        Put(s"$collectionPath/xxx", "") ~> Route.seal(routes(creds)) ~> check {
-            val response = responseAs[String]
-            status should be(UnsupportedMediaType)
-        }
-    }
-
-    it should "put should reject request missing property exec" in {
-        implicit val tid = transid()
-        val content = """|{"name":"name","publish":true}""".stripMargin.parseJson.asJsObject
-        Put(s"$collectionPath/xxx", content) ~> Route.seal(routes(creds)) ~> check {
-            val response = responseAs[String]
-            status should be(BadRequest)
-        }
-    }
-
-    it should "put should reject request with malformed property exec" in {
-        implicit val tid = transid()
-        val content = """|{"name":"name",
+  it should "put should reject request with malformed property exec" in {
+    implicit val tid = transid()
+    val content = """|{"name":"name",
                          |"publish":true,
                          |"exec":""}""".stripMargin.parseJson.asJsObject
-        Put(s"$collectionPath/xxx", content) ~> Route.seal(routes(creds)) ~> check {
-            val response = responseAs[String]
-            status should be(BadRequest)
-        }
+    Put(s"$collectionPath/xxx", content) ~> Route.seal(routes(creds)) ~> check {
+      val response = responseAs[String]
+      status should be(BadRequest)
+    }
+  }
+
+  it should "reject create with exec which is too big" in {
+    implicit val tid = transid()
+    val code = "a" * (actionLimit.toBytes.toInt + 1)
+    val exec: Exec = jsDefault(code)
+    val content = JsObject("exec" -> exec.toJson)
+    Put(s"$collectionPath/${aname}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(RequestEntityTooLarge)
+      responseAs[String] should include {
+        Messages.entityTooBig(SizeError(WhiskAction.execFieldName, exec.size, Exec.sizeLimit))
+      }
+    }
+  }
+
+  it should "reject update with exec which is too big" in {
+    implicit val tid = transid()
+    val oldCode = "function main()"
+    val code = "a" * (actionLimit.toBytes.toInt + 1)
+    val action = WhiskAction(namespace, aname, jsDefault("??"))
+    val exec: Exec = jsDefault(code)
+    val content = JsObject("exec" -> exec.toJson)
+    put(entityStore, action)
+    Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(RequestEntityTooLarge)
+      responseAs[String] should include {
+        Messages.entityTooBig(SizeError(WhiskAction.execFieldName, exec.size, Exec.sizeLimit))
+      }
+    }
+  }
+
+  it should "reject create with parameters which are too big" in {
+    implicit val tid = transid()
+    val keys: List[Long] =
+      List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
+    val parameters = keys map { key =>
+      Parameters(key.toString, "a" * 10)
+    } reduce (_ ++ _)
+    val content = s"""{"exec":{"kind":"nodejs","code":"??"},"parameters":$parameters}""".stripMargin
+    Put(s"$collectionPath/${aname}", content.parseJson.asJsObject) ~> Route.seal(routes(creds)) ~> check {
+      status should be(RequestEntityTooLarge)
+      responseAs[String] should include {
+        Messages.entityTooBig(SizeError(WhiskEntity.paramsFieldName, parameters.size, Parameters.sizeLimit))
+      }
+    }
+  }
+
+  it should "reject create with annotations which are too big" in {
+    implicit val tid = transid()
+    val keys: List[Long] =
+      List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
+    val annotations = keys map { key =>
+      Parameters(key.toString, "a" * 10)
+    } reduce (_ ++ _)
+    val content = s"""{"exec":{"kind":"nodejs","code":"??"},"annotations":$annotations}""".stripMargin
+    Put(s"$collectionPath/${aname}", content.parseJson.asJsObject) ~> Route.seal(routes(creds)) ~> check {
+      status should be(RequestEntityTooLarge)
+      responseAs[String] should include {
+        Messages.entityTooBig(SizeError(WhiskEntity.annotationsFieldName, annotations.size, Parameters.sizeLimit))
+      }
+    }
+  }
+
+  it should "reject activation with entity which is too big" in {
+    implicit val tid = transid()
+    val code = "a" * (allowedActivationEntitySize.toInt + 1)
+    val content = s"""{"a":"$code"}""".stripMargin
+    Post(s"$collectionPath/${aname}", content.parseJson.asJsObject) ~> Route.seal(routes(creds)) ~> check {
+      status should be(RequestEntityTooLarge)
+      responseAs[String] should include {
+        Messages.entityTooBig(
+          SizeError(fieldDescriptionForSizeError, (content.length).B, allowedActivationEntitySize.B))
+      }
+    }
+  }
+
+  it should "put should accept request with missing optional properties" in {
+    implicit val tid = transid()
+    val action = WhiskAction(namespace, aname, jsDefault("??"))
+    val content = WhiskActionPut(Some(action.exec))
+    Put(s"$collectionPath/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      deleteAction(action.docid)
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response should be(
+        WhiskAction(
+          action.namespace,
+          action.name,
+          action.exec,
+          action.parameters,
+          action.limits,
+          action.version,
+          action.publish,
+          action.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6)))
+    }
+  }
+
+  it should "put should accept blackbox exec with empty code property" in {
+    implicit val tid = transid()
+    val action = WhiskAction(namespace, aname, bb("bb"))
+    val content = Map("exec" -> Map("kind" -> "blackbox", "code" -> "", "image" -> "bb")).toJson.asJsObject
+    Put(s"$collectionPath/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      deleteAction(action.docid)
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response should be(
+        WhiskAction(
+          action.namespace,
+          action.name,
+          action.exec,
+          action.parameters,
+          action.limits,
+          action.version,
+          action.publish,
+          action.annotations ++ Parameters(WhiskAction.execFieldName, Exec.BLACKBOX)))
+      response.exec shouldBe an[BlackBoxExec]
+      response.exec.asInstanceOf[BlackBoxExec].code shouldBe empty
+    }
+  }
+
+  it should "put should accept blackbox exec with non-empty code property" in {
+    implicit val tid = transid()
+    val action = WhiskAction(namespace, aname, bb("bb", "cc"))
+    val content = Map("exec" -> Map("kind" -> "blackbox", "code" -> "cc", "image" -> "bb")).toJson.asJsObject
+    Put(s"$collectionPath/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      deleteAction(action.docid)
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response should be(
+        WhiskAction(
+          action.namespace,
+          action.name,
+          action.exec,
+          action.parameters,
+          action.limits,
+          action.version,
+          action.publish,
+          action.annotations ++ Parameters(WhiskAction.execFieldName, Exec.BLACKBOX)))
+      response.exec shouldBe an[BlackBoxExec]
+      val bb = response.exec.asInstanceOf[BlackBoxExec]
+      bb.code shouldBe Some("cc")
+      bb.binary shouldBe false
+    }
+  }
+
+  private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
+  private def seqParameters(seq: Vector[FullyQualifiedEntityName]) = Parameters("_actions", seq.toJson)
+
+  // this test is sneaky; the installation of the sequence is done directly in the db
+  // and api checks are skipped
+  it should "reset parameters when changing sequence action to non sequence" in {
+    implicit val tid = transid()
+    val components = Vector("x/a", "x/b").map(stringToFullyQualifiedName(_))
+    val action = WhiskAction(namespace, aname, sequence(components), seqParameters(components))
+    val content = WhiskActionPut(Some(jsDefault("")))
+    put(entityStore, action, false)
+
+    // create an action sequence
+    Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      deleteAction(action.docid)
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response.exec.kind should be(NODEJS6)
+      response.parameters shouldBe Parameters()
+    }
+  }
+
+  // this test is sneaky; the installation of the sequence is done directly in the db
+  // and api checks are skipped
+  it should "preserve new parameters when changing sequence action to non sequence" in {
+    implicit val tid = transid()
+    val components = Vector("x/a", "x/b").map(stringToFullyQualifiedName(_))
+    val action = WhiskAction(namespace, aname, sequence(components), seqParameters(components))
+    val content = WhiskActionPut(Some(jsDefault("")), parameters = Some(Parameters("a", "A")))
+    put(entityStore, action, false)
+
+    // create an action sequence
+    Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      deleteAction(action.docid)
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response.exec.kind should be(NODEJS6)
+      response.parameters should be(Parameters("a", "A"))
+    }
+  }
+
+  it should "put should accept request with parameters property" in {
+    implicit val tid = transid()
+    val action = WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
+    val content = WhiskActionPut(Some(action.exec), Some(action.parameters))
+
+    // it should "reject put action in namespace not owned by subject" in
+    val auser = WhiskAuthHelpers.newIdentity()
+    Put(s"/$namespace/${collection.path}/${action.name}", content) ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden)
     }
 
-    it should "reject create with exec which is too big" in {
-        implicit val tid = transid()
-        val code = "a" * (actionLimit.toBytes.toInt + 1)
-        val exec: Exec = jsDefault(code)
-        val content = JsObject("exec" -> exec.toJson)
-        Put(s"$collectionPath/${aname}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(RequestEntityTooLarge)
-            responseAs[String] should include {
-                Messages.entityTooBig(SizeError(WhiskAction.execFieldName, exec.size, Exec.sizeLimit))
-            }
-        }
+    Put(s"$collectionPath/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      deleteAction(action.docid)
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response should be(
+        WhiskAction(
+          action.namespace,
+          action.name,
+          action.exec,
+          action.parameters,
+          action.limits,
+          action.version,
+          action.publish,
+          action.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6)))
+    }
+  }
+
+  it should "put should reject request with parameters property as jsobject" in {
+    implicit val tid = transid()
+    val action = WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
+    val content = WhiskActionPut(Some(action.exec), Some(action.parameters))
+    val params = """{ "parameters": { "a": "b" } }""".parseJson.asJsObject
+    val json = JsObject(WhiskActionPut.serdes.write(content).asJsObject.fields ++ params.fields)
+    Put(s"$collectionPath/${action.name}", json) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+    }
+  }
+
+  it should "put should accept request with limits property" in {
+    implicit val tid = transid()
+    val action = WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
+    val content = WhiskActionPut(
+      Some(action.exec),
+      Some(action.parameters),
+      Some(ActionLimitsOption(Some(action.limits.timeout), Some(action.limits.memory), Some(action.limits.logs))))
+    Put(s"$collectionPath/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      deleteAction(action.docid)
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response should be(
+        WhiskAction(
+          action.namespace,
+          action.name,
+          action.exec,
+          action.parameters,
+          action.limits,
+          action.version,
+          action.publish,
+          action.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6)))
+    }
+  }
+
+  it should "put and then get action from cache" in {
+    val action = WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
+    val content = WhiskActionPut(
+      Some(action.exec),
+      Some(action.parameters),
+      Some(ActionLimitsOption(Some(action.limits.timeout), Some(action.limits.memory), Some(action.limits.logs))))
+    val name = action.name
+
+    // first request invalidates any previous entries and caches new result
+    Put(s"$collectionPath/$name", content) ~> Route.seal(routes(creds)(transid())) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response should be(
+        WhiskAction(
+          action.namespace,
+          action.name,
+          action.exec,
+          action.parameters,
+          action.limits,
+          action.version,
+          action.publish,
+          action.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6)))
+    }
+    stream.toString should include(s"caching ${CacheKey(action)}")
+    stream.reset()
+
+    // second request should fetch from cache
+    Get(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response should be(
+        WhiskAction(
+          action.namespace,
+          action.name,
+          action.exec,
+          action.parameters,
+          action.limits,
+          action.version,
+          action.publish,
+          action.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6)))
     }
 
-    it should "reject update with exec which is too big" in {
-        implicit val tid = transid()
-        val oldCode = "function main()"
-        val code = "a" * (actionLimit.toBytes.toInt + 1)
-        val action = WhiskAction(namespace, aname, jsDefault("??"))
-        val exec: Exec = jsDefault(code)
-        val content = JsObject("exec" -> exec.toJson)
-        put(entityStore, action)
-        Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(RequestEntityTooLarge)
-            responseAs[String] should include {
-                Messages.entityTooBig(SizeError(WhiskAction.execFieldName, exec.size, Exec.sizeLimit))
-            }
-        }
+    stream.toString should include(s"serving from cache: ${CacheKey(action)}")
+    stream.reset()
+
+    // delete should invalidate cache
+    Delete(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response should be(
+        WhiskAction(
+          action.namespace,
+          action.name,
+          action.exec,
+          action.parameters,
+          action.limits,
+          action.version,
+          action.publish,
+          action.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6)))
+    }
+    stream.toString should include(s"invalidating ${CacheKey(action)}")
+    stream.reset()
+  }
+
+  it should "reject put with conflict for pre-existing action" in {
+    implicit val tid = transid()
+    val action = WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
+    val content = WhiskActionPut(Some(action.exec))
+    put(entityStore, action)
+    Put(s"$collectionPath/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(Conflict)
+    }
+  }
+
+  it should "update action with a put" in {
+    implicit val tid = transid()
+    val action = WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
+    val content = WhiskActionPut(Some(jsDefault("_")), Some(Parameters("x", "X")))
+    put(entityStore, action)
+    Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      deleteAction(action.docid)
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response should be {
+        WhiskAction(
+          action.namespace,
+          action.name,
+          content.exec.get,
+          content.parameters.get,
+          version = action.version.upPatch,
+          annotations = action.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6))
+      }
+    }
+  }
+
+  it should "update action parameters with a put" in {
+    implicit val tid = transid()
+    val action = WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
+    val content = WhiskActionPut(parameters = Some(Parameters("x", "X")))
+    put(entityStore, action)
+    Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      deleteAction(action.docid)
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response should be {
+        WhiskAction(
+          action.namespace,
+          action.name,
+          action.exec,
+          content.parameters.get,
+          version = action.version.upPatch,
+          annotations = action.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6))
+      }
+    }
+  }
+
+  //// POST /actions/name
+  it should "invoke an action with arguments, nonblocking" in {
+    implicit val tid = transid()
+    val action = WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
+    val args = JsObject("xxx" -> "yyy".toJson)
+    put(entityStore, action)
+
+    // it should "reject post to action in namespace not owned by subject"
+    val auser = WhiskAuthHelpers.newIdentity()
+    Post(s"/$namespace/${collection.path}/${action.name}", args) ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden)
     }
 
-    it should "reject create with parameters which are too big" in {
-        implicit val tid = transid()
-        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
-        val parameters = keys map { key =>
-            Parameters(key.toString, "a" * 10)
-        } reduce (_ ++ _)
-        val content = s"""{"exec":{"kind":"nodejs","code":"??"},"parameters":$parameters}""".stripMargin
-        Put(s"$collectionPath/${aname}", content.parseJson.asJsObject) ~> Route.seal(routes(creds)) ~> check {
-            status should be(RequestEntityTooLarge)
-            responseAs[String] should include {
-                Messages.entityTooBig(SizeError(WhiskEntity.paramsFieldName, parameters.size, Parameters.sizeLimit))
-            }
-        }
+    Post(s"$collectionPath/${action.name}", args) ~> Route.seal(routes(creds)) ~> check {
+      status should be(Accepted)
+      val response = responseAs[JsObject]
+      response.fields("activationId") should not be None
     }
 
-    it should "reject create with annotations which are too big" in {
-        implicit val tid = transid()
-        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
-        val annotations = keys map { key =>
-            Parameters(key.toString, "a" * 10)
-        } reduce (_ ++ _)
-        val content = s"""{"exec":{"kind":"nodejs","code":"??"},"annotations":$annotations}""".stripMargin
-        Put(s"$collectionPath/${aname}", content.parseJson.asJsObject) ~> Route.seal(routes(creds)) ~> check {
-            status should be(RequestEntityTooLarge)
-            responseAs[String] should include {
-                Messages.entityTooBig(SizeError(WhiskEntity.annotationsFieldName, annotations.size, Parameters.sizeLimit))
-            }
-        }
+    // it should "ignore &result when invoking nonblocking action"
+    Post(s"$collectionPath/${action.name}?result=true", args) ~> Route.seal(routes(creds)) ~> check {
+      status should be(Accepted)
+      val response = responseAs[JsObject]
+      response.fields("activationId") should not be None
+    }
+  }
+
+  it should "invoke an action, nonblocking" in {
+    implicit val tid = transid()
+    val action = WhiskAction(namespace, aname, jsDefault("??"))
+    put(entityStore, action)
+    Post(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(Accepted)
+      val response = responseAs[JsObject]
+      response.fields("activationId") should not be None
+    }
+  }
+
+  it should "invoke an action, blocking with default timeout" in {
+    implicit val tid = transid()
+    val action = WhiskAction(
+      namespace,
+      aname,
+      jsDefault("??"),
+      limits = ActionLimits(TimeLimit(1 second), MemoryLimit(), LogLimit()))
+    put(entityStore, action)
+    Post(s"$collectionPath/${action.name}?blocking=true") ~> Route.seal(routes(creds)) ~> check {
+      // status should be accepted because there is no active ack response and
+      // db polling will fail since there is no record of the activation
+      status should be(Accepted)
+      val response = responseAs[JsObject]
+      response.fields("activationId") should not be None
+    }
+  }
+
+  it should "invoke an action, blocking and retrieve result via db polling" in {
+    implicit val tid = transid()
+    val action = WhiskAction(namespace, aname, jsDefault("??"))
+    val activation = WhiskActivation(
+      action.namespace,
+      action.name,
+      creds.subject,
+      activationIdFactory.make(),
+      start = Instant.now,
+      end = Instant.now,
+      response = ActivationResponse.success(Some(JsObject("test" -> "yes".toJson))))
+    put(entityStore, action)
+    // storing the activation in the db will allow the db polling to retrieve it
+    // the test harness makes sure the activation id observed by the test matches
+    // the one generated by the api handler
+    put(activationStore, activation)
+    try {
+      Post(s"$collectionPath/${action.name}?blocking=true") ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[JsObject]
+        response should be(activation.withoutLogs.toExtendedJson)
+      }
+
+      // repeat invoke, get only result back
+      Post(s"$collectionPath/${action.name}?blocking=true&result=true") ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[JsObject]
+        response should be(activation.resultAsJson)
+      }
+    } finally {
+      deleteActivation(activation.docid)
+    }
+  }
+
+  it should "invoke an action, blocking and retrieve result via active ack" in {
+    implicit val tid = transid()
+    val action = WhiskAction(namespace, aname, jsDefault("??"))
+    val activation = WhiskActivation(
+      action.namespace,
+      action.name,
+      creds.subject,
+      activationIdFactory.make(),
+      start = Instant.now,
+      end = Instant.now,
+      response = ActivationResponse.success(Some(JsObject("test" -> "yes".toJson))))
+    put(entityStore, action)
+
+    try {
+      // do not store the activation in the db, instead register it as the response to generate on active ack
+      loadBalancer.whiskActivationStub = Some((1.milliseconds, activation))
+
+      Post(s"$collectionPath/${action.name}?blocking=true") ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[JsObject]
+        response should be(activation.withoutLogs.toExtendedJson)
+      }
+
+      // repeat invoke, get only result back
+      Post(s"$collectionPath/${action.name}?blocking=true&result=true") ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[JsObject]
+        response should be(activation.resultAsJson)
+      }
+    } finally {
+      loadBalancer.whiskActivationStub = None
+    }
+  }
+
+  it should "invoke an action, blocking up to specified timeout and retrieve result via active ack" in {
+    implicit val tid = transid()
+    val action = WhiskAction(namespace, aname, jsDefault("??"))
+    val activation = WhiskActivation(
+      action.namespace,
+      action.name,
+      creds.subject,
+      activationIdFactory.make(),
+      start = Instant.now,
+      end = Instant.now,
+      response = ActivationResponse.success(Some(JsObject("test" -> "yes".toJson))))
+    put(entityStore, action)
+
+    try {
+      // do not store the activation in the db, instead register it as the response to generate on active ack
+      loadBalancer.whiskActivationStub = Some((300.milliseconds, activation))
+
+      Post(s"$collectionPath/${action.name}?blocking=true&timeout=0") ~> Route.seal(routes(creds)) ~> check {
+        status shouldBe BadRequest
+        responseAs[String] should include(Messages.invalidTimeout(WhiskActionsApi.maxWaitForBlockingActivation))
+      }
+
+      Post(s"$collectionPath/${action.name}?blocking=true&timeout=65000") ~> Route.seal(routes(creds)) ~> check {
+        status shouldBe BadRequest
+        responseAs[String] should include(Messages.invalidTimeout(WhiskActionsApi.maxWaitForBlockingActivation))
+      }
+
+      // will not wait long enough should get accepted status
+      Post(s"$collectionPath/${action.name}?blocking=true&timeout=100") ~> Route.seal(routes(creds)) ~> check {
+        status shouldBe Accepted
+      }
+
+      // repeat this time wait longer than active ack delay
+      Post(s"$collectionPath/${action.name}?blocking=true&timeout=500") ~> Route.seal(routes(creds)) ~> check {
+        status shouldBe OK
+        val response = responseAs[JsObject]
+        response shouldBe activation.withoutLogs.toExtendedJson
+      }
+    } finally {
+      loadBalancer.whiskActivationStub = None
+    }
+  }
+
+  it should "invoke a blocking action and return error response when activation fails" in {
+    implicit val tid = transid()
+    val action = WhiskAction(namespace, aname, jsDefault("??"))
+    val activation = WhiskActivation(
+      action.namespace,
+      action.name,
+      creds.subject,
+      activationIdFactory.make(),
+      start = Instant.now,
+      end = Instant.now,
+      response = ActivationResponse.whiskError("test"))
+    put(entityStore, action)
+    // storing the activation in the db will allow the db polling to retrieve it
+    // the test harness makes sure the activaiton id observed by the test matches
+    // the one generated by the api handler
+    put(activationStore, activation)
+    try {
+      Post(s"$collectionPath/${action.name}?blocking=true") ~> Route.seal(routes(creds)) ~> check {
+        status should be(InternalServerError)
+        val response = responseAs[JsObject]
+        response should be(activation.withoutLogs.toExtendedJson)
+      }
+    } finally {
+      deleteActivation(activation.docid)
+    }
+  }
+
+  it should "report proper error when record is corrupted on delete" in {
+    implicit val tid = transid()
+    val entity = BadEntity(namespace, aname)
+    put(entityStore, entity)
+
+    Delete(s"$collectionPath/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(InternalServerError)
+      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
+    }
+  }
+
+  it should "report proper error when record is corrupted on get" in {
+    implicit val tid = transid()
+    val entity = BadEntity(namespace, aname)
+    put(entityStore, entity)
+
+    Get(s"$collectionPath/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(InternalServerError)
+      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
+    }
+  }
+
+  it should "report proper error when record is corrupted on put" in {
+    implicit val tid = transid()
+    val entity = BadEntity(namespace, aname)
+    put(entityStore, entity)
+
+    val components = Vector(stringToFullyQualifiedName(s"$namespace/${entity.name}"))
+    val content = WhiskActionPut(Some(sequence(components)))
+
+    Put(s"$collectionPath/$aname", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(InternalServerError)
+      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
+    }
+  }
+
+  // get and delete allowed, create/update with deprecated exec not allowed, post/invoke not allowed
+  it should "report proper error when runtime is deprecated" in {
+    implicit val tid = transid()
+    val action = WhiskAction(namespace, aname, swift("??"))
+    val okUpdate = WhiskActionPut(Some(swift3("_")))
+    val badUpdate = WhiskActionPut(Some(swift("_")))
+
+    Put(s"$collectionPath/${action.name}", WhiskActionPut(Some(action.exec))) ~> Route.seal(routes(creds)) ~> check {
+      status shouldBe BadRequest
+      responseAs[ErrorResponse].error shouldBe Messages.runtimeDeprecated(action.exec)
     }
 
-    it should "reject activation with entity which is too big" in {
-        implicit val tid = transid()
-        val code = "a" * (allowedActivationEntitySize.toInt + 1)
-        val content = s"""{"a":"$code"}""".stripMargin
-        Post(s"$collectionPath/${aname}", content.parseJson.asJsObject) ~> Route.seal(routes(creds)) ~> check {
-            status should be(RequestEntityTooLarge)
-            responseAs[String] should include {
-                Messages.entityTooBig(SizeError(fieldDescriptionForSizeError, (content.length).B, allowedActivationEntitySize.B))
-            }
-        }
+    Put(s"$collectionPath/${action.name}?overwrite=true", WhiskActionPut(Some(action.exec))) ~> Route.seal(
+      routes(creds)) ~> check {
+      status shouldBe BadRequest
+      responseAs[ErrorResponse].error shouldBe Messages.runtimeDeprecated(action.exec)
     }
 
-    it should "put should accept request with missing optional properties" in {
-        implicit val tid = transid()
-        val action = WhiskAction(namespace, aname, jsDefault("??"))
-        val content = WhiskActionPut(Some(action.exec))
-        Put(s"$collectionPath/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            deleteAction(action.docid)
-            status should be(OK)
-            val response = responseAs[WhiskAction]
-            response should be(WhiskAction(action.namespace, action.name, action.exec,
-                action.parameters, action.limits, action.version,
-                action.publish, action.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6)))
-        }
+    put(entityStore, action)
+
+    Put(s"$collectionPath/${action.name}?overwrite=true", JsObject()) ~> Route.seal(routes(creds)) ~> check {
+      status shouldBe BadRequest
+      responseAs[ErrorResponse].error shouldBe Messages.runtimeDeprecated(action.exec)
     }
 
-    it should "put should accept blackbox exec with empty code property" in {
-        implicit val tid = transid()
-        val action = WhiskAction(namespace, aname, bb("bb"))
-        val content = Map("exec" -> Map("kind" -> "blackbox", "code" -> "", "image" -> "bb")).toJson.asJsObject
-        Put(s"$collectionPath/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            deleteAction(action.docid)
-            status should be(OK)
-            val response = responseAs[WhiskAction]
-            response should be(WhiskAction(action.namespace, action.name, action.exec,
-                action.parameters, action.limits, action.version,
-                action.publish, action.annotations ++ Parameters(WhiskAction.execFieldName, Exec.BLACKBOX)))
-            response.exec shouldBe an[BlackBoxExec]
-            response.exec.asInstanceOf[BlackBoxExec].code shouldBe empty
-        }
+    Put(s"$collectionPath/${action.name}?overwrite=true", badUpdate) ~> Route.seal(routes(creds)) ~> check {
+      status shouldBe BadRequest
+      responseAs[ErrorResponse].error shouldBe Messages.runtimeDeprecated(action.exec)
     }
 
-    it should "put should accept blackbox exec with non-empty code property" in {
-        implicit val tid = transid()
-        val action = WhiskAction(namespace, aname, bb("bb", "cc"))
-        val content = Map("exec" -> Map("kind" -> "blackbox", "code" -> "cc", "image" -> "bb")).toJson.asJsObject
-        Put(s"$collectionPath/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            deleteAction(action.docid)
-            status should be(OK)
-            val response = responseAs[WhiskAction]
-            response should be(WhiskAction(action.namespace, action.name, action.exec,
-                action.parameters, action.limits, action.version,
-                action.publish, action.annotations ++ Parameters(WhiskAction.execFieldName, Exec.BLACKBOX)))
-            response.exec shouldBe an[BlackBoxExec]
-            val bb = response.exec.asInstanceOf[BlackBoxExec]
-            bb.code shouldBe Some("cc")
-            bb.binary shouldBe false
-        }
+    Post(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)) ~> check {
+      status shouldBe BadRequest
+      responseAs[ErrorResponse].error shouldBe Messages.runtimeDeprecated(action.exec)
     }
 
-    private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
-    private def seqParameters(seq: Vector[FullyQualifiedEntityName]) = Parameters("_actions", seq.toJson)
-
-    // this test is sneaky; the installation of the sequence is done directly in the db
-    // and api checks are skipped
-    it should "reset parameters when changing sequence action to non sequence" in {
-        implicit val tid = transid()
-        val components = Vector("x/a", "x/b").map(stringToFullyQualifiedName(_))
-        val action = WhiskAction(namespace, aname, sequence(components), seqParameters(components))
-        val content = WhiskActionPut(Some(jsDefault("")))
-        put(entityStore, action, false)
-
-        // create an action sequence
-        Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            deleteAction(action.docid)
-            status should be(OK)
-            val response = responseAs[WhiskAction]
-            response.exec.kind should be(NODEJS6)
-            response.parameters shouldBe Parameters()
-        }
+    Get(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)) ~> check {
+      status shouldBe OK
     }
 
-    // this test is sneaky; the installation of the sequence is done directly in the db
-    // and api checks are skipped
-    it should "preserve new parameters when changing sequence action to non sequence" in {
-        implicit val tid = transid()
-        val components = Vector("x/a", "x/b").map(stringToFullyQualifiedName(_))
-        val action = WhiskAction(namespace, aname, sequence(components), seqParameters(components))
-        val content = WhiskActionPut(Some(jsDefault("")), parameters = Some(Parameters("a", "A")))
-        put(entityStore, action, false)
-
-        // create an action sequence
-        Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            deleteAction(action.docid)
-            status should be(OK)
-            val response = responseAs[WhiskAction]
-            response.exec.kind should be(NODEJS6)
-            response.parameters should be(Parameters("a", "A"))
-        }
+    Delete(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)) ~> check {
+      status shouldBe OK
     }
 
-    it should "put should accept request with parameters property" in {
-        implicit val tid = transid()
-        val action = WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
-        val content = WhiskActionPut(Some(action.exec), Some(action.parameters))
+    put(entityStore, action)
 
-        // it should "reject put action in namespace not owned by subject" in
-        val auser = WhiskAuthHelpers.newIdentity()
-        Put(s"/$namespace/${collection.path}/${action.name}", content) ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden)
-        }
-
-        Put(s"$collectionPath/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            deleteAction(action.docid)
-            status should be(OK)
-            val response = responseAs[WhiskAction]
-            response should be(WhiskAction(action.namespace, action.name, action.exec,
-                action.parameters, action.limits, action.version,
-                action.publish, action.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6)))
-        }
+    Put(s"$collectionPath/${action.name}?overwrite=true", okUpdate) ~> Route.seal(routes(creds)) ~> check {
+      deleteAction(action.docid)
+      status shouldBe OK
     }
-
-    it should "put should reject request with parameters property as jsobject" in {
-        implicit val tid = transid()
-        val action = WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
-        val content = WhiskActionPut(Some(action.exec), Some(action.parameters))
-        val params = """{ "parameters": { "a": "b" } }""".parseJson.asJsObject
-        val json = JsObject(WhiskActionPut.serdes.write(content).asJsObject.fields ++ params.fields)
-        Put(s"$collectionPath/${action.name}", json) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-        }
-    }
-
-    it should "put should accept request with limits property" in {
-        implicit val tid = transid()
-        val action = WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
-        val content = WhiskActionPut(Some(action.exec), Some(action.parameters), Some(ActionLimitsOption(Some(action.limits.timeout), Some(action.limits.memory), Some(action.limits.logs))))
-        Put(s"$collectionPath/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            deleteAction(action.docid)
-            status should be(OK)
-            val response = responseAs[WhiskAction]
-            response should be(WhiskAction(action.namespace, action.name, action.exec,
-                action.parameters, action.limits, action.version,
-                action.publish, action.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6)))
-        }
-    }
-
-    it should "put and then get action from cache" in {
-        val action = WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
-        val content = WhiskActionPut(Some(action.exec), Some(action.parameters), Some(ActionLimitsOption(Some(action.limits.timeout), Some(action.limits.memory), Some(action.limits.logs))))
-        val name = action.name
-
-        // first request invalidates any previous entries and caches new result
-        Put(s"$collectionPath/$name", content) ~> Route.seal(routes(creds)(transid())) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskAction]
-            response should be(WhiskAction(action.namespace, action.name, action.exec,
-                action.parameters, action.limits, action.version,
-                action.publish, action.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6)))
-        }
-        stream.toString should include(s"caching ${CacheKey(action)}")
-        stream.reset()
-
-        // second request should fetch from cache
-        Get(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskAction]
-            response should be(WhiskAction(action.namespace, action.name, action.exec,
-                action.parameters, action.limits, action.version,
-                action.publish, action.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6)))
-        }
-
-        stream.toString should include(s"serving from cache: ${CacheKey(action)}")
-        stream.reset()
-
-        // delete should invalidate cache
-        Delete(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskAction]
-            response should be(WhiskAction(action.namespace, action.name, action.exec,
-                action.parameters, action.limits, action.version,
-                action.publish, action.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6)))
-        }
-        stream.toString should include(s"invalidating ${CacheKey(action)}")
-        stream.reset()
-    }
-
-    it should "reject put with conflict for pre-existing action" in {
-        implicit val tid = transid()
-        val action = WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
-        val content = WhiskActionPut(Some(action.exec))
-        put(entityStore, action)
-        Put(s"$collectionPath/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(Conflict)
-        }
-    }
-
-    it should "update action with a put" in {
-        implicit val tid = transid()
-        val action = WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
-        val content = WhiskActionPut(Some(jsDefault("_")), Some(Parameters("x", "X")))
-        put(entityStore, action)
-        Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            deleteAction(action.docid)
-            status should be(OK)
-            val response = responseAs[WhiskAction]
-            response should be {
-                WhiskAction(action.namespace, action.name, content.exec.get, content.parameters.get, version = action.version.upPatch,
-                    annotations = action.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6))
-            }
-        }
-    }
-
-    it should "update action parameters with a put" in {
-        implicit val tid = transid()
-        val action = WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
-        val content = WhiskActionPut(parameters = Some(Parameters("x", "X")))
-        put(entityStore, action)
-        Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            deleteAction(action.docid)
-            status should be(OK)
-            val response = responseAs[WhiskAction]
-            response should be {
-                WhiskAction(action.namespace, action.name, action.exec, content.parameters.get, version = action.version.upPatch,
-                    annotations = action.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6))
-            }
-        }
-    }
-
-    //// POST /actions/name
-    it should "invoke an action with arguments, nonblocking" in {
-        implicit val tid = transid()
-        val action = WhiskAction(namespace, aname, jsDefault("??"), Parameters("x", "b"))
-        val args = JsObject("xxx" -> "yyy".toJson)
-        put(entityStore, action)
-
-        // it should "reject post to action in namespace not owned by subject"
-        val auser = WhiskAuthHelpers.newIdentity()
-        Post(s"/$namespace/${collection.path}/${action.name}", args) ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden)
-        }
-
-        Post(s"$collectionPath/${action.name}", args) ~> Route.seal(routes(creds)) ~> check {
-            status should be(Accepted)
-            val response = responseAs[JsObject]
-            response.fields("activationId") should not be None
-        }
-
-        // it should "ignore &result when invoking nonblocking action"
-        Post(s"$collectionPath/${action.name}?result=true", args) ~> Route.seal(routes(creds)) ~> check {
-            status should be(Accepted)
-            val response = responseAs[JsObject]
-            response.fields("activationId") should not be None
-        }
-    }
-
-    it should "invoke an action, nonblocking" in {
-        implicit val tid = transid()
-        val action = WhiskAction(namespace, aname, jsDefault("??"))
-        put(entityStore, action)
-        Post(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(Accepted)
-            val response = responseAs[JsObject]
-            response.fields("activationId") should not be None
-        }
-    }
-
-    it should "invoke an action, blocking with default timeout" in {
-        implicit val tid = transid()
-        val action = WhiskAction(namespace, aname, jsDefault("??"), limits = ActionLimits(TimeLimit(1 second), MemoryLimit(), LogLimit()))
-        put(entityStore, action)
-        Post(s"$collectionPath/${action.name}?blocking=true") ~> Route.seal(routes(creds)) ~> check {
-            // status should be accepted because there is no active ack response and
-            // db polling will fail since there is no record of the activation
-            status should be(Accepted)
-            val response = responseAs[JsObject]
-            response.fields("activationId") should not be None
-        }
-    }
-
-    it should "invoke an action, blocking and retrieve result via db polling" in {
-        implicit val tid = transid()
-        val action = WhiskAction(namespace, aname, jsDefault("??"))
-        val activation = WhiskActivation(action.namespace, action.name, creds.subject, activationIdFactory.make(),
-            start = Instant.now,
-            end = Instant.now,
-            response = ActivationResponse.success(Some(JsObject("test" -> "yes".toJson))))
-        put(entityStore, action)
-        // storing the activation in the db will allow the db polling to retrieve it
-        // the test harness makes sure the activation id observed by the test matches
-        // the one generated by the api handler
-        put(activationStore, activation)
-        try {
-            Post(s"$collectionPath/${action.name}?blocking=true") ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                val response = responseAs[JsObject]
-                response should be(activation.withoutLogs.toExtendedJson)
-            }
-
-            // repeat invoke, get only result back
-            Post(s"$collectionPath/${action.name}?blocking=true&result=true") ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                val response = responseAs[JsObject]
-                response should be(activation.resultAsJson)
-            }
-        } finally {
-            deleteActivation(activation.docid)
-        }
-    }
-
-    it should "invoke an action, blocking and retrieve result via active ack" in {
-        implicit val tid = transid()
-        val action = WhiskAction(namespace, aname, jsDefault("??"))
-        val activation = WhiskActivation(action.namespace, action.name, creds.subject, activationIdFactory.make(),
-            start = Instant.now,
-            end = Instant.now,
-            response = ActivationResponse.success(Some(JsObject("test" -> "yes".toJson))))
-        put(entityStore, action)
-
-        try {
-            // do not store the activation in the db, instead register it as the response to generate on active ack
-            loadBalancer.whiskActivationStub = Some((1.milliseconds, activation))
-
-            Post(s"$collectionPath/${action.name}?blocking=true") ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                val response = responseAs[JsObject]
-                response should be(activation.withoutLogs.toExtendedJson)
-            }
-
-            // repeat invoke, get only result back
-            Post(s"$collectionPath/${action.name}?blocking=true&result=true") ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                val response = responseAs[JsObject]
-                response should be(activation.resultAsJson)
-            }
-        } finally {
-            loadBalancer.whiskActivationStub = None
-        }
-    }
-
-    it should "invoke an action, blocking up to specified timeout and retrieve result via active ack" in {
-        implicit val tid = transid()
-        val action = WhiskAction(namespace, aname, jsDefault("??"))
-        val activation = WhiskActivation(action.namespace, action.name, creds.subject, activationIdFactory.make(),
-            start = Instant.now,
-            end = Instant.now,
-            response = ActivationResponse.success(Some(JsObject("test" -> "yes".toJson))))
-        put(entityStore, action)
-
-        try {
-            // do not store the activation in the db, instead register it as the response to generate on active ack
-            loadBalancer.whiskActivationStub = Some((300.milliseconds, activation))
-
-            Post(s"$collectionPath/${action.name}?blocking=true&timeout=0") ~> Route.seal(routes(creds)) ~> check {
-                status shouldBe BadRequest
-                responseAs[String] should include(Messages.invalidTimeout(WhiskActionsApi.maxWaitForBlockingActivation))
-            }
-
-            Post(s"$collectionPath/${action.name}?blocking=true&timeout=65000") ~> Route.seal(routes(creds)) ~> check {
-                status shouldBe BadRequest
-                responseAs[String] should include(Messages.invalidTimeout(WhiskActionsApi.maxWaitForBlockingActivation))
-            }
-
-            // will not wait long enough should get accepted status
-            Post(s"$collectionPath/${action.name}?blocking=true&timeout=100") ~> Route.seal(routes(creds)) ~> check {
-                status shouldBe Accepted
-            }
-
-            // repeat this time wait longer than active ack delay
-            Post(s"$collectionPath/${action.name}?blocking=true&timeout=500") ~> Route.seal(routes(creds)) ~> check {
-                status shouldBe OK
-                val response = responseAs[JsObject]
-                response shouldBe activation.withoutLogs.toExtendedJson
-            }
-        } finally {
-            loadBalancer.whiskActivationStub = None
-        }
-    }
-
-    it should "invoke a blocking action and return error response when activation fails" in {
-        implicit val tid = transid()
-        val action = WhiskAction(namespace, aname, jsDefault("??"))
-        val activation = WhiskActivation(action.namespace, action.name, creds.subject, activationIdFactory.make(),
-            start = Instant.now,
-            end = Instant.now,
-            response = ActivationResponse.whiskError("test"))
-        put(entityStore, action)
-        // storing the activation in the db will allow the db polling to retrieve it
-        // the test harness makes sure the activaiton id observed by the test matches
-        // the one generated by the api handler
-        put(activationStore, activation)
-        try {
-            Post(s"$collectionPath/${action.name}?blocking=true") ~> Route.seal(routes(creds)) ~> check {
-                status should be(InternalServerError)
-                val response = responseAs[JsObject]
-                response should be(activation.withoutLogs.toExtendedJson)
-            }
-        } finally {
-            deleteActivation(activation.docid)
-        }
-    }
-
-    it should "report proper error when record is corrupted on delete" in {
-        implicit val tid = transid()
-        val entity = BadEntity(namespace, aname)
-        put(entityStore, entity)
-
-        Delete(s"$collectionPath/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(InternalServerError)
-            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-        }
-    }
-
-    it should "report proper error when record is corrupted on get" in {
-        implicit val tid = transid()
-        val entity = BadEntity(namespace, aname)
-        put(entityStore, entity)
-
-        Get(s"$collectionPath/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(InternalServerError)
-            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-        }
-    }
-
-    it should "report proper error when record is corrupted on put" in {
-        implicit val tid = transid()
-        val entity = BadEntity(namespace, aname)
-        put(entityStore, entity)
-
-        val components = Vector(stringToFullyQualifiedName(s"$namespace/${entity.name}"))
-        val content = WhiskActionPut(Some(sequence(components)))
-
-        Put(s"$collectionPath/$aname", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(InternalServerError)
-            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-        }
-    }
-
-    // get and delete allowed, create/update with deprecated exec not allowed, post/invoke not allowed
-    it should "report proper error when runtime is deprecated" in {
-        implicit val tid = transid()
-        val action = WhiskAction(namespace, aname, swift("??"))
-        val okUpdate = WhiskActionPut(Some(swift3("_")))
-        val badUpdate = WhiskActionPut(Some(swift("_")))
-
-        Put(s"$collectionPath/${action.name}", WhiskActionPut(Some(action.exec))) ~> Route.seal(routes(creds)) ~> check {
-            status shouldBe BadRequest
-            responseAs[ErrorResponse].error shouldBe Messages.runtimeDeprecated(action.exec)
-        }
-
-        Put(s"$collectionPath/${action.name}?overwrite=true", WhiskActionPut(Some(action.exec))) ~> Route.seal(routes(creds)) ~> check {
-            status shouldBe BadRequest
-            responseAs[ErrorResponse].error shouldBe Messages.runtimeDeprecated(action.exec)
-        }
-
-        put(entityStore, action)
-
-        Put(s"$collectionPath/${action.name}?overwrite=true", JsObject()) ~> Route.seal(routes(creds)) ~> check {
-            status shouldBe BadRequest
-            responseAs[ErrorResponse].error shouldBe Messages.runtimeDeprecated(action.exec)
-        }
-
-        Put(s"$collectionPath/${action.name}?overwrite=true", badUpdate) ~> Route.seal(routes(creds)) ~> check {
-            status shouldBe BadRequest
-            responseAs[ErrorResponse].error shouldBe Messages.runtimeDeprecated(action.exec)
-        }
-
-        Post(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)) ~> check {
-            status shouldBe BadRequest
-            responseAs[ErrorResponse].error shouldBe Messages.runtimeDeprecated(action.exec)
-        }
-
-        Get(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)) ~> check {
-            status shouldBe OK
-        }
-
-        Delete(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)) ~> check {
-            status shouldBe OK
-        }
-
-        put(entityStore, action)
-
-        Put(s"$collectionPath/${action.name}?overwrite=true", okUpdate) ~> Route.seal(routes(creds)) ~> check {
-            deleteAction(action.docid)
-            status shouldBe OK
-        }
-    }
+  }
 }

--- a/tests/src/test/scala/whisk/core/controller/test/ActivationsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActivationsApiTests.scala
@@ -52,316 +52,410 @@ import whisk.spi.SpiLoader
 @RunWith(classOf[JUnitRunner])
 class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi {
 
-    /** Activations API tests */
-    behavior of "Activations API"
+  /** Activations API tests */
+  behavior of "Activations API"
 
-    val creds = WhiskAuthHelpers.newIdentity()
-    val namespace = EntityPath(creds.subject.asString)
-    val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
-    def aname = MakeName.next("activations_tests")
+  val creds = WhiskAuthHelpers.newIdentity()
+  val namespace = EntityPath(creds.subject.asString)
+  val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
+  def aname = MakeName.next("activations_tests")
 
-    //// GET /activations
-    it should "get summary activation by namespace" in {
-        implicit val tid = transid()
-        // create two sets of activation records, and check that only one set is served back
-        val creds1 = WhiskAuthHelpers.newAuth()
-        (1 to 2).map { i =>
-            WhiskActivation(EntityPath(creds1.subject.asString), aname, creds1.subject, ActivationId(), start = Instant.now, end = Instant.now)
-        } foreach { put(entityStore, _) }
+  //// GET /activations
+  it should "get summary activation by namespace" in {
+    implicit val tid = transid()
+    // create two sets of activation records, and check that only one set is served back
+    val creds1 = WhiskAuthHelpers.newAuth()
+    (1 to 2).map { i =>
+      WhiskActivation(
+        EntityPath(creds1.subject.asString),
+        aname,
+        creds1.subject,
+        ActivationId(),
+        start = Instant.now,
+        end = Instant.now)
+    } foreach { put(entityStore, _) }
 
-        val actionName = aname
-        val activations = (1 to 2).map { i =>
-            WhiskActivation(namespace, actionName, creds.subject, ActivationId(), start = Instant.now, end = Instant.now)
-        }.toList
-        activations foreach { put(activationStore, _) }
-        waitOnView(activationStore, namespace, 2)
-        whisk.utils.retry {
-            Get(s"$collectionPath") ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                val rawResponse = responseAs[List[JsObject]]
-                val response = responseAs[List[JsObject]]
-                activations.length should be(response.length)
-                activations forall { a => response contains a.summaryAsJson } should be(true)
-                rawResponse forall { a => a.getFields("for") match { case Seq(JsString(n)) => n == actionName.asString case _ => false } }
-            }
+    val actionName = aname
+    val activations = (1 to 2).map { i =>
+      WhiskActivation(namespace, actionName, creds.subject, ActivationId(), start = Instant.now, end = Instant.now)
+    }.toList
+    activations foreach { put(activationStore, _) }
+    waitOnView(activationStore, namespace, 2)
+    whisk.utils.retry {
+      Get(s"$collectionPath") ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val rawResponse = responseAs[List[JsObject]]
+        val response = responseAs[List[JsObject]]
+        activations.length should be(response.length)
+        activations forall { a =>
+          response contains a.summaryAsJson
+        } should be(true)
+        rawResponse forall { a =>
+          a.getFields("for") match {
+            case Seq(JsString(n)) => n == actionName.asString
+            case _                => false
+          }
         }
-
-        // it should "list activations with explicit namespace owned by subject" in {
-        whisk.utils.retry {
-            Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                val rawResponse = responseAs[List[JsObject]]
-                val response = responseAs[List[JsObject]]
-                activations.length should be(response.length)
-                activations forall { a => response contains a.summaryAsJson } should be(true)
-                rawResponse forall { a => a.getFields("for") match { case Seq(JsString(n)) => n == actionName.asString case _ => false } }
-            }
-        }
-
-        // it should "reject list activations with explicit namespace not owned by subject" in {
-        val auser = WhiskAuthHelpers.newIdentity()
-        Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden)
-        }
+      }
     }
 
-    //// GET /activations?docs=true
-    it should "get full activation by namespace" in {
-        implicit val tid = transid()
-        // create two sets of activation records, and check that only one set is served back
-        val creds1 = WhiskAuthHelpers.newAuth()
-        (1 to 2).map { i =>
-            WhiskActivation(EntityPath(creds1.subject.asString), aname, creds1.subject, ActivationId(), start = Instant.now, end = Instant.now)
-        } foreach { put(entityStore, _) }
-
-        val actionName = aname
-        val activations = (1 to 2).map { i =>
-            WhiskActivation(namespace, actionName, creds.subject, ActivationId(), start = Instant.now, end = Instant.now, response = ActivationResponse.success(Some(JsNumber(5))))
-        }.toList
-        activations foreach { put(activationStore, _) }
-        waitOnView(activationStore, namespace, 2)
-
-        whisk.utils.retry {
-            Get(s"$collectionPath?docs=true") ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                val response = responseAs[List[JsObject]]
-                activations.length should be(response.length)
-                activations forall { a => response contains a.toExtendedJson } should be(true)
-            }
+    // it should "list activations with explicit namespace owned by subject" in {
+    whisk.utils.retry {
+      Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val rawResponse = responseAs[List[JsObject]]
+        val response = responseAs[List[JsObject]]
+        activations.length should be(response.length)
+        activations forall { a =>
+          response contains a.summaryAsJson
+        } should be(true)
+        rawResponse forall { a =>
+          a.getFields("for") match {
+            case Seq(JsString(n)) => n == actionName.asString
+            case _                => false
+          }
         }
+      }
     }
 
-    //// GET /activations?docs=true&since=xxx&upto=yyy
-    it should "get full activation by namespace within a date range" in {
-        implicit val tid = transid()
-        // create two sets of activation records, and check that only one set is served back
-        val creds1 = WhiskAuthHelpers.newAuth()
-        (1 to 2).map { i =>
-            WhiskActivation(EntityPath(creds1.subject.asString), aname, creds1.subject, ActivationId(), start = Instant.now, end = Instant.now)
-        } foreach { put(activationStore, _) }
+    // it should "reject list activations with explicit namespace not owned by subject" in {
+    val auser = WhiskAuthHelpers.newIdentity()
+    Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden)
+    }
+  }
 
-        val actionName = aname
-        val now = Instant.now(Clock.systemUTC())
-        val since = now.plusSeconds(10)
-        val upto = now.plusSeconds(30)
-        implicit val activations = Seq(
-            WhiskActivation(namespace, actionName, creds.subject, ActivationId(), start = now.plusSeconds(9), end = now),
-            WhiskActivation(namespace, actionName, creds.subject, ActivationId(), start = now.plusSeconds(20), end = now.plusSeconds(20)), // should match
-            WhiskActivation(namespace, actionName, creds.subject, ActivationId(), start = now.plusSeconds(10), end = now.plusSeconds(20)), // should match
-            WhiskActivation(namespace, actionName, creds.subject, ActivationId(), start = now.plusSeconds(31), end = now.plusSeconds(20)),
-            WhiskActivation(namespace, actionName, creds.subject, ActivationId(), start = now.plusSeconds(30), end = now.plusSeconds(20))) // should match
-        activations foreach { put(activationStore, _) }
-        waitOnView(activationStore, namespace, activations.length)
+  //// GET /activations?docs=true
+  it should "get full activation by namespace" in {
+    implicit val tid = transid()
+    // create two sets of activation records, and check that only one set is served back
+    val creds1 = WhiskAuthHelpers.newAuth()
+    (1 to 2).map { i =>
+      WhiskActivation(
+        EntityPath(creds1.subject.asString),
+        aname,
+        creds1.subject,
+        ActivationId(),
+        start = Instant.now,
+        end = Instant.now)
+    } foreach { put(entityStore, _) }
 
-        // get between two time stamps
-        whisk.utils.retry {
-            Get(s"$collectionPath?docs=true&since=${since.toEpochMilli}&upto=${upto.toEpochMilli}") ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                val response = responseAs[List[JsObject]]
-                val expected = activations filter {
-                    case e => (e.start.equals(since) || e.start.equals(upto) || (e.start.isAfter(since) && e.start.isBefore(upto)))
-                }
-                expected.length should be(response.length)
-                expected forall { a => response contains a.toExtendedJson } should be(true)
-            }
+    val actionName = aname
+    val activations = (1 to 2).map { i =>
+      WhiskActivation(
+        namespace,
+        actionName,
+        creds.subject,
+        ActivationId(),
+        start = Instant.now,
+        end = Instant.now,
+        response = ActivationResponse.success(Some(JsNumber(5))))
+    }.toList
+    activations foreach { put(activationStore, _) }
+    waitOnView(activationStore, namespace, 2)
+
+    whisk.utils.retry {
+      Get(s"$collectionPath?docs=true") ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[List[JsObject]]
+        activations.length should be(response.length)
+        activations forall { a =>
+          response contains a.toExtendedJson
+        } should be(true)
+      }
+    }
+  }
+
+  //// GET /activations?docs=true&since=xxx&upto=yyy
+  it should "get full activation by namespace within a date range" in {
+    implicit val tid = transid()
+    // create two sets of activation records, and check that only one set is served back
+    val creds1 = WhiskAuthHelpers.newAuth()
+    (1 to 2).map { i =>
+      WhiskActivation(
+        EntityPath(creds1.subject.asString),
+        aname,
+        creds1.subject,
+        ActivationId(),
+        start = Instant.now,
+        end = Instant.now)
+    } foreach { put(activationStore, _) }
+
+    val actionName = aname
+    val now = Instant.now(Clock.systemUTC())
+    val since = now.plusSeconds(10)
+    val upto = now.plusSeconds(30)
+    implicit val activations = Seq(
+      WhiskActivation(namespace, actionName, creds.subject, ActivationId(), start = now.plusSeconds(9), end = now),
+      WhiskActivation(
+        namespace,
+        actionName,
+        creds.subject,
+        ActivationId(),
+        start = now.plusSeconds(20),
+        end = now.plusSeconds(20)), // should match
+      WhiskActivation(
+        namespace,
+        actionName,
+        creds.subject,
+        ActivationId(),
+        start = now.plusSeconds(10),
+        end = now.plusSeconds(20)), // should match
+      WhiskActivation(
+        namespace,
+        actionName,
+        creds.subject,
+        ActivationId(),
+        start = now.plusSeconds(31),
+        end = now.plusSeconds(20)),
+      WhiskActivation(
+        namespace,
+        actionName,
+        creds.subject,
+        ActivationId(),
+        start = now.plusSeconds(30),
+        end = now.plusSeconds(20))) // should match
+    activations foreach { put(activationStore, _) }
+    waitOnView(activationStore, namespace, activations.length)
+
+    // get between two time stamps
+    whisk.utils.retry {
+      Get(s"$collectionPath?docs=true&since=${since.toEpochMilli}&upto=${upto.toEpochMilli}") ~> Route.seal(
+        routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[List[JsObject]]
+        val expected = activations filter {
+          case e =>
+            (e.start.equals(since) || e.start.equals(upto) || (e.start.isAfter(since) && e.start.isBefore(upto)))
         }
-
-        // get 'upto' with no defined since value should return all activation 'upto'
-        whisk.utils.retry {
-            Get(s"$collectionPath?docs=true&upto=${upto.toEpochMilli}") ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                val response = responseAs[List[JsObject]]
-                val expected = activations filter {
-                    case e => e.start.equals(upto) || e.start.isBefore(upto)
-                }
-                expected.length should be(response.length)
-                expected forall { a => response contains a.toExtendedJson } should be(true)
-            }
-        }
-
-        // get 'since' with no defined upto value should return all activation 'since'
-        whisk.utils.retry {
-            Get(s"$collectionPath?docs=true&since=${since.toEpochMilli}") ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                val response = responseAs[List[JsObject]]
-                val expected = activations filter {
-                    case e => e.start.equals(since) || e.start.isAfter(since)
-                }
-                expected.length should be(response.length)
-                expected forall { a => response contains a.toExtendedJson } should be(true)
-            }
-        }
+        expected.length should be(response.length)
+        expected forall { a =>
+          response contains a.toExtendedJson
+        } should be(true)
+      }
     }
 
-    //// GET /activations?name=xyz
-    it should "get summary activation by namespace and action name" in {
-        implicit val tid = transid()
-
-        // create two sets of activation records, and check that only one set is served back
-        val creds1 = WhiskAuthHelpers.newAuth()
-        (1 to 2).map { i =>
-            WhiskActivation(EntityPath(creds1.subject.asString), aname, creds1.subject, ActivationId(), start = Instant.now, end = Instant.now)
-        } foreach { put(activationStore, _) }
-
-        val activations = (1 to 2).map { i =>
-            WhiskActivation(namespace, EntityName(s"xyz"), creds.subject, ActivationId(), start = Instant.now, end = Instant.now)
-        }.toList
-        activations foreach { put(activationStore, _) }
-        waitOnView(activationStore, namespace, 2)
-
-        whisk.utils.retry {
-            Get(s"$collectionPath?name=xyz") ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                val response = responseAs[List[JsObject]]
-                activations.length should be(response.length)
-                activations forall { a => response contains a.summaryAsJson } should be(true)
-            }
+    // get 'upto' with no defined since value should return all activation 'upto'
+    whisk.utils.retry {
+      Get(s"$collectionPath?docs=true&upto=${upto.toEpochMilli}") ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[List[JsObject]]
+        val expected = activations filter {
+          case e => e.start.equals(upto) || e.start.isBefore(upto)
         }
+        expected.length should be(response.length)
+        expected forall { a =>
+          response contains a.toExtendedJson
+        } should be(true)
+      }
     }
 
-    it should "reject activation list when limit is greater than maximum allowed value" in {
-        implicit val tid = transid()
-        val exceededMaxLimit = WhiskActivationsApi.maxActivationLimit + 1
-        val response = Get(s"$collectionPath?limit=$exceededMaxLimit") ~> Route.seal(routes(creds)) ~> check {
-            val response = responseAs[String]
-            response should include(Messages.maxActivationLimitExceeded(exceededMaxLimit, WhiskActivationsApi.maxActivationLimit))
-            status should be(BadRequest)
+    // get 'since' with no defined upto value should return all activation 'since'
+    whisk.utils.retry {
+      Get(s"$collectionPath?docs=true&since=${since.toEpochMilli}") ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[List[JsObject]]
+        val expected = activations filter {
+          case e => e.start.equals(since) || e.start.isAfter(since)
         }
+        expected.length should be(response.length)
+        expected forall { a =>
+          response contains a.toExtendedJson
+        } should be(true)
+      }
+    }
+  }
+
+  //// GET /activations?name=xyz
+  it should "get summary activation by namespace and action name" in {
+    implicit val tid = transid()
+
+    // create two sets of activation records, and check that only one set is served back
+    val creds1 = WhiskAuthHelpers.newAuth()
+    (1 to 2).map { i =>
+      WhiskActivation(
+        EntityPath(creds1.subject.asString),
+        aname,
+        creds1.subject,
+        ActivationId(),
+        start = Instant.now,
+        end = Instant.now)
+    } foreach { put(activationStore, _) }
+
+    val activations = (1 to 2).map { i =>
+      WhiskActivation(
+        namespace,
+        EntityName(s"xyz"),
+        creds.subject,
+        ActivationId(),
+        start = Instant.now,
+        end = Instant.now)
+    }.toList
+    activations foreach { put(activationStore, _) }
+    waitOnView(activationStore, namespace, 2)
+
+    whisk.utils.retry {
+      Get(s"$collectionPath?name=xyz") ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[List[JsObject]]
+        activations.length should be(response.length)
+        activations forall { a =>
+          response contains a.summaryAsJson
+        } should be(true)
+      }
+    }
+  }
+
+  it should "reject activation list when limit is greater than maximum allowed value" in {
+    implicit val tid = transid()
+    val exceededMaxLimit = WhiskActivationsApi.maxActivationLimit + 1
+    val response = Get(s"$collectionPath?limit=$exceededMaxLimit") ~> Route.seal(routes(creds)) ~> check {
+      val response = responseAs[String]
+      response should include(
+        Messages.maxActivationLimitExceeded(exceededMaxLimit, WhiskActivationsApi.maxActivationLimit))
+      status should be(BadRequest)
+    }
+  }
+
+  it should "reject get activation by namespace and action name when action name is not a valid name" in {
+    implicit val tid = transid()
+    Get(s"$collectionPath?name=0%20") ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+    }
+  }
+
+  it should "reject get activation with invalid since/upto value" in {
+    implicit val tid = transid()
+    Get(s"$collectionPath?since=xxx") ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+    }
+    Get(s"$collectionPath?upto=yyy") ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+    }
+  }
+
+  //// GET /activations/id
+  it should "get activation by id" in {
+    implicit val tid = transid()
+    val activation =
+      WhiskActivation(namespace, aname, creds.subject, ActivationId(), start = Instant.now, end = Instant.now)
+    put(activationStore, activation)
+
+    Get(s"$collectionPath/${activation.activationId.asString}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[JsObject]
+      response should be(activation.toExtendedJson)
     }
 
-    it should "reject get activation by namespace and action name when action name is not a valid name" in {
-        implicit val tid = transid()
-        Get(s"$collectionPath?name=0%20") ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-        }
+    // it should "get activation by name in explicit namespace owned by subject" in
+    Get(s"/$namespace/${collection.path}/${activation.activationId.asString}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[JsObject]
+      response should be(activation.toExtendedJson)
     }
 
-    it should "reject get activation with invalid since/upto value" in {
-        implicit val tid = transid()
-        Get(s"$collectionPath?since=xxx") ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-        }
-        Get(s"$collectionPath?upto=yyy") ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-        }
+    // it should "reject get activation by name in explicit namespace not owned by subject" in
+    val auser = WhiskAuthHelpers.newIdentity()
+    Get(s"/$namespace/${collection.path}/${activation.activationId.asString}") ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden)
+    }
+  }
+
+  //// GET /activations/id/result
+  it should "get activation result by id" in {
+    implicit val tid = transid()
+    val activation =
+      WhiskActivation(namespace, aname, creds.subject, ActivationId(), start = Instant.now, end = Instant.now)
+    put(activationStore, activation)
+
+    Get(s"$collectionPath/${activation.activationId.asString}/result") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[JsObject]
+      response should be(activation.response.toExtendedJson)
+    }
+  }
+
+  //// GET /activations/id/logs
+  it should "get activation logs by id" in {
+    implicit val tid = transid()
+    val activation =
+      WhiskActivation(namespace, aname, creds.subject, ActivationId(), start = Instant.now, end = Instant.now)
+    put(activationStore, activation)
+
+    Get(s"$collectionPath/${activation.activationId.asString}/logs") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[JsObject]
+      response should be(activation.logs.toJsonObject)
+    }
+  }
+
+  //// GET /activations/id/bogus
+  it should "reject request to get invalid activation resource" in {
+    implicit val tid = transid()
+    val activation =
+      WhiskActivation(namespace, aname, creds.subject, ActivationId(), start = Instant.now, end = Instant.now)
+    put(entityStore, activation)
+
+    Get(s"$collectionPath/${activation.activationId.asString}/bogus") ~> Route.seal(routes(creds)) ~> check {
+      status should be(NotFound)
+    }
+  }
+
+  it should "reject get requests with invalid activation ids" in {
+    implicit val tid = transid()
+    val activationId = ActivationId().toString
+    val tooshort = activationId.substring(0, 31)
+    val toolong = activationId + "xxx"
+    val malformed = tooshort + "z"
+
+    Get(s"$collectionPath/$tooshort") ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[String] shouldBe Messages.activationIdLengthError(SizeError("Activation id", tooshort.length.B, 32.B))
     }
 
-    //// GET /activations/id
-    it should "get activation by id" in {
-        implicit val tid = transid()
-        val activation = WhiskActivation(namespace, aname, creds.subject, ActivationId(), start = Instant.now, end = Instant.now)
-        put(activationStore, activation)
-
-        Get(s"$collectionPath/${activation.activationId.asString}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[JsObject]
-            response should be(activation.toExtendedJson)
-        }
-
-        // it should "get activation by name in explicit namespace owned by subject" in
-        Get(s"/$namespace/${collection.path}/${activation.activationId.asString}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[JsObject]
-            response should be(activation.toExtendedJson)
-        }
-
-        // it should "reject get activation by name in explicit namespace not owned by subject" in
-        val auser = WhiskAuthHelpers.newIdentity()
-        Get(s"/$namespace/${collection.path}/${activation.activationId.asString}") ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden)
-        }
+    Get(s"$collectionPath/$toolong") ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[String] shouldBe Messages.activationIdLengthError(SizeError("Activation id", toolong.length.B, 32.B))
     }
 
-    //// GET /activations/id/result
-    it should "get activation result by id" in {
-        implicit val tid = transid()
-        val activation = WhiskActivation(namespace, aname, creds.subject, ActivationId(), start = Instant.now, end = Instant.now)
-        put(activationStore, activation)
-
-        Get(s"$collectionPath/${activation.activationId.asString}/result") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[JsObject]
-            response should be(activation.response.toExtendedJson)
-        }
+    Get(s"$collectionPath/$malformed") ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
     }
+  }
 
-    //// GET /activations/id/logs
-    it should "get activation logs by id" in {
-        implicit val tid = transid()
-        val activation = WhiskActivation(namespace, aname, creds.subject, ActivationId(), start = Instant.now, end = Instant.now)
-        put(activationStore, activation)
-
-        Get(s"$collectionPath/${activation.activationId.asString}/logs") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[JsObject]
-            response should be(activation.logs.toJsonObject)
-        }
+  it should "reject request with put" in {
+    implicit val tid = transid()
+    Put(s"$collectionPath/${ActivationId()}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(MethodNotAllowed)
     }
+  }
 
-    //// GET /activations/id/bogus
-    it should "reject request to get invalid activation resource" in {
-        implicit val tid = transid()
-        val activation = WhiskActivation(namespace, aname, creds.subject, ActivationId(), start = Instant.now, end = Instant.now)
-        put(entityStore, activation)
-
-        Get(s"$collectionPath/${activation.activationId.asString}/bogus") ~> Route.seal(routes(creds)) ~> check {
-            status should be(NotFound)
-        }
+  it should "reject request with post" in {
+    implicit val tid = transid()
+    Post(s"$collectionPath/${ActivationId()}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(MethodNotAllowed)
     }
+  }
 
-    it should "reject get requests with invalid activation ids" in {
-        implicit val tid = transid()
-        val activationId = ActivationId().toString
-        val tooshort = activationId.substring(0, 31)
-        val toolong = activationId + "xxx"
-        val malformed = tooshort + "z"
-
-        Get(s"$collectionPath/$tooshort") ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[String] shouldBe Messages.activationIdLengthError(SizeError("Activation id", tooshort.length.B, 32.B))
-        }
-
-        Get(s"$collectionPath/$toolong") ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[String] shouldBe Messages.activationIdLengthError(SizeError("Activation id", toolong.length.B, 32.B))
-        }
-
-        Get(s"$collectionPath/$malformed") ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-        }
+  it should "reject request with delete" in {
+    implicit val tid = transid()
+    Delete(s"$collectionPath/${ActivationId()}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(MethodNotAllowed)
     }
+  }
 
-    it should "reject request with put" in {
-        implicit val tid = transid()
-        Put(s"$collectionPath/${ActivationId()}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(MethodNotAllowed)
-        }
+  it should "report proper error when record is corrupted on get" in {
+
+    val activationStore = SpiLoader
+      .get[ArtifactStoreProvider]
+      .makeStore[WhiskEntity](whiskConfig, _.dbActivations)(WhiskEntityJsonFormat, system, logging)
+    implicit val tid = transid()
+    val entity = BadEntity(namespace, EntityName(ActivationId().toString))
+    put(activationStore, entity)
+
+    Get(s"$collectionPath/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(InternalServerError)
+      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
     }
-
-    it should "reject request with post" in {
-        implicit val tid = transid()
-        Post(s"$collectionPath/${ActivationId()}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(MethodNotAllowed)
-        }
-    }
-
-    it should "reject request with delete" in {
-        implicit val tid = transid()
-        Delete(s"$collectionPath/${ActivationId()}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(MethodNotAllowed)
-        }
-    }
-
-    it should "report proper error when record is corrupted on get" in {
-
-        val activationStore = SpiLoader.get[ArtifactStoreProvider].makeStore[WhiskEntity](whiskConfig, _.dbActivations)(WhiskEntityJsonFormat, system, logging)
-        implicit val tid = transid()
-        val entity = BadEntity(namespace, EntityName(ActivationId().toString))
-        put(activationStore, entity)
-
-        Get(s"$collectionPath/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(InternalServerError)
-            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-        }
-    }
+  }
 }

--- a/tests/src/test/scala/whisk/core/controller/test/AuthenticateTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/AuthenticateTests.scala
@@ -42,89 +42,89 @@ import whisk.core.entitlement.Privilege
  */
 @RunWith(classOf[JUnitRunner])
 class AuthenticateTests extends ControllerTestCommon with Authenticate {
-    behavior of "Authenticate"
+  behavior of "Authenticate"
 
-    it should "authorize a known user using different namespaces and cache key, and reject invalid secret" in {
-        implicit val tid = transid()
-        val subject = Subject()
+  it should "authorize a known user using different namespaces and cache key, and reject invalid secret" in {
+    implicit val tid = transid()
+    val subject = Subject()
 
-        val namespaces = Set(
-            WhiskNamespace(MakeName.next("authenticatev_tests"), AuthKey()),
-            WhiskNamespace(MakeName.next("authenticatev_tests"), AuthKey()))
-        val entry = WhiskAuth(subject, namespaces)
-        put(authStore, entry) // this test entry is reclaimed when the test completes
+    val namespaces = Set(
+      WhiskNamespace(MakeName.next("authenticatev_tests"), AuthKey()),
+      WhiskNamespace(MakeName.next("authenticatev_tests"), AuthKey()))
+    val entry = WhiskAuth(subject, namespaces)
+    put(authStore, entry) // this test entry is reclaimed when the test completes
 
-        // Try to login with each specific namespace
-        namespaces.foreach { ns =>
-            println(s"Trying to login to $ns")
-            waitOnView(authStore, ns.authkey, 1) // wait for the view to be updated
-            val pass = BasicHttpCredentials(ns.authkey.uuid.asString, ns.authkey.key.asString)
-            val user = Await.result(validateCredentials(Some(pass)), dbOpTimeout)
-            user.get shouldBe Identity(subject, ns.name, ns.authkey, Privilege.ALL)
+    // Try to login with each specific namespace
+    namespaces.foreach { ns =>
+      println(s"Trying to login to $ns")
+      waitOnView(authStore, ns.authkey, 1) // wait for the view to be updated
+      val pass = BasicHttpCredentials(ns.authkey.uuid.asString, ns.authkey.key.asString)
+      val user = Await.result(validateCredentials(Some(pass)), dbOpTimeout)
+      user.get shouldBe Identity(subject, ns.name, ns.authkey, Privilege.ALL)
 
-            // first lookup should have been from datastore
-            stream.toString should include(s"serving from datastore: ${CacheKey(ns.authkey)}")
-            stream.reset()
+      // first lookup should have been from datastore
+      stream.toString should include(s"serving from datastore: ${CacheKey(ns.authkey)}")
+      stream.reset()
 
-            // repeat query, now should be served from cache
-            val cachedUser = Await.result(validateCredentials(Some(pass))(transid()), dbOpTimeout)
-            cachedUser.get shouldBe Identity(subject, ns.name, ns.authkey, Privilege.ALL)
+      // repeat query, now should be served from cache
+      val cachedUser = Await.result(validateCredentials(Some(pass))(transid()), dbOpTimeout)
+      cachedUser.get shouldBe Identity(subject, ns.name, ns.authkey, Privilege.ALL)
 
-            stream.toString should include(s"serving from cache: ${CacheKey(ns.authkey)}")
-            stream.reset()
-        }
-
-        // check that invalid keys are rejected
-        val ns = namespaces.head
-        val key = ns.authkey.key.asString
-        Seq(key.drop(1), key.dropRight(1), key + "x", AuthKey().key.asString).foreach { k =>
-            val pass = BasicHttpCredentials(ns.authkey.uuid.asString, k)
-            val user = Await.result(validateCredentials(Some(pass)), dbOpTimeout)
-            user shouldBe empty
-        }
+      stream.toString should include(s"serving from cache: ${CacheKey(ns.authkey)}")
+      stream.reset()
     }
 
-    it should "not log key during validation" in {
-        implicit val tid = transid()
-        val creds = WhiskAuthHelpers.newIdentity()
-        val pass = BasicHttpCredentials(creds.authkey.uuid.asString, creds.authkey.key.asString)
-        val user = Await.result(validateCredentials(Some(pass)), dbOpTimeout)
-        user should be(None)
-        stream.toString should not include creds.authkey.key.asString
+    // check that invalid keys are rejected
+    val ns = namespaces.head
+    val key = ns.authkey.key.asString
+    Seq(key.drop(1), key.dropRight(1), key + "x", AuthKey().key.asString).foreach { k =>
+      val pass = BasicHttpCredentials(ns.authkey.uuid.asString, k)
+      val user = Await.result(validateCredentials(Some(pass)), dbOpTimeout)
+      user shouldBe empty
     }
+  }
 
-    it should "not authorize an unknown user" in {
-        implicit val tid = transid()
-        val creds = WhiskAuthHelpers.newIdentity()
-        val pass = BasicHttpCredentials(creds.authkey.uuid.asString, creds.authkey.key.asString)
-        val user = Await.result(validateCredentials(Some(pass)), dbOpTimeout)
-        user should be(None)
-    }
+  it should "not log key during validation" in {
+    implicit val tid = transid()
+    val creds = WhiskAuthHelpers.newIdentity()
+    val pass = BasicHttpCredentials(creds.authkey.uuid.asString, creds.authkey.key.asString)
+    val user = Await.result(validateCredentials(Some(pass)), dbOpTimeout)
+    user should be(None)
+    stream.toString should not include creds.authkey.key.asString
+  }
 
-    it should "not authorize when no user creds are provided" in {
-        implicit val tid = transid()
-        val user = Await.result(validateCredentials(None), dbOpTimeout)
-        user should be(None)
-    }
+  it should "not authorize an unknown user" in {
+    implicit val tid = transid()
+    val creds = WhiskAuthHelpers.newIdentity()
+    val pass = BasicHttpCredentials(creds.authkey.uuid.asString, creds.authkey.key.asString)
+    val user = Await.result(validateCredentials(Some(pass)), dbOpTimeout)
+    user should be(None)
+  }
 
-    it should "not authorize when malformed user is provided" in {
-        implicit val tid = transid()
-        val pass = BasicHttpCredentials("x", Secret().asString)
-        val user = Await.result(validateCredentials(Some(pass)), dbOpTimeout)
-        user should be(None)
-    }
+  it should "not authorize when no user creds are provided" in {
+    implicit val tid = transid()
+    val user = Await.result(validateCredentials(None), dbOpTimeout)
+    user should be(None)
+  }
 
-    it should "not authorize when malformed secret is provided" in {
-        implicit val tid = transid()
-        val pass = BasicHttpCredentials(UUID().asString, "x")
-        val user = Await.result(validateCredentials(Some(pass)), dbOpTimeout)
-        user should be(None)
-    }
+  it should "not authorize when malformed user is provided" in {
+    implicit val tid = transid()
+    val pass = BasicHttpCredentials("x", Secret().asString)
+    val user = Await.result(validateCredentials(Some(pass)), dbOpTimeout)
+    user should be(None)
+  }
 
-    it should "not authorize when malformed creds are provided" in {
-        implicit val tid = transid()
-        val pass = BasicHttpCredentials("x", "y")
-        val user = Await.result(validateCredentials(Some(pass)), dbOpTimeout)
-        user should be(None)
-    }
+  it should "not authorize when malformed secret is provided" in {
+    implicit val tid = transid()
+    val pass = BasicHttpCredentials(UUID().asString, "x")
+    val user = Await.result(validateCredentials(Some(pass)), dbOpTimeout)
+    user should be(None)
+  }
+
+  it should "not authorize when malformed creds are provided" in {
+    implicit val tid = transid()
+    val pass = BasicHttpCredentials("x", "y")
+    val user = Await.result(validateCredentials(Some(pass)), dbOpTimeout)
+    user should be(None)
+  }
 }

--- a/tests/src/test/scala/whisk/core/controller/test/AuthenticateV2Tests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/AuthenticateV2Tests.scala
@@ -47,29 +47,27 @@ import whisk.core.entity.Identity
 @RunWith(classOf[JUnitRunner])
 class AuthenticateV2Tests extends ControllerTestCommon with Authenticate {
 
-    // Creates a new unique name each time its called
-    def aname = MakeName.next("authenticatev2_tests")
+  // Creates a new unique name each time its called
+  def aname = MakeName.next("authenticatev2_tests")
 
-    behavior of "Authenticate V2"
+  behavior of "Authenticate V2"
 
-    it should "authorize a known user using the new database schema in different namespaces" in {
-        implicit val tid = transid()
-        val subject = Subject()
+  it should "authorize a known user using the new database schema in different namespaces" in {
+    implicit val tid = transid()
+    val subject = Subject()
 
-        val namespaces = Set(
-            WhiskNamespace(aname, AuthKey()),
-            WhiskNamespace(aname, AuthKey()))
+    val namespaces = Set(WhiskNamespace(aname, AuthKey()), WhiskNamespace(aname, AuthKey()))
 
-        val entry = WhiskAuth(subject, namespaces)
+    val entry = WhiskAuth(subject, namespaces)
 
-        put(authStore, entry)
+    put(authStore, entry)
 
-        // Try to login with each specific namespace
-        namespaces.foreach { ns =>
-            println(s"Trying to login to $ns")
-            val pass = BasicHttpCredentials(ns.authkey.uuid.asString, ns.authkey.key.asString)
-            val user = Await.result(validateCredentials(Some(pass)), dbOpTimeout)
-            user.get shouldBe Identity(subject, ns.name, ns.authkey, Privilege.ALL)
-        }
+    // Try to login with each specific namespace
+    namespaces.foreach { ns =>
+      println(s"Trying to login to $ns")
+      val pass = BasicHttpCredentials(ns.authkey.uuid.asString, ns.authkey.key.asString)
+      val user = Await.result(validateCredentials(Some(pass)), dbOpTimeout)
+      user.get shouldBe Identity(subject, ns.name, ns.authkey, Privilege.ALL)
     }
+  }
 }

--- a/tests/src/test/scala/whisk/core/controller/test/EntitlementProviderTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/EntitlementProviderTests.scala
@@ -45,574 +45,586 @@ import whisk.http.Messages
  * "using Specs2RouteTest DSL to chain HTTP requests for unit testing, as in ~>"
  */
 @RunWith(classOf[JUnitRunner])
-class EntitlementProviderTests
-    extends ControllerTestCommon
-    with ScalaFutures {
+class EntitlementProviderTests extends ControllerTestCommon with ScalaFutures {
 
-    behavior of "Entitlement Provider"
+  behavior of "Entitlement Provider"
 
-    val requestTimeout = 10.seconds
-    val someUser = WhiskAuthHelpers.newIdentity()
-    val adminUser = WhiskAuthHelpers.newIdentity(Subject("admin"))
-    val guestUser = WhiskAuthHelpers.newIdentity(Subject("anonym"))
+  val requestTimeout = 10.seconds
+  val someUser = WhiskAuthHelpers.newIdentity()
+  val adminUser = WhiskAuthHelpers.newIdentity(Subject("admin"))
+  val guestUser = WhiskAuthHelpers.newIdentity(Subject("anonym"))
 
-    it should "authorize a user to only read from their collection" in {
-        implicit val tid = transid()
-        val collections = Seq(ACTIONS, RULES, TRIGGERS, PACKAGES, ACTIVATIONS, NAMESPACES)
-        val resources = collections map { Resource(someUser.namespace.toPath, _, None) }
-        resources foreach { r =>
-            Await.ready(entitlementProvider.check(someUser, READ, r), requestTimeout).eitherValue.get shouldBe Right({})
-            Await.ready(entitlementProvider.check(someUser, PUT, r), requestTimeout).eitherValue.get shouldBe Left(RejectRequest(Forbidden))
-            Await.ready(entitlementProvider.check(someUser, DELETE, r), requestTimeout).eitherValue.get shouldBe Left(RejectRequest(Forbidden))
-            Await.ready(entitlementProvider.check(someUser, ACTIVATE, r), requestTimeout).eitherValue.get shouldBe Left(RejectRequest(Forbidden))
-            Await.ready(entitlementProvider.check(someUser, REJECT, r), requestTimeout).eitherValue.get shouldBe Left(RejectRequest(Forbidden))
-        }
+  it should "authorize a user to only read from their collection" in {
+    implicit val tid = transid()
+    val collections = Seq(ACTIONS, RULES, TRIGGERS, PACKAGES, ACTIVATIONS, NAMESPACES)
+    val resources = collections map { Resource(someUser.namespace.toPath, _, None) }
+    resources foreach { r =>
+      Await.ready(entitlementProvider.check(someUser, READ, r), requestTimeout).eitherValue.get shouldBe Right({})
+      Await.ready(entitlementProvider.check(someUser, PUT, r), requestTimeout).eitherValue.get shouldBe Left(
+        RejectRequest(Forbidden))
+      Await.ready(entitlementProvider.check(someUser, DELETE, r), requestTimeout).eitherValue.get shouldBe Left(
+        RejectRequest(Forbidden))
+      Await.ready(entitlementProvider.check(someUser, ACTIVATE, r), requestTimeout).eitherValue.get shouldBe Left(
+        RejectRequest(Forbidden))
+      Await.ready(entitlementProvider.check(someUser, REJECT, r), requestTimeout).eitherValue.get shouldBe Left(
+        RejectRequest(Forbidden))
+    }
+  }
+
+  it should "not authorize a user to list someone else's collection or access it by other other right" in {
+    implicit val tid = transid()
+    val collections = Seq(ACTIONS, RULES, TRIGGERS, PACKAGES, ACTIVATIONS, NAMESPACES)
+    val resources = collections map { Resource(someUser.namespace.toPath, _, None) }
+    resources foreach { r =>
+      // it is permissible to list packages in any namespace (provided they are either owned by
+      // the subject requesting access or the packages are public); that is, the entitlement is more
+      // fine grained and applies to public vs private private packages (hence permit READ on PACKAGES to
+      // be true
+      if ((r.collection == PACKAGES)) {
+        Await.ready(entitlementProvider.check(guestUser, READ, r), requestTimeout).eitherValue.get shouldBe Right({})
+      } else {
+        Await.ready(entitlementProvider.check(guestUser, READ, r), requestTimeout).eitherValue.get shouldBe Left(
+          RejectRequest(Forbidden))
+      }
+      Await.ready(entitlementProvider.check(guestUser, PUT, r), requestTimeout).eitherValue.get shouldBe Left(
+        RejectRequest(Forbidden))
+      Await.ready(entitlementProvider.check(guestUser, DELETE, r), requestTimeout).eitherValue.get shouldBe Left(
+        RejectRequest(Forbidden))
+      Await.ready(entitlementProvider.check(guestUser, ACTIVATE, r), requestTimeout).eitherValue.get shouldBe Left(
+        RejectRequest(Forbidden))
+      Await.ready(entitlementProvider.check(guestUser, REJECT, r), requestTimeout).eitherValue.get shouldBe Left(
+        RejectRequest(Forbidden))
+    }
+  }
+
+  it should "authorize a user to CRUD or activate (if supported) an entity in a collection" in {
+    implicit val tid = transid()
+    // packages are tested separately
+    val collections = Seq(ACTIONS, RULES, TRIGGERS)
+    val resources = collections map { Resource(someUser.namespace.toPath, _, Some("xyz")) }
+    resources foreach { r =>
+      Await.ready(entitlementProvider.check(someUser, READ, r), requestTimeout).eitherValue.get shouldBe Right({})
+      Await.ready(entitlementProvider.check(someUser, PUT, r), requestTimeout).eitherValue.get shouldBe Right({})
+      Await.ready(entitlementProvider.check(someUser, DELETE, r), requestTimeout).eitherValue.get shouldBe Right({})
+      Await.ready(entitlementProvider.check(someUser, ACTIVATE, r), requestTimeout).eitherValue.get shouldBe Right({})
+    }
+  }
+
+  it should "not authorize a user to CRUD an entity in a collection if authkey has no CRUD rights" in {
+    implicit val tid = transid()
+    val subject = Subject()
+    val someUser = Identity(subject, EntityName(subject.asString), AuthKey(), Set(Privilege.ACTIVATE))
+    val collections = Seq(ACTIONS, RULES, TRIGGERS)
+    val resources = collections map { Resource(someUser.namespace.toPath, _, Some("xyz")) }
+    resources foreach { r =>
+      Await.ready(entitlementProvider.check(someUser, READ, r), requestTimeout).eitherValue.get shouldBe Left(
+        RejectRequest(Forbidden))
+      Await.ready(entitlementProvider.check(someUser, PUT, r), requestTimeout).eitherValue.get shouldBe Left(
+        RejectRequest(Forbidden))
+      Await.ready(entitlementProvider.check(someUser, DELETE, r), requestTimeout).eitherValue.get shouldBe Left(
+        RejectRequest(Forbidden))
+      Await.ready(entitlementProvider.check(someUser, ACTIVATE, r), requestTimeout).eitherValue.get shouldBe Right({})
+    }
+  }
+
+  it should "not authorize a user to CRUD or activate an entity in a collection that does not support CRUD or activate" in {
+    implicit val tid = transid()
+    val collections = Seq(NAMESPACES, ACTIVATIONS)
+    val resources = collections map { Resource(someUser.namespace.toPath, _, Some("xyz")) }
+    resources foreach { r =>
+      Await.ready(entitlementProvider.check(someUser, READ, r), requestTimeout).eitherValue.get shouldBe Right({})
+      Await.ready(entitlementProvider.check(someUser, PUT, r), requestTimeout).eitherValue.get shouldBe Left(
+        RejectRequest(Forbidden))
+      Await.ready(entitlementProvider.check(someUser, DELETE, r), requestTimeout).eitherValue.get shouldBe Left(
+        RejectRequest(Forbidden))
+      Await.ready(entitlementProvider.check(someUser, ACTIVATE, r), requestTimeout).eitherValue.get shouldBe Left(
+        RejectRequest(Forbidden))
+    }
+  }
+
+  it should "not authorize a user to CRUD or activate an entity in someone else's collection" in {
+    implicit val tid = transid()
+    val collections = Seq(ACTIONS, RULES, TRIGGERS, PACKAGES)
+    val resources = collections map { Resource(someUser.namespace.toPath, _, Some("xyz")) }
+    resources foreach { r =>
+      Await.ready(entitlementProvider.check(guestUser, READ, r), requestTimeout).eitherValue.get shouldBe Left(
+        RejectRequest(Forbidden))
+      Await.ready(entitlementProvider.check(guestUser, PUT, r), requestTimeout).eitherValue.get shouldBe Left(
+        RejectRequest(Forbidden))
+      Await.ready(entitlementProvider.check(guestUser, DELETE, r), requestTimeout).eitherValue.get shouldBe Left(
+        RejectRequest(Forbidden))
+      Await.ready(entitlementProvider.check(guestUser, ACTIVATE, r), requestTimeout).eitherValue.get shouldBe Left(
+        RejectRequest(Forbidden))
+    }
+  }
+
+  it should "authorize a user to list, create/update/delete a package" in {
+    implicit val tid = transid()
+    val collections = Seq(PACKAGES)
+    val resources = collections map { Resource(someUser.namespace.toPath, _, Some("xyz")) }
+    resources foreach { r =>
+      // read should fail because the lookup for the package will fail
+      Await.ready(entitlementProvider.check(someUser, READ, r), requestTimeout).eitherValue.get shouldBe Left(
+        RejectRequest(NotFound))
+      // create/put/delete should be allowed
+      Await.ready(entitlementProvider.check(someUser, PUT, r), requestTimeout).eitherValue.get shouldBe Right({})
+      Await.ready(entitlementProvider.check(someUser, DELETE, r), requestTimeout).eitherValue.get shouldBe Right({})
+      // activate is not allowed on a package
+      Await.ready(entitlementProvider.check(someUser, ACTIVATE, r), requestTimeout).eitherValue.get shouldBe Left(
+        RejectRequest(Forbidden))
+    }
+  }
+
+  it should "grant access to entire collection to another user" in {
+    implicit val tid = transid()
+    val all = Resource(someUser.namespace.toPath, ACTIONS, None)
+    val one = Resource(someUser.namespace.toPath, ACTIONS, Some("xyz"))
+    Await.ready(entitlementProvider.check(adminUser, READ, all), requestTimeout).eitherValue.get should not be Right({})
+    Await.ready(entitlementProvider.check(adminUser, READ, one), requestTimeout).eitherValue.get should not be Right({})
+    Await.result(entitlementProvider.grant(adminUser.subject, READ, all), requestTimeout) // granted
+    Await.ready(entitlementProvider.check(adminUser, READ, all), requestTimeout).eitherValue.get shouldBe Right({})
+    Await.ready(entitlementProvider.check(adminUser, READ, one), requestTimeout).eitherValue.get shouldBe Right({})
+    Await.result(entitlementProvider.revoke(adminUser.subject, READ, all), requestTimeout) // revoked
+  }
+
+  it should "grant access to specific resource to a user" in {
+    implicit val tid = transid()
+    val all = Resource(someUser.namespace.toPath, ACTIONS, None)
+    val one = Resource(someUser.namespace.toPath, ACTIONS, Some("xyz"))
+    Await.ready(entitlementProvider.check(adminUser, READ, all), requestTimeout).eitherValue.get should not be Right({})
+    Await.ready(entitlementProvider.check(adminUser, READ, one), requestTimeout).eitherValue.get should not be Right({})
+    Await
+      .ready(entitlementProvider.check(adminUser, DELETE, one), requestTimeout)
+      .eitherValue
+      .get should not be Right({})
+    Await.result(entitlementProvider.grant(adminUser.subject, READ, one), requestTimeout) // granted
+    Await.ready(entitlementProvider.check(adminUser, READ, all), requestTimeout).eitherValue.get should not be Right({})
+    Await.ready(entitlementProvider.check(adminUser, READ, one), requestTimeout).eitherValue.get shouldBe Right({})
+    Await
+      .ready(entitlementProvider.check(adminUser, DELETE, one), requestTimeout)
+      .eitherValue
+      .get should not be Right({})
+    Await.result(entitlementProvider.revoke(adminUser.subject, READ, one), requestTimeout) // revoked
+  }
+
+  behavior of "Package Collection"
+
+  it should "only allow read access for listing package collection" in {
+    implicit val tid = transid()
+    implicit val ep = entitlementProvider
+
+    val paths = Seq(
+      (READ, someUser, Right(true)),
+      (PUT, someUser, Right(false)),
+      (DELETE, someUser, Right(false)),
+      (ACTIVATE, someUser, Right(false)),
+      (REJECT, someUser, Right(false)),
+      (READ, guestUser, Right(true)),
+      (PUT, guestUser, Right(false)),
+      (DELETE, guestUser, Right(false)),
+      (ACTIVATE, guestUser, Right(false)),
+      (REJECT, guestUser, Right(false)))
+
+    paths foreach {
+      case (priv, who, expected) =>
+        val check = new PackageCollection(entityStore).implicitRights(
+          who,
+          Set(who.namespace.asString),
+          priv,
+          // any user can list any namespace packages
+          // (because this performs a db view lookup which is later filtered)
+          Resource(someUser.namespace.toPath, PACKAGES, None))
+        Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
+    }
+  }
+
+  it should "reject entitlement if package doesn't exist" in {
+    implicit val tid = transid()
+    implicit val ep = entitlementProvider
+
+    val paths = Seq(
+      (READ, someUser, Left(RejectRequest(NotFound))), // for owner, give more information
+      (PUT, someUser, Right(true)),
+      (DELETE, someUser, Right(true)),
+      (ACTIVATE, someUser, Right(false)),
+      (REJECT, someUser, Right(false)),
+      (READ, guestUser, Right(false)),
+      (PUT, guestUser, Right(false)),
+      (DELETE, guestUser, Right(false)),
+      (ACTIVATE, guestUser, Right(false)),
+      (REJECT, guestUser, Right(false)))
+
+    paths foreach {
+      case (priv, who, expected) =>
+        val check = new PackageCollection(entityStore).implicitRights(
+          who,
+          Set(who.namespace.asString),
+          priv,
+          Resource(someUser.namespace.toPath, PACKAGES, Some("xyz")))
+        Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
+    }
+  }
+
+  it should "reject entitlement if package doesn't deserialize" in {
+    implicit val tid = transid()
+    implicit val ep = entitlementProvider
+
+    val paths = Seq(
+      (READ, someUser, Left(RejectRequest(Conflict, Messages.conformanceMessage))), // for owner, give more information
+      (PUT, someUser, Right(true)),
+      (DELETE, someUser, Right(true)),
+      (ACTIVATE, someUser, Right(false)),
+      (REJECT, someUser, Right(false)),
+      (READ, guestUser, Right(false)),
+      (PUT, guestUser, Right(false)),
+      (DELETE, guestUser, Right(false)),
+      (ACTIVATE, guestUser, Right(false)),
+      (REJECT, guestUser, Right(false)))
+
+    // this forces a doc mismatch error
+    val action = WhiskAction(someUser.namespace.toPath, MakeName.next(), jsDefault(""))
+    put(entityStore, action)
+    paths foreach {
+      case (priv, who, expected) =>
+        val check = new PackageCollection(entityStore).implicitRights(
+          who,
+          Set(who.namespace.asString),
+          priv,
+          Resource(someUser.namespace.toPath, PACKAGES, Some(action.name.asString)))
+        Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
+    }
+  }
+
+  it should "not allow guest access to private package" in {
+    implicit val tid = transid()
+    implicit val ep = entitlementProvider
+
+    val provider = WhiskPackage(someUser.namespace.toPath, MakeName.next())
+    put(entityStore, provider)
+
+    val paths = Seq(
+      (READ, someUser, Right(true)),
+      (PUT, someUser, Right(true)),
+      (DELETE, someUser, Right(true)),
+      (ACTIVATE, someUser, Right(false)),
+      (REJECT, someUser, Right(false)),
+      (READ, guestUser, Right(false)),
+      (PUT, guestUser, Right(false)),
+      (DELETE, guestUser, Right(false)),
+      (ACTIVATE, guestUser, Right(false)),
+      (REJECT, guestUser, Right(false)))
+
+    paths foreach {
+      case (priv, who, expected) =>
+        val check = new PackageCollection(entityStore).implicitRights(
+          who,
+          Set(who.namespace.asString),
+          priv,
+          Resource(someUser.namespace.toPath, PACKAGES, Some(provider.name.asString)))
+        Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
+    }
+  }
+
+  it should "not allow guest access to binding of private package" in {
+    implicit val tid = transid()
+    implicit val ep = entitlementProvider
+
+    // simulate entitlement change on package for which binding was once entitled
+    val provider = WhiskPackage(someUser.namespace.toPath, MakeName.next())
+    val binding = WhiskPackage(guestUser.namespace.toPath, MakeName.next(), provider.bind)
+    put(entityStore, provider, false)
+    put(entityStore, binding)
+
+    val paths = Seq(
+      (READ, someUser, Right(false)),
+      (PUT, someUser, Right(false)),
+      (DELETE, someUser, Right(false)),
+      (ACTIVATE, someUser, Right(false)),
+      (REJECT, someUser, Right(false)),
+      (READ, guestUser, Right(false)), // not allowed to read referenced package
+      (PUT, guestUser, Right(true)), // can update
+      (DELETE, guestUser, Right(true)), // and delete the binding however
+      (ACTIVATE, guestUser, Right(false)),
+      (REJECT, guestUser, Right(false)))
+
+    paths foreach {
+      case (priv, who, expected) =>
+        val check = new PackageCollection(entityStore).implicitRights(
+          who,
+          Set(who.namespace.asString),
+          priv,
+          Resource(guestUser.namespace.toPath, PACKAGES, Some(binding.name.asString)))
+        Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
     }
 
-    it should "not authorize a user to list someone else's collection or access it by other other right" in {
-        implicit val tid = transid()
-        val collections = Seq(ACTIONS, RULES, TRIGGERS, PACKAGES, ACTIVATIONS, NAMESPACES)
-        val resources = collections map { Resource(someUser.namespace.toPath, _, None) }
-        resources foreach { r =>
-            // it is permissible to list packages in any namespace (provided they are either owned by
-            // the subject requesting access or the packages are public); that is, the entitlement is more
-            // fine grained and applies to public vs private private packages (hence permit READ on PACKAGES to
-            // be true
-            if ((r.collection == PACKAGES)) {
-                Await.ready(entitlementProvider.check(guestUser, READ, r), requestTimeout).eitherValue.get shouldBe Right({})
-            } else {
-                Await.ready(entitlementProvider.check(guestUser, READ, r), requestTimeout).eitherValue.get shouldBe Left(RejectRequest(Forbidden))
-            }
-            Await.ready(entitlementProvider.check(guestUser, PUT, r), requestTimeout).eitherValue.get shouldBe Left(RejectRequest(Forbidden))
-            Await.ready(entitlementProvider.check(guestUser, DELETE, r), requestTimeout).eitherValue.get shouldBe Left(RejectRequest(Forbidden))
-            Await.ready(entitlementProvider.check(guestUser, ACTIVATE, r), requestTimeout).eitherValue.get shouldBe Left(RejectRequest(Forbidden))
-            Await.ready(entitlementProvider.check(guestUser, REJECT, r), requestTimeout).eitherValue.get shouldBe Left(RejectRequest(Forbidden))
-        }
+    // simulate package deletion for which binding was once entitled
+    deletePackage(provider.docid)
+    paths foreach {
+      case (priv, who, expected) =>
+        val check = new PackageCollection(entityStore).implicitRights(
+          who,
+          Set(who.namespace.asString),
+          priv,
+          Resource(guestUser.namespace.toPath, PACKAGES, Some(binding.name.asString)))
+        Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
     }
+  }
 
-    it should "authorize a user to CRUD or activate (if supported) an entity in a collection" in {
-        implicit val tid = transid()
-        // packages are tested separately
-        val collections = Seq(ACTIONS, RULES, TRIGGERS)
-        val resources = collections map { Resource(someUser.namespace.toPath, _, Some("xyz")) }
-        resources foreach { r =>
-            Await.ready(entitlementProvider.check(someUser, READ, r), requestTimeout).eitherValue.get shouldBe Right({})
-            Await.ready(entitlementProvider.check(someUser, PUT, r), requestTimeout).eitherValue.get shouldBe Right({})
-            Await.ready(entitlementProvider.check(someUser, DELETE, r), requestTimeout).eitherValue.get shouldBe Right({})
-            Await.ready(entitlementProvider.check(someUser, ACTIVATE, r), requestTimeout).eitherValue.get shouldBe Right({})
-        }
+  it should "not allow guest access to public binding of package" in {
+    implicit val tid = transid()
+    implicit val ep = entitlementProvider
+
+    // simulate entitlement change on package for which binding was once entitled
+    val provider = WhiskPackage(someUser.namespace.toPath, MakeName.next(), None, publish = true)
+    val binding = WhiskPackage(guestUser.namespace.toPath, MakeName.next(), provider.bind, publish = true)
+    put(entityStore, provider)
+    put(entityStore, binding)
+
+    val paths = Seq(
+      (READ, someUser, Right(false)), // cannot access a public binding
+      (PUT, someUser, Right(false)),
+      (DELETE, someUser, Right(false)),
+      (ACTIVATE, someUser, Right(false)),
+      (REJECT, someUser, Right(false)),
+      (READ, guestUser, Right(true)), // can read
+      (PUT, guestUser, Right(true)), // can update
+      (DELETE, guestUser, Right(true)), // and delete the binding
+      (ACTIVATE, guestUser, Right(false)),
+      (REJECT, guestUser, Right(false)))
+
+    paths foreach {
+      case (priv, who, expected) =>
+        val check = new PackageCollection(entityStore).implicitRights(
+          who,
+          Set(who.namespace.asString),
+          priv,
+          Resource(guestUser.namespace.toPath, PACKAGES, Some(binding.name.asString)))
+        Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
     }
+  }
 
-    it should "not authorize a user to CRUD an entity in a collection if authkey has no CRUD rights" in {
-        implicit val tid = transid()
-        val subject = Subject()
-        val someUser = Identity(subject, EntityName(subject.asString), AuthKey(), Set(Privilege.ACTIVATE))
-        val collections = Seq(ACTIONS, RULES, TRIGGERS)
-        val resources = collections map { Resource(someUser.namespace.toPath, _, Some("xyz")) }
-        resources foreach { r =>
-            Await.ready(entitlementProvider.check(someUser, READ, r), requestTimeout).eitherValue.get shouldBe Left(RejectRequest(Forbidden))
-            Await.ready(entitlementProvider.check(someUser, PUT, r), requestTimeout).eitherValue.get shouldBe Left(RejectRequest(Forbidden))
-            Await.ready(entitlementProvider.check(someUser, DELETE, r), requestTimeout).eitherValue.get shouldBe Left(RejectRequest(Forbidden))
-            Await.ready(entitlementProvider.check(someUser, ACTIVATE, r), requestTimeout).eitherValue.get shouldBe Right({})
-        }
+  it should "allow guest access to binding of public package" in {
+    implicit val tid = transid()
+    implicit val ep = entitlementProvider
+
+    val provider = WhiskPackage(someUser.namespace.toPath, MakeName.next(), None, publish = true)
+    val binding = WhiskPackage(guestUser.namespace.toPath, MakeName.next(), provider.bind)
+    put(entityStore, provider)
+    put(entityStore, binding)
+
+    val paths = Seq(
+      (READ, someUser, Right(false)),
+      (PUT, someUser, Right(false)),
+      (DELETE, someUser, Right(false)),
+      (ACTIVATE, someUser, Right(false)),
+      (REJECT, someUser, Right(false)),
+      (READ, guestUser, Right(true)), // can read package + binding
+      (PUT, guestUser, Right(true)), // can update
+      (DELETE, guestUser, Right(true)), // and delete the binding
+      (ACTIVATE, guestUser, Right(false)),
+      (REJECT, guestUser, Right(false)))
+
+    paths foreach {
+      case (priv, who, expected) =>
+        val check = new PackageCollection(entityStore).implicitRights(
+          who,
+          Set(who.namespace.asString),
+          priv,
+          Resource(guestUser.namespace.toPath, PACKAGES, Some(binding.name.asString)))
+        Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
     }
+  }
 
-    it should "not authorize a user to CRUD or activate an entity in a collection that does not support CRUD or activate" in {
-        implicit val tid = transid()
-        val collections = Seq(NAMESPACES, ACTIVATIONS)
-        val resources = collections map { Resource(someUser.namespace.toPath, _, Some("xyz")) }
-        resources foreach { r =>
-            Await.ready(entitlementProvider.check(someUser, READ, r), requestTimeout).eitherValue.get shouldBe Right({})
-            Await.ready(entitlementProvider.check(someUser, PUT, r), requestTimeout).eitherValue.get shouldBe Left(RejectRequest(Forbidden))
-            Await.ready(entitlementProvider.check(someUser, DELETE, r), requestTimeout).eitherValue.get shouldBe Left(RejectRequest(Forbidden))
-            Await.ready(entitlementProvider.check(someUser, ACTIVATE, r), requestTimeout).eitherValue.get shouldBe Left(RejectRequest(Forbidden))
-        }
+  behavior of "Action Collection"
+
+  it should "only allow read access for listing action collection" in {
+    implicit val tid = transid()
+    implicit val ep = entitlementProvider
+
+    val paths = Seq(
+      (READ, someUser, Right(true)),
+      (PUT, someUser, Right(false)),
+      (DELETE, someUser, Right(false)),
+      (ACTIVATE, someUser, Right(false)),
+      (REJECT, someUser, Right(false)),
+      (READ, guestUser, Right(false)),
+      (PUT, guestUser, Right(false)),
+      (DELETE, guestUser, Right(false)),
+      (ACTIVATE, guestUser, Right(false)),
+      (REJECT, guestUser, Right(false)))
+
+    paths foreach {
+      case (priv, who, expected) =>
+        val check = new ActionCollection(entityStore).implicitRights(
+          who,
+          Set(who.namespace.asString),
+          priv,
+          // any user can list any namespace packages
+          // (because this performs a db view lookup which is later filtered)
+          Resource(someUser.namespace.toPath, ACTIONS, None))
+        Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
     }
+  }
 
-    it should "not authorize a user to CRUD or activate an entity in someone else's collection" in {
-        implicit val tid = transid()
-        val collections = Seq(ACTIONS, RULES, TRIGGERS, PACKAGES)
-        val resources = collections map { Resource(someUser.namespace.toPath, _, Some("xyz")) }
-        resources foreach { r =>
-            Await.ready(entitlementProvider.check(guestUser, READ, r), requestTimeout).eitherValue.get shouldBe Left(RejectRequest(Forbidden))
-            Await.ready(entitlementProvider.check(guestUser, PUT, r), requestTimeout).eitherValue.get shouldBe Left(RejectRequest(Forbidden))
-            Await.ready(entitlementProvider.check(guestUser, DELETE, r), requestTimeout).eitherValue.get shouldBe Left(RejectRequest(Forbidden))
-            Await.ready(entitlementProvider.check(guestUser, ACTIVATE, r), requestTimeout).eitherValue.get shouldBe Left(RejectRequest(Forbidden))
-        }
+  it should "allow guest access to read or activate an action in a package if package is public" in {
+    implicit val tid = transid()
+    implicit val ep = entitlementProvider
+
+    val paths = Seq(
+      (READ, someUser, Right(true)),
+      (PUT, someUser, Right(true)),
+      (DELETE, someUser, Right(true)),
+      (ACTIVATE, someUser, Right(true)),
+      (REJECT, someUser, Right(false)),
+      (READ, guestUser, Right(true)),
+      (PUT, guestUser, Right(false)),
+      (DELETE, guestUser, Right(false)),
+      (ACTIVATE, guestUser, Right(true)),
+      (REJECT, guestUser, Right(false)))
+
+    val provider = WhiskPackage(someUser.namespace.toPath, MakeName.next(), None, publish = true)
+    val action = WhiskAction(provider.fullPath, MakeName.next(), jsDefault(""))
+    put(entityStore, provider)
+    put(entityStore, action)
+
+    paths foreach {
+      case (priv, who, expected) =>
+        val check = new ActionCollection(entityStore).implicitRights(
+          who,
+          Set(who.namespace.asString),
+          priv,
+          Resource(action.namespace, ACTIONS, Some(action.name.asString)))
+        Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
     }
+  }
 
-    it should "authorize a user to list, create/update/delete a package" in {
-        implicit val tid = transid()
-        val collections = Seq(PACKAGES)
-        val resources = collections map { Resource(someUser.namespace.toPath, _, Some("xyz")) }
-        resources foreach { r =>
-            // read should fail because the lookup for the package will fail
-            Await.ready(entitlementProvider.check(someUser, READ, r), requestTimeout).eitherValue.get shouldBe Left(RejectRequest(NotFound))
-            // create/put/delete should be allowed
-            Await.ready(entitlementProvider.check(someUser, PUT, r), requestTimeout).eitherValue.get shouldBe Right({})
-            Await.ready(entitlementProvider.check(someUser, DELETE, r), requestTimeout).eitherValue.get shouldBe Right({})
-            // activate is not allowed on a package
-            Await.ready(entitlementProvider.check(someUser, ACTIVATE, r), requestTimeout).eitherValue.get shouldBe Left(RejectRequest(Forbidden))
-        }
+  it should "reject guest access to read or activate an action in a package if package is private" in {
+    implicit val tid = transid()
+    implicit val ep = entitlementProvider
+
+    val paths = Seq(
+      (READ, someUser, Right(true)),
+      (PUT, someUser, Right(true)),
+      (DELETE, someUser, Right(true)),
+      (ACTIVATE, someUser, Right(true)),
+      (REJECT, someUser, Right(false)),
+      (READ, guestUser, Left(RejectRequest(Forbidden))),
+      (PUT, guestUser, Right(false)),
+      (DELETE, guestUser, Right(false)),
+      (ACTIVATE, guestUser, Left(RejectRequest(Forbidden))),
+      (REJECT, guestUser, Right(false)))
+
+    val provider = WhiskPackage(someUser.namespace.toPath, MakeName.next(), None, publish = false)
+    val action = WhiskAction(provider.fullPath, MakeName.next(), jsDefault(""))
+    put(entityStore, provider)
+    put(entityStore, action)
+
+    paths foreach {
+      case (priv, who, expected) =>
+        val check = new ActionCollection(entityStore).implicitRights(
+          who,
+          Set(who.namespace.asString),
+          priv,
+          Resource(action.namespace, ACTIONS, Some(action.name.asString)))
+        Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
     }
+  }
 
-    it should "grant access to entire collection to another user" in {
-        implicit val tid = transid()
-        val all = Resource(someUser.namespace.toPath, ACTIONS, None)
-        val one = Resource(someUser.namespace.toPath, ACTIONS, Some("xyz"))
-        Await.ready(entitlementProvider.check(adminUser, READ, all), requestTimeout).eitherValue.get should not be Right({})
-        Await.ready(entitlementProvider.check(adminUser, READ, one), requestTimeout).eitherValue.get should not be Right({})
-        Await.result(entitlementProvider.grant(adminUser.subject, READ, all), requestTimeout) // granted
-        Await.ready(entitlementProvider.check(adminUser, READ, all), requestTimeout).eitherValue.get shouldBe Right({})
-        Await.ready(entitlementProvider.check(adminUser, READ, one), requestTimeout).eitherValue.get shouldBe Right({})
-        Await.result(entitlementProvider.revoke(adminUser.subject, READ, all), requestTimeout) // revoked
+  it should "allow guest access to read or activate an action in a package binding if package is public" in {
+    implicit val tid = transid()
+    implicit val ep = entitlementProvider
+
+    val paths = Seq(
+      (READ, someUser, Left(RejectRequest(Forbidden))),
+      (PUT, someUser, Right(false)),
+      (DELETE, someUser, Right(false)),
+      (ACTIVATE, someUser, Left(RejectRequest(Forbidden))),
+      (REJECT, someUser, Right(false)),
+      (READ, guestUser, Right(true)),
+      (PUT, guestUser, Right(true)),
+      (DELETE, guestUser, Right(true)),
+      (ACTIVATE, guestUser, Right(true)),
+      (REJECT, guestUser, Right(false)))
+
+    val provider = WhiskPackage(someUser.namespace.toPath, MakeName.next(), None, publish = true)
+    val binding = WhiskPackage(guestUser.namespace.toPath, MakeName.next(), provider.bind)
+    val action = WhiskAction(binding.fullPath, MakeName.next(), jsDefault(""))
+    put(entityStore, provider)
+    put(entityStore, binding)
+    put(entityStore, action)
+
+    paths foreach {
+      case (priv, who, expected) =>
+        val check = new ActionCollection(entityStore).implicitRights(
+          who,
+          Set(who.namespace.asString),
+          priv,
+          Resource(action.namespace, ACTIONS, Some(action.name.asString)))
+        Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
     }
+  }
 
-    it should "grant access to specific resource to a user" in {
-        implicit val tid = transid()
-        val all = Resource(someUser.namespace.toPath, ACTIONS, None)
-        val one = Resource(someUser.namespace.toPath, ACTIONS, Some("xyz"))
-        Await.ready(entitlementProvider.check(adminUser, READ, all), requestTimeout).eitherValue.get should not be Right({})
-        Await.ready(entitlementProvider.check(adminUser, READ, one), requestTimeout).eitherValue.get should not be Right({})
-        Await.ready(entitlementProvider.check(adminUser, DELETE, one), requestTimeout).eitherValue.get should not be Right({})
-        Await.result(entitlementProvider.grant(adminUser.subject, READ, one), requestTimeout) // granted
-        Await.ready(entitlementProvider.check(adminUser, READ, all), requestTimeout).eitherValue.get should not be Right({})
-        Await.ready(entitlementProvider.check(adminUser, READ, one), requestTimeout).eitherValue.get shouldBe Right({})
-        Await.ready(entitlementProvider.check(adminUser, DELETE, one), requestTimeout).eitherValue.get should not be Right({})
-        Await.result(entitlementProvider.revoke(adminUser.subject, READ, one), requestTimeout) // revoked
+  it should "reject guest access to read or activate an action in a package binding if package is private" in {
+    implicit val tid = transid()
+    implicit val ep = entitlementProvider
+
+    val paths = Seq(
+      (READ, someUser, Left(RejectRequest(Forbidden))),
+      (PUT, someUser, Right(false)),
+      (DELETE, someUser, Right(false)),
+      (ACTIVATE, someUser, Left(RejectRequest(Forbidden))),
+      (REJECT, someUser, Right(false)),
+      (READ, guestUser, Left(RejectRequest(Forbidden))),
+      (PUT, guestUser, Right(true)),
+      (DELETE, guestUser, Right(true)),
+      (ACTIVATE, guestUser, Left(RejectRequest(Forbidden))),
+      (REJECT, guestUser, Right(false)))
+
+    val provider = WhiskPackage(someUser.namespace.toPath, MakeName.next(), None, publish = false)
+    val binding = WhiskPackage(guestUser.namespace.toPath, MakeName.next(), provider.bind)
+    val action = WhiskAction(binding.fullPath, MakeName.next(), jsDefault(""))
+    put(entityStore, provider)
+    put(entityStore, binding)
+    put(entityStore, action)
+
+    paths foreach {
+      case (priv, who, expected) =>
+        val check = new ActionCollection(entityStore).implicitRights(
+          who,
+          Set(who.namespace.asString),
+          priv,
+          Resource(action.namespace, ACTIONS, Some(action.name.asString)))
+        Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
     }
+  }
 
-    behavior of "Package Collection"
+  it should "reject guest access to read or activate an action in default package" in {
+    implicit val tid = transid()
+    implicit val ep = entitlementProvider
 
-    it should "only allow read access for listing package collection" in {
-        implicit val tid = transid()
-        implicit val ep = entitlementProvider
+    val paths = Seq(
+      (READ, someUser, Right(true)),
+      (PUT, someUser, Right(true)),
+      (DELETE, someUser, Right(true)),
+      (ACTIVATE, someUser, Right(true)),
+      (REJECT, someUser, Right(false)),
+      (READ, guestUser, Right(false)),
+      (PUT, guestUser, Right(false)),
+      (DELETE, guestUser, Right(false)),
+      (ACTIVATE, guestUser, Right(false)),
+      (REJECT, guestUser, Right(false)))
 
-        val paths = Seq(
-            (READ, someUser, Right(true)),
-            (PUT, someUser, Right(false)),
-            (DELETE, someUser, Right(false)),
-            (ACTIVATE, someUser, Right(false)),
-            (REJECT, someUser, Right(false)),
+    val action = WhiskAction(someUser.namespace.toPath, MakeName.next(), jsDefault(""))
+    put(entityStore, action)
 
-            (READ, guestUser, Right(true)),
-            (PUT, guestUser, Right(false)),
-            (DELETE, guestUser, Right(false)),
-            (ACTIVATE, guestUser, Right(false)),
-            (REJECT, guestUser, Right(false)))
-
-        paths foreach {
-            case (priv, who, expected) =>
-                val check = new PackageCollection(entityStore).implicitRights(
-                    who,
-                    Set(who.namespace.asString),
-                    priv,
-                    // any user can list any namespace packages
-                    // (because this performs a db view lookup which is later filtered)
-                    Resource(someUser.namespace.toPath, PACKAGES, None))
-                Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
-        }
+    paths foreach {
+      case (priv, who, expected) =>
+        val check = new ActionCollection(entityStore).implicitRights(
+          who,
+          Set(who.namespace.asString),
+          priv,
+          Resource(action.namespace, ACTIONS, Some(action.name.asString)))
+        Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
     }
-
-    it should "reject entitlement if package doesn't exist" in {
-        implicit val tid = transid()
-        implicit val ep = entitlementProvider
-
-        val paths = Seq(
-            (READ, someUser, Left(RejectRequest(NotFound))), // for owner, give more information
-            (PUT, someUser, Right(true)),
-            (DELETE, someUser, Right(true)),
-            (ACTIVATE, someUser, Right(false)),
-            (REJECT, someUser, Right(false)),
-
-            (READ, guestUser, Right(false)),
-            (PUT, guestUser, Right(false)),
-            (DELETE, guestUser, Right(false)),
-            (ACTIVATE, guestUser, Right(false)),
-            (REJECT, guestUser, Right(false)))
-
-        paths foreach {
-            case (priv, who, expected) =>
-                val check = new PackageCollection(entityStore).implicitRights(
-                    who,
-                    Set(who.namespace.asString),
-                    priv,
-                    Resource(someUser.namespace.toPath, PACKAGES, Some("xyz")))
-                Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
-        }
-    }
-
-    it should "reject entitlement if package doesn't deserialize" in {
-        implicit val tid = transid()
-        implicit val ep = entitlementProvider
-
-        val paths = Seq(
-            (READ, someUser, Left(RejectRequest(Conflict, Messages.conformanceMessage))), // for owner, give more information
-            (PUT, someUser, Right(true)),
-            (DELETE, someUser, Right(true)),
-            (ACTIVATE, someUser, Right(false)),
-            (REJECT, someUser, Right(false)),
-
-            (READ, guestUser, Right(false)),
-            (PUT, guestUser, Right(false)),
-            (DELETE, guestUser, Right(false)),
-            (ACTIVATE, guestUser, Right(false)),
-            (REJECT, guestUser, Right(false)))
-
-        // this forces a doc mismatch error
-        val action = WhiskAction(someUser.namespace.toPath, MakeName.next(), jsDefault(""))
-        put(entityStore, action)
-        paths foreach {
-            case (priv, who, expected) =>
-                val check = new PackageCollection(entityStore).implicitRights(
-                    who,
-                    Set(who.namespace.asString),
-                    priv,
-                    Resource(someUser.namespace.toPath, PACKAGES, Some(action.name.asString)))
-                Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
-        }
-    }
-
-    it should "not allow guest access to private package" in {
-        implicit val tid = transid()
-        implicit val ep = entitlementProvider
-
-        val provider = WhiskPackage(someUser.namespace.toPath, MakeName.next())
-        put(entityStore, provider)
-
-        val paths = Seq(
-            (READ, someUser, Right(true)),
-            (PUT, someUser, Right(true)),
-            (DELETE, someUser, Right(true)),
-            (ACTIVATE, someUser, Right(false)),
-            (REJECT, someUser, Right(false)),
-
-            (READ, guestUser, Right(false)),
-            (PUT, guestUser, Right(false)),
-            (DELETE, guestUser, Right(false)),
-            (ACTIVATE, guestUser, Right(false)),
-            (REJECT, guestUser, Right(false)))
-
-        paths foreach {
-            case (priv, who, expected) =>
-                val check = new PackageCollection(entityStore).implicitRights(
-                    who,
-                    Set(who.namespace.asString),
-                    priv,
-                    Resource(someUser.namespace.toPath, PACKAGES, Some(provider.name.asString)))
-                Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
-        }
-    }
-
-    it should "not allow guest access to binding of private package" in {
-        implicit val tid = transid()
-        implicit val ep = entitlementProvider
-
-        // simulate entitlement change on package for which binding was once entitled
-        val provider = WhiskPackage(someUser.namespace.toPath, MakeName.next())
-        val binding = WhiskPackage(guestUser.namespace.toPath, MakeName.next(), provider.bind)
-        put(entityStore, provider, false)
-        put(entityStore, binding)
-
-        val paths = Seq(
-            (READ, someUser, Right(false)),
-            (PUT, someUser, Right(false)),
-            (DELETE, someUser, Right(false)),
-            (ACTIVATE, someUser, Right(false)),
-            (REJECT, someUser, Right(false)),
-
-            (READ, guestUser, Right(false)), // not allowed to read referenced package
-            (PUT, guestUser, Right(true)), // can update
-            (DELETE, guestUser, Right(true)), // and delete the binding however
-            (ACTIVATE, guestUser, Right(false)),
-            (REJECT, guestUser, Right(false)))
-
-        paths foreach {
-            case (priv, who, expected) =>
-                val check = new PackageCollection(entityStore).implicitRights(
-                    who,
-                    Set(who.namespace.asString),
-                    priv,
-                    Resource(guestUser.namespace.toPath, PACKAGES, Some(binding.name.asString)))
-                Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
-        }
-
-        // simulate package deletion for which binding was once entitled
-        deletePackage(provider.docid)
-        paths foreach {
-            case (priv, who, expected) =>
-                val check = new PackageCollection(entityStore).implicitRights(
-                    who,
-                    Set(who.namespace.asString),
-                    priv,
-                    Resource(guestUser.namespace.toPath, PACKAGES, Some(binding.name.asString)))
-                Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
-        }
-    }
-
-    it should "not allow guest access to public binding of package" in {
-        implicit val tid = transid()
-        implicit val ep = entitlementProvider
-
-        // simulate entitlement change on package for which binding was once entitled
-        val provider = WhiskPackage(someUser.namespace.toPath, MakeName.next(), None, publish = true)
-        val binding = WhiskPackage(guestUser.namespace.toPath, MakeName.next(), provider.bind, publish = true)
-        put(entityStore, provider)
-        put(entityStore, binding)
-
-        val paths = Seq(
-            (READ, someUser, Right(false)), // cannot access a public binding
-            (PUT, someUser, Right(false)),
-            (DELETE, someUser, Right(false)),
-            (ACTIVATE, someUser, Right(false)),
-            (REJECT, someUser, Right(false)),
-
-            (READ, guestUser, Right(true)), // can read
-            (PUT, guestUser, Right(true)), // can update
-            (DELETE, guestUser, Right(true)), // and delete the binding
-            (ACTIVATE, guestUser, Right(false)),
-            (REJECT, guestUser, Right(false)))
-
-        paths foreach {
-            case (priv, who, expected) =>
-                val check = new PackageCollection(entityStore).implicitRights(
-                    who,
-                    Set(who.namespace.asString),
-                    priv,
-                    Resource(guestUser.namespace.toPath, PACKAGES, Some(binding.name.asString)))
-                Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
-        }
-    }
-
-    it should "allow guest access to binding of public package" in {
-        implicit val tid = transid()
-        implicit val ep = entitlementProvider
-
-        val provider = WhiskPackage(someUser.namespace.toPath, MakeName.next(), None, publish = true)
-        val binding = WhiskPackage(guestUser.namespace.toPath, MakeName.next(), provider.bind)
-        put(entityStore, provider)
-        put(entityStore, binding)
-
-        val paths = Seq(
-            (READ, someUser, Right(false)),
-            (PUT, someUser, Right(false)),
-            (DELETE, someUser, Right(false)),
-            (ACTIVATE, someUser, Right(false)),
-            (REJECT, someUser, Right(false)),
-
-            (READ, guestUser, Right(true)), // can read package + binding
-            (PUT, guestUser, Right(true)), // can update
-            (DELETE, guestUser, Right(true)), // and delete the binding
-            (ACTIVATE, guestUser, Right(false)),
-            (REJECT, guestUser, Right(false)))
-
-        paths foreach {
-            case (priv, who, expected) =>
-                val check = new PackageCollection(entityStore).implicitRights(
-                    who,
-                    Set(who.namespace.asString),
-                    priv,
-                    Resource(guestUser.namespace.toPath, PACKAGES, Some(binding.name.asString)))
-                Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
-        }
-    }
-
-    behavior of "Action Collection"
-
-    it should "only allow read access for listing action collection" in {
-        implicit val tid = transid()
-        implicit val ep = entitlementProvider
-
-        val paths = Seq(
-            (READ, someUser, Right(true)),
-            (PUT, someUser, Right(false)),
-            (DELETE, someUser, Right(false)),
-            (ACTIVATE, someUser, Right(false)),
-            (REJECT, someUser, Right(false)),
-
-            (READ, guestUser, Right(false)),
-            (PUT, guestUser, Right(false)),
-            (DELETE, guestUser, Right(false)),
-            (ACTIVATE, guestUser, Right(false)),
-            (REJECT, guestUser, Right(false)))
-
-        paths foreach {
-            case (priv, who, expected) =>
-                val check = new ActionCollection(entityStore).implicitRights(
-                    who,
-                    Set(who.namespace.asString),
-                    priv,
-                    // any user can list any namespace packages
-                    // (because this performs a db view lookup which is later filtered)
-                    Resource(someUser.namespace.toPath, ACTIONS, None))
-                Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
-        }
-    }
-
-    it should "allow guest access to read or activate an action in a package if package is public" in {
-        implicit val tid = transid()
-        implicit val ep = entitlementProvider
-
-        val paths = Seq(
-            (READ, someUser, Right(true)),
-            (PUT, someUser, Right(true)),
-            (DELETE, someUser, Right(true)),
-            (ACTIVATE, someUser, Right(true)),
-            (REJECT, someUser, Right(false)),
-
-            (READ, guestUser, Right(true)),
-            (PUT, guestUser, Right(false)),
-            (DELETE, guestUser, Right(false)),
-            (ACTIVATE, guestUser, Right(true)),
-            (REJECT, guestUser, Right(false)))
-
-        val provider = WhiskPackage(someUser.namespace.toPath, MakeName.next(), None, publish = true)
-        val action = WhiskAction(provider.fullPath, MakeName.next(), jsDefault(""))
-        put(entityStore, provider)
-        put(entityStore, action)
-
-        paths foreach {
-            case (priv, who, expected) =>
-                val check = new ActionCollection(entityStore).implicitRights(
-                    who,
-                    Set(who.namespace.asString),
-                    priv,
-                    Resource(action.namespace, ACTIONS, Some(action.name.asString)))
-                Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
-        }
-    }
-
-    it should "reject guest access to read or activate an action in a package if package is private" in {
-        implicit val tid = transid()
-        implicit val ep = entitlementProvider
-
-        val paths = Seq(
-            (READ, someUser, Right(true)),
-            (PUT, someUser, Right(true)),
-            (DELETE, someUser, Right(true)),
-            (ACTIVATE, someUser, Right(true)),
-            (REJECT, someUser, Right(false)),
-
-            (READ, guestUser, Left(RejectRequest(Forbidden))),
-            (PUT, guestUser, Right(false)),
-            (DELETE, guestUser, Right(false)),
-            (ACTIVATE, guestUser, Left(RejectRequest(Forbidden))),
-            (REJECT, guestUser, Right(false)))
-
-        val provider = WhiskPackage(someUser.namespace.toPath, MakeName.next(), None, publish = false)
-        val action = WhiskAction(provider.fullPath, MakeName.next(), jsDefault(""))
-        put(entityStore, provider)
-        put(entityStore, action)
-
-        paths foreach {
-            case (priv, who, expected) =>
-                val check = new ActionCollection(entityStore).implicitRights(
-                    who,
-                    Set(who.namespace.asString),
-                    priv,
-                    Resource(action.namespace, ACTIONS, Some(action.name.asString)))
-                Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
-        }
-    }
-
-    it should "allow guest access to read or activate an action in a package binding if package is public" in {
-        implicit val tid = transid()
-        implicit val ep = entitlementProvider
-
-        val paths = Seq(
-            (READ, someUser, Left(RejectRequest(Forbidden))),
-            (PUT, someUser, Right(false)),
-            (DELETE, someUser, Right(false)),
-            (ACTIVATE, someUser, Left(RejectRequest(Forbidden))),
-            (REJECT, someUser, Right(false)),
-
-            (READ, guestUser, Right(true)),
-            (PUT, guestUser, Right(true)),
-            (DELETE, guestUser, Right(true)),
-            (ACTIVATE, guestUser, Right(true)),
-            (REJECT, guestUser, Right(false)))
-
-        val provider = WhiskPackage(someUser.namespace.toPath, MakeName.next(), None, publish = true)
-        val binding = WhiskPackage(guestUser.namespace.toPath, MakeName.next(), provider.bind)
-        val action = WhiskAction(binding.fullPath, MakeName.next(), jsDefault(""))
-        put(entityStore, provider)
-        put(entityStore, binding)
-        put(entityStore, action)
-
-        paths foreach {
-            case (priv, who, expected) =>
-                val check = new ActionCollection(entityStore).implicitRights(
-                    who,
-                    Set(who.namespace.asString),
-                    priv,
-                    Resource(action.namespace, ACTIONS, Some(action.name.asString)))
-                Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
-        }
-    }
-
-    it should "reject guest access to read or activate an action in a package binding if package is private" in {
-        implicit val tid = transid()
-        implicit val ep = entitlementProvider
-
-        val paths = Seq(
-            (READ, someUser, Left(RejectRequest(Forbidden))),
-            (PUT, someUser, Right(false)),
-            (DELETE, someUser, Right(false)),
-            (ACTIVATE, someUser, Left(RejectRequest(Forbidden))),
-            (REJECT, someUser, Right(false)),
-
-            (READ, guestUser, Left(RejectRequest(Forbidden))),
-            (PUT, guestUser, Right(true)),
-            (DELETE, guestUser, Right(true)),
-            (ACTIVATE, guestUser, Left(RejectRequest(Forbidden))),
-            (REJECT, guestUser, Right(false)))
-
-        val provider = WhiskPackage(someUser.namespace.toPath, MakeName.next(), None, publish = false)
-        val binding = WhiskPackage(guestUser.namespace.toPath, MakeName.next(), provider.bind)
-        val action = WhiskAction(binding.fullPath, MakeName.next(), jsDefault(""))
-        put(entityStore, provider)
-        put(entityStore, binding)
-        put(entityStore, action)
-
-        paths foreach {
-            case (priv, who, expected) =>
-                val check = new ActionCollection(entityStore).implicitRights(
-                    who,
-                    Set(who.namespace.asString),
-                    priv,
-                    Resource(action.namespace, ACTIONS, Some(action.name.asString)))
-                Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
-        }
-    }
-
-    it should "reject guest access to read or activate an action in default package" in {
-        implicit val tid = transid()
-        implicit val ep = entitlementProvider
-
-        val paths = Seq(
-            (READ, someUser, Right(true)),
-            (PUT, someUser, Right(true)),
-            (DELETE, someUser, Right(true)),
-            (ACTIVATE, someUser, Right(true)),
-            (REJECT, someUser, Right(false)),
-
-            (READ, guestUser, Right(false)),
-            (PUT, guestUser, Right(false)),
-            (DELETE, guestUser, Right(false)),
-            (ACTIVATE, guestUser, Right(false)),
-            (REJECT, guestUser, Right(false)))
-
-        val action = WhiskAction(someUser.namespace.toPath, MakeName.next(), jsDefault(""))
-        put(entityStore, action)
-
-        paths foreach {
-            case (priv, who, expected) =>
-                val check = new ActionCollection(entityStore).implicitRights(
-                    who,
-                    Set(who.namespace.asString),
-                    priv,
-                    Resource(action.namespace, ACTIONS, Some(action.name.asString)))
-                Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
-        }
-    }
+  }
 }

--- a/tests/src/test/scala/whisk/core/controller/test/NamespacesApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/NamespacesApiTests.scala
@@ -52,66 +52,68 @@ import spray.json.JsArray
 @RunWith(classOf[JUnitRunner])
 class NamespacesApiTests extends ControllerTestCommon with WhiskNamespacesApi {
 
-    /** Triggers API tests */
-    behavior of "Namespaces API"
+  /** Triggers API tests */
+  behavior of "Namespaces API"
 
-    val collectionPath = s"/${collection.path}"
-    val creds = WhiskAuthHelpers.newIdentity()
-    val namespace = EntityPath(creds.subject.asString)
+  val collectionPath = s"/${collection.path}"
+  val creds = WhiskAuthHelpers.newIdentity()
+  val namespace = EntityPath(creds.subject.asString)
 
-    it should "list namespaces for subject" in {
-        implicit val tid = transid()
-        Get(collectionPath) ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val ns = responseAs[List[EntityPath]]
-            ns should be(List(EntityPath(creds.subject.asString)))
-        }
+  it should "list namespaces for subject" in {
+    implicit val tid = transid()
+    Get(collectionPath) ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val ns = responseAs[List[EntityPath]]
+      ns should be(List(EntityPath(creds.subject.asString)))
     }
+  }
 
-    it should "list namespaces for subject with trailing /" in {
-        implicit val tid = transid()
-        Get(s"$collectionPath/") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val ns = responseAs[List[EntityPath]]
-            ns should be(List(EntityPath(creds.subject.asString)))
-        }
+  it should "list namespaces for subject with trailing /" in {
+    implicit val tid = transid()
+    Get(s"$collectionPath/") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val ns = responseAs[List[EntityPath]]
+      ns should be(List(EntityPath(creds.subject.asString)))
     }
+  }
 
-    it should "get namespace entities for subject" in {
-        implicit val tid = transid()
-        Get(s"$collectionPath/${creds.subject}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val ns = responseAs[JsObject]
-            ns should be(JsObject(Namespaces.emptyNamespace map { kv => (kv._1, JsArray()) }))
-        }
+  it should "get namespace entities for subject" in {
+    implicit val tid = transid()
+    Get(s"$collectionPath/${creds.subject}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val ns = responseAs[JsObject]
+      ns should be(JsObject(Namespaces.emptyNamespace map { kv =>
+        (kv._1, JsArray())
+      }))
     }
+  }
 
-    it should "reject get namespace entities for unauthorized subject" in {
-        implicit val tid = transid()
-        val anothercred = WhiskAuthHelpers.newIdentity()
-        Get(s"$collectionPath/${anothercred.subject}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(Forbidden)
-        }
+  it should "reject get namespace entities for unauthorized subject" in {
+    implicit val tid = transid()
+    val anothercred = WhiskAuthHelpers.newIdentity()
+    Get(s"$collectionPath/${anothercred.subject}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(Forbidden)
     }
+  }
 
-    it should "reject request with put" in {
-        implicit val tid = transid()
-        Put(s"$collectionPath/${creds.subject}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(MethodNotAllowed)
-        }
+  it should "reject request with put" in {
+    implicit val tid = transid()
+    Put(s"$collectionPath/${creds.subject}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(MethodNotAllowed)
     }
+  }
 
-    it should "reject request with post" in {
-        implicit val tid = transid()
-        Post(s"$collectionPath/${creds.subject}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(MethodNotAllowed)
-        }
+  it should "reject request with post" in {
+    implicit val tid = transid()
+    Post(s"$collectionPath/${creds.subject}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(MethodNotAllowed)
     }
+  }
 
-    it should "reject request with delete" in {
-        implicit val tid = transid()
-        Delete(s"$collectionPath/${creds.subject}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(MethodNotAllowed)
-        }
+  it should "reject request with delete" in {
+    implicit val tid = transid()
+    Delete(s"$collectionPath/${creds.subject}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(MethodNotAllowed)
     }
+  }
 }

--- a/tests/src/test/scala/whisk/core/controller/test/PackageActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/PackageActionsApiTests.scala
@@ -52,575 +52,586 @@ import whisk.http.Messages
 @RunWith(classOf[JUnitRunner])
 class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
 
-    /** Package Actions API tests */
-    behavior of "Package Actions API"
+  /** Package Actions API tests */
+  behavior of "Package Actions API"
 
-    val creds = WhiskAuthHelpers.newIdentity()
-    val namespace = EntityPath(creds.subject.asString)
-    val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
-    def aname = MakeName.next("package_action_tests")
+  val creds = WhiskAuthHelpers.newIdentity()
+  val namespace = EntityPath(creds.subject.asString)
+  val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
+  def aname = MakeName.next("package_action_tests")
 
-    //// GET /actions/package/
-    it should "list all actions in package" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname)
-        val actions = (1 to 2).map { _ =>
-            WhiskAction(provider.fullPath, aname, jsDefault("??"))
-        }
-        put(entityStore, provider)
-        actions foreach { put(entityStore, _) }
-        whisk.utils.retry {
-            Get(s"$collectionPath/${provider.name}/") ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                val response = responseAs[List[JsObject]]
-                actions.length should be(response.length)
-                actions forall { a => response contains a.summaryAsJson } should be(true)
-            }
-        }
+  //// GET /actions/package/
+  it should "list all actions in package" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname)
+    val actions = (1 to 2).map { _ =>
+      WhiskAction(provider.fullPath, aname, jsDefault("??"))
+    }
+    put(entityStore, provider)
+    actions foreach { put(entityStore, _) }
+    whisk.utils.retry {
+      Get(s"$collectionPath/${provider.name}/") ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[List[JsObject]]
+        actions.length should be(response.length)
+        actions forall { a =>
+          response contains a.summaryAsJson
+        } should be(true)
+      }
+    }
+  }
+
+  it should "list all actions in package binding" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname)
+    val reference = WhiskPackage(namespace, aname, provider.bind)
+    val actions = (1 to 2).map { _ =>
+      WhiskAction(provider.fullPath, aname, jsDefault("??"))
+    }
+    put(entityStore, provider)
+    put(entityStore, reference)
+    actions foreach { put(entityStore, _) }
+    whisk.utils.retry {
+      Get(s"$collectionPath/${reference.name}/") ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[List[JsObject]]
+        actions.length should be(response.length)
+        actions forall { a =>
+          response contains a.summaryAsJson
+        } should be(true)
+      }
+    }
+  }
+
+  it should "include action in package when listing all actions" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname, None)
+    val action1 = WhiskAction(namespace, aname, jsDefault("??"), Parameters(), ActionLimits())
+    val action2 = WhiskAction(provider.fullPath, aname, jsDefault("??"))
+    put(entityStore, provider)
+    put(entityStore, action1)
+    put(entityStore, action2)
+    whisk.utils.retry {
+      Get(s"$collectionPath") ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[List[JsObject]]
+        response.length should be(2)
+        response contains action1.summaryAsJson should be(true)
+        response contains action2.summaryAsJson should be(true)
+      }
+    }
+  }
+
+  it should "reject ambiguous list actions in package without trailing slash" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname, None)
+    put(entityStore, provider)
+    whisk.utils.retry {
+      Get(s"$collectionPath/${provider.name}") ~> Route.seal(routes(creds)) ~> check {
+        status should be(Conflict)
+      }
+    }
+  }
+
+  it should "reject invalid verb on get package actions" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname, None)
+    put(entityStore, provider)
+    Delete(s"$collectionPath/${provider.name}/") ~> Route.seal(routes(creds)) ~> check {
+      status should be(NotFound)
+    }
+  }
+
+  //// PUT /actions/package/name
+  it should "put action in package" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname)
+    val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
+    val content = WhiskActionPut(Some(action.exec))
+    put(entityStore, provider)
+    Put(s"$collectionPath/${provider.name}/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      deleteAction(action.docid)
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response should be(
+        WhiskAction(
+          action.namespace,
+          action.name,
+          action.exec,
+          action.parameters,
+          action.limits,
+          action.version,
+          action.publish,
+          action.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6)))
+    }
+  }
+
+  it should "reject put action in package that does not exist" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname)
+    val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
+    val content = WhiskActionPut(Some(action.exec))
+    Put(s"$collectionPath/${provider.name}/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(NotFound)
+    }
+  }
+
+  it should "reject put action in package binding where package doesn't exist" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname, None, publish = true)
+    val binding = WhiskPackage(namespace, aname, provider.bind)
+    val content = WhiskActionPut(Some(jsDefault("??")))
+    put(entityStore, binding)
+    Put(s"$collectionPath/${binding.name}/$aname", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+    }
+  }
+
+  it should "reject put action in package binding" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname, None, publish = true)
+    val binding = WhiskPackage(namespace, aname, provider.bind)
+    val content = WhiskActionPut(Some(jsDefault("??")))
+    put(entityStore, provider)
+    put(entityStore, binding)
+    Put(s"$collectionPath/${binding.name}/$aname", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+    }
+  }
+
+  it should "reject put action in package owned by different subject" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(EntityPath(Subject().asString), aname, publish = true)
+    val content = WhiskActionPut(Some(jsDefault("??")))
+    put(entityStore, provider)
+    Put(s"/${provider.namespace}/${collection.path}/${provider.name}/$aname", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(Forbidden)
+    }
+  }
+
+  //// DEL /actions/package/name
+  it should "delete action in package" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname)
+    val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
+    put(entityStore, provider)
+    put(entityStore, action)
+
+    // it should "reject delete action in package owned by different subject" in {
+    val auser = WhiskAuthHelpers.newIdentity()
+    Delete(s"/${provider.namespace}/${collection.path}/${provider.name}/${action.name}") ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden)
     }
 
-    it should "list all actions in package binding" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname)
-        val reference = WhiskPackage(namespace, aname, provider.bind)
-        val actions = (1 to 2).map { _ =>
-            WhiskAction(provider.fullPath, aname, jsDefault("??"))
-        }
-        put(entityStore, provider)
-        put(entityStore, reference)
-        actions foreach { put(entityStore, _) }
-        whisk.utils.retry {
-            Get(s"$collectionPath/${reference.name}/") ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                val response = responseAs[List[JsObject]]
-                actions.length should be(response.length)
-                actions forall { a => response contains a.summaryAsJson } should be(true)
-            }
-        }
+    Delete(s"$collectionPath/${provider.name}/${action.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response should be(action)
+    }
+  }
+
+  it should "reject delete action in package that does not exist" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname)
+    val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
+    put(entityStore, action)
+    Delete(s"$collectionPath/${provider.name}/${action.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(NotFound)
+    }
+  }
+
+  it should "reject delete non-existent action in package" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname)
+    val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
+    put(entityStore, provider)
+    Delete(s"$collectionPath/${provider.name}/${action.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(NotFound)
+    }
+  }
+
+  it should "reject delete action in package binding where package doesn't exist" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname, None, publish = true)
+    val binding = WhiskPackage(namespace, aname, provider.bind)
+    val content = WhiskActionPut(Some(jsDefault("??")))
+    put(entityStore, binding)
+    Delete(s"$collectionPath/${binding.name}/$aname") ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+    }
+  }
+
+  it should "reject delete action in package binding" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname, None, publish = true)
+    val binding = WhiskPackage(namespace, aname, provider.bind)
+    val content = WhiskActionPut(Some(jsDefault("??")))
+    put(entityStore, provider)
+    put(entityStore, binding)
+    Delete(s"$collectionPath/${binding.name}/$aname") ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+    }
+  }
+
+  it should "reject delete action in package owned by different subject" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(EntityPath(Subject().asString), aname, publish = true)
+    val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
+    put(entityStore, provider)
+    put(entityStore, action)
+    Delete(s"/${provider.namespace}/${collection.path}/${provider.name}/${action.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(Forbidden)
+    }
+  }
+
+  //// GET /actions/package/name
+  it should "get action in package" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname, None, Parameters("p", "P"), publish = true)
+    val action = WhiskAction(provider.fullPath, aname, jsDefault("??"), Parameters("a", "A"))
+    put(entityStore, provider)
+    put(entityStore, action)
+    whisk.utils.retry {
+      Get(s"$collectionPath/${provider.name}/${action.name}") ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[WhiskAction]
+        response should be(action inherit provider.parameters)
+      }
+    }
+  }
+
+  it should "get action in package binding with public package" in {
+    implicit val tid = transid()
+    val auser = WhiskAuthHelpers.newIdentity()
+    val provider = WhiskPackage(namespace, aname, None, publish = true)
+    val binding = WhiskPackage(EntityPath(auser.subject.asString), aname, provider.bind, Parameters("b", "B"))
+    val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
+    put(entityStore, provider)
+    put(entityStore, binding)
+    put(entityStore, action)
+    whisk.utils.retry {
+      Get(s"$collectionPath/${binding.name}/${action.name}") ~> Route.seal(routes(auser)) ~> check {
+        status should be(OK)
+        val response = responseAs[WhiskAction]
+        response should be(action inherit (provider.parameters ++ binding.parameters))
+      }
+    }
+  }
+
+  it should "get action in package binding with public package with overriding parameters" in {
+    implicit val tid = transid()
+    val auser = WhiskAuthHelpers.newIdentity()
+    val provider = WhiskPackage(namespace, aname, None, Parameters("p", "P"), publish = true)
+    val binding = WhiskPackage(EntityPath(auser.subject.asString), aname, provider.bind, Parameters("b", "B"))
+    val action = WhiskAction(provider.fullPath, aname, jsDefault("??"), Parameters("a", "A") ++ Parameters("b", "b"))
+    put(entityStore, provider)
+    put(entityStore, binding)
+    put(entityStore, action)
+    whisk.utils.retry {
+      Get(s"$collectionPath/${binding.name}/${action.name}") ~> Route.seal(routes(auser)) ~> check {
+        status should be(OK)
+        val response = responseAs[WhiskAction]
+        response should be(action inherit (provider.parameters ++ binding.parameters))
+      }
+    }
+  }
+
+  // NOTE: does not work because entitlement model does not allow for an explicit
+  // check on either one or both of the binding and package
+  ignore should "get action in package binding with explicit entitlement grant" in {
+    implicit val tid = transid()
+    val auser = WhiskAuthHelpers.newIdentity()
+    val provider = WhiskPackage(namespace, aname, None, Parameters("p", "P"), publish = false)
+    val binding = WhiskPackage(EntityPath(auser.subject.asString), aname, provider.bind, Parameters("b", "B"))
+    val action = WhiskAction(provider.fullPath, aname, jsDefault("??"), Parameters("a", "A"))
+    put(entityStore, provider)
+    put(entityStore, binding)
+    put(entityStore, action)
+    val pkgaccess = Resource(provider.namespace, PACKAGES, Some(provider.name.asString))
+    Await.result(entitlementProvider.grant(auser.subject, READ, pkgaccess), 1 second)
+    Get(s"$collectionPath/${binding.name}/${action.name}") ~> Route.seal(routes(auser)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response should be(action inherit (provider.parameters ++ binding.parameters))
+    }
+  }
+
+  it should "reject get action in package that does not exist" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname)
+    val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
+    put(entityStore, action)
+    Get(s"$collectionPath/${provider.name}/${action.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(NotFound)
+    }
+  }
+
+  it should "reject get non-existent action in package" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname)
+    val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
+    put(entityStore, provider)
+    Get(s"$collectionPath/${provider.name}/${action.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(NotFound)
+    }
+  }
+
+  it should "reject get action in package binding that does not exist" in {
+    implicit val tid = transid()
+    val name = aname
+    val auser = WhiskAuthHelpers.newIdentity()
+    val provider = WhiskPackage(namespace, aname, None, Parameters("p", "P"), publish = true)
+    val binding = WhiskPackage(EntityPath(auser.subject.asString), aname, provider.bind, Parameters("b", "B"))
+    val action = WhiskAction(provider.fullPath, aname, jsDefault("??"), Parameters("a", "A"))
+    put(entityStore, provider)
+    put(entityStore, action)
+    Get(s"$collectionPath/${binding.name}/${action.name}") ~> Route.seal(routes(auser)) ~> check {
+      status should be(NotFound)
+    }
+  }
+
+  it should "reject get action in package binding with package that does not exist" in {
+    implicit val tid = transid()
+    val name = aname
+    val auser = WhiskAuthHelpers.newIdentity()
+    val provider = WhiskPackage(namespace, aname, None, Parameters("p", "P"), publish = true)
+    val binding = WhiskPackage(EntityPath(auser.subject.asString), aname, provider.bind, Parameters("b", "B"))
+    val action = WhiskAction(provider.fullPath, aname, jsDefault("??"), Parameters("a", "A"))
+    put(entityStore, binding)
+    put(entityStore, action)
+    Get(s"$collectionPath/${binding.name}/${action.name}") ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden) // do not leak that package does not exist
+    }
+  }
+
+  it should "reject get non-existing action in package binding" in {
+    implicit val tid = transid()
+    val name = aname
+    val auser = WhiskAuthHelpers.newIdentity()
+    val provider = WhiskPackage(namespace, aname, None, Parameters("p", "P"), publish = true)
+    val binding = WhiskPackage(EntityPath(auser.subject.asString), aname, provider.bind, Parameters("b", "B"))
+    val action = WhiskAction(provider.fullPath, aname, jsDefault("??"), Parameters("a", "A"))
+    put(entityStore, provider)
+    put(entityStore, binding)
+    Get(s"$collectionPath/${binding.name}/${action.name}") ~> Route.seal(routes(auser)) ~> check {
+      status should be(NotFound)
+    }
+  }
+
+  it should "reject get action in package binding with private package" in {
+    implicit val tid = transid()
+    val auser = WhiskAuthHelpers.newIdentity()
+    val provider = WhiskPackage(namespace, aname, None, Parameters("p", "P"), publish = false)
+    val binding = WhiskPackage(EntityPath(auser.subject.asString), aname, provider.bind, Parameters("b", "B"))
+    val action = WhiskAction(provider.fullPath, aname, jsDefault("??"), Parameters("a", "A"))
+    put(entityStore, provider)
+    put(entityStore, binding)
+    put(entityStore, action)
+    Get(s"$collectionPath/${binding.name}/${action.name}") ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden)
+    }
+  }
+
+  //// POST /actions/name
+  it should "allow owner to invoke an action in package" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname)
+    val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
+    val content = JsObject("xxx" -> "yyy".toJson)
+    put(entityStore, provider)
+    put(entityStore, action)
+    Post(s"$collectionPath/${provider.name}/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(Accepted)
+      val response = responseAs[JsObject]
+      response.fields("activationId") should not be None
+    }
+  }
+
+  it should "allow non-owner to invoke an action in public package" in {
+    implicit val tid = transid()
+    val auser = WhiskAuthHelpers.newIdentity()
+    val provider = WhiskPackage(namespace, aname, publish = true)
+    val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
+    val content = JsObject("xxx" -> "yyy".toJson)
+    put(entityStore, provider)
+    put(entityStore, action)
+    Post(s"/$namespace/${collection.path}/${provider.name}/${action.name}", content) ~> Route.seal(routes(auser)) ~> check {
+      status should be(Accepted)
+      val response = responseAs[JsObject]
+      response.fields("activationId") should not be None
+    }
+  }
+
+  it should "invoke action in package binding with public package" in {
+    implicit val tid = transid()
+    val auser = WhiskAuthHelpers.newIdentity()
+    val provider = WhiskPackage(namespace, aname, publish = true)
+    val reference = WhiskPackage(EntityPath(auser.subject.asString), aname, provider.bind)
+    val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
+    val content = JsObject("x" -> "x".toJson, "z" -> "Z".toJson)
+    put(entityStore, provider)
+    put(entityStore, reference)
+    put(entityStore, action)
+    Post(s"$collectionPath/${reference.name}/${action.name}", content) ~> Route.seal(routes(auser)) ~> check {
+      status should be(Accepted)
+      val response = responseAs[JsObject]
+      response.fields("activationId") should not be None
+    }
+  }
+
+  // NOTE: does not work because entitlement model does not allow for an explicit
+  // check on either one or both of the binding and package
+  ignore should "invoke action in package binding with explicit entitlement grant even if package is not public" in {
+    implicit val tid = transid()
+    val auser = WhiskAuthHelpers.newIdentity()
+    val provider = WhiskPackage(namespace, aname, publish = false)
+    val reference = WhiskPackage(EntityPath(auser.subject.asString), aname, provider.bind)
+    val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
+    val content = JsObject("x" -> "x".toJson, "z" -> "Z".toJson)
+    put(entityStore, provider)
+    put(entityStore, reference)
+    put(entityStore, action)
+    val pkgaccess = Resource(provider.namespace, PACKAGES, Some(provider.name.asString))
+    Await.result(entitlementProvider.grant(auser.subject, ACTIVATE, pkgaccess), 1 second)
+    Post(s"$collectionPath/${reference.name}/${action.name}", content) ~> Route.seal(routes(auser)) ~> check {
+      status should be(Accepted)
+      val response = responseAs[JsObject]
+      response.fields("activationId") should not be None
+    }
+  }
+
+  it should "reject non-owner invoking an action in private package" in {
+    implicit val tid = transid()
+    val auser = WhiskAuthHelpers.newIdentity()
+    val provider = WhiskPackage(namespace, aname, publish = false)
+    val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
+    val content = JsObject("xxx" -> "yyy".toJson)
+    put(entityStore, provider)
+    put(entityStore, action)
+    Post(s"/$namespace/${collection.path}/${provider.name}/${action.name}", content) ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden)
+    }
+  }
+
+  it should "reject invoking an action in package that does not exist" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname, publish = false)
+    val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
+    val content = JsObject("xxx" -> "yyy".toJson)
+    put(entityStore, action)
+    Post(s"$collectionPath/${provider.name}/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(NotFound)
+    }
+  }
+
+  it should "reject invoking a non-existent action in package" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname, publish = false)
+    val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
+    val content = JsObject("xxx" -> "yyy".toJson)
+    put(entityStore, action)
+    Post(s"$collectionPath/${provider.name}/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(NotFound)
+    }
+  }
+
+  it should "reject invoke action in package binding with private package" in {
+    implicit val tid = transid()
+    val auser = WhiskAuthHelpers.newIdentity()
+    val provider = WhiskPackage(namespace, aname, publish = false)
+    val reference = WhiskPackage(EntityPath(auser.subject.asString), aname, provider.bind)
+    val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
+    val content = JsObject("x" -> "x".toJson, "z" -> "Z".toJson)
+    put(entityStore, provider)
+    put(entityStore, reference)
+    put(entityStore, action)
+    Post(s"$collectionPath/${reference.name}/${action.name}", content) ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden)
+    }
+  }
+
+  it should "report proper error when provider record is corrupted on delete" in {
+    implicit val tid = transid()
+    val provider = BadEntity(namespace, aname)
+    val entity = BadEntity(provider.namespace.addPath(provider.name), aname)
+    put(entityStore, provider)
+    put(entityStore, entity)
+
+    Delete(s"$collectionPath/${provider.name}/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
+      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
+    }
+  }
+
+  it should "report proper error when record is corrupted on delete" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname)
+    val entity = BadEntity(provider.fullPath, aname)
+    put(entityStore, provider, false)
+    put(entityStore, entity, false)
+
+    Delete(s"$collectionPath/${provider.name}/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(InternalServerError)
+      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
+    }
+  }
+
+  it should "report proper error when provider record is corrupted on get" in {
+    implicit val tid = transid()
+    val provider = BadEntity(namespace, aname)
+    val entity = BadEntity(provider.namespace.addPath(provider.name), aname)
+    put(entityStore, provider)
+    put(entityStore, entity)
+
+    Get(s"$collectionPath/${provider.name}/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(InternalServerError)
+      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
     }
 
-    it should "include action in package when listing all actions" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname, None)
-        val action1 = WhiskAction(namespace, aname, jsDefault("??"), Parameters(), ActionLimits())
-        val action2 = WhiskAction(provider.fullPath, aname, jsDefault("??"))
-        put(entityStore, provider)
-        put(entityStore, action1)
-        put(entityStore, action2)
-        whisk.utils.retry {
-            Get(s"$collectionPath") ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                val response = responseAs[List[JsObject]]
-                response.length should be(2)
-                response contains action1.summaryAsJson should be(true)
-                response contains action2.summaryAsJson should be(true)
-            }
-        }
+    val auser = WhiskAuthHelpers.newIdentity()
+    Get(s"/${provider.namespace}/${collection.path}/${provider.name}/${entity.name}") ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden)
+      responseAs[ErrorResponse].error shouldBe Messages.notAuthorizedtoOperateOnResource
     }
+  }
 
-    it should "reject ambiguous list actions in package without trailing slash" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname, None)
-        put(entityStore, provider)
-        whisk.utils.retry {
-            Get(s"$collectionPath/${provider.name}") ~> Route.seal(routes(creds)) ~> check {
-                status should be(Conflict)
-            }
-        }
+  it should "report proper error when record is corrupted on get" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname)
+    val entity = BadEntity(provider.fullPath, aname)
+    put(entityStore, provider)
+    put(entityStore, entity)
+
+    Get(s"$collectionPath/${provider.name}/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(InternalServerError)
+      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
     }
+  }
 
-    it should "reject invalid verb on get package actions" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname, None)
-        put(entityStore, provider)
-        Delete(s"$collectionPath/${provider.name}/") ~> Route.seal(routes(creds)) ~> check {
-            status should be(NotFound)
-        }
+  it should "report proper error when provider record is corrupted on put" in {
+    implicit val tid = transid()
+    val provider = BadEntity(namespace, aname)
+    val entity = BadEntity(provider.namespace.addPath(provider.name), aname)
+    put(entityStore, provider)
+    put(entityStore, entity)
+
+    val content = WhiskActionPut()
+    Put(s"$collectionPath/${provider.name}/${entity.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(InternalServerError)
+      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
     }
+  }
 
-    //// PUT /actions/package/name
-    it should "put action in package" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname)
-        val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
-        val content = WhiskActionPut(Some(action.exec))
-        put(entityStore, provider)
-        Put(s"$collectionPath/${provider.name}/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            deleteAction(action.docid)
-            status should be(OK)
-            val response = responseAs[WhiskAction]
-            response should be(WhiskAction(action.namespace, action.name, action.exec,
-                action.parameters, action.limits, action.version,
-                action.publish, action.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6)))
-        }
+  it should "report proper error when record is corrupted on put" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname)
+    val entity = BadEntity(provider.fullPath, aname)
+    put(entityStore, provider)
+    put(entityStore, entity)
+
+    val content = WhiskActionPut()
+    Put(s"$collectionPath/${provider.name}/${entity.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(InternalServerError)
+      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
     }
-
-    it should "reject put action in package that does not exist" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname)
-        val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
-        val content = WhiskActionPut(Some(action.exec))
-        Put(s"$collectionPath/${provider.name}/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(NotFound)
-        }
-    }
-
-    it should "reject put action in package binding where package doesn't exist" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname, None, publish = true)
-        val binding = WhiskPackage(namespace, aname, provider.bind)
-        val content = WhiskActionPut(Some(jsDefault("??")))
-        put(entityStore, binding)
-        Put(s"$collectionPath/${binding.name}/$aname", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-        }
-    }
-
-    it should "reject put action in package binding" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname, None, publish = true)
-        val binding = WhiskPackage(namespace, aname, provider.bind)
-        val content = WhiskActionPut(Some(jsDefault("??")))
-        put(entityStore, provider)
-        put(entityStore, binding)
-        Put(s"$collectionPath/${binding.name}/$aname", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-        }
-    }
-
-    it should "reject put action in package owned by different subject" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(EntityPath(Subject().asString), aname, publish = true)
-        val content = WhiskActionPut(Some(jsDefault("??")))
-        put(entityStore, provider)
-        Put(s"/${provider.namespace}/${collection.path}/${provider.name}/$aname", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(Forbidden)
-        }
-    }
-
-    //// DEL /actions/package/name
-    it should "delete action in package" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname)
-        val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
-        put(entityStore, provider)
-        put(entityStore, action)
-
-        // it should "reject delete action in package owned by different subject" in {
-        val auser = WhiskAuthHelpers.newIdentity()
-        Delete(s"/${provider.namespace}/${collection.path}/${provider.name}/${action.name}") ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden)
-        }
-
-        Delete(s"$collectionPath/${provider.name}/${action.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskAction]
-            response should be(action)
-        }
-    }
-
-    it should "reject delete action in package that does not exist" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname)
-        val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
-        put(entityStore, action)
-        Delete(s"$collectionPath/${provider.name}/${action.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(NotFound)
-        }
-    }
-
-    it should "reject delete non-existent action in package" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname)
-        val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
-        put(entityStore, provider)
-        Delete(s"$collectionPath/${provider.name}/${action.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(NotFound)
-        }
-    }
-
-    it should "reject delete action in package binding where package doesn't exist" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname, None, publish = true)
-        val binding = WhiskPackage(namespace, aname, provider.bind)
-        val content = WhiskActionPut(Some(jsDefault("??")))
-        put(entityStore, binding)
-        Delete(s"$collectionPath/${binding.name}/$aname") ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-        }
-    }
-
-    it should "reject delete action in package binding" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname, None, publish = true)
-        val binding = WhiskPackage(namespace, aname, provider.bind)
-        val content = WhiskActionPut(Some(jsDefault("??")))
-        put(entityStore, provider)
-        put(entityStore, binding)
-        Delete(s"$collectionPath/${binding.name}/$aname") ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-        }
-    }
-
-    it should "reject delete action in package owned by different subject" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(EntityPath(Subject().asString), aname, publish = true)
-        val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
-        put(entityStore, provider)
-        put(entityStore, action)
-        Delete(s"/${provider.namespace}/${collection.path}/${provider.name}/${action.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(Forbidden)
-        }
-    }
-
-    //// GET /actions/package/name
-    it should "get action in package" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname, None, Parameters("p", "P"), publish = true)
-        val action = WhiskAction(provider.fullPath, aname, jsDefault("??"), Parameters("a", "A"))
-        put(entityStore, provider)
-        put(entityStore, action)
-        whisk.utils.retry {
-            Get(s"$collectionPath/${provider.name}/${action.name}") ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                val response = responseAs[WhiskAction]
-                response should be(action inherit provider.parameters)
-            }
-        }
-    }
-
-    it should "get action in package binding with public package" in {
-        implicit val tid = transid()
-        val auser = WhiskAuthHelpers.newIdentity()
-        val provider = WhiskPackage(namespace, aname, None, publish = true)
-        val binding = WhiskPackage(EntityPath(auser.subject.asString), aname, provider.bind, Parameters("b", "B"))
-        val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
-        put(entityStore, provider)
-        put(entityStore, binding)
-        put(entityStore, action)
-        whisk.utils.retry {
-            Get(s"$collectionPath/${binding.name}/${action.name}") ~> Route.seal(routes(auser)) ~> check {
-                status should be(OK)
-                val response = responseAs[WhiskAction]
-                response should be(action inherit (provider.parameters ++ binding.parameters))
-            }
-        }
-    }
-
-    it should "get action in package binding with public package with overriding parameters" in {
-        implicit val tid = transid()
-        val auser = WhiskAuthHelpers.newIdentity()
-        val provider = WhiskPackage(namespace, aname, None, Parameters("p", "P"), publish = true)
-        val binding = WhiskPackage(EntityPath(auser.subject.asString), aname, provider.bind, Parameters("b", "B"))
-        val action = WhiskAction(provider.fullPath, aname, jsDefault("??"), Parameters("a", "A") ++ Parameters("b", "b"))
-        put(entityStore, provider)
-        put(entityStore, binding)
-        put(entityStore, action)
-        whisk.utils.retry {
-            Get(s"$collectionPath/${binding.name}/${action.name}") ~> Route.seal(routes(auser)) ~> check {
-                status should be(OK)
-                val response = responseAs[WhiskAction]
-                response should be(action inherit (provider.parameters ++ binding.parameters))
-            }
-        }
-    }
-
-    // NOTE: does not work because entitlement model does not allow for an explicit
-    // check on either one or both of the binding and package
-    ignore should "get action in package binding with explicit entitlement grant" in {
-        implicit val tid = transid()
-        val auser = WhiskAuthHelpers.newIdentity()
-        val provider = WhiskPackage(namespace, aname, None, Parameters("p", "P"), publish = false)
-        val binding = WhiskPackage(EntityPath(auser.subject.asString), aname, provider.bind, Parameters("b", "B"))
-        val action = WhiskAction(provider.fullPath, aname, jsDefault("??"), Parameters("a", "A"))
-        put(entityStore, provider)
-        put(entityStore, binding)
-        put(entityStore, action)
-        val pkgaccess = Resource(provider.namespace, PACKAGES, Some(provider.name.asString))
-        Await.result(entitlementProvider.grant(auser.subject, READ, pkgaccess), 1 second)
-        Get(s"$collectionPath/${binding.name}/${action.name}") ~> Route.seal(routes(auser)) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskAction]
-            response should be(action inherit (provider.parameters ++ binding.parameters))
-        }
-    }
-
-    it should "reject get action in package that does not exist" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname)
-        val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
-        put(entityStore, action)
-        Get(s"$collectionPath/${provider.name}/${action.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(NotFound)
-        }
-    }
-
-    it should "reject get non-existent action in package" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname)
-        val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
-        put(entityStore, provider)
-        Get(s"$collectionPath/${provider.name}/${action.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(NotFound)
-        }
-    }
-
-    it should "reject get action in package binding that does not exist" in {
-        implicit val tid = transid()
-        val name = aname
-        val auser = WhiskAuthHelpers.newIdentity()
-        val provider = WhiskPackage(namespace, aname, None, Parameters("p", "P"), publish = true)
-        val binding = WhiskPackage(EntityPath(auser.subject.asString), aname, provider.bind, Parameters("b", "B"))
-        val action = WhiskAction(provider.fullPath, aname, jsDefault("??"), Parameters("a", "A"))
-        put(entityStore, provider)
-        put(entityStore, action)
-        Get(s"$collectionPath/${binding.name}/${action.name}") ~> Route.seal(routes(auser)) ~> check {
-            status should be(NotFound)
-        }
-    }
-
-    it should "reject get action in package binding with package that does not exist" in {
-        implicit val tid = transid()
-        val name = aname
-        val auser = WhiskAuthHelpers.newIdentity()
-        val provider = WhiskPackage(namespace, aname, None, Parameters("p", "P"), publish = true)
-        val binding = WhiskPackage(EntityPath(auser.subject.asString), aname, provider.bind, Parameters("b", "B"))
-        val action = WhiskAction(provider.fullPath, aname, jsDefault("??"), Parameters("a", "A"))
-        put(entityStore, binding)
-        put(entityStore, action)
-        Get(s"$collectionPath/${binding.name}/${action.name}") ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden) // do not leak that package does not exist
-        }
-    }
-
-    it should "reject get non-existing action in package binding" in {
-        implicit val tid = transid()
-        val name = aname
-        val auser = WhiskAuthHelpers.newIdentity()
-        val provider = WhiskPackage(namespace, aname, None, Parameters("p", "P"), publish = true)
-        val binding = WhiskPackage(EntityPath(auser.subject.asString), aname, provider.bind, Parameters("b", "B"))
-        val action = WhiskAction(provider.fullPath, aname, jsDefault("??"), Parameters("a", "A"))
-        put(entityStore, provider)
-        put(entityStore, binding)
-        Get(s"$collectionPath/${binding.name}/${action.name}") ~> Route.seal(routes(auser)) ~> check {
-            status should be(NotFound)
-        }
-    }
-
-    it should "reject get action in package binding with private package" in {
-        implicit val tid = transid()
-        val auser = WhiskAuthHelpers.newIdentity()
-        val provider = WhiskPackage(namespace, aname, None, Parameters("p", "P"), publish = false)
-        val binding = WhiskPackage(EntityPath(auser.subject.asString), aname, provider.bind, Parameters("b", "B"))
-        val action = WhiskAction(provider.fullPath, aname, jsDefault("??"), Parameters("a", "A"))
-        put(entityStore, provider)
-        put(entityStore, binding)
-        put(entityStore, action)
-        Get(s"$collectionPath/${binding.name}/${action.name}") ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden)
-        }
-    }
-
-    //// POST /actions/name
-    it should "allow owner to invoke an action in package" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname)
-        val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
-        val content = JsObject("xxx" -> "yyy".toJson)
-        put(entityStore, provider)
-        put(entityStore, action)
-        Post(s"$collectionPath/${provider.name}/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(Accepted)
-            val response = responseAs[JsObject]
-            response.fields("activationId") should not be None
-        }
-    }
-
-    it should "allow non-owner to invoke an action in public package" in {
-        implicit val tid = transid()
-        val auser = WhiskAuthHelpers.newIdentity()
-        val provider = WhiskPackage(namespace, aname, publish = true)
-        val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
-        val content = JsObject("xxx" -> "yyy".toJson)
-        put(entityStore, provider)
-        put(entityStore, action)
-        Post(s"/$namespace/${collection.path}/${provider.name}/${action.name}", content) ~> Route.seal(routes(auser)) ~> check {
-            status should be(Accepted)
-            val response = responseAs[JsObject]
-            response.fields("activationId") should not be None
-        }
-    }
-
-    it should "invoke action in package binding with public package" in {
-        implicit val tid = transid()
-        val auser = WhiskAuthHelpers.newIdentity()
-        val provider = WhiskPackage(namespace, aname, publish = true)
-        val reference = WhiskPackage(EntityPath(auser.subject.asString), aname, provider.bind)
-        val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
-        val content = JsObject("x" -> "x".toJson, "z" -> "Z".toJson)
-        put(entityStore, provider)
-        put(entityStore, reference)
-        put(entityStore, action)
-        Post(s"$collectionPath/${reference.name}/${action.name}", content) ~> Route.seal(routes(auser)) ~> check {
-            status should be(Accepted)
-            val response = responseAs[JsObject]
-            response.fields("activationId") should not be None
-        }
-    }
-
-    // NOTE: does not work because entitlement model does not allow for an explicit
-    // check on either one or both of the binding and package
-    ignore should "invoke action in package binding with explicit entitlement grant even if package is not public" in {
-        implicit val tid = transid()
-        val auser = WhiskAuthHelpers.newIdentity()
-        val provider = WhiskPackage(namespace, aname, publish = false)
-        val reference = WhiskPackage(EntityPath(auser.subject.asString), aname, provider.bind)
-        val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
-        val content = JsObject("x" -> "x".toJson, "z" -> "Z".toJson)
-        put(entityStore, provider)
-        put(entityStore, reference)
-        put(entityStore, action)
-        val pkgaccess = Resource(provider.namespace, PACKAGES, Some(provider.name.asString))
-        Await.result(entitlementProvider.grant(auser.subject, ACTIVATE, pkgaccess), 1 second)
-        Post(s"$collectionPath/${reference.name}/${action.name}", content) ~> Route.seal(routes(auser)) ~> check {
-            status should be(Accepted)
-            val response = responseAs[JsObject]
-            response.fields("activationId") should not be None
-        }
-    }
-
-    it should "reject non-owner invoking an action in private package" in {
-        implicit val tid = transid()
-        val auser = WhiskAuthHelpers.newIdentity()
-        val provider = WhiskPackage(namespace, aname, publish = false)
-        val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
-        val content = JsObject("xxx" -> "yyy".toJson)
-        put(entityStore, provider)
-        put(entityStore, action)
-        Post(s"/$namespace/${collection.path}/${provider.name}/${action.name}", content) ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden)
-        }
-    }
-
-    it should "reject invoking an action in package that does not exist" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname, publish = false)
-        val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
-        val content = JsObject("xxx" -> "yyy".toJson)
-        put(entityStore, action)
-        Post(s"$collectionPath/${provider.name}/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(NotFound)
-        }
-    }
-
-    it should "reject invoking a non-existent action in package" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname, publish = false)
-        val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
-        val content = JsObject("xxx" -> "yyy".toJson)
-        put(entityStore, action)
-        Post(s"$collectionPath/${provider.name}/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(NotFound)
-        }
-    }
-
-    it should "reject invoke action in package binding with private package" in {
-        implicit val tid = transid()
-        val auser = WhiskAuthHelpers.newIdentity()
-        val provider = WhiskPackage(namespace, aname, publish = false)
-        val reference = WhiskPackage(EntityPath(auser.subject.asString), aname, provider.bind)
-        val action = WhiskAction(provider.fullPath, aname, jsDefault("??"))
-        val content = JsObject("x" -> "x".toJson, "z" -> "Z".toJson)
-        put(entityStore, provider)
-        put(entityStore, reference)
-        put(entityStore, action)
-        Post(s"$collectionPath/${reference.name}/${action.name}", content) ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden)
-        }
-    }
-
-    it should "report proper error when provider record is corrupted on delete" in {
-        implicit val tid = transid()
-        val provider = BadEntity(namespace, aname)
-        val entity = BadEntity(provider.namespace.addPath(provider.name), aname)
-        put(entityStore, provider)
-        put(entityStore, entity)
-
-        Delete(s"$collectionPath/${provider.name}/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
-            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-        }
-    }
-
-    it should "report proper error when record is corrupted on delete" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname)
-        val entity = BadEntity(provider.fullPath, aname)
-        put(entityStore, provider, false)
-        put(entityStore, entity, false)
-
-        Delete(s"$collectionPath/${provider.name}/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(InternalServerError)
-            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-        }
-    }
-
-    it should "report proper error when provider record is corrupted on get" in {
-        implicit val tid = transid()
-        val provider = BadEntity(namespace, aname)
-        val entity = BadEntity(provider.namespace.addPath(provider.name), aname)
-        put(entityStore, provider)
-        put(entityStore, entity)
-
-        Get(s"$collectionPath/${provider.name}/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(InternalServerError)
-            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-        }
-
-        val auser = WhiskAuthHelpers.newIdentity()
-        Get(s"/${provider.namespace}/${collection.path}/${provider.name}/${entity.name}") ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden)
-            responseAs[ErrorResponse].error shouldBe Messages.notAuthorizedtoOperateOnResource
-        }
-    }
-
-    it should "report proper error when record is corrupted on get" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname)
-        val entity = BadEntity(provider.fullPath, aname)
-        put(entityStore, provider)
-        put(entityStore, entity)
-
-        Get(s"$collectionPath/${provider.name}/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(InternalServerError)
-            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-        }
-    }
-
-    it should "report proper error when provider record is corrupted on put" in {
-        implicit val tid = transid()
-        val provider = BadEntity(namespace, aname)
-        val entity = BadEntity(provider.namespace.addPath(provider.name), aname)
-        put(entityStore, provider)
-        put(entityStore, entity)
-
-        val content = WhiskActionPut()
-        Put(s"$collectionPath/${provider.name}/${entity.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(InternalServerError)
-            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-        }
-    }
-
-    it should "report proper error when record is corrupted on put" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname)
-        val entity = BadEntity(provider.fullPath, aname)
-        put(entityStore, provider)
-        put(entityStore, entity)
-
-        val content = WhiskActionPut()
-        Put(s"$collectionPath/${provider.name}/${entity.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(InternalServerError)
-            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-        }
-    }
+  }
 }

--- a/tests/src/test/scala/whisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/PackagesApiTests.scala
@@ -49,655 +49,693 @@ import whisk.http.Messages
 @RunWith(classOf[JUnitRunner])
 class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
 
-    /** Packages API tests */
-    behavior of "Packages API"
+  /** Packages API tests */
+  behavior of "Packages API"
 
-    val creds = WhiskAuthHelpers.newIdentity()
-    val namespace = EntityPath(creds.subject.asString)
-    val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
-    def aname() = MakeName.next("packages_tests")
-    val parametersLimit = Parameters.sizeLimit
+  val creds = WhiskAuthHelpers.newIdentity()
+  val namespace = EntityPath(creds.subject.asString)
+  val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
+  def aname() = MakeName.next("packages_tests")
+  val parametersLimit = Parameters.sizeLimit
 
-    private def bindingAnnotation(binding: Binding) = {
-        Parameters(WhiskPackage.bindingFieldName, Binding.serdes.write(binding))
-    }
+  private def bindingAnnotation(binding: Binding) = {
+    Parameters(WhiskPackage.bindingFieldName, Binding.serdes.write(binding))
+  }
 
-    //// GET /packages
-    it should "list all packages/references" in {
-        implicit val tid = transid()
-        // create packages and package bindings, and confirm API lists all of them
-        val providers = (1 to 4).map { i =>
-            if (i % 2 == 0) {
-                WhiskPackage(namespace, aname(), None)
-            } else {
-                val binding = Some(Binding(namespace.root, aname()))
-                WhiskPackage(namespace, aname(), binding)
-            }
-        }.toList
-        providers foreach { put(entityStore, _) }
-        waitOnView(entityStore, WhiskPackage, namespace, providers.length)
-        whisk.utils.retry {
-            Get(s"$collectionPath") ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                val response = responseAs[List[JsObject]]
-                providers.length should be(response.length)
-                providers forall { p => response contains p.summaryAsJson } should be(true)
-            }
-        }
-
-        val auser = WhiskAuthHelpers.newIdentity()
-        Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(auser)) ~> check {
-            val response = responseAs[List[JsObject]]
-            response should be(List()) // cannot list packages that are private in another namespace
-        }
-    }
-
-    it should "list all public packages in explicit namespace excluding bindings" in {
-        implicit val tid = transid()
-        // create packages and package bindings, set some public and confirm API lists only public packages
-        val namespaces = Seq(namespace, EntityPath(aname().toString), EntityPath(aname().toString))
-        val providers = Seq(
-            WhiskPackage(namespaces(0), aname(), None, publish = true),
-            WhiskPackage(namespaces(1), aname(), None, publish = true),
-            WhiskPackage(namespaces(2), aname(), None, publish = true))
-        val references = Seq(
-            WhiskPackage(namespaces(0), aname(), providers(0).bind, publish = true),
-            WhiskPackage(namespaces(0), aname(), providers(0).bind, publish = false),
-            WhiskPackage(namespaces(0), aname(), providers(1).bind, publish = true),
-            WhiskPackage(namespaces(0), aname(), providers(1).bind, publish = false))
-        (providers ++ references) foreach { put(entityStore, _) }
-        waitOnView(entityStore, WhiskPackage, namespaces(1), 1)
-        waitOnView(entityStore, WhiskPackage, namespaces(2), 1)
-        waitOnView(entityStore, WhiskPackage, namespaces(0), 1 + 4)
-        Get(s"$collectionPath") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[List[JsObject]]
-            val expected = providers.filter { _.namespace == namespace } ++ references
-            response.length should be >= (expected.length)
-            expected forall { p => (response contains p.summaryAsJson) } should be(true)
-        }
-
-        val auser = WhiskAuthHelpers.newIdentity()
-        Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(auser)) ~> check {
-            status should be(OK)
-            val response = responseAs[List[JsObject]]
-            val expected = providers.filter {
-                p => p.namespace == namespace && p.publish
-            } ++ references.filter {
-                p => p.publish && p.binding == None
-            }
-            response.length should be >= (expected.length)
-            expected forall { p => (response contains p.summaryAsJson) } should be(true)
-        }
-    }
-
-    ignore should "list all public packages excluding bindings" in {
-        implicit val tid = transid()
-        // create packages and package bindings, set some public and confirm API lists only public packages
-        val namespaces = Seq(namespace, EntityPath(aname().toString), EntityPath(aname().toString))
-        val providers = Seq(
-            WhiskPackage(namespaces(0), aname(), None, publish = false),
-            WhiskPackage(namespaces(1), aname(), None, publish = true),
-            WhiskPackage(namespaces(2), aname(), None, publish = true))
-        val references = Seq(
-            WhiskPackage(namespaces(0), aname(), providers(0).bind, publish = true),
-            WhiskPackage(namespaces(0), aname(), providers(0).bind, publish = false),
-            WhiskPackage(namespaces(0), aname(), providers(1).bind, publish = true),
-            WhiskPackage(namespaces(0), aname(), providers(1).bind, publish = false))
-        (providers ++ references) foreach { put(entityStore, _) }
-        waitOnView(entityStore, WhiskPackage, namespaces(1), 1)
-        waitOnView(entityStore, WhiskPackage, namespaces(2), 1)
-        waitOnView(entityStore, WhiskPackage, namespaces(0), 1 + 4)
-        Get(s"$collectionPath?public=true") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[List[JsObject]]
-            val expected = providers filter { _.publish }
-            response.length should be >= (expected.length)
-            expected forall { p => (response contains p.summaryAsJson) && p.binding == None } should be(true)
-        }
-    }
-
-    // ?public disabled
-    ignore should "list all public packages including ones with same name but in different namespaces" in {
-        implicit val tid = transid()
-        // create packages and package bindings, set some public and confirm API lists only public packages
-        val namespaces = Seq(namespace, EntityPath(aname().toString), EntityPath(aname().toString))
-        val pkgname = aname()
-        val providers = Seq(
-            WhiskPackage(namespaces(0), pkgname, None, publish = false),
-            WhiskPackage(namespaces(1), pkgname, None, publish = true),
-            WhiskPackage(namespaces(2), pkgname, None, publish = true))
-        providers foreach { put(entityStore, _) }
-        waitOnView(entityStore, WhiskPackage, namespaces(0), 1)
-        waitOnView(entityStore, WhiskPackage, namespaces(1), 1)
-        waitOnView(entityStore, WhiskPackage, namespaces(2), 1)
-        Get(s"$collectionPath?public=true") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[List[JsObject]]
-            val expected = providers filter { _.publish }
-            response.length should be >= (expected.length)
-            expected forall { p => (response contains p.summaryAsJson) && p.binding == None } should be(true)
-        }
-    }
-
-    // confirm ?public disabled
-    it should "ignore ?public on list all packages" in {
-        implicit val tid = transid()
-        Get(s"$collectionPath?public=true") ~> Route.seal(routes(creds)) ~> check {
-            implicit val tid = transid()
-            // create packages and package bindings, set some public and confirm API lists only public packages
-            val namespaces = Seq(namespace, EntityPath(aname().toString), EntityPath(aname().toString))
-            val pkgname = aname()
-            val providers = Seq(
-                WhiskPackage(namespaces(0), pkgname, None, publish = true),
-                WhiskPackage(namespaces(1), pkgname, None, publish = true),
-                WhiskPackage(namespaces(2), pkgname, None, publish = true))
-            providers foreach { put(entityStore, _) }
-            waitOnView(entityStore, WhiskPackage, namespaces(0), 1)
-            waitOnView(entityStore, WhiskPackage, namespaces(1), 1)
-            waitOnView(entityStore, WhiskPackage, namespaces(2), 1)
-            Get(s"$collectionPath?public=true") ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                val response = responseAs[List[JsObject]]
-                val expected = providers filter { _.namespace == creds.namespace.toPath }
-                response.length should be >= (expected.length)
-                expected forall { p => (response contains p.summaryAsJson) && p.binding == None } should be(true)
-            }
-        }
-    }
-
-    // ?public disabled
-    ignore should "reject list all public packages with invalid parameters" in {
-        implicit val tid = transid()
-        Get(s"$collectionPath?public=true&docs=true") ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-        }
-    }
-
-    //// GET /packages/name
-    it should "get package" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname(), None)
-        put(entityStore, provider)
-        Get(s"$collectionPath/${provider.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskPackageWithActions]
-            response should be(provider withActions ())
-        }
-
-        Get(s"$collectionPath/${provider.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskPackageWithActions]
-            response should be(provider withActions ())
-        }
-    }
-
-    it should "get package reference for private package in same namespace" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname(), None, Parameters("a", "A") ++ Parameters("b", "B"))
-        val reference = WhiskPackage(namespace, aname(), provider.bind, Parameters("b", "b") ++ Parameters("c", "C"))
-        put(entityStore, provider)
-        put(entityStore, reference)
-        Get(s"$collectionPath/${reference.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskPackageWithActions]
-            response should be(reference inherit provider.parameters withActions ())
-            // this is redundant in case the precedence orders on inherit are changed incorrectly
-            response.wp.parameters should be(Parameters("a", "A") ++ Parameters("b", "b") ++ Parameters("c", "C"))
-        }
-    }
-
-    it should "not get package reference for a private package in other namespace" in {
-        implicit val tid = transid()
-        val privateCreds = WhiskAuthHelpers.newIdentity()
-        val privateNamespace = EntityPath(privateCreds.subject.asString)
-
-        val provider = WhiskPackage(privateNamespace, aname())
-        val reference = WhiskPackage(namespace, aname(), provider.bind)
-        put(entityStore, provider)
-        put(entityStore, reference)
-        Get(s"$collectionPath/${reference.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(Forbidden)
-        }
-    }
-
-    it should "get package with its actions and feeds" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname())
-        val action = WhiskAction(provider.namespace.addPath(provider.name), aname(), jsDefault("??"))
-        val feed = WhiskAction(provider.namespace.addPath(provider.name), aname(), jsDefault("??"), annotations = Parameters(Parameters.Feed, "true"))
-        put(entityStore, provider)
-        put(entityStore, action)
-        put(entityStore, feed)
-
-        // it should "reject get private package from other subject" in {
-        val auser = WhiskAuthHelpers.newIdentity()
-        Get(s"/$namespace/${collection.path}/${provider.name}") ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden)
-        }
-
-        Get(s"$collectionPath/${provider.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskPackageWithActions]
-            response should be(provider withActions (List(action, feed)))
-        }
-    }
-
-    it should "get package reference with its actions and feeds" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname())
-        val reference = WhiskPackage(namespace, aname(), provider.bind)
-        val action = WhiskAction(provider.namespace.addPath(provider.name), aname(), jsDefault("??"))
-        val feed = WhiskAction(provider.namespace.addPath(provider.name), aname(), jsDefault("??"), annotations = Parameters(Parameters.Feed, "true"))
-        put(entityStore, provider)
-        put(entityStore, reference)
-        put(entityStore, action)
-        put(entityStore, feed)
-
-        // it should "reject get package reference from other subject" in {
-        val auser = WhiskAuthHelpers.newIdentity()
-        Get(s"/$namespace/${collection.path}/${reference.name}") ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden)
-        }
-
-        Get(s"$collectionPath/${reference.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskPackageWithActions]
-            response should be(reference withActions (List(action, feed)))
-        }
-    }
-
-    it should "not get package reference with its actions and feeds from private package" in {
-        implicit val tid = transid()
-        val privateCreds = WhiskAuthHelpers.newIdentity()
-        val privateNamespace = EntityPath(privateCreds.subject.asString)
-        val provider = WhiskPackage(privateNamespace, aname())
-        val reference = WhiskPackage(namespace, aname(), provider.bind)
-        val action = WhiskAction(provider.namespace.addPath(provider.name), aname(), jsDefault("??"))
-        val feed = WhiskAction(provider.namespace.addPath(provider.name), aname(), jsDefault("??"), annotations = Parameters(Parameters.Feed, "true"))
-        put(entityStore, provider)
-        put(entityStore, reference)
-        put(entityStore, action)
-        put(entityStore, feed)
-
-        // it should "reject get package reference from other subject" in {
-        val auser = WhiskAuthHelpers.newIdentity()
-        Get(s"/$namespace/${collection.path}/${reference.name}") ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden)
-        }
-
-        Get(s"$collectionPath/${reference.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(Forbidden)
-        }
-    }
-
-    //// PUT /packages/name
-    it should "create package" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname(), None, annotations = Parameters("a", "b"))
-        // binding annotation should be removed
-        val someBindingAnnotation = Parameters(WhiskPackage.bindingFieldName, "???")
-        val content = WhiskPackagePut(annotations = Some(someBindingAnnotation ++ Parameters("a", "b")))
-        Put(s"$collectionPath/${provider.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            deletePackage(provider.docid)
-            status should be(OK)
-            val response = responseAs[WhiskPackage]
-            response should be(provider)
-        }
-    }
-
-    it should "create package reference with explicit namespace" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname())
-        val reference = WhiskPackage(namespace, aname(), provider.bind, annotations = bindingAnnotation(provider.bind.get) ++ Parameters("a", "b"))
-        // binding annotation should be removed and set by controller
-        val someBindingAnnotation = Parameters(WhiskPackage.bindingFieldName, "???")
-        val content = WhiskPackagePut(reference.binding, annotations = Some(someBindingAnnotation ++ Parameters("a", "b")))
-        put(entityStore, provider)
-
-        // it should "reject create package reference in some other namespace" in {
-        val auser = WhiskAuthHelpers.newIdentity()
-        Put(s"/$namespace/${collection.path}/${reference.name}", content) ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden)
-        }
-
-        Put(s"/$namespace/${collection.path}/${reference.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            deletePackage(reference.docid)
-            status should be(OK)
-            val response = responseAs[WhiskPackage]
-            response should be(reference)
-        }
-    }
-
-    it should "not create package reference from private package in another namespace" in {
-        implicit val tid = transid()
-        val privateCreds = WhiskAuthHelpers.newIdentity()
-        val privateNamespace = EntityPath(privateCreds.subject.asString)
-
-        val provider = WhiskPackage(privateNamespace, aname())
-        val reference = WhiskPackage(namespace, aname(), provider.bind)
-        // binding annotation should be removed and set by controller
-        val content = WhiskPackagePut(reference.binding)
-        put(entityStore, provider)
-
-        Put(s"/$namespace/${collection.path}/${reference.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(Forbidden)
-        }
-    }
-
-    it should "create package reference with implicit namespace" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname())
-        val reference = WhiskPackage(namespace, aname(), Some(Binding(EntityPath.DEFAULT.root, provider.name)))
-        val content = WhiskPackagePut(reference.binding)
-        put(entityStore, provider)
-        Put(s"$collectionPath/${reference.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            deletePackage(reference.docid)
-            status should be(OK)
-            val response = responseAs[WhiskPackage]
-            response should be {
-                WhiskPackage(reference.namespace, reference.name, provider.bind,
-                    annotations = bindingAnnotation(provider.bind.get))
-            }
-        }
-    }
-
-    it should "reject create package reference when referencing non-existent package in same namespace" in {
-        implicit val tid = transid()
+  //// GET /packages
+  it should "list all packages/references" in {
+    implicit val tid = transid()
+    // create packages and package bindings, and confirm API lists all of them
+    val providers = (1 to 4).map { i =>
+      if (i % 2 == 0) {
+        WhiskPackage(namespace, aname(), None)
+      } else {
         val binding = Some(Binding(namespace.root, aname()))
-        val content = WhiskPackagePut(binding)
-        Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[ErrorResponse].error should include(Messages.bindingDoesNotExist)
-        }
+        WhiskPackage(namespace, aname(), binding)
+      }
+    }.toList
+    providers foreach { put(entityStore, _) }
+    waitOnView(entityStore, WhiskPackage, namespace, providers.length)
+    whisk.utils.retry {
+      Get(s"$collectionPath") ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[List[JsObject]]
+        providers.length should be(response.length)
+        providers forall { p =>
+          response contains p.summaryAsJson
+        } should be(true)
+      }
     }
 
-    it should "reject create package reference when referencing non-existent package in another namespace" in {
-        implicit val tid = transid()
-        val privateCreds = WhiskAuthHelpers.newIdentity()
-        val privateNamespace = EntityPath(privateCreds.subject.asString)
+    val auser = WhiskAuthHelpers.newIdentity()
+    Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(auser)) ~> check {
+      val response = responseAs[List[JsObject]]
+      response should be(List()) // cannot list packages that are private in another namespace
+    }
+  }
 
-        val binding = Some(Binding(privateNamespace.root, aname()))
-        val content = WhiskPackagePut(binding)
-        Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(Forbidden)
-        }
+  it should "list all public packages in explicit namespace excluding bindings" in {
+    implicit val tid = transid()
+    // create packages and package bindings, set some public and confirm API lists only public packages
+    val namespaces = Seq(namespace, EntityPath(aname().toString), EntityPath(aname().toString))
+    val providers = Seq(
+      WhiskPackage(namespaces(0), aname(), None, publish = true),
+      WhiskPackage(namespaces(1), aname(), None, publish = true),
+      WhiskPackage(namespaces(2), aname(), None, publish = true))
+    val references = Seq(
+      WhiskPackage(namespaces(0), aname(), providers(0).bind, publish = true),
+      WhiskPackage(namespaces(0), aname(), providers(0).bind, publish = false),
+      WhiskPackage(namespaces(0), aname(), providers(1).bind, publish = true),
+      WhiskPackage(namespaces(0), aname(), providers(1).bind, publish = false))
+    (providers ++ references) foreach { put(entityStore, _) }
+    waitOnView(entityStore, WhiskPackage, namespaces(1), 1)
+    waitOnView(entityStore, WhiskPackage, namespaces(2), 1)
+    waitOnView(entityStore, WhiskPackage, namespaces(0), 1 + 4)
+    Get(s"$collectionPath") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[List[JsObject]]
+      val expected = providers.filter { _.namespace == namespace } ++ references
+      response.length should be >= (expected.length)
+      expected forall { p =>
+        (response contains p.summaryAsJson)
+      } should be(true)
     }
 
-    it should "reject create package reference when referencing a non-package" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname())
-        val reference = WhiskPackage(namespace, aname(), provider.bind)
-        val content = WhiskPackagePut(Some(Binding(reference.namespace.root, reference.name)))
-        put(entityStore, provider)
-        put(entityStore, reference)
-        Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[ErrorResponse].error should include(Messages.bindingCannotReferenceBinding)
-        }
+    val auser = WhiskAuthHelpers.newIdentity()
+    Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(auser)) ~> check {
+      status should be(OK)
+      val response = responseAs[List[JsObject]]
+      val expected = providers.filter { p =>
+        p.namespace == namespace && p.publish
+      } ++ references.filter { p =>
+        p.publish && p.binding == None
+      }
+      response.length should be >= (expected.length)
+      expected forall { p =>
+        (response contains p.summaryAsJson)
+      } should be(true)
+    }
+  }
+
+  ignore should "list all public packages excluding bindings" in {
+    implicit val tid = transid()
+    // create packages and package bindings, set some public and confirm API lists only public packages
+    val namespaces = Seq(namespace, EntityPath(aname().toString), EntityPath(aname().toString))
+    val providers = Seq(
+      WhiskPackage(namespaces(0), aname(), None, publish = false),
+      WhiskPackage(namespaces(1), aname(), None, publish = true),
+      WhiskPackage(namespaces(2), aname(), None, publish = true))
+    val references = Seq(
+      WhiskPackage(namespaces(0), aname(), providers(0).bind, publish = true),
+      WhiskPackage(namespaces(0), aname(), providers(0).bind, publish = false),
+      WhiskPackage(namespaces(0), aname(), providers(1).bind, publish = true),
+      WhiskPackage(namespaces(0), aname(), providers(1).bind, publish = false))
+    (providers ++ references) foreach { put(entityStore, _) }
+    waitOnView(entityStore, WhiskPackage, namespaces(1), 1)
+    waitOnView(entityStore, WhiskPackage, namespaces(2), 1)
+    waitOnView(entityStore, WhiskPackage, namespaces(0), 1 + 4)
+    Get(s"$collectionPath?public=true") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[List[JsObject]]
+      val expected = providers filter { _.publish }
+      response.length should be >= (expected.length)
+      expected forall { p =>
+        (response contains p.summaryAsJson) && p.binding == None
+      } should be(true)
+    }
+  }
+
+  // ?public disabled
+  ignore should "list all public packages including ones with same name but in different namespaces" in {
+    implicit val tid = transid()
+    // create packages and package bindings, set some public and confirm API lists only public packages
+    val namespaces = Seq(namespace, EntityPath(aname().toString), EntityPath(aname().toString))
+    val pkgname = aname()
+    val providers = Seq(
+      WhiskPackage(namespaces(0), pkgname, None, publish = false),
+      WhiskPackage(namespaces(1), pkgname, None, publish = true),
+      WhiskPackage(namespaces(2), pkgname, None, publish = true))
+    providers foreach { put(entityStore, _) }
+    waitOnView(entityStore, WhiskPackage, namespaces(0), 1)
+    waitOnView(entityStore, WhiskPackage, namespaces(1), 1)
+    waitOnView(entityStore, WhiskPackage, namespaces(2), 1)
+    Get(s"$collectionPath?public=true") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[List[JsObject]]
+      val expected = providers filter { _.publish }
+      response.length should be >= (expected.length)
+      expected forall { p =>
+        (response contains p.summaryAsJson) && p.binding == None
+      } should be(true)
+    }
+  }
+
+  // confirm ?public disabled
+  it should "ignore ?public on list all packages" in {
+    implicit val tid = transid()
+    Get(s"$collectionPath?public=true") ~> Route.seal(routes(creds)) ~> check {
+      implicit val tid = transid()
+      // create packages and package bindings, set some public and confirm API lists only public packages
+      val namespaces = Seq(namespace, EntityPath(aname().toString), EntityPath(aname().toString))
+      val pkgname = aname()
+      val providers = Seq(
+        WhiskPackage(namespaces(0), pkgname, None, publish = true),
+        WhiskPackage(namespaces(1), pkgname, None, publish = true),
+        WhiskPackage(namespaces(2), pkgname, None, publish = true))
+      providers foreach { put(entityStore, _) }
+      waitOnView(entityStore, WhiskPackage, namespaces(0), 1)
+      waitOnView(entityStore, WhiskPackage, namespaces(1), 1)
+      waitOnView(entityStore, WhiskPackage, namespaces(2), 1)
+      Get(s"$collectionPath?public=true") ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[List[JsObject]]
+        val expected = providers filter { _.namespace == creds.namespace.toPath }
+        response.length should be >= (expected.length)
+        expected forall { p =>
+          (response contains p.summaryAsJson) && p.binding == None
+        } should be(true)
+      }
+    }
+  }
+
+  // ?public disabled
+  ignore should "reject list all public packages with invalid parameters" in {
+    implicit val tid = transid()
+    Get(s"$collectionPath?public=true&docs=true") ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+    }
+  }
+
+  //// GET /packages/name
+  it should "get package" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname(), None)
+    put(entityStore, provider)
+    Get(s"$collectionPath/${provider.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskPackageWithActions]
+      response should be(provider withActions ())
     }
 
-    it should "reject create package reference when annotations are too big" in {
-        implicit val tid = transid()
-        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
-        val annotations = keys map { key =>
-            Parameters(key.toString, "a" * 10)
-        } reduce (_ ++ _)
-        val content = s"""{"annotations":$annotations}""".parseJson.asJsObject
-        Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(RequestEntityTooLarge)
-            responseAs[String] should include {
-                Messages.entityTooBig(SizeError(WhiskEntity.annotationsFieldName, annotations.size, Parameters.sizeLimit))
-            }
-        }
+    Get(s"$collectionPath/${provider.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskPackageWithActions]
+      response should be(provider withActions ())
+    }
+  }
+
+  it should "get package reference for private package in same namespace" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname(), None, Parameters("a", "A") ++ Parameters("b", "B"))
+    val reference = WhiskPackage(namespace, aname(), provider.bind, Parameters("b", "b") ++ Parameters("c", "C"))
+    put(entityStore, provider)
+    put(entityStore, reference)
+    Get(s"$collectionPath/${reference.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskPackageWithActions]
+      response should be(reference inherit provider.parameters withActions ())
+      // this is redundant in case the precedence orders on inherit are changed incorrectly
+      response.wp.parameters should be(Parameters("a", "A") ++ Parameters("b", "b") ++ Parameters("c", "C"))
+    }
+  }
+
+  it should "not get package reference for a private package in other namespace" in {
+    implicit val tid = transid()
+    val privateCreds = WhiskAuthHelpers.newIdentity()
+    val privateNamespace = EntityPath(privateCreds.subject.asString)
+
+    val provider = WhiskPackage(privateNamespace, aname())
+    val reference = WhiskPackage(namespace, aname(), provider.bind)
+    put(entityStore, provider)
+    put(entityStore, reference)
+    Get(s"$collectionPath/${reference.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(Forbidden)
+    }
+  }
+
+  it should "get package with its actions and feeds" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname())
+    val action = WhiskAction(provider.namespace.addPath(provider.name), aname(), jsDefault("??"))
+    val feed = WhiskAction(
+      provider.namespace.addPath(provider.name),
+      aname(),
+      jsDefault("??"),
+      annotations = Parameters(Parameters.Feed, "true"))
+    put(entityStore, provider)
+    put(entityStore, action)
+    put(entityStore, feed)
+
+    // it should "reject get private package from other subject" in {
+    val auser = WhiskAuthHelpers.newIdentity()
+    Get(s"/$namespace/${collection.path}/${provider.name}") ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden)
     }
 
-    it should "reject create package reference when parameters are too big" in {
-        implicit val tid = transid()
-        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
-        val parameters = keys map { key =>
-            Parameters(key.toString, "a" * 10)
-        } reduce (_ ++ _)
-        val content = s"""{"parameters":$parameters}""".parseJson.asJsObject
-        Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(RequestEntityTooLarge)
-            responseAs[String] should include {
-                Messages.entityTooBig(SizeError(WhiskEntity.paramsFieldName, parameters.size, Parameters.sizeLimit))
-            }
-        }
+    Get(s"$collectionPath/${provider.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskPackageWithActions]
+      response should be(provider withActions (List(action, feed)))
+    }
+  }
+
+  it should "get package reference with its actions and feeds" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname())
+    val reference = WhiskPackage(namespace, aname(), provider.bind)
+    val action = WhiskAction(provider.namespace.addPath(provider.name), aname(), jsDefault("??"))
+    val feed = WhiskAction(
+      provider.namespace.addPath(provider.name),
+      aname(),
+      jsDefault("??"),
+      annotations = Parameters(Parameters.Feed, "true"))
+    put(entityStore, provider)
+    put(entityStore, reference)
+    put(entityStore, action)
+    put(entityStore, feed)
+
+    // it should "reject get package reference from other subject" in {
+    val auser = WhiskAuthHelpers.newIdentity()
+    Get(s"/$namespace/${collection.path}/${reference.name}") ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden)
     }
 
-    it should "reject update package reference when parameters are too big" in {
-        implicit val tid = transid()
-        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
-        val parameters = keys map { key =>
-            Parameters(key.toString, "a" * 10)
-        } reduce (_ ++ _)
-        val provider = WhiskPackage(namespace, aname())
-        val content = s"""{"parameters":$parameters}""".parseJson.asJsObject
-        put(entityStore, provider)
-        Put(s"$collectionPath/${aname()}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(RequestEntityTooLarge)
-            responseAs[String] should include {
-                Messages.entityTooBig(SizeError(WhiskEntity.paramsFieldName, parameters.size, Parameters.sizeLimit))
-            }
-        }
+    Get(s"$collectionPath/${reference.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskPackageWithActions]
+      response should be(reference withActions (List(action, feed)))
+    }
+  }
+
+  it should "not get package reference with its actions and feeds from private package" in {
+    implicit val tid = transid()
+    val privateCreds = WhiskAuthHelpers.newIdentity()
+    val privateNamespace = EntityPath(privateCreds.subject.asString)
+    val provider = WhiskPackage(privateNamespace, aname())
+    val reference = WhiskPackage(namespace, aname(), provider.bind)
+    val action = WhiskAction(provider.namespace.addPath(provider.name), aname(), jsDefault("??"))
+    val feed = WhiskAction(
+      provider.namespace.addPath(provider.name),
+      aname(),
+      jsDefault("??"),
+      annotations = Parameters(Parameters.Feed, "true"))
+    put(entityStore, provider)
+    put(entityStore, reference)
+    put(entityStore, action)
+    put(entityStore, feed)
+
+    // it should "reject get package reference from other subject" in {
+    val auser = WhiskAuthHelpers.newIdentity()
+    Get(s"/$namespace/${collection.path}/${reference.name}") ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden)
     }
 
-    it should "update package" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname())
-        val content = WhiskPackagePut(publish = Some(true))
-        put(entityStore, provider)
+    Get(s"$collectionPath/${reference.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(Forbidden)
+    }
+  }
 
-        // it should "reject update package owned by different user" in {
-        val auser = WhiskAuthHelpers.newIdentity()
-        Put(s"/$namespace/${collection.path}/${provider.name}?overwrite=true", content) ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden)
-        }
+  //// PUT /packages/name
+  it should "create package" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname(), None, annotations = Parameters("a", "b"))
+    // binding annotation should be removed
+    val someBindingAnnotation = Parameters(WhiskPackage.bindingFieldName, "???")
+    val content = WhiskPackagePut(annotations = Some(someBindingAnnotation ++ Parameters("a", "b")))
+    Put(s"$collectionPath/${provider.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      deletePackage(provider.docid)
+      status should be(OK)
+      val response = responseAs[WhiskPackage]
+      response should be(provider)
+    }
+  }
 
-        Put(s"$collectionPath/${provider.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            deletePackage(provider.docid)
-            val response = responseAs[WhiskPackage]
-            response should be(WhiskPackage(namespace, provider.name, None, version = provider.version.upPatch, publish = true))
-        }
+  it should "create package reference with explicit namespace" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname())
+    val reference = WhiskPackage(
+      namespace,
+      aname(),
+      provider.bind,
+      annotations = bindingAnnotation(provider.bind.get) ++ Parameters("a", "b"))
+    // binding annotation should be removed and set by controller
+    val someBindingAnnotation = Parameters(WhiskPackage.bindingFieldName, "???")
+    val content = WhiskPackagePut(reference.binding, annotations = Some(someBindingAnnotation ++ Parameters("a", "b")))
+    put(entityStore, provider)
+
+    // it should "reject create package reference in some other namespace" in {
+    val auser = WhiskAuthHelpers.newIdentity()
+    Put(s"/$namespace/${collection.path}/${reference.name}", content) ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden)
     }
 
-    it should "update package reference" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname())
-        val reference = WhiskPackage(namespace, aname(), provider.bind, annotations = bindingAnnotation(provider.bind.get))
-        // create a bogus binding annotation which should be replaced by the PUT
-        val someBindingAnnotation = Some(Parameters(WhiskPackage.bindingFieldName, "???") ++ Parameters("a", "b"))
-        val content = WhiskPackagePut(publish = Some(true), annotations = someBindingAnnotation)
-        put(entityStore, provider)
-        put(entityStore, reference)
+    Put(s"/$namespace/${collection.path}/${reference.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      deletePackage(reference.docid)
+      status should be(OK)
+      val response = responseAs[WhiskPackage]
+      response should be(reference)
+    }
+  }
 
-        // it should "reject update package reference owned by different user"
-        val auser = WhiskAuthHelpers.newIdentity()
-        Put(s"/$namespace/${collection.path}/${reference.name}?overwrite=true", content) ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden)
-        }
+  it should "not create package reference from private package in another namespace" in {
+    implicit val tid = transid()
+    val privateCreds = WhiskAuthHelpers.newIdentity()
+    val privateNamespace = EntityPath(privateCreds.subject.asString)
 
-        Put(s"$collectionPath/${reference.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            deletePackage(reference.docid)
-            status should be(OK)
-            val response = responseAs[WhiskPackage]
-            response should be {
-                WhiskPackage(reference.namespace, reference.name, reference.binding,
-                    version = reference.version.upPatch,
-                    publish = true,
-                    annotations = reference.annotations ++ Parameters("a", "b"))
-            }
-        }
+    val provider = WhiskPackage(privateNamespace, aname())
+    val reference = WhiskPackage(namespace, aname(), provider.bind)
+    // binding annotation should be removed and set by controller
+    val content = WhiskPackagePut(reference.binding)
+    put(entityStore, provider)
+
+    Put(s"/$namespace/${collection.path}/${reference.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(Forbidden)
+    }
+  }
+
+  it should "create package reference with implicit namespace" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname())
+    val reference = WhiskPackage(namespace, aname(), Some(Binding(EntityPath.DEFAULT.root, provider.name)))
+    val content = WhiskPackagePut(reference.binding)
+    put(entityStore, provider)
+    Put(s"$collectionPath/${reference.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      deletePackage(reference.docid)
+      status should be(OK)
+      val response = responseAs[WhiskPackage]
+      response should be {
+        WhiskPackage(
+          reference.namespace,
+          reference.name,
+          provider.bind,
+          annotations = bindingAnnotation(provider.bind.get))
+      }
+    }
+  }
+
+  it should "reject create package reference when referencing non-existent package in same namespace" in {
+    implicit val tid = transid()
+    val binding = Some(Binding(namespace.root, aname()))
+    val content = WhiskPackagePut(binding)
+    Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[ErrorResponse].error should include(Messages.bindingDoesNotExist)
+    }
+  }
+
+  it should "reject create package reference when referencing non-existent package in another namespace" in {
+    implicit val tid = transid()
+    val privateCreds = WhiskAuthHelpers.newIdentity()
+    val privateNamespace = EntityPath(privateCreds.subject.asString)
+
+    val binding = Some(Binding(privateNamespace.root, aname()))
+    val content = WhiskPackagePut(binding)
+    Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(Forbidden)
+    }
+  }
+
+  it should "reject create package reference when referencing a non-package" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname())
+    val reference = WhiskPackage(namespace, aname(), provider.bind)
+    val content = WhiskPackagePut(Some(Binding(reference.namespace.root, reference.name)))
+    put(entityStore, provider)
+    put(entityStore, reference)
+    Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[ErrorResponse].error should include(Messages.bindingCannotReferenceBinding)
+    }
+  }
+
+  it should "reject create package reference when annotations are too big" in {
+    implicit val tid = transid()
+    val keys: List[Long] =
+      List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
+    val annotations = keys map { key =>
+      Parameters(key.toString, "a" * 10)
+    } reduce (_ ++ _)
+    val content = s"""{"annotations":$annotations}""".parseJson.asJsObject
+    Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(RequestEntityTooLarge)
+      responseAs[String] should include {
+        Messages.entityTooBig(SizeError(WhiskEntity.annotationsFieldName, annotations.size, Parameters.sizeLimit))
+      }
+    }
+  }
+
+  it should "reject create package reference when parameters are too big" in {
+    implicit val tid = transid()
+    val keys: List[Long] =
+      List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
+    val parameters = keys map { key =>
+      Parameters(key.toString, "a" * 10)
+    } reduce (_ ++ _)
+    val content = s"""{"parameters":$parameters}""".parseJson.asJsObject
+    Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(RequestEntityTooLarge)
+      responseAs[String] should include {
+        Messages.entityTooBig(SizeError(WhiskEntity.paramsFieldName, parameters.size, Parameters.sizeLimit))
+      }
+    }
+  }
+
+  it should "reject update package reference when parameters are too big" in {
+    implicit val tid = transid()
+    val keys: List[Long] =
+      List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
+    val parameters = keys map { key =>
+      Parameters(key.toString, "a" * 10)
+    } reduce (_ ++ _)
+    val provider = WhiskPackage(namespace, aname())
+    val content = s"""{"parameters":$parameters}""".parseJson.asJsObject
+    put(entityStore, provider)
+    Put(s"$collectionPath/${aname()}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(RequestEntityTooLarge)
+      responseAs[String] should include {
+        Messages.entityTooBig(SizeError(WhiskEntity.paramsFieldName, parameters.size, Parameters.sizeLimit))
+      }
+    }
+  }
+
+  it should "update package" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname())
+    val content = WhiskPackagePut(publish = Some(true))
+    put(entityStore, provider)
+
+    // it should "reject update package owned by different user" in {
+    val auser = WhiskAuthHelpers.newIdentity()
+    Put(s"/$namespace/${collection.path}/${provider.name}?overwrite=true", content) ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden)
     }
 
-    it should "reject update package with binding" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname())
-        val content = WhiskPackagePut(provider.bind)
-        put(entityStore, provider)
-        Put(s"$collectionPath/${provider.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(Conflict)
-            responseAs[ErrorResponse].error should include(Messages.packageCannotBecomeBinding)
-        }
+    Put(s"$collectionPath/${provider.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      deletePackage(provider.docid)
+      val response = responseAs[WhiskPackage]
+      response should be(
+        WhiskPackage(namespace, provider.name, None, version = provider.version.upPatch, publish = true))
+    }
+  }
+
+  it should "update package reference" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname())
+    val reference = WhiskPackage(namespace, aname(), provider.bind, annotations = bindingAnnotation(provider.bind.get))
+    // create a bogus binding annotation which should be replaced by the PUT
+    val someBindingAnnotation = Some(Parameters(WhiskPackage.bindingFieldName, "???") ++ Parameters("a", "b"))
+    val content = WhiskPackagePut(publish = Some(true), annotations = someBindingAnnotation)
+    put(entityStore, provider)
+    put(entityStore, reference)
+
+    // it should "reject update package reference owned by different user"
+    val auser = WhiskAuthHelpers.newIdentity()
+    Put(s"/$namespace/${collection.path}/${reference.name}?overwrite=true", content) ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden)
     }
 
-    it should "reject update package reference when new binding refers to non-existent package in same namespace" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname())
-        val reference = WhiskPackage(namespace, aname(), provider.bind)
-        val content = WhiskPackagePut(reference.binding)
-        put(entityStore, reference)
-        Put(s"$collectionPath/${reference.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[ErrorResponse].error should include(Messages.bindingDoesNotExist)
-        }
+    Put(s"$collectionPath/${reference.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      deletePackage(reference.docid)
+      status should be(OK)
+      val response = responseAs[WhiskPackage]
+      response should be {
+        WhiskPackage(
+          reference.namespace,
+          reference.name,
+          reference.binding,
+          version = reference.version.upPatch,
+          publish = true,
+          annotations = reference.annotations ++ Parameters("a", "b"))
+      }
+    }
+  }
+
+  it should "reject update package with binding" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname())
+    val content = WhiskPackagePut(provider.bind)
+    put(entityStore, provider)
+    Put(s"$collectionPath/${provider.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(Conflict)
+      responseAs[ErrorResponse].error should include(Messages.packageCannotBecomeBinding)
+    }
+  }
+
+  it should "reject update package reference when new binding refers to non-existent package in same namespace" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname())
+    val reference = WhiskPackage(namespace, aname(), provider.bind)
+    val content = WhiskPackagePut(reference.binding)
+    put(entityStore, reference)
+    Put(s"$collectionPath/${reference.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[ErrorResponse].error should include(Messages.bindingDoesNotExist)
+    }
+  }
+
+  it should "reject update package reference when new binding refers to non-existent package in another namespace" in {
+    implicit val tid = transid()
+    val privateCreds = WhiskAuthHelpers.newIdentity()
+    val privateNamespace = EntityPath(privateCreds.subject.asString)
+
+    val provider = WhiskPackage(privateNamespace, aname())
+    val reference = WhiskPackage(namespace, aname(), provider.bind)
+    val content = WhiskPackagePut(reference.binding)
+    put(entityStore, reference)
+    Put(s"$collectionPath/${reference.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(Forbidden)
+    }
+  }
+
+  it should "reject update package reference when new binding refers to private package in another namespace" in {
+    implicit val tid = transid()
+    val privateCreds = WhiskAuthHelpers.newIdentity()
+    val privateNamespace = EntityPath(privateCreds.subject.asString)
+
+    val provider = WhiskPackage(privateNamespace, aname())
+    val reference = WhiskPackage(namespace, aname(), provider.bind)
+    val content = WhiskPackagePut(reference.binding)
+    put(entityStore, provider)
+    put(entityStore, reference)
+    Put(s"$collectionPath/${reference.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(Forbidden)
+    }
+  }
+
+  //// DEL /packages/name
+  it should "delete package" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname())
+    put(entityStore, provider)
+
+    // it should "reject deleting package owned by different user" in {
+    val auser = WhiskAuthHelpers.newIdentity()
+    Get(s"/$namespace/${collection.path}/${provider.name}") ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden)
     }
 
-    it should "reject update package reference when new binding refers to non-existent package in another namespace" in {
-        implicit val tid = transid()
-        val privateCreds = WhiskAuthHelpers.newIdentity()
-        val privateNamespace = EntityPath(privateCreds.subject.asString)
+    Delete(s"$collectionPath/${provider.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskPackage]
+      response should be(provider)
+    }
+  }
 
-        val provider = WhiskPackage(privateNamespace, aname())
-        val reference = WhiskPackage(namespace, aname(), provider.bind)
-        val content = WhiskPackagePut(reference.binding)
-        put(entityStore, reference)
-        Put(s"$collectionPath/${reference.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(Forbidden)
-        }
+  it should "delete package reference regardless of package existence" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname())
+    val reference = WhiskPackage(namespace, aname(), provider.bind)
+    put(entityStore, reference)
+
+    // it should "reject deleting package reference owned by different user" in {
+    val auser = WhiskAuthHelpers.newIdentity()
+    Get(s"/$namespace/${collection.path}/${reference.name}") ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden)
     }
 
-    it should "reject update package reference when new binding refers to private package in another namespace" in {
-        implicit val tid = transid()
-        val privateCreds = WhiskAuthHelpers.newIdentity()
-        val privateNamespace = EntityPath(privateCreds.subject.asString)
+    Delete(s"$collectionPath/${reference.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskPackage]
+      response should be(reference)
+    }
+  }
 
-        val provider = WhiskPackage(privateNamespace, aname())
-        val reference = WhiskPackage(namespace, aname(), provider.bind)
-        val content = WhiskPackagePut(reference.binding)
-        put(entityStore, provider)
-        put(entityStore, reference)
-        Put(s"$collectionPath/${reference.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(Forbidden)
-        }
+  it should "reject delete non-empty package" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname())
+    val action = WhiskAction(provider.namespace.addPath(provider.name), aname(), jsDefault("??"))
+    put(entityStore, provider)
+    put(entityStore, action)
+    whisk.utils.retry {
+      Get(s"$collectionPath/${provider.name}") ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[JsObject]
+        response.fields("actions").asInstanceOf[JsArray].elements.length should be(1)
+      }
     }
 
-    //// DEL /packages/name
-    it should "delete package" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname())
-        put(entityStore, provider)
-
-        // it should "reject deleting package owned by different user" in {
-        val auser = WhiskAuthHelpers.newIdentity()
-        Get(s"/$namespace/${collection.path}/${provider.name}") ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden)
-        }
-
-        Delete(s"$collectionPath/${provider.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskPackage]
-            response should be(provider)
-        }
+    Delete(s"$collectionPath/${provider.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(Conflict)
+      val response = responseAs[ErrorResponse]
+      response.error should include("Package not empty (contains 1 entity)")
+      response.code.id should be >= 1L
     }
+  }
 
-    it should "delete package reference regardless of package existence" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname())
-        val reference = WhiskPackage(namespace, aname(), provider.bind)
-        put(entityStore, reference)
-
-        // it should "reject deleting package reference owned by different user" in {
-        val auser = WhiskAuthHelpers.newIdentity()
-        Get(s"/$namespace/${collection.path}/${reference.name}") ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden)
-        }
-
-        Delete(s"$collectionPath/${reference.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskPackage]
-            response should be(reference)
-        }
+  //// invalid resource
+  it should "reject invalid resource" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname())
+    put(entityStore, provider)
+    Get(s"$collectionPath/${provider.name}/bar") ~> Route.seal(routes(creds)) ~> check {
+      status should be(NotFound)
     }
+  }
 
-    it should "reject delete non-empty package" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname())
-        val action = WhiskAction(provider.namespace.addPath(provider.name), aname(), jsDefault("??"))
-        put(entityStore, provider)
-        put(entityStore, action)
-        whisk.utils.retry {
-            Get(s"$collectionPath/${provider.name}") ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                val response = responseAs[JsObject]
-                response.fields("actions").asInstanceOf[JsArray].elements.length should be(1)
-            }
-        }
+  it should "reject bind to non-package" in {
+    implicit val tid = transid()
+    val action = WhiskAction(namespace, aname(), jsDefault("??"))
+    val reference = WhiskPackage(namespace, aname(), Some(Binding(action.namespace.root, action.name)))
+    val content = WhiskPackagePut(reference.binding)
 
-        Delete(s"$collectionPath/${provider.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(Conflict)
-            val response = responseAs[ErrorResponse]
-            response.error should include("Package not empty (contains 1 entity)")
-            response.code.id should be >= 1L
-        }
+    put(entityStore, action)
+
+    Put(s"$collectionPath/${reference.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(Conflict)
+      responseAs[ErrorResponse].error should include(Messages.requestedBindingIsNotValid)
     }
+  }
 
-    //// invalid resource
-    it should "reject invalid resource" in {
-        implicit val tid = transid()
-        val provider = WhiskPackage(namespace, aname())
-        put(entityStore, provider)
-        Get(s"$collectionPath/${provider.name}/bar") ~> Route.seal(routes(creds)) ~> check {
-            status should be(NotFound)
-        }
+  it should "report proper error when record is corrupted on delete" in {
+    implicit val tid = transid()
+    val entity = BadEntity(namespace, aname())
+    put(entityStore, entity)
+
+    Delete(s"$collectionPath/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(InternalServerError)
+      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
     }
+  }
 
-    it should "reject bind to non-package" in {
-        implicit val tid = transid()
-        val action = WhiskAction(namespace, aname(), jsDefault("??"))
-        val reference = WhiskPackage(namespace, aname(), Some(Binding(action.namespace.root, action.name)))
-        val content = WhiskPackagePut(reference.binding)
+  it should "report proper error when record is corrupted on get" in {
+    implicit val tid = transid()
+    val entity = BadEntity(namespace, aname())
+    put(entityStore, entity)
 
-        put(entityStore, action)
-
-        Put(s"$collectionPath/${reference.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(Conflict)
-            responseAs[ErrorResponse].error should include(Messages.requestedBindingIsNotValid)
-        }
+    Get(s"$collectionPath/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(InternalServerError)
     }
+  }
 
-    it should "report proper error when record is corrupted on delete" in {
-        implicit val tid = transid()
-        val entity = BadEntity(namespace, aname())
-        put(entityStore, entity)
+  it should "report proper error when record is corrupted on put" in {
+    implicit val tid = transid()
+    val entity = BadEntity(namespace, aname())
+    put(entityStore, entity)
 
-        Delete(s"$collectionPath/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(InternalServerError)
-            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-        }
+    val content = WhiskPackagePut()
+    Put(s"$collectionPath/${entity.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(InternalServerError)
+      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
     }
-
-    it should "report proper error when record is corrupted on get" in {
-        implicit val tid = transid()
-        val entity = BadEntity(namespace, aname())
-        put(entityStore, entity)
-
-        Get(s"$collectionPath/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(InternalServerError)
-        }
-    }
-
-    it should "report proper error when record is corrupted on put" in {
-        implicit val tid = transid()
-        val entity = BadEntity(namespace, aname())
-        put(entityStore, entity)
-
-        val content = WhiskPackagePut()
-        Put(s"$collectionPath/${entity.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(InternalServerError)
-            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-        }
-    }
+  }
 }

--- a/tests/src/test/scala/whisk/core/controller/test/RateThrottleTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/RateThrottleTests.scala
@@ -36,35 +36,32 @@ import whisk.core.entity.UserLimits
  * "using Specification DSL to write unit tests, as in should, must, not, be"
  */
 @RunWith(classOf[JUnitRunner])
-class RateThrottleTests
-    extends FlatSpec
-    with Matchers
-    with StreamLogging {
+class RateThrottleTests extends FlatSpec with Matchers with StreamLogging {
 
-    implicit val transid = TransactionId.testing
-    val subject = WhiskAuthHelpers.newIdentity()
+  implicit val transid = TransactionId.testing
+  val subject = WhiskAuthHelpers.newIdentity()
 
-    behavior of "Rate Throttle"
+  behavior of "Rate Throttle"
 
-    it should "throttle when rate exceeds allowed threshold" in {
-        new RateThrottler("test", 0, _.limits.invocationsPerMinute).check(subject) shouldBe false
-        val rt = new RateThrottler("test", 1, _.limits.invocationsPerMinute)
-        rt.check(subject) shouldBe true
-        rt.check(subject) shouldBe false
-        rt.check(subject) shouldBe false
-        Thread.sleep(1.minute.toMillis)
-        rt.check(subject) shouldBe true
-    }
+  it should "throttle when rate exceeds allowed threshold" in {
+    new RateThrottler("test", 0, _.limits.invocationsPerMinute).check(subject) shouldBe false
+    val rt = new RateThrottler("test", 1, _.limits.invocationsPerMinute)
+    rt.check(subject) shouldBe true
+    rt.check(subject) shouldBe false
+    rt.check(subject) shouldBe false
+    Thread.sleep(1.minute.toMillis)
+    rt.check(subject) shouldBe true
+  }
 
-    it should "check against an alternative limit if passed in" in {
-        val withLimits = subject.copy(limits = UserLimits(invocationsPerMinute = Some(5)))
-        val rt = new RateThrottler("test", 1, _.limits.invocationsPerMinute)
-        rt.check(withLimits) shouldBe true // 1
-        rt.check(withLimits) shouldBe true // 2
-        rt.check(withLimits) shouldBe true // 3
-        rt.check(withLimits) shouldBe true // 4
-        rt.check(withLimits) shouldBe true // 5
-        rt.check(withLimits) shouldBe false
-    }
+  it should "check against an alternative limit if passed in" in {
+    val withLimits = subject.copy(limits = UserLimits(invocationsPerMinute = Some(5)))
+    val rt = new RateThrottler("test", 1, _.limits.invocationsPerMinute)
+    rt.check(withLimits) shouldBe true // 1
+    rt.check(withLimits) shouldBe true // 2
+    rt.check(withLimits) shouldBe true // 3
+    rt.check(withLimits) shouldBe true // 4
+    rt.check(withLimits) shouldBe true // 5
+    rt.check(withLimits) shouldBe false
+  }
 
 }

--- a/tests/src/test/scala/whisk/core/controller/test/RespondWithHeadersTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/RespondWithHeadersTests.scala
@@ -43,49 +43,49 @@ import whisk.core.controller.RespondWithHeaders
 @RunWith(classOf[JUnitRunner])
 class RespondWithHeadersTests extends ControllerTestCommon with RespondWithHeaders {
 
-    behavior of "General API"
+  behavior of "General API"
 
-    val routes = {
-        pathPrefix("api" / "v1") {
-            sendCorsHeaders {
-                path("one") {
-                    complete(OK)
-                } ~ path("two") {
-                    complete(OK)
-                } ~ options {
-                    complete(OK)
-                } ~ reject
-            }
-        } ~ pathPrefix("other") {
-            complete(OK)
-        }
+  val routes = {
+    pathPrefix("api" / "v1") {
+      sendCorsHeaders {
+        path("one") {
+          complete(OK)
+        } ~ path("two") {
+          complete(OK)
+        } ~ options {
+          complete(OK)
+        } ~ reject
+      }
+    } ~ pathPrefix("other") {
+      complete(OK)
     }
+  }
 
-    it should "respond to options" in {
-        Options("/api/v1") ~> Route.seal(routes) ~> check {
-            headers should contain allOf (allowOrigin, allowHeaders)
-        }
+  it should "respond to options" in {
+    Options("/api/v1") ~> Route.seal(routes) ~> check {
+      headers should contain allOf (allowOrigin, allowHeaders)
     }
+  }
 
-    it should "respond to options on every route under /api/v1" in {
-        Options("/api/v1/one") ~> Route.seal(routes) ~> check {
-            headers should contain allOf (allowOrigin, allowHeaders)
-        }
-        Options("/api/v1/two") ~> Route.seal(routes) ~> check {
-            headers should contain allOf (allowOrigin, allowHeaders)
-        }
+  it should "respond to options on every route under /api/v1" in {
+    Options("/api/v1/one") ~> Route.seal(routes) ~> check {
+      headers should contain allOf (allowOrigin, allowHeaders)
     }
+    Options("/api/v1/two") ~> Route.seal(routes) ~> check {
+      headers should contain allOf (allowOrigin, allowHeaders)
+    }
+  }
 
-    it should "respond to options even on bogus routes under /api/v1" in {
-        Options("/api/v1/bogus") ~> Route.seal(routes) ~> check {
-            headers should contain allOf (allowOrigin, allowHeaders)
-        }
+  it should "respond to options even on bogus routes under /api/v1" in {
+    Options("/api/v1/bogus") ~> Route.seal(routes) ~> check {
+      headers should contain allOf (allowOrigin, allowHeaders)
     }
+  }
 
-    it should "not respond to options on routes before /api/v1" in {
-        Options("/api") ~> Route.seal(routes) ~> check {
-            status shouldBe NotFound
-        }
+  it should "not respond to options on routes before /api/v1" in {
+    Options("/api") ~> Route.seal(routes) ~> check {
+      status shouldBe NotFound
     }
+  }
 
 }

--- a/tests/src/test/scala/whisk/core/controller/test/RulesApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/RulesApiTests.scala
@@ -52,881 +52,983 @@ import whisk.http.Messages
 @RunWith(classOf[JUnitRunner])
 class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
-    /** Rules API tests */
-    behavior of "Rules API"
+  /** Rules API tests */
+  behavior of "Rules API"
 
-    val creds = WhiskAuthHelpers.newIdentity()
-    val namespace = EntityPath(creds.subject.asString)
-    def aname() = MakeName.next("rules_tests")
-    def afullname(namespace: EntityPath, name: String) = FullyQualifiedEntityName(namespace, EntityName(name))
-    val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
-    val activeStatus = s"""{"status":"${Status.ACTIVE}"}""".parseJson.asJsObject
-    val inactiveStatus = s"""{"status":"${Status.INACTIVE}"}""".parseJson.asJsObject
-    val parametersLimit = Parameters.sizeLimit
+  val creds = WhiskAuthHelpers.newIdentity()
+  val namespace = EntityPath(creds.subject.asString)
+  def aname() = MakeName.next("rules_tests")
+  def afullname(namespace: EntityPath, name: String) = FullyQualifiedEntityName(namespace, EntityName(name))
+  val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
+  val activeStatus = s"""{"status":"${Status.ACTIVE}"}""".parseJson.asJsObject
+  val inactiveStatus = s"""{"status":"${Status.INACTIVE}"}""".parseJson.asJsObject
+  val parametersLimit = Parameters.sizeLimit
 
-    //// GET /rules
-    it should "list rules by default/explicit namespace" in {
-        implicit val tid = transid()
+  //// GET /rules
+  it should "list rules by default/explicit namespace" in {
+    implicit val tid = transid()
 
-        val rules = (1 to 2).map { i =>
-            WhiskRule(namespace, aname(), afullname(namespace, "bogus trigger"), afullname(namespace, "bogus action"))
-        }.toList
-        rules foreach { put(entityStore, _) }
-        waitOnView(entityStore, WhiskRule, namespace, 2)
-        Get(s"$collectionPath") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[List[JsObject]]
-            rules.length should be(response.length)
-            rules forall { r => response contains r.summaryAsJson } should be(true)
-        }
-
-        // it should "list trirulesggers with explicit namespace owned by subject" in {
-        Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[List[JsObject]]
-            rules.length should be(response.length)
-            rules forall { r => response contains r.summaryAsJson } should be(true)
-        }
-
-        // it should "reject list rules with explicit namespace not owned by subject" in {
-        val auser = WhiskAuthHelpers.newIdentity()
-        Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden)
-        }
+    val rules = (1 to 2).map { i =>
+      WhiskRule(namespace, aname(), afullname(namespace, "bogus trigger"), afullname(namespace, "bogus action"))
+    }.toList
+    rules foreach { put(entityStore, _) }
+    waitOnView(entityStore, WhiskRule, namespace, 2)
+    Get(s"$collectionPath") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[List[JsObject]]
+      rules.length should be(response.length)
+      rules forall { r =>
+        response contains r.summaryAsJson
+      } should be(true)
     }
 
-    //?docs disabled
-    ignore should "list rules by default namespace with full docs" in {
-        implicit val tid = transid()
-
-        val rules = (1 to 2).map { i =>
-            WhiskRule(namespace, aname(), afullname(namespace, "bogus trigger"), afullname(namespace, "bogus action"))
-        }.toList
-        rules foreach { put(entityStore, _) }
-        waitOnView(entityStore, WhiskRule, namespace, 2)
-        Get(s"$collectionPath?docs=true") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[List[WhiskRule]]
-            rules.length should be(response.length)
-            rules forall { r => response contains r } should be(true)
-        }
+    // it should "list trirulesggers with explicit namespace owned by subject" in {
+    Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[List[JsObject]]
+      rules.length should be(response.length)
+      rules forall { r =>
+        response contains r.summaryAsJson
+      } should be(true)
     }
 
-    //// GET /rule/name
-    it should "get rule by name in default/explicit namespace" in {
-        implicit val tid = transid()
+    // it should "reject list rules with explicit namespace not owned by subject" in {
+    val auser = WhiskAuthHelpers.newIdentity()
+    Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden)
+    }
+  }
 
-        val rule = WhiskRule(namespace, aname(), afullname(namespace, "bogus trigger"), afullname(namespace, "bogus action"))
-        put(entityStore, rule)
-        Get(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskRuleResponse]
-            response should be(rule.withStatus(Status.INACTIVE))
-        }
+  //?docs disabled
+  ignore should "list rules by default namespace with full docs" in {
+    implicit val tid = transid()
 
-        // it should "get trigger by name in explicit namespace owned by subject" in
-        Get(s"/$namespace/${collection.path}/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskRuleResponse]
-            response should be(rule.withStatus(Status.INACTIVE))
-        }
+    val rules = (1 to 2).map { i =>
+      WhiskRule(namespace, aname(), afullname(namespace, "bogus trigger"), afullname(namespace, "bogus action"))
+    }.toList
+    rules foreach { put(entityStore, _) }
+    waitOnView(entityStore, WhiskRule, namespace, 2)
+    Get(s"$collectionPath?docs=true") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[List[WhiskRule]]
+      rules.length should be(response.length)
+      rules forall { r =>
+        response contains r
+      } should be(true)
+    }
+  }
 
-        // it should "reject get trigger by name in explicit namespace not owned by subject" in
-        val auser = WhiskAuthHelpers.newIdentity()
-        Get(s"/$namespace/${collection.path}/${rule.name}") ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden)
-        }
+  //// GET /rule/name
+  it should "get rule by name in default/explicit namespace" in {
+    implicit val tid = transid()
+
+    val rule =
+      WhiskRule(namespace, aname(), afullname(namespace, "bogus trigger"), afullname(namespace, "bogus action"))
+    put(entityStore, rule)
+    Get(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskRuleResponse]
+      response should be(rule.withStatus(Status.INACTIVE))
     }
 
-    it should "reject get of non existent rule" in {
-        implicit val tid = transid()
-
-        Get(s"$collectionPath/xxx") ~> Route.seal(routes(creds)) ~> check {
-            status should be(NotFound)
-        }
+    // it should "get trigger by name in explicit namespace owned by subject" in
+    Get(s"/$namespace/${collection.path}/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskRuleResponse]
+      response should be(rule.withStatus(Status.INACTIVE))
     }
 
-    it should "get rule with active state in trigger" in {
-        implicit val tid = transid()
+    // it should "reject get trigger by name in explicit namespace not owned by subject" in
+    val auser = WhiskAuthHelpers.newIdentity()
+    Get(s"/$namespace/${collection.path}/${rule.name}") ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden)
+    }
+  }
 
-        val rule = WhiskRule(namespace, EntityName("get_active_rule"), afullname(namespace, "get_active_rule trigger"), afullname(namespace, "an action"))
-        val trigger = WhiskTrigger(rule.trigger.path, rule.trigger.name, rules = Some {
-            Map(rule.fullyQualifiedName(false) -> ReducedRule(rule.action, Status.ACTIVE))
-        })
+  it should "reject get of non existent rule" in {
+    implicit val tid = transid()
 
-        put(entityStore, trigger)
-        put(entityStore, rule)
+    Get(s"$collectionPath/xxx") ~> Route.seal(routes(creds)) ~> check {
+      status should be(NotFound)
+    }
+  }
 
-        Get(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskRuleResponse]
-            response should be(rule.withStatus(Status.ACTIVE))
-        }
+  it should "get rule with active state in trigger" in {
+    implicit val tid = transid()
+
+    val rule = WhiskRule(
+      namespace,
+      EntityName("get_active_rule"),
+      afullname(namespace, "get_active_rule trigger"),
+      afullname(namespace, "an action"))
+    val trigger = WhiskTrigger(rule.trigger.path, rule.trigger.name, rules = Some {
+      Map(rule.fullyQualifiedName(false) -> ReducedRule(rule.action, Status.ACTIVE))
+    })
+
+    put(entityStore, trigger)
+    put(entityStore, rule)
+
+    Get(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskRuleResponse]
+      response should be(rule.withStatus(Status.ACTIVE))
+    }
+  }
+
+  it should "get rule with no rule-entries in trigger" in {
+    implicit val tid = transid()
+
+    val trigger = WhiskTrigger(namespace, EntityName("get_rule_with_empty_trigger trigger"))
+    val rule = WhiskRule(
+      namespace,
+      EntityName("get_rule_with_empty_trigger"),
+      trigger.fullyQualifiedName(false),
+      afullname(namespace, "an action"))
+
+    put(entityStore, trigger)
+    put(entityStore, rule)
+
+    Get(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskRuleResponse]
+      response should be(rule.withStatus(Status.INACTIVE))
+    }
+  }
+
+  it should "report Conflict if the name was of a different type" in {
+    implicit val tid = transid()
+
+    val trigger = WhiskTrigger(namespace, aname())
+
+    put(entityStore, trigger)
+
+    Get(s"/$namespace/${collection.path}/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(Conflict)
+    }
+  }
+
+  // DEL /rules/name
+  it should "not reject delete rule in state active" in {
+    implicit val tid = transid()
+
+    val rule = WhiskRule(
+      namespace,
+      EntityName("reject_delete_rule_active"),
+      FullyQualifiedEntityName(namespace, aname()),
+      afullname(namespace, "an action"))
+    val trigger = WhiskTrigger(namespace, rule.trigger.name, rules = Some {
+      Map(rule.fullyQualifiedName(false) -> ReducedRule(rule.action, Status.ACTIVE))
+    })
+
+    put(entityStore, trigger)
+    put(entityStore, rule)
+
+    Delete(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
+      deleteTrigger(trigger.docid)
+
+      status should be(OK)
+      val response = responseAs[WhiskRuleResponse]
+      response should be(rule.withStatus(Status.INACTIVE))
+    }
+  }
+
+  it should "delete rule in state inactive" in {
+    implicit val tid = transid()
+
+    val rule = WhiskRule(
+      namespace,
+      aname(),
+      FullyQualifiedEntityName(namespace, aname()),
+      FullyQualifiedEntityName(namespace, aname()))
+    val triggerLink = ReducedRule(rule.action, Status.INACTIVE)
+    val trigger = WhiskTrigger(
+      rule.trigger.path,
+      rule.trigger.name,
+      rules = Some(Map(rule.fullyQualifiedName(false) -> triggerLink)))
+
+    put(entityStore, trigger, false)
+    put(entityStore, rule)
+
+    Delete(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
+      val t = get(entityStore, trigger.docid, WhiskTrigger)
+      deleteTrigger(t.docid)
+
+      status should be(OK)
+      t.rules.get.get(rule.fullyQualifiedName(false)) shouldBe None
+      val response = responseAs[WhiskRuleResponse]
+      response should be(rule.withStatus(Status.INACTIVE))
+    }
+  }
+
+  it should "delete rule in state inactive even if the trigger has been deleted" in {
+    implicit val tid = transid()
+
+    val rule = WhiskRule(
+      namespace,
+      EntityName("delete_rule_inactive"),
+      afullname(namespace, "a trigger"),
+      afullname(namespace, "an action"))
+
+    put(entityStore, rule)
+
+    Delete(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskRuleResponse]
+      response should be(rule.withStatus(Status.INACTIVE))
+    }
+  }
+
+  it should "delete rule in state inactive even if the trigger has no reference to the rule" in {
+    implicit val tid = transid()
+
+    val rule =
+      WhiskRule(namespace, aname(), FullyQualifiedEntityName(namespace, aname()), afullname(namespace, "an action"))
+    val trigger = WhiskTrigger(rule.trigger.path, rule.trigger.name)
+
+    put(entityStore, trigger, false)
+    put(entityStore, rule)
+
+    Delete(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
+      deleteTrigger(trigger.docid)
+
+      status should be(OK)
+      val response = responseAs[WhiskRuleResponse]
+      response should be(rule.withStatus(Status.INACTIVE))
+    }
+  }
+
+  //// PUT /rules/name
+  it should "create rule" in {
+    implicit val tid = transid()
+
+    val rule = WhiskRule(
+      namespace,
+      aname(),
+      FullyQualifiedEntityName(namespace, aname()),
+      FullyQualifiedEntityName(namespace, aname()))
+    val trigger = WhiskTrigger(rule.trigger.path, rule.trigger.name)
+    val action = WhiskAction(rule.action.path, rule.action.name, jsDefault("??"))
+    val content = WhiskRulePut(Some(rule.trigger), Some(rule.action))
+
+    put(entityStore, trigger, false)
+    put(entityStore, action)
+
+    Put(s"$collectionPath/${rule.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      val t = get(entityStore, trigger.docid, WhiskTrigger)
+      deleteTrigger(t.docid)
+      deleteRule(rule.docid)
+
+      status should be(OK)
+      val response = responseAs[WhiskRuleResponse]
+      response should be(rule.withStatus(Status.ACTIVE))
+      t.rules.get(rule.fullyQualifiedName(false)) shouldBe ReducedRule(action.fullyQualifiedName(false), Status.ACTIVE)
+    }
+  }
+
+  it should "create rule without fully qualifying name" in {
+    implicit val tid = transid()
+
+    val rule = WhiskRule(
+      namespace,
+      aname(),
+      FullyQualifiedEntityName(namespace, aname()),
+      FullyQualifiedEntityName(namespace, aname()))
+    val trigger = WhiskTrigger(rule.trigger.path, rule.trigger.name)
+    val action = WhiskAction(rule.action.path, rule.action.name, jsDefault("??"))
+    val content = JsObject(
+      "trigger" -> JsString(s"/_/${trigger.name.asString}"),
+      "action" -> JsString(s"/_/${action.name.asString}"))
+
+    put(entityStore, trigger, false)
+    put(entityStore, action)
+
+    Put(s"$collectionPath/${rule.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      val t = get(entityStore, trigger.docid, WhiskTrigger)
+      deleteTrigger(t.docid)
+      deleteRule(rule.docid)
+
+      status should be(OK)
+      val response = responseAs[WhiskRuleResponse]
+      response should be(rule.withStatus(Status.ACTIVE))
+      t.rules.get(rule.fullyQualifiedName(false)) shouldBe ReducedRule(action.fullyQualifiedName(false), Status.ACTIVE)
+    }
+  }
+
+  it should "reject create rule without namespace in referenced entities" in {
+    implicit val tid = transid()
+
+    val rule = WhiskRule(
+      namespace,
+      aname(),
+      FullyQualifiedEntityName(namespace, aname()),
+      FullyQualifiedEntityName(namespace, aname()))
+    val trigger = WhiskTrigger(rule.trigger.path, rule.trigger.name)
+    val action = WhiskAction(rule.action.path, rule.action.name, jsDefault("??"))
+    val contentT =
+      JsObject("trigger" -> trigger.name.toJson, "action" -> action.fullyQualifiedName(false).toDocId.toJson)
+    val contentA =
+      JsObject("action" -> action.name.toJson, "trigger" -> trigger.fullyQualifiedName(false).toDocId.toJson)
+
+    Put(s"$collectionPath/${rule.name}", contentT) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[String] shouldBe s"The request content was malformed:\nrequirement failed: ${Messages.malformedFullyQualifiedEntityName}"
     }
 
-    it should "get rule with no rule-entries in trigger" in {
-        implicit val tid = transid()
+    Put(s"$collectionPath/${rule.name}", contentA) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[String] shouldBe s"The request content was malformed:\nrequirement failed: ${Messages.malformedFullyQualifiedEntityName}"
+    }
+  }
 
-        val trigger = WhiskTrigger(namespace, EntityName("get_rule_with_empty_trigger trigger"))
-        val rule = WhiskRule(namespace, EntityName("get_rule_with_empty_trigger"), trigger.fullyQualifiedName(false), afullname(namespace, "an action"))
+  it should "create rule with an action in a package" in {
+    implicit val tid = transid()
 
-        put(entityStore, trigger)
-        put(entityStore, rule)
+    val provider = WhiskPackage(namespace, aname(), publish = true)
+    val action = WhiskAction(provider.fullPath, aname(), jsDefault("??"))
+    val trigger = WhiskTrigger(namespace, aname())
+    val rule = WhiskRule(namespace, aname(), trigger.fullyQualifiedName(false), action.fullyQualifiedName(false))
+    val content = WhiskRulePut(Some(rule.trigger), Some(rule.action))
 
-        Get(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskRuleResponse]
-            response should be(rule.withStatus(Status.INACTIVE))
-        }
+    put(entityStore, provider)
+    put(entityStore, trigger, false)
+    put(entityStore, action)
+
+    Put(s"$collectionPath/${rule.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      val t = get(entityStore, trigger.docid, WhiskTrigger)
+      deleteTrigger(t.docid)
+      deleteRule(rule.docid)
+
+      status should be(OK)
+      val response = responseAs[WhiskRuleResponse]
+      response should be(rule.withStatus(Status.ACTIVE))
+      t.rules.get(rule.fullyQualifiedName(false)) shouldBe ReducedRule(action.fullyQualifiedName(false), Status.ACTIVE)
+    }
+  }
+
+  it should "create rule with an action in a binding" in {
+    implicit val tid = transid()
+
+    val provider = WhiskPackage(namespace, aname(), publish = true)
+    val reference = WhiskPackage(namespace, aname(), provider.bind)
+    val action = WhiskAction(provider.fullPath, aname(), jsDefault("??"))
+    val trigger = WhiskTrigger(namespace, aname())
+    val actionReference = reference.binding.map(b => b.namespace.addPath(b.name)).get
+    val rule = WhiskRule(
+      namespace,
+      aname(),
+      trigger.fullyQualifiedName(false),
+      FullyQualifiedEntityName(actionReference, action.name))
+    val content = WhiskRulePut(Some(rule.trigger), Some(rule.action))
+
+    put(entityStore, provider)
+    put(entityStore, reference)
+    put(entityStore, trigger, false)
+    put(entityStore, action)
+
+    Put(s"$collectionPath/${rule.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      val t = get(entityStore, trigger.docid, WhiskTrigger)
+      deleteTrigger(t.docid)
+      deleteRule(rule.docid)
+
+      status should be(OK)
+      val response = responseAs[WhiskRuleResponse]
+      response should be(rule.withStatus(Status.ACTIVE))
+      t.rules.get(rule.fullyQualifiedName(false)) shouldBe ReducedRule(action.fullyQualifiedName(false), Status.ACTIVE)
+    }
+  }
+
+  it should "reject create rule with annotations which are too big" in {
+    implicit val tid = transid()
+
+    val trigger = WhiskTrigger(namespace, aname())
+    val action = WhiskAction(namespace, aname(), jsDefault("??"))
+
+    val keys: List[Long] =
+      List.range(Math.pow(10, 9) toLong, (Parameters.sizeLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
+    val annotations = keys map { key =>
+      Parameters(key.toString, "a" * 10)
+    } reduce (_ ++ _)
+    val content =
+      s"""{"trigger":"${trigger.name}","action":"${action.name}","annotations":$annotations}""".parseJson.asJsObject
+
+    put(entityStore, trigger, false)
+    put(entityStore, action)
+
+    Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(creds)) ~> check {
+      val t = get(entityStore, trigger.docid, WhiskTrigger)
+      deleteTrigger(t.docid)
+
+      status should be(RequestEntityTooLarge)
+      responseAs[String] should include {
+        Messages.entityTooBig(SizeError(WhiskEntity.annotationsFieldName, annotations.size, Parameters.sizeLimit))
+      }
+    }
+  }
+
+  it should "reject update rule with annotations which are too big" in {
+    implicit val tid = transid()
+
+    val trigger = WhiskTrigger(namespace, aname())
+    val action = WhiskAction(namespace, aname(), jsDefault("??"))
+    val rule = WhiskRule(namespace, aname(), trigger.fullyQualifiedName(false), action.fullyQualifiedName(false))
+
+    val keys: List[Long] =
+      List.range(Math.pow(10, 9) toLong, (Parameters.sizeLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
+    val annotations = keys map { key =>
+      Parameters(key.toString, "a" * 10)
+    } reduce (_ ++ _)
+    val content =
+      s"""{"trigger":"${trigger.name}","action":"${action.name}","annotations":$annotations}""".parseJson.asJsObject
+
+    put(entityStore, trigger, false)
+    put(entityStore, action)
+    put(entityStore, rule)
+
+    Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      val t = get(entityStore, trigger.docid, WhiskTrigger)
+      deleteTrigger(t.docid)
+
+      status should be(RequestEntityTooLarge)
+      responseAs[String] should include {
+        Messages.entityTooBig(SizeError(WhiskEntity.annotationsFieldName, annotations.size, Parameters.sizeLimit))
+      }
+    }
+  }
+
+  it should "reject rule if action does not exist" in {
+    implicit val tid = transid()
+
+    val trigger = WhiskTrigger(namespace, aname())
+    val content = WhiskRulePut(Some(trigger.fullyQualifiedName(false)), Some(afullname(namespace, "bogus action")))
+
+    put(entityStore, trigger)
+
+    Put(s"$collectionPath/xxx", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[String] === s"${content.action.get.qualifiedNameWithLeadingSlash} does not exist"
+    }
+  }
+
+  it should "reject rule if trigger does not exist" in {
+    implicit val tid = transid()
+
+    val action = WhiskAction(namespace, aname(), jsDefault("??"))
+    val content = WhiskRulePut(Some(afullname(namespace, "bogus trigger")), Some(action.fullyQualifiedName(false)))
+
+    put(entityStore, action)
+
+    Put(s"$collectionPath/xxx", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[String] === s"${content.trigger.get.qualifiedNameWithLeadingSlash} does not exist"
+    }
+  }
+
+  it should "reject rule if neither action or trigger do not exist" in {
+    implicit val tid = transid()
+
+    val content = WhiskRulePut(Some(afullname(namespace, "bogus trigger")), Some(afullname(namespace, "bogus action")))
+
+    Put(s"$collectionPath/xxx", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[String].contains("does not exist") should be(true)
+    }
+  }
+
+  it should "update rule with new trigger and action at once" in {
+    implicit val tid = transid()
+
+    val trigger = WhiskTrigger(namespace, aname())
+    val action = WhiskAction(namespace, aname(), jsDefault("??"))
+    val rule =
+      WhiskRule(namespace, aname(), afullname(namespace, "bogus trigger"), afullname(namespace, "bogus action"))
+    val content = WhiskRulePut(Some(trigger.fullyQualifiedName(false)), Some(action.fullyQualifiedName(false)))
+
+    put(entityStore, trigger, false)
+    put(entityStore, action)
+    put(entityStore, rule, false)
+
+    Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      val t = get(entityStore, trigger.docid, WhiskTrigger)
+      deleteTrigger(t.docid)
+      deleteRule(rule.docid)
+
+      status should be(OK)
+
+      t.rules.get(rule.fullyQualifiedName(false)).action should be(action.fullyQualifiedName(false))
+      val response = responseAs[WhiskRuleResponse]
+      response should be(
+        WhiskRuleResponse(
+          namespace,
+          rule.name,
+          Status.ACTIVE,
+          trigger.fullyQualifiedName(false),
+          action.fullyQualifiedName(false),
+          version = SemVer().upPatch))
+    }
+  }
+
+  it should "update rule with a new action while passing the same trigger" in {
+    implicit val tid = transid()
+
+    val trigger = WhiskTrigger(namespace, aname())
+    val action = WhiskAction(namespace, aname(), jsDefault("??"))
+    val rule = WhiskRule(namespace, aname(), trigger.fullyQualifiedName(false), afullname(namespace, "bogus action"))
+    val content = WhiskRulePut(Some(trigger.fullyQualifiedName(false)), Some(action.fullyQualifiedName(false)))
+
+    put(entityStore, trigger, false)
+    put(entityStore, action)
+    put(entityStore, rule, false)
+
+    Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      val t = get(entityStore, trigger.docid, WhiskTrigger)
+      deleteTrigger(t.docid)
+      deleteRule(rule.docid)
+
+      status should be(OK)
+      t.rules.get(rule.fullyQualifiedName(false)).action should be(action.fullyQualifiedName(false))
+      val response = responseAs[WhiskRuleResponse]
+      response should be(
+        WhiskRuleResponse(
+          namespace,
+          rule.name,
+          Status.ACTIVE,
+          trigger.fullyQualifiedName(false),
+          action.fullyQualifiedName(false),
+          version = SemVer().upPatch))
+    }
+  }
+
+  it should "update rule with just a new action" in {
+    implicit val tid = transid()
+
+    val trigger = WhiskTrigger(namespace, aname())
+    val action = WhiskAction(namespace, aname(), jsDefault("??"))
+    val rule = WhiskRule(namespace, aname(), trigger.fullyQualifiedName(false), afullname(namespace, "bogus action"))
+    val content = WhiskRulePut(action = Some(action.fullyQualifiedName(false)))
+
+    put(entityStore, trigger, false)
+    put(entityStore, action)
+    put(entityStore, rule, false)
+
+    Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      val t = get(entityStore, trigger.docid, WhiskTrigger)
+      deleteTrigger(t.docid)
+      deleteRule(rule.docid)
+
+      status should be(OK)
+      t.rules.get(rule.fullyQualifiedName(false)).action should be(action.fullyQualifiedName(false))
+      val response = responseAs[WhiskRuleResponse]
+      response should be(
+        WhiskRuleResponse(
+          namespace,
+          rule.name,
+          Status.ACTIVE,
+          trigger.fullyQualifiedName(false),
+          action.fullyQualifiedName(false),
+          version = SemVer().upPatch))
+    }
+  }
+
+  it should "update rule with just a new trigger" in {
+    implicit val tid = transid()
+
+    val trigger = WhiskTrigger(namespace, aname())
+    val action = WhiskAction(namespace, aname(), jsDefault("??"))
+    val rule = WhiskRule(namespace, aname(), trigger.fullyQualifiedName(false), action.fullyQualifiedName(false))
+    val content = WhiskRulePut(trigger = Some(trigger.fullyQualifiedName(false)))
+
+    put(entityStore, trigger, false)
+    put(entityStore, action)
+    put(entityStore, rule, false)
+
+    Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      val t = get(entityStore, trigger.docid, WhiskTrigger)
+      deleteTrigger(t.docid)
+      deleteRule(rule.docid)
+
+      status should be(OK)
+      t.rules.get.get(rule.fullyQualifiedName(false)) shouldBe a[Some[_]]
+      val response = responseAs[WhiskRuleResponse]
+      response should be(
+        WhiskRuleResponse(
+          namespace,
+          rule.name,
+          Status.ACTIVE,
+          trigger.fullyQualifiedName(false),
+          action.fullyQualifiedName(false),
+          version = SemVer().upPatch))
+    }
+  }
+
+  it should "update rule when no new content is provided" in {
+    implicit val tid = transid()
+    val trigger = WhiskTrigger(namespace, aname())
+    val action = WhiskAction(namespace, aname(), jsDefault("??"))
+    val rule = WhiskRule(namespace, aname(), trigger.fullyQualifiedName(false), action.fullyQualifiedName(false))
+    val content = WhiskRulePut(None, None, None, None, None)
+
+    put(entityStore, trigger, false)
+    put(entityStore, action)
+    put(entityStore, rule, false)
+
+    Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      deleteTrigger(trigger.docid)
+      deleteRule(rule.docid)
+
+      status should be(OK)
+      val response = responseAs[WhiskRuleResponse]
+      response should be(
+        WhiskRuleResponse(
+          namespace,
+          rule.name,
+          Status.ACTIVE,
+          trigger.fullyQualifiedName(false),
+          action.fullyQualifiedName(false),
+          version = SemVer().upPatch))
+    }
+  }
+
+  it should "reject update rule if trigger does not exist" in {
+    implicit val tid = transid()
+
+    val action = WhiskAction(namespace, aname(), jsDefault("??"))
+    val rule = WhiskRule(namespace, aname(), afullname(namespace, "bogus trigger"), action.fullyQualifiedName(false))
+    val content = WhiskRulePut(action = Some(action.fullyQualifiedName(false)))
+
+    put(entityStore, action)
+    put(entityStore, rule)
+
+    Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[String] === s"${rule.trigger.qualifiedNameWithLeadingSlash} does not exist"
+    }
+  }
+
+  it should "reject update rule if action does not exist" in {
+    implicit val tid = transid()
+
+    val trigger = WhiskTrigger(namespace, aname())
+    val rule = WhiskRule(namespace, aname(), trigger.fullyQualifiedName(false), afullname(namespace, "bogus action"))
+    val content = WhiskRulePut(trigger = Some(trigger.fullyQualifiedName(false)))
+
+    put(entityStore, trigger)
+    put(entityStore, rule)
+
+    Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[String] === s"${rule.action.qualifiedNameWithLeadingSlash} does not exist"
+    }
+  }
+
+  it should "reject update rule if neither trigger or action exist" in {
+    implicit val tid = transid()
+    val rule =
+      WhiskRule(namespace, aname(), afullname(namespace, "bogus trigger"), afullname(namespace, "bogus action"))
+    val content = WhiskRulePut(None, None, None, None, None)
+
+    put(entityStore, rule)
+
+    Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[String] should {
+        include(s"${rule.action.qualifiedNameWithLeadingSlash} does not exist") or
+          include(s"${rule.trigger.qualifiedNameWithLeadingSlash} does not exist")
+      }
+    }
+  }
+
+  it should "not reject update rule in state active" in {
+    implicit val tid = transid()
+
+    val rule = WhiskRule(namespace, aname(), afullname(namespace, "a trigger"), afullname(namespace, "an action"))
+    val trigger = WhiskTrigger(namespace, rule.trigger.name, rules = Some {
+      Map(rule.fullyQualifiedName(false) -> ReducedRule(rule.action, Status.ACTIVE))
+    })
+    val action = WhiskAction(namespace, aname(), jsDefault("??"))
+    val content = WhiskRulePut(Some(trigger.fullyQualifiedName(false)), Some(action.fullyQualifiedName(false)))
+
+    put(entityStore, trigger, false)
+    put(entityStore, action)
+    put(entityStore, rule, false)
+
+    Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      val t = get(entityStore, trigger.docid, WhiskTrigger)
+      deleteTrigger(t.docid)
+      deleteRule(rule.docid)
+
+      status should be(OK)
+      t.rules.get(rule.fullyQualifiedName(false)).action should be(action.fullyQualifiedName(false))
+      val response = responseAs[WhiskRuleResponse]
+      response should be(
+        WhiskRuleResponse(
+          namespace,
+          rule.name,
+          Status.ACTIVE,
+          trigger.fullyQualifiedName(false),
+          action.fullyQualifiedName(false),
+          version = SemVer().upPatch))
+    }
+  }
+
+  //// POST /rules/name
+  it should "do nothing to disable already disabled rule" in {
+    implicit val tid = transid()
+
+    val rule = WhiskRule(namespace, aname(), afullname(namespace, "a trigger"), afullname(namespace, "an action"))
+
+    put(entityStore, rule)
+
+    Post(s"$collectionPath/${rule.name}", inactiveStatus) ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+    }
+  }
+
+  it should "do nothing to enable already enabled rule" in {
+    implicit val tid = transid()
+
+    val rule = WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, "an action"))
+    val trigger = WhiskTrigger(namespace, rule.trigger.name, rules = Some {
+      Map(rule.fullyQualifiedName(false) -> ReducedRule(rule.action, Status.ACTIVE))
+    })
+
+    put(entityStore, trigger)
+    put(entityStore, rule)
+
+    Post(s"$collectionPath/${rule.name}", activeStatus) ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+    }
+  }
+
+  it should "reject post with status undefined" in {
+    implicit val tid = transid()
+
+    Post(s"$collectionPath/xyz") ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+    }
+  }
+
+  it should "reject post with invalid status" in {
+    implicit val tid = transid()
+
+    val badStatus = s"""{"status":"xxx"}""".parseJson.asJsObject
+
+    Post(s"$collectionPath/xyz", badStatus) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+    }
+  }
+
+  it should "activate rule" in {
+    implicit val tid = transid()
+
+    val rule = WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, "an action"))
+    val trigger = WhiskTrigger(namespace, rule.trigger.name, rules = Some {
+      Map(rule.fullyQualifiedName(false) -> ReducedRule(rule.action, Status.INACTIVE))
+    })
+
+    put(entityStore, trigger, false)
+    put(entityStore, rule)
+
+    Post(s"$collectionPath/${rule.name}", activeStatus) ~> Route.seal(routes(creds)) ~> check {
+      val t = get(entityStore, trigger.docid, WhiskTrigger)
+      deleteTrigger(t.docid)
+
+      status should be(OK)
+
+      t.rules.get(rule.fullyQualifiedName(false)).status should be(Status.ACTIVE)
+    }
+  }
+
+  it should "activate rule without rule in trigger" in {
+    implicit val tid = transid()
+
+    val rule = WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, "an action"))
+    val trigger = WhiskTrigger(namespace, rule.trigger.name)
+
+    put(entityStore, trigger, false)
+    put(entityStore, rule)
+
+    Post(s"$collectionPath/${rule.name}", activeStatus) ~> Route.seal(routes(creds)) ~> check {
+      val t = get(entityStore, trigger.docid, WhiskTrigger)
+      deleteTrigger(t.docid)
+
+      status should be(OK)
+      t.rules.get(rule.fullyQualifiedName(false)).status should be(Status.ACTIVE)
+    }
+  }
+
+  it should "reject rule activation, if the trigger is absent" in {
+    implicit val tid = transid()
+
+    val rule = WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, "an action"))
+
+    put(entityStore, rule)
+
+    Post(s"$collectionPath/${rule.name}", activeStatus) ~> Route.seal(routes(creds)) ~> check {
+      status should be(NotFound)
+    }
+  }
+
+  it should "deactivate rule" in {
+    implicit val tid = transid()
+
+    val rule = WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, "an action"))
+    val trigger = WhiskTrigger(namespace, rule.trigger.name, rules = Some {
+      Map(rule.fullyQualifiedName(false) -> ReducedRule(rule.action, Status.ACTIVE))
+    })
+
+    put(entityStore, trigger, false)
+    put(entityStore, rule)
+
+    Post(s"$collectionPath/${rule.name}", inactiveStatus) ~> Route.seal(routes(creds)) ~> check {
+      val t = get(entityStore, trigger.docid, WhiskTrigger)
+      deleteTrigger(t.docid)
+
+      status should be(OK)
+      t.rules.get(rule.fullyQualifiedName(false)).status should be(Status.INACTIVE)
+    }
+  }
+
+  // invalid resource
+  it should "reject invalid resource" in {
+    implicit val tid = transid()
+
+    val rule = WhiskRule(namespace, aname(), afullname(namespace, "a trigger"), afullname(namespace, "an action"))
+
+    put(entityStore, rule)
+
+    Get(s"$collectionPath/${rule.name}/bar") ~> Route.seal(routes(creds)) ~> check {
+      status should be(NotFound)
+    }
+  }
+
+  // migration path
+  it should "handle a rule with the old schema gracefully" in {
+    implicit val tid = transid()
+
+    val rule = OldWhiskRule(namespace, aname(), EntityName("a trigger"), EntityName("an action"), Status.ACTIVE)
+
+    put(entityStore, rule)
+
+    Get(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskRuleResponse]
+      response should be(rule.toWhiskRule.withStatus(Status.INACTIVE))
+    }
+  }
+
+  it should "create rule even if the attached trigger has the old schema" in {
+    implicit val tid = transid()
+
+    val rule = WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, aname().name))
+    val trigger = OldWhiskTrigger(namespace, rule.trigger.name)
+
+    val action = WhiskAction(namespace, rule.action.name, jsDefault("??"))
+    val content = WhiskRulePut(Some(rule.trigger), Some(rule.action))
+
+    put(entityStore, trigger, false)
+    put(entityStore, action)
+
+    Put(s"$collectionPath/${rule.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      val t = get(entityStore, trigger.docid, WhiskTrigger)
+      deleteTrigger(t.docid)
+      deleteRule(rule.docid)
+
+      status should be(OK)
+      t.rules.get(rule.fullyQualifiedName(false)) shouldBe ReducedRule(action.fullyQualifiedName(false), Status.ACTIVE)
+      val response = responseAs[WhiskRuleResponse]
+      response should be(rule.withStatus(Status.ACTIVE))
+    }
+  }
+
+  it should "activate rule even if it is still in the old schema" in {
+    implicit val tid = transid()
+
+    val ruleNameQualified = FullyQualifiedEntityName(namespace, aname())
+    val triggerName = aname()
+    val actionName = FullyQualifiedEntityName(namespace, aname())
+    val rule = OldWhiskRule(namespace, ruleNameQualified.name, triggerName, actionName.name, Status.ACTIVE)
+    val trigger = WhiskTrigger(
+      namespace,
+      triggerName,
+      rules = Some(Map(ruleNameQualified -> ReducedRule(actionName, Status.INACTIVE))))
+
+    put(entityStore, trigger, false)
+    put(entityStore, rule)
+
+    Post(s"$collectionPath/${rule.name}", activeStatus) ~> Route.seal(routes(creds)) ~> check {
+      val t = get(entityStore, trigger.docid, WhiskTrigger)
+      deleteTrigger(t.docid)
+
+      status should be(OK)
+
+      t.rules.get(ruleNameQualified).status should be(Status.ACTIVE)
+    }
+  }
+
+  it should "report proper error when record is corrupted on delete" in {
+    implicit val tid = transid()
+    val entity = BadEntity(namespace, aname())
+    put(entityStore, entity)
+
+    Delete(s"$collectionPath/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(InternalServerError)
+      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
+    }
+  }
+
+  it should "report proper error when record is corrupted on get" in {
+    implicit val tid = transid()
+    val entity = BadEntity(namespace, aname())
+    put(entityStore, entity)
+
+    Get(s"$collectionPath/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(InternalServerError)
+      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
+    }
+  }
+
+  it should "report proper error when record is corrupted on put" in {
+    implicit val tid = transid()
+    val entity = BadEntity(namespace, aname())
+    put(entityStore, entity)
+
+    val content = WhiskRulePut()
+    Put(s"$collectionPath/${entity.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(InternalServerError)
+      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
+    }
+  }
+
+  it should "report proper error when action record is corrupted on put" in {
+    implicit val tid = transid()
+    val tentity = BadEntity(namespace, aname())
+    val aentity = BadEntity(namespace, aname())
+    val rule = WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, aname().name))
+    val trigger = WhiskTrigger(namespace, rule.trigger.name)
+    val action = WhiskAction(namespace, rule.action.name, jsDefault("??"))
+
+    val contenta = WhiskRulePut(Some(tentity.fullyQualifiedName(false)), Some(aentity.fullyQualifiedName(false)))
+    val contentb = WhiskRulePut(Some(trigger.fullyQualifiedName(false)), Some(aentity.fullyQualifiedName(false)))
+    val contentc = WhiskRulePut(Some(tentity.fullyQualifiedName(false)), Some(action.fullyQualifiedName(false)))
+
+    put(entityStore, tentity)
+    put(entityStore, aentity)
+    put(entityStore, trigger)
+    put(entityStore, action)
+
+    Put(s"$collectionPath/${aname()}", contenta) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
     }
 
-    it should "report Conflict if the name was of a different type" in {
-        implicit val tid = transid()
-
-        val trigger = WhiskTrigger(namespace, aname())
-
-        put(entityStore, trigger)
-
-        Get(s"/$namespace/${collection.path}/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(Conflict)
-        }
+    Put(s"$collectionPath/${aname()}", contentb) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
     }
 
-    // DEL /rules/name
-    it should "not reject delete rule in state active" in {
-        implicit val tid = transid()
-
-        val rule = WhiskRule(namespace, EntityName("reject_delete_rule_active"), FullyQualifiedEntityName(namespace, aname()), afullname(namespace, "an action"))
-        val trigger = WhiskTrigger(namespace, rule.trigger.name, rules = Some {
-            Map(rule.fullyQualifiedName(false) -> ReducedRule(rule.action, Status.ACTIVE))
-        })
-
-        put(entityStore, trigger)
-        put(entityStore, rule)
-
-        Delete(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
-            deleteTrigger(trigger.docid)
-
-            status should be(OK)
-            val response = responseAs[WhiskRuleResponse]
-            response should be(rule.withStatus(Status.INACTIVE))
-        }
+    Put(s"$collectionPath/${aname()}", contentc) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
     }
-
-    it should "delete rule in state inactive" in {
-        implicit val tid = transid()
-
-        val rule = WhiskRule(namespace, aname(), FullyQualifiedEntityName(namespace, aname()), FullyQualifiedEntityName(namespace, aname()))
-        val triggerLink = ReducedRule(rule.action, Status.INACTIVE)
-        val trigger = WhiskTrigger(rule.trigger.path, rule.trigger.name, rules = Some(Map(rule.fullyQualifiedName(false) -> triggerLink)))
-
-        put(entityStore, trigger, false)
-        put(entityStore, rule)
-
-        Delete(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
-            val t = get(entityStore, trigger.docid, WhiskTrigger)
-            deleteTrigger(t.docid)
-
-            status should be(OK)
-            t.rules.get.get(rule.fullyQualifiedName(false)) shouldBe None
-            val response = responseAs[WhiskRuleResponse]
-            response should be(rule.withStatus(Status.INACTIVE))
-        }
-    }
-
-    it should "delete rule in state inactive even if the trigger has been deleted" in {
-        implicit val tid = transid()
-
-        val rule = WhiskRule(namespace, EntityName("delete_rule_inactive"), afullname(namespace, "a trigger"), afullname(namespace, "an action"))
-
-        put(entityStore, rule)
-
-        Delete(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskRuleResponse]
-            response should be(rule.withStatus(Status.INACTIVE))
-        }
-    }
-
-    it should "delete rule in state inactive even if the trigger has no reference to the rule" in {
-        implicit val tid = transid()
-
-        val rule = WhiskRule(namespace, aname(), FullyQualifiedEntityName(namespace, aname()), afullname(namespace, "an action"))
-        val trigger = WhiskTrigger(rule.trigger.path, rule.trigger.name)
-
-        put(entityStore, trigger, false)
-        put(entityStore, rule)
-
-        Delete(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
-            deleteTrigger(trigger.docid)
-
-            status should be(OK)
-            val response = responseAs[WhiskRuleResponse]
-            response should be(rule.withStatus(Status.INACTIVE))
-        }
-    }
-
-    //// PUT /rules/name
-    it should "create rule" in {
-        implicit val tid = transid()
-
-        val rule = WhiskRule(namespace, aname(), FullyQualifiedEntityName(namespace, aname()), FullyQualifiedEntityName(namespace, aname()))
-        val trigger = WhiskTrigger(rule.trigger.path, rule.trigger.name)
-        val action = WhiskAction(rule.action.path, rule.action.name, jsDefault("??"))
-        val content = WhiskRulePut(Some(rule.trigger), Some(rule.action))
-
-        put(entityStore, trigger, false)
-        put(entityStore, action)
-
-        Put(s"$collectionPath/${rule.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            val t = get(entityStore, trigger.docid, WhiskTrigger)
-            deleteTrigger(t.docid)
-            deleteRule(rule.docid)
-
-            status should be(OK)
-            val response = responseAs[WhiskRuleResponse]
-            response should be(rule.withStatus(Status.ACTIVE))
-            t.rules.get(rule.fullyQualifiedName(false)) shouldBe ReducedRule(action.fullyQualifiedName(false), Status.ACTIVE)
-        }
-    }
-
-    it should "create rule without fully qualifying name" in {
-        implicit val tid = transid()
-
-        val rule = WhiskRule(namespace, aname(), FullyQualifiedEntityName(namespace, aname()), FullyQualifiedEntityName(namespace, aname()))
-        val trigger = WhiskTrigger(rule.trigger.path, rule.trigger.name)
-        val action = WhiskAction(rule.action.path, rule.action.name, jsDefault("??"))
-        val content = JsObject("trigger" -> JsString(s"/_/${trigger.name.asString}"), "action" -> JsString(s"/_/${action.name.asString}"))
-
-        put(entityStore, trigger, false)
-        put(entityStore, action)
-
-        Put(s"$collectionPath/${rule.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            val t = get(entityStore, trigger.docid, WhiskTrigger)
-            deleteTrigger(t.docid)
-            deleteRule(rule.docid)
-
-            status should be(OK)
-            val response = responseAs[WhiskRuleResponse]
-            response should be(rule.withStatus(Status.ACTIVE))
-            t.rules.get(rule.fullyQualifiedName(false)) shouldBe ReducedRule(action.fullyQualifiedName(false), Status.ACTIVE)
-        }
-    }
-
-    it should "reject create rule without namespace in referenced entities" in {
-        implicit val tid = transid()
-
-        val rule = WhiskRule(namespace, aname(), FullyQualifiedEntityName(namespace, aname()), FullyQualifiedEntityName(namespace, aname()))
-        val trigger = WhiskTrigger(rule.trigger.path, rule.trigger.name)
-        val action = WhiskAction(rule.action.path, rule.action.name, jsDefault("??"))
-        val contentT = JsObject("trigger" -> trigger.name.toJson, "action" -> action.fullyQualifiedName(false).toDocId.toJson)
-        val contentA = JsObject("action" -> action.name.toJson, "trigger" -> trigger.fullyQualifiedName(false).toDocId.toJson)
-
-        Put(s"$collectionPath/${rule.name}", contentT) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[String] shouldBe s"The request content was malformed:\nrequirement failed: ${Messages.malformedFullyQualifiedEntityName}"
-        }
-
-        Put(s"$collectionPath/${rule.name}", contentA) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[String] shouldBe s"The request content was malformed:\nrequirement failed: ${Messages.malformedFullyQualifiedEntityName}"
-        }
-    }
-
-    it should "create rule with an action in a package" in {
-        implicit val tid = transid()
-
-        val provider = WhiskPackage(namespace, aname(), publish = true)
-        val action = WhiskAction(provider.fullPath, aname(), jsDefault("??"))
-        val trigger = WhiskTrigger(namespace, aname())
-        val rule = WhiskRule(namespace, aname(), trigger.fullyQualifiedName(false), action.fullyQualifiedName(false))
-        val content = WhiskRulePut(Some(rule.trigger), Some(rule.action))
-
-        put(entityStore, provider)
-        put(entityStore, trigger, false)
-        put(entityStore, action)
-
-        Put(s"$collectionPath/${rule.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            val t = get(entityStore, trigger.docid, WhiskTrigger)
-            deleteTrigger(t.docid)
-            deleteRule(rule.docid)
-
-            status should be(OK)
-            val response = responseAs[WhiskRuleResponse]
-            response should be(rule.withStatus(Status.ACTIVE))
-            t.rules.get(rule.fullyQualifiedName(false)) shouldBe ReducedRule(action.fullyQualifiedName(false), Status.ACTIVE)
-        }
-    }
-
-    it should "create rule with an action in a binding" in {
-        implicit val tid = transid()
-
-        val provider = WhiskPackage(namespace, aname(), publish = true)
-        val reference = WhiskPackage(namespace, aname(), provider.bind)
-        val action = WhiskAction(provider.fullPath, aname(), jsDefault("??"))
-        val trigger = WhiskTrigger(namespace, aname())
-        val actionReference = reference.binding.map(b => b.namespace.addPath(b.name)).get
-        val rule = WhiskRule(namespace, aname(), trigger.fullyQualifiedName(false), FullyQualifiedEntityName(actionReference, action.name))
-        val content = WhiskRulePut(Some(rule.trigger), Some(rule.action))
-
-        put(entityStore, provider)
-        put(entityStore, reference)
-        put(entityStore, trigger, false)
-        put(entityStore, action)
-
-        Put(s"$collectionPath/${rule.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            val t = get(entityStore, trigger.docid, WhiskTrigger)
-            deleteTrigger(t.docid)
-            deleteRule(rule.docid)
-
-            status should be(OK)
-            val response = responseAs[WhiskRuleResponse]
-            response should be(rule.withStatus(Status.ACTIVE))
-            t.rules.get(rule.fullyQualifiedName(false)) shouldBe ReducedRule(action.fullyQualifiedName(false), Status.ACTIVE)
-        }
-    }
-
-    it should "reject create rule with annotations which are too big" in {
-        implicit val tid = transid()
-
-        val trigger = WhiskTrigger(namespace, aname())
-        val action = WhiskAction(namespace, aname(), jsDefault("??"))
-
-        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (Parameters.sizeLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
-        val annotations = keys map { key =>
-            Parameters(key.toString, "a" * 10)
-        } reduce (_ ++ _)
-        val content = s"""{"trigger":"${trigger.name}","action":"${action.name}","annotations":$annotations}""".parseJson.asJsObject
-
-        put(entityStore, trigger, false)
-        put(entityStore, action)
-
-        Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(creds)) ~> check {
-            val t = get(entityStore, trigger.docid, WhiskTrigger)
-            deleteTrigger(t.docid)
-
-            status should be(RequestEntityTooLarge)
-            responseAs[String] should include {
-                Messages.entityTooBig(SizeError(WhiskEntity.annotationsFieldName, annotations.size, Parameters.sizeLimit))
-            }
-        }
-    }
-
-    it should "reject update rule with annotations which are too big" in {
-        implicit val tid = transid()
-
-        val trigger = WhiskTrigger(namespace, aname())
-        val action = WhiskAction(namespace, aname(), jsDefault("??"))
-        val rule = WhiskRule(namespace, aname(), trigger.fullyQualifiedName(false), action.fullyQualifiedName(false))
-
-        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (Parameters.sizeLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
-        val annotations = keys map { key =>
-            Parameters(key.toString, "a" * 10)
-        } reduce (_ ++ _)
-        val content = s"""{"trigger":"${trigger.name}","action":"${action.name}","annotations":$annotations}""".parseJson.asJsObject
-
-        put(entityStore, trigger, false)
-        put(entityStore, action)
-        put(entityStore, rule)
-
-        Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            val t = get(entityStore, trigger.docid, WhiskTrigger)
-            deleteTrigger(t.docid)
-
-            status should be(RequestEntityTooLarge)
-            responseAs[String] should include {
-                Messages.entityTooBig(SizeError(WhiskEntity.annotationsFieldName, annotations.size, Parameters.sizeLimit))
-            }
-        }
-    }
-
-    it should "reject rule if action does not exist" in {
-        implicit val tid = transid()
-
-        val trigger = WhiskTrigger(namespace, aname())
-        val content = WhiskRulePut(Some(trigger.fullyQualifiedName(false)), Some(afullname(namespace, "bogus action")))
-
-        put(entityStore, trigger)
-
-        Put(s"$collectionPath/xxx", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[String] === s"${content.action.get.qualifiedNameWithLeadingSlash} does not exist"
-        }
-    }
-
-    it should "reject rule if trigger does not exist" in {
-        implicit val tid = transid()
-
-        val action = WhiskAction(namespace, aname(), jsDefault("??"))
-        val content = WhiskRulePut(Some(afullname(namespace, "bogus trigger")), Some(action.fullyQualifiedName(false)))
-
-        put(entityStore, action)
-
-        Put(s"$collectionPath/xxx", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[String] === s"${content.trigger.get.qualifiedNameWithLeadingSlash} does not exist"
-        }
-    }
-
-    it should "reject rule if neither action or trigger do not exist" in {
-        implicit val tid = transid()
-
-        val content = WhiskRulePut(Some(afullname(namespace, "bogus trigger")), Some(afullname(namespace, "bogus action")))
-
-        Put(s"$collectionPath/xxx", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[String].contains("does not exist") should be(true)
-        }
-    }
-
-    it should "update rule with new trigger and action at once" in {
-        implicit val tid = transid()
-
-        val trigger = WhiskTrigger(namespace, aname())
-        val action = WhiskAction(namespace, aname(), jsDefault("??"))
-        val rule = WhiskRule(namespace, aname(), afullname(namespace, "bogus trigger"), afullname(namespace, "bogus action"))
-        val content = WhiskRulePut(Some(trigger.fullyQualifiedName(false)), Some(action.fullyQualifiedName(false)))
-
-        put(entityStore, trigger, false)
-        put(entityStore, action)
-        put(entityStore, rule, false)
-
-        Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            val t = get(entityStore, trigger.docid, WhiskTrigger)
-            deleteTrigger(t.docid)
-            deleteRule(rule.docid)
-
-            status should be(OK)
-
-            t.rules.get(rule.fullyQualifiedName(false)).action should be(action.fullyQualifiedName(false))
-            val response = responseAs[WhiskRuleResponse]
-            response should be(WhiskRuleResponse(namespace, rule.name, Status.ACTIVE, trigger.fullyQualifiedName(false), action.fullyQualifiedName(false), version = SemVer().upPatch))
-        }
-    }
-
-    it should "update rule with a new action while passing the same trigger" in {
-        implicit val tid = transid()
-
-        val trigger = WhiskTrigger(namespace, aname())
-        val action = WhiskAction(namespace, aname(), jsDefault("??"))
-        val rule = WhiskRule(namespace, aname(), trigger.fullyQualifiedName(false), afullname(namespace, "bogus action"))
-        val content = WhiskRulePut(Some(trigger.fullyQualifiedName(false)), Some(action.fullyQualifiedName(false)))
-
-        put(entityStore, trigger, false)
-        put(entityStore, action)
-        put(entityStore, rule, false)
-
-        Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            val t = get(entityStore, trigger.docid, WhiskTrigger)
-            deleteTrigger(t.docid)
-            deleteRule(rule.docid)
-
-            status should be(OK)
-            t.rules.get(rule.fullyQualifiedName(false)).action should be(action.fullyQualifiedName(false))
-            val response = responseAs[WhiskRuleResponse]
-            response should be(WhiskRuleResponse(namespace, rule.name, Status.ACTIVE, trigger.fullyQualifiedName(false), action.fullyQualifiedName(false), version = SemVer().upPatch))
-        }
-    }
-
-    it should "update rule with just a new action" in {
-        implicit val tid = transid()
-
-        val trigger = WhiskTrigger(namespace, aname())
-        val action = WhiskAction(namespace, aname(), jsDefault("??"))
-        val rule = WhiskRule(namespace, aname(), trigger.fullyQualifiedName(false), afullname(namespace, "bogus action"))
-        val content = WhiskRulePut(action = Some(action.fullyQualifiedName(false)))
-
-        put(entityStore, trigger, false)
-        put(entityStore, action)
-        put(entityStore, rule, false)
-
-        Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            val t = get(entityStore, trigger.docid, WhiskTrigger)
-            deleteTrigger(t.docid)
-            deleteRule(rule.docid)
-
-            status should be(OK)
-            t.rules.get(rule.fullyQualifiedName(false)).action should be(action.fullyQualifiedName(false))
-            val response = responseAs[WhiskRuleResponse]
-            response should be(WhiskRuleResponse(namespace, rule.name, Status.ACTIVE, trigger.fullyQualifiedName(false), action.fullyQualifiedName(false), version = SemVer().upPatch))
-        }
-    }
-
-    it should "update rule with just a new trigger" in {
-        implicit val tid = transid()
-
-        val trigger = WhiskTrigger(namespace, aname())
-        val action = WhiskAction(namespace, aname(), jsDefault("??"))
-        val rule = WhiskRule(namespace, aname(), trigger.fullyQualifiedName(false), action.fullyQualifiedName(false))
-        val content = WhiskRulePut(trigger = Some(trigger.fullyQualifiedName(false)))
-
-        put(entityStore, trigger, false)
-        put(entityStore, action)
-        put(entityStore, rule, false)
-
-        Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            val t = get(entityStore, trigger.docid, WhiskTrigger)
-            deleteTrigger(t.docid)
-            deleteRule(rule.docid)
-
-            status should be(OK)
-            t.rules.get.get(rule.fullyQualifiedName(false)) shouldBe a[Some[_]]
-            val response = responseAs[WhiskRuleResponse]
-            response should be(WhiskRuleResponse(namespace, rule.name, Status.ACTIVE, trigger.fullyQualifiedName(false), action.fullyQualifiedName(false), version = SemVer().upPatch))
-        }
-    }
-
-    it should "update rule when no new content is provided" in {
-        implicit val tid = transid()
-        val trigger = WhiskTrigger(namespace, aname())
-        val action = WhiskAction(namespace, aname(), jsDefault("??"))
-        val rule = WhiskRule(namespace, aname(), trigger.fullyQualifiedName(false), action.fullyQualifiedName(false))
-        val content = WhiskRulePut(None, None, None, None, None)
-
-        put(entityStore, trigger, false)
-        put(entityStore, action)
-        put(entityStore, rule, false)
-
-        Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            deleteTrigger(trigger.docid)
-            deleteRule(rule.docid)
-
-            status should be(OK)
-            val response = responseAs[WhiskRuleResponse]
-            response should be(WhiskRuleResponse(namespace, rule.name, Status.ACTIVE, trigger.fullyQualifiedName(false), action.fullyQualifiedName(false), version = SemVer().upPatch))
-        }
-    }
-
-    it should "reject update rule if trigger does not exist" in {
-        implicit val tid = transid()
-
-        val action = WhiskAction(namespace, aname(), jsDefault("??"))
-        val rule = WhiskRule(namespace, aname(), afullname(namespace, "bogus trigger"), action.fullyQualifiedName(false))
-        val content = WhiskRulePut(action = Some(action.fullyQualifiedName(false)))
-
-        put(entityStore, action)
-        put(entityStore, rule)
-
-        Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[String] === s"${rule.trigger.qualifiedNameWithLeadingSlash} does not exist"
-        }
-    }
-
-    it should "reject update rule if action does not exist" in {
-        implicit val tid = transid()
-
-        val trigger = WhiskTrigger(namespace, aname())
-        val rule = WhiskRule(namespace, aname(), trigger.fullyQualifiedName(false), afullname(namespace, "bogus action"))
-        val content = WhiskRulePut(trigger = Some(trigger.fullyQualifiedName(false)))
-
-        put(entityStore, trigger)
-        put(entityStore, rule)
-
-        Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[String] === s"${rule.action.qualifiedNameWithLeadingSlash} does not exist"
-        }
-    }
-
-    it should "reject update rule if neither trigger or action exist" in {
-        implicit val tid = transid()
-        val rule = WhiskRule(namespace, aname(), afullname(namespace, "bogus trigger"), afullname(namespace, "bogus action"))
-        val content = WhiskRulePut(None, None, None, None, None)
-
-        put(entityStore, rule)
-
-        Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[String] should {
-                include(s"${rule.action.qualifiedNameWithLeadingSlash} does not exist") or
-                    include(s"${rule.trigger.qualifiedNameWithLeadingSlash} does not exist")
-            }
-        }
-    }
-
-    it should "not reject update rule in state active" in {
-        implicit val tid = transid()
-
-        val rule = WhiskRule(namespace, aname(), afullname(namespace, "a trigger"), afullname(namespace, "an action"))
-        val trigger = WhiskTrigger(namespace, rule.trigger.name, rules = Some {
-            Map(rule.fullyQualifiedName(false) -> ReducedRule(rule.action, Status.ACTIVE))
-        })
-        val action = WhiskAction(namespace, aname(), jsDefault("??"))
-        val content = WhiskRulePut(Some(trigger.fullyQualifiedName(false)), Some(action.fullyQualifiedName(false)))
-
-        put(entityStore, trigger, false)
-        put(entityStore, action)
-        put(entityStore, rule, false)
-
-        Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            val t = get(entityStore, trigger.docid, WhiskTrigger)
-            deleteTrigger(t.docid)
-            deleteRule(rule.docid)
-
-            status should be(OK)
-            t.rules.get(rule.fullyQualifiedName(false)).action should be(action.fullyQualifiedName(false))
-            val response = responseAs[WhiskRuleResponse]
-            response should be(WhiskRuleResponse(namespace, rule.name, Status.ACTIVE, trigger.fullyQualifiedName(false), action.fullyQualifiedName(false), version = SemVer().upPatch))
-        }
-    }
-
-    //// POST /rules/name
-    it should "do nothing to disable already disabled rule" in {
-        implicit val tid = transid()
-
-        val rule = WhiskRule(namespace, aname(), afullname(namespace, "a trigger"), afullname(namespace, "an action"))
-
-        put(entityStore, rule)
-
-        Post(s"$collectionPath/${rule.name}", inactiveStatus) ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-        }
-    }
-
-    it should "do nothing to enable already enabled rule" in {
-        implicit val tid = transid()
-
-        val rule = WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, "an action"))
-        val trigger = WhiskTrigger(namespace, rule.trigger.name, rules = Some {
-            Map(rule.fullyQualifiedName(false) -> ReducedRule(rule.action, Status.ACTIVE))
-        })
-
-        put(entityStore, trigger)
-        put(entityStore, rule)
-
-        Post(s"$collectionPath/${rule.name}", activeStatus) ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-        }
-    }
-
-    it should "reject post with status undefined" in {
-        implicit val tid = transid()
-
-        Post(s"$collectionPath/xyz") ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-        }
-    }
-
-    it should "reject post with invalid status" in {
-        implicit val tid = transid()
-
-        val badStatus = s"""{"status":"xxx"}""".parseJson.asJsObject
-
-        Post(s"$collectionPath/xyz", badStatus) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-        }
-    }
-
-    it should "activate rule" in {
-        implicit val tid = transid()
-
-        val rule = WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, "an action"))
-        val trigger = WhiskTrigger(namespace, rule.trigger.name, rules = Some {
-            Map(rule.fullyQualifiedName(false) -> ReducedRule(rule.action, Status.INACTIVE))
-        })
-
-        put(entityStore, trigger, false)
-        put(entityStore, rule)
-
-        Post(s"$collectionPath/${rule.name}", activeStatus) ~> Route.seal(routes(creds)) ~> check {
-            val t = get(entityStore, trigger.docid, WhiskTrigger)
-            deleteTrigger(t.docid)
-
-            status should be(OK)
-
-            t.rules.get(rule.fullyQualifiedName(false)).status should be(Status.ACTIVE)
-        }
-    }
-
-    it should "activate rule without rule in trigger" in {
-        implicit val tid = transid()
-
-        val rule = WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, "an action"))
-        val trigger = WhiskTrigger(namespace, rule.trigger.name)
-
-        put(entityStore, trigger, false)
-        put(entityStore, rule)
-
-        Post(s"$collectionPath/${rule.name}", activeStatus) ~> Route.seal(routes(creds)) ~> check {
-            val t = get(entityStore, trigger.docid, WhiskTrigger)
-            deleteTrigger(t.docid)
-
-            status should be(OK)
-            t.rules.get(rule.fullyQualifiedName(false)).status should be(Status.ACTIVE)
-        }
-    }
-
-    it should "reject rule activation, if the trigger is absent" in {
-        implicit val tid = transid()
-
-        val rule = WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, "an action"))
-
-        put(entityStore, rule)
-
-        Post(s"$collectionPath/${rule.name}", activeStatus) ~> Route.seal(routes(creds)) ~> check {
-            status should be(NotFound)
-        }
-    }
-
-    it should "deactivate rule" in {
-        implicit val tid = transid()
-
-        val rule = WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, "an action"))
-        val trigger = WhiskTrigger(namespace, rule.trigger.name, rules = Some {
-            Map(rule.fullyQualifiedName(false) -> ReducedRule(rule.action, Status.ACTIVE))
-        })
-
-        put(entityStore, trigger, false)
-        put(entityStore, rule)
-
-        Post(s"$collectionPath/${rule.name}", inactiveStatus) ~> Route.seal(routes(creds)) ~> check {
-            val t = get(entityStore, trigger.docid, WhiskTrigger)
-            deleteTrigger(t.docid)
-
-            status should be(OK)
-            t.rules.get(rule.fullyQualifiedName(false)).status should be(Status.INACTIVE)
-        }
-    }
-
-    // invalid resource
-    it should "reject invalid resource" in {
-        implicit val tid = transid()
-
-        val rule = WhiskRule(namespace, aname(), afullname(namespace, "a trigger"), afullname(namespace, "an action"))
-
-        put(entityStore, rule)
-
-        Get(s"$collectionPath/${rule.name}/bar") ~> Route.seal(routes(creds)) ~> check {
-            status should be(NotFound)
-        }
-    }
-
-    // migration path
-    it should "handle a rule with the old schema gracefully" in {
-        implicit val tid = transid()
-
-        val rule = OldWhiskRule(namespace, aname(), EntityName("a trigger"), EntityName("an action"), Status.ACTIVE)
-
-        put(entityStore, rule)
-
-        Get(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskRuleResponse]
-            response should be(rule.toWhiskRule.withStatus(Status.INACTIVE))
-        }
-    }
-
-    it should "create rule even if the attached trigger has the old schema" in {
-        implicit val tid = transid()
-
-        val rule = WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, aname().name))
-        val trigger = OldWhiskTrigger(namespace, rule.trigger.name)
-
-        val action = WhiskAction(namespace, rule.action.name, jsDefault("??"))
-        val content = WhiskRulePut(Some(rule.trigger), Some(rule.action))
-
-        put(entityStore, trigger, false)
-        put(entityStore, action)
-
-        Put(s"$collectionPath/${rule.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            val t = get(entityStore, trigger.docid, WhiskTrigger)
-            deleteTrigger(t.docid)
-            deleteRule(rule.docid)
-
-            status should be(OK)
-            t.rules.get(rule.fullyQualifiedName(false)) shouldBe ReducedRule(action.fullyQualifiedName(false), Status.ACTIVE)
-            val response = responseAs[WhiskRuleResponse]
-            response should be(rule.withStatus(Status.ACTIVE))
-        }
-    }
-
-    it should "activate rule even if it is still in the old schema" in {
-        implicit val tid = transid()
-
-        val ruleNameQualified = FullyQualifiedEntityName(namespace, aname())
-        val triggerName = aname()
-        val actionName = FullyQualifiedEntityName(namespace, aname())
-        val rule = OldWhiskRule(namespace, ruleNameQualified.name, triggerName, actionName.name, Status.ACTIVE)
-        val trigger = WhiskTrigger(namespace, triggerName, rules = Some(Map(ruleNameQualified -> ReducedRule(actionName, Status.INACTIVE))))
-
-        put(entityStore, trigger, false)
-        put(entityStore, rule)
-
-        Post(s"$collectionPath/${rule.name}", activeStatus) ~> Route.seal(routes(creds)) ~> check {
-            val t = get(entityStore, trigger.docid, WhiskTrigger)
-            deleteTrigger(t.docid)
-
-            status should be(OK)
-
-            t.rules.get(ruleNameQualified).status should be(Status.ACTIVE)
-        }
-    }
-
-    it should "report proper error when record is corrupted on delete" in {
-        implicit val tid = transid()
-        val entity = BadEntity(namespace, aname())
-        put(entityStore, entity)
-
-        Delete(s"$collectionPath/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(InternalServerError)
-            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-        }
-    }
-
-    it should "report proper error when record is corrupted on get" in {
-        implicit val tid = transid()
-        val entity = BadEntity(namespace, aname())
-        put(entityStore, entity)
-
-        Get(s"$collectionPath/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(InternalServerError)
-            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-        }
-    }
-
-    it should "report proper error when record is corrupted on put" in {
-        implicit val tid = transid()
-        val entity = BadEntity(namespace, aname())
-        put(entityStore, entity)
-
-        val content = WhiskRulePut()
-        Put(s"$collectionPath/${entity.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(InternalServerError)
-            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-        }
-    }
-
-    it should "report proper error when action record is corrupted on put" in {
-        implicit val tid = transid()
-        val tentity = BadEntity(namespace, aname())
-        val aentity = BadEntity(namespace, aname())
-        val rule = WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, aname().name))
-        val trigger = WhiskTrigger(namespace, rule.trigger.name)
-        val action = WhiskAction(namespace, rule.action.name, jsDefault("??"))
-
-        val contenta = WhiskRulePut(Some(tentity.fullyQualifiedName(false)), Some(aentity.fullyQualifiedName(false)))
-        val contentb = WhiskRulePut(Some(trigger.fullyQualifiedName(false)), Some(aentity.fullyQualifiedName(false)))
-        val contentc = WhiskRulePut(Some(tentity.fullyQualifiedName(false)), Some(action.fullyQualifiedName(false)))
-
-        put(entityStore, tentity)
-        put(entityStore, aentity)
-        put(entityStore, trigger)
-        put(entityStore, action)
-
-        Put(s"$collectionPath/${aname()}", contenta) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-        }
-
-        Put(s"$collectionPath/${aname()}", contentb) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-        }
-
-        Put(s"$collectionPath/${aname()}", contentc) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-        }
-    }
+  }
 }

--- a/tests/src/test/scala/whisk/core/controller/test/SequenceApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/SequenceApiTests.scala
@@ -40,394 +40,399 @@ import whisk.http.Messages
  * Tests Sequence API - stand-alone tests that require only the controller to be up
  */
 @RunWith(classOf[JUnitRunner])
-class SequenceApiTests
-    extends ControllerTestCommon
-    with WhiskActionsApi {
+class SequenceApiTests extends ControllerTestCommon with WhiskActionsApi {
 
-    behavior of "Sequence API"
+  behavior of "Sequence API"
 
-    val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
-    val creds = WhiskAuthHelpers.newIdentity()
-    val namespace = EntityPath(creds.subject.asString)
-    val defaultNamespace = EntityPath.DEFAULT
-    def aname() = MakeName.next("sequence_tests")
-    val allowedActionDuration = 120 seconds
+  val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
+  val creds = WhiskAuthHelpers.newIdentity()
+  val namespace = EntityPath(creds.subject.asString)
+  val defaultNamespace = EntityPath.DEFAULT
+  def aname() = MakeName.next("sequence_tests")
+  val allowedActionDuration = 120 seconds
 
-    it should "reject creation of sequence with more actions than allowed limit" in {
-        implicit val tid = transid()
-        val seqName = EntityName(s"${aname()}_toomanyactions")
-        // put the component action in the entity store so it's found
-        val component = WhiskAction(namespace, aname(), jsDefault("??"))
-        put(entityStore, component)
-        // create exec sequence that will violate max length
-        val limit = whiskConfig.actionSequenceLimit.toInt + 1 // one more than allowed
-        val components = for (i <- 1 to limit) yield stringToFullyQualifiedName(component.docid.asString)
-        val content = WhiskActionPut(Some(sequence(components.toVector)))
+  it should "reject creation of sequence with more actions than allowed limit" in {
+    implicit val tid = transid()
+    val seqName = EntityName(s"${aname()}_toomanyactions")
+    // put the component action in the entity store so it's found
+    val component = WhiskAction(namespace, aname(), jsDefault("??"))
+    put(entityStore, component)
+    // create exec sequence that will violate max length
+    val limit = whiskConfig.actionSequenceLimit.toInt + 1 // one more than allowed
+    val components = for (i <- 1 to limit) yield stringToFullyQualifiedName(component.docid.asString)
+    val content = WhiskActionPut(Some(sequence(components.toVector)))
 
-        // create an action sequence
-        Put(s"$collectionPath/${seqName.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[ErrorResponse].error shouldBe Messages.sequenceIsTooLong
-        }
+    // create an action sequence
+    Put(s"$collectionPath/${seqName.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[ErrorResponse].error shouldBe Messages.sequenceIsTooLong
+    }
+  }
+
+  it should "reject creation of sequence with no component specified" in {
+    implicit val tid = transid()
+    val seqName = s"${aname()}_no_component"
+    // create exec sequence with no component
+    val content = WhiskActionPut(Some(sequence(Vector())))
+
+    // create an action sequence
+    Put(s"$collectionPath/$seqName", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[ErrorResponse].error shouldBe Messages.sequenceNoComponent
+    }
+  }
+
+  it should "reject update of sequence with no component specified" in {
+    implicit val tid = transid()
+    val seqName = s"${aname()}_update_no_component"
+    // install fake sequence in db to be able to do update
+    val components = Vector("a", "b")
+    putSimpleSequenceInDB(seqName, namespace, components)
+    // update sequence with no component
+    val updateContent = WhiskActionPut(Some(sequence(Vector())))
+
+    // create an action sequence
+    Put(s"$collectionPath/$seqName?overwrite=true", updateContent) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[ErrorResponse].error shouldBe Messages.sequenceNoComponent
+    }
+  }
+
+  it should "reject creation of sequence with non-existent action" in {
+    implicit val tid = transid()
+    val seqName = EntityName(s"${aname()}_componentnotfound")
+    val bogus = s"${aname()}_bogus"
+    val bogusAction = s"/$namespace/$bogus"
+    val components = Vector(bogusAction).map(stringToFullyQualifiedName(_))
+    val content = WhiskActionPut(Some(sequence(components)))
+
+    // create an action sequence
+    Put(s"$collectionPath/${seqName.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[ErrorResponse].error shouldBe Messages.sequenceComponentNotFound
+    }
+  }
+
+  it should "reject create sequence that points to itself" in {
+    implicit val tid = transid()
+    val seqName = s"${aname()}_cyclic"
+    val sSeq = makeSimpleSequence(seqName, namespace, Vector(seqName), false)
+
+    // create an action sequence
+    val content = WhiskActionPut(Some(sSeq.exec))
+    Put(s"$collectionPath/$seqName", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[ErrorResponse].error shouldBe Messages.sequenceIsCyclic
+    }
+  }
+
+  it should "reject create sequence that points to itself with many components" in {
+    implicit val tid = transid()
+
+    // put the action in the entity store so it's found
+    val component = WhiskAction(namespace, aname(), jsDefault("??"))
+    put(entityStore, component)
+
+    val seqName = s"${aname()}_cyclic"
+    val sSeq =
+      makeSimpleSequence(seqName, namespace, Vector(component.name.asString, seqName, component.name.asString), false)
+
+    // create an action sequence
+    val content = WhiskActionPut(Some(sSeq.exec))
+    Put(s"$collectionPath/$seqName", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[ErrorResponse].error shouldBe Messages.sequenceIsCyclic
+    }
+  }
+
+  it should "reject update of sequence with cycle" in {
+    implicit val tid = transid()
+    val seqName = EntityName(s"${aname()}_cycle")
+    // put the component action in the entity store so it's found
+    val component = WhiskAction(namespace, aname(), jsDefault("??"))
+    put(entityStore, component)
+    // create valid exec sequence initially
+    val components = for (i <- 1 to 2) yield stringToFullyQualifiedName(component.docid.asString)
+    val content = WhiskActionPut(Some(sequence(components.toVector)))
+
+    // create a valid action sequence first
+    Put(s"$collectionPath/${seqName.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
     }
 
-    it should "reject creation of sequence with no component specified" in {
-        implicit val tid = transid()
-        val seqName = s"${aname()}_no_component"
-        // create exec sequence with no component
-        val content = WhiskActionPut(Some(sequence(Vector())))
+    // now create exec sequence with a self-reference
+    val seqNameWithNamespace = stringToFullyQualifiedName(s"/${namespace}/${seqName.name}")
+    val updatedSeq = components.updated(1, seqNameWithNamespace)
+    val updatedContent = WhiskActionPut(Some(sequence(updatedSeq.toVector)))
 
-        // create an action sequence
-        Put(s"$collectionPath/$seqName", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[ErrorResponse].error shouldBe Messages.sequenceNoComponent
-        }
+    // update the sequence
+    Put(s"$collectionPath/${seqName.name}?overwrite=true", updatedContent) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[ErrorResponse].error shouldBe Messages.sequenceIsCyclic
+    }
+  }
+
+  it should "allow creation of sequence provided the number of actions is <= than allowed limit" in {
+    implicit val tid = transid()
+    val seqName = EntityName(s"${aname()}_normal")
+    // put the component action in the entity store so it's found
+    val component = WhiskAction(namespace, aname(), jsDefault("??"))
+    put(entityStore, component)
+    // create valid exec sequence
+    val limit = whiskConfig.actionSequenceLimit.toInt
+    val components = for (i <- 1 to limit) yield stringToFullyQualifiedName(component.docid.asString)
+    val content = WhiskActionPut(Some(sequence(components.toVector)))
+
+    // create an action sequence
+    Put(s"$collectionPath/${seqName.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+    }
+  }
+
+  it should "allow creation of sequence with actions with package bindings" in {
+    implicit val tid = transid()
+    val seqName = EntityName(s"${aname()}_withbindings")
+
+    // create the package
+    val pkg = s"${aname()}_pkg"
+    val wp = WhiskPackage(namespace, EntityName(pkg), None, publish = true)
+    put(entityStore, wp)
+
+    // create binding to wp
+    val pkgWithBinding = s"${aname()}_pkgbinding"
+    val wpBinding = WhiskPackage(namespace, EntityName(pkgWithBinding), wp.bind)
+    put(entityStore, wpBinding)
+
+    // put the action in the entity store so it exists
+    val actionName = s"${aname()}_action"
+    val namespaceWithPkg = s"/$namespace/$pkg"
+    val action = WhiskAction(EntityPath(namespaceWithPkg), EntityName(actionName), jsDefault("??"))
+    put(entityStore, action)
+
+    // create sequence that refers to action with binding
+    val components = Vector(s"/$defaultNamespace/$pkgWithBinding/$actionName").map(stringToFullyQualifiedName(_))
+    val content = WhiskActionPut(Some(sequence(components)))
+
+    // create an action sequence
+    Put(s"$collectionPath/${seqName.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[String]
+    }
+  }
+
+  it should "reject update of sequence with cycle through bindings" in {
+    implicit val tid = transid()
+    val seqName = EntityName(s"${aname()}_cycle_binding")
+
+    // put the action in the entity store so it's found
+    val component = WhiskAction(namespace, aname(), jsDefault("??"))
+    put(entityStore, component)
+    val components = for (i <- 1 to 2) yield stringToFullyQualifiedName(component.docid.asString)
+
+    // create package
+    val pkg = s"${aname()}_pkg"
+    val wp = WhiskPackage(namespace, EntityName(pkg), None, publish = true)
+    put(entityStore, wp)
+
+    // create an action sequence
+    val namespaceWithPkg = EntityPath(s"/$namespace/$pkg")
+    val content = WhiskActionPut(Some(sequence(components.toVector)))
+    Put(s"$collectionPath/$pkg/${seqName.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
     }
 
-    it should "reject update of sequence with no component specified" in {
-        implicit val tid = transid()
-        val seqName = s"${aname()}_update_no_component"
-        // install fake sequence in db to be able to do update
-        val components = Vector("a", "b")
-        putSimpleSequenceInDB(seqName, namespace, components)
-        // update sequence with no component
-        val updateContent = WhiskActionPut(Some(sequence(Vector())))
+    // create binding
+    val pkgWithBinding = s"${aname()}_pkgbinding"
+    val wpBinding = WhiskPackage(namespace, EntityName(pkgWithBinding), wp.bind)
+    put(entityStore, wpBinding)
 
-        // create an action sequence
-        Put(s"$collectionPath/$seqName?overwrite=true", updateContent) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[ErrorResponse].error shouldBe Messages.sequenceNoComponent
-        }
+    // now update the sequence to refer to itself through the binding
+    val seqNameWithBinding = stringToFullyQualifiedName(s"/$namespace/$pkgWithBinding/${seqName.name}")
+    val updatedSeq = components.updated(1, seqNameWithBinding)
+    val updatedContent = WhiskActionPut(Some(sequence(updatedSeq.toVector)))
+
+    // update the sequence
+    Put(s"$collectionPath/$pkg/${seqName.name}?overwrite=true", updatedContent) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[ErrorResponse].error shouldBe Messages.sequenceIsCyclic
+    }
+  }
+
+  it should "reject creation of a sequence with components that don't have at least namespace and action name" in {
+    implicit val tid = transid()
+    val content = JsObject("exec" -> JsObject("kind" -> Exec.SEQUENCE.toJson, "components" -> Vector("a", "b").toJson))
+
+    Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      // the content will fail to deserialize on the route directive,
+      // and without a custom rejection, the response will be a string
+      responseAs[String] shouldBe s"The request content was malformed:\nrequirement failed: ${Messages.malformedFullyQualifiedEntityName}"
+    }
+  }
+
+  it should "reject update of a sequence with components that don't have at least namespace and action name" in {
+    implicit val tid = transid()
+    val content = JsObject("exec" -> JsObject("kind" -> Exec.SEQUENCE.toJson, "components" -> Vector("a", "b").toJson))
+
+    // update an action sequence
+    Put(s"$collectionPath/${aname()}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      // the content will fail to deserialize on the route directive,
+      // and without a custom rejection, the response will be a string
+      responseAs[String] shouldBe s"The request content was malformed:\nrequirement failed: ${Messages.malformedFullyQualifiedEntityName}"
+    }
+  }
+
+  it should "create a sequence of type s -> (x, x) where x is a sequence and correctly count the atomic actions" in {
+    implicit val tid = transid()
+    val actionCnt = 2
+
+    // make sequence x and install it in db
+    val xSeqName = s"${aname()}_x"
+    val components = for (i <- 1 to actionCnt) yield s"${aname()}_p"
+    putSimpleSequenceInDB(xSeqName, namespace, components.toVector)
+
+    // create an action sequence s
+    val sSeqName = s"${aname()}_s"
+    val sSeq = makeSimpleSequence(sSeqName, namespace, Vector(xSeqName, xSeqName), false) // x is installed in the db already
+    val content = WhiskActionPut(Some(sSeq.exec))
+
+    Console.withOut(stream) {
+      Put(s"$collectionPath/$sSeqName", content) ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        logContains(s"atomic action count ${2 * actionCnt}")(stream)
+      }
+    }
+  }
+
+  /**
+   * Tests the following sequence:
+   * y -> a
+   * x -> b, z
+   * s -> a, x, y
+   *
+   * Update z -> s should not work
+   * Update s -> a, s, b should not work
+   * Update z -> y should work (no cycle) act cnt 1
+   * Update s -> a, x, y, a, b should work (no cycle) act cnt 6
+   */
+  it should "create a complex sequence, allow updates with no cycle and reject updates with cycle" in {
+    val limit = whiskConfig.actionSequenceLimit.toInt
+    assert(whiskConfig.actionSequenceLimit.toInt >= 6)
+    implicit val tid = transid()
+    val actionCnt = 4
+    val aAct = s"${aname()}_a"
+    val yAct = s"${aname()}_y"
+    val yComp = Vector(aAct)
+    // make seq y and store it in the db
+    putSimpleSequenceInDB(yAct, namespace, yComp)
+    val bAct = s"${aname()}_b"
+    val zAct = s"${aname()}_z"
+    val xAct = s"${aname()}_x"
+    val xComp = Vector(bAct, zAct)
+    // make sequence x and install it in db
+    putSimpleSequenceInDB(xAct, namespace, xComp)
+    val sAct = s"${aname()}_s"
+    val sSeq = makeSimpleSequence(sAct, namespace, Vector(s"$aAct", s"$xAct", s"$yAct"), false) // a, x, y  in the db already
+    // create an action sequence s
+    val content = WhiskActionPut(Some(sSeq.exec))
+
+    stream.reset()
+    Console.withOut(stream) {
+      Put(s"$collectionPath/$sAct", content) ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+      }
+      logContains("atomic action count 4")(stream)
     }
 
-    it should "reject creation of sequence with non-existent action" in {
-        implicit val tid = transid()
-        val seqName = EntityName(s"${aname()}_componentnotfound")
-        val bogus = s"${aname()}_bogus"
-        val bogusAction = s"/$namespace/$bogus"
-        val components = Vector(bogusAction).map(stringToFullyQualifiedName(_))
-        val content = WhiskActionPut(Some(sequence(components)))
-
-        // create an action sequence
-        Put(s"$collectionPath/${seqName.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[ErrorResponse].error shouldBe Messages.sequenceComponentNotFound
-        }
+    // update action z to point to s --- should be rejected
+    val zUpdate = makeSimpleSequence(zAct, namespace, Vector(s"$sAct"), false) // s in the db already
+    val zUpdateContent = WhiskActionPut(Some(zUpdate.exec))
+    Put(s"$collectionPath/$zAct?overwrite=true", zUpdateContent) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[ErrorResponse].error shouldBe Messages.sequenceIsCyclic
     }
 
-    it should "reject create sequence that points to itself" in {
-        implicit val tid = transid()
-        val seqName = s"${aname()}_cyclic"
-        val sSeq = makeSimpleSequence(seqName, namespace, Vector(seqName), false)
-
-        // create an action sequence
-        val content = WhiskActionPut(Some(sSeq.exec))
-        Put(s"$collectionPath/$seqName", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[ErrorResponse].error shouldBe Messages.sequenceIsCyclic
-        }
+    // update action s to point to a, s, b --- should be rejected
+    val sUpdate = makeSimpleSequence(sAct, namespace, Vector(s"$aAct", s"$sAct", s"$bAct"), false) // s in the db already
+    val sUpdateContent = WhiskActionPut(Some(sUpdate.exec))
+    Put(s"$collectionPath/$sAct?overwrite=true", sUpdateContent) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[ErrorResponse].error shouldBe Messages.sequenceIsCyclic
     }
 
-    it should "reject create sequence that points to itself with many components" in {
-        implicit val tid = transid()
-
-        // put the action in the entity store so it's found
-        val component = WhiskAction(namespace, aname(), jsDefault("??"))
-        put(entityStore, component)
-
-        val seqName = s"${aname()}_cyclic"
-        val sSeq = makeSimpleSequence(seqName, namespace, Vector(component.name.asString, seqName, component.name.asString), false)
-
-        // create an action sequence
-        val content = WhiskActionPut(Some(sSeq.exec))
-        Put(s"$collectionPath/$seqName", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[ErrorResponse].error shouldBe Messages.sequenceIsCyclic
-        }
+    // update action z to point to y
+    val zSeq = makeSimpleSequence(zAct, namespace, Vector(s"$yAct"), false) // y  in the db already
+    val updateContent = WhiskActionPut(Some(zSeq.exec))
+    stream.reset()
+    Console.withOut(stream) {
+      Put(s"$collectionPath/$zAct?overwrite=true", updateContent) ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+      }
+      logContains("atomic action count 1")(stream)
     }
-
-    it should "reject update of sequence with cycle" in {
-        implicit val tid = transid()
-        val seqName = EntityName(s"${aname()}_cycle")
-        // put the component action in the entity store so it's found
-        val component = WhiskAction(namespace, aname(), jsDefault("??"))
-        put(entityStore, component)
-        // create valid exec sequence initially
-        val components = for (i <- 1 to 2) yield stringToFullyQualifiedName(component.docid.asString)
-        val content = WhiskActionPut(Some(sequence(components.toVector)))
-
-        // create a valid action sequence first
-        Put(s"$collectionPath/${seqName.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-        }
-
-        // now create exec sequence with a self-reference
-        val seqNameWithNamespace = stringToFullyQualifiedName(s"/${namespace}/${seqName.name}")
-        val updatedSeq = components.updated(1, seqNameWithNamespace)
-        val updatedContent = WhiskActionPut(Some(sequence(updatedSeq.toVector)))
-
-        // update the sequence
-        Put(s"$collectionPath/${seqName.name}?overwrite=true", updatedContent) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[ErrorResponse].error shouldBe Messages.sequenceIsCyclic
-        }
+    // update sequence s to s -> a, x, y, a, b
+    val newS = makeSimpleSequence(sAct, namespace, Vector(s"$aAct", s"$xAct", s"$yAct", s"$aAct", s"$bAct"), false) // a, x, y, b  in the db already
+    val newSContent = WhiskActionPut(Some(newS.exec))
+    stream.reset()
+    Console.withOut(stream) {
+      Put(s"${collectionPath}/$sAct?overwrite=true", newSContent) ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+      }
+      logContains("atomic action count 6")(stream)
     }
+  }
 
-    it should "allow creation of sequence provided the number of actions is <= than allowed limit" in {
-        implicit val tid = transid()
-        val seqName = EntityName(s"${aname()}_normal")
-        // put the component action in the entity store so it's found
-        val component = WhiskAction(namespace, aname(), jsDefault("??"))
-        put(entityStore, component)
-        // create valid exec sequence
-        val limit = whiskConfig.actionSequenceLimit.toInt
-        val components = for (i <- 1 to limit) yield stringToFullyQualifiedName(component.docid.asString)
-        val content = WhiskActionPut(Some(sequence(components.toVector)))
+  /**
+   * Makes a simple sequence action and installs it in the db (no call to wsk api/cli).
+   * All actions are in the default package.
+   *
+   * @param sequenceName the name of the sequence
+   * @param ns the namespace to be used when creating the component actions and the sequence action
+   * @param components the names of the actions (entity names, no namespace)
+   */
+  private def putSimpleSequenceInDB(sequenceName: String, ns: EntityPath, components: Vector[String])(
+    implicit tid: TransactionId) = {
+    val seqAction = makeSimpleSequence(sequenceName, ns, components)
+    put(entityStore, seqAction)
+  }
 
-        // create an action sequence
-        Put(s"$collectionPath/${seqName.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-        }
+  /**
+   * Returns a WhiskAction that can be used to create/update a sequence.
+   * If instructed to do so, installs the component actions in the db.
+   * All actions are in the default package.
+   *
+   * @param sequenceName the name of the sequence
+   * @param ns the namespace to be used when creating the component actions and the sequence action
+   * @param componentNames the names of the actions (entity names, no namespace)
+   * @param installDB if true, installs the component actions in the db (default true)
+   */
+  private def makeSimpleSequence(sequenceName: String,
+                                 ns: EntityPath,
+                                 componentNames: Vector[String],
+                                 installDB: Boolean = true)(implicit tid: TransactionId): WhiskAction = {
+    if (installDB) {
+      // create bogus wsk actions
+      val wskActions = componentNames.toSet[String] map { c =>
+        WhiskAction(ns, EntityName(c), jsDefault("??"))
+      }
+      // add them to the db
+      wskActions.foreach { put(entityStore, _) }
     }
-
-    it should "allow creation of sequence with actions with package bindings" in {
-        implicit val tid = transid()
-        val seqName = EntityName(s"${aname()}_withbindings")
-
-        // create the package
-        val pkg = s"${aname()}_pkg"
-        val wp = WhiskPackage(namespace, EntityName(pkg), None, publish = true)
-        put(entityStore, wp)
-
-        // create binding to wp
-        val pkgWithBinding = s"${aname()}_pkgbinding"
-        val wpBinding = WhiskPackage(namespace, EntityName(pkgWithBinding), wp.bind)
-        put(entityStore, wpBinding)
-
-        // put the action in the entity store so it exists
-        val actionName = s"${aname()}_action"
-        val namespaceWithPkg = s"/$namespace/$pkg"
-        val action = WhiskAction(EntityPath(namespaceWithPkg), EntityName(actionName), jsDefault("??"))
-        put(entityStore, action)
-
-        // create sequence that refers to action with binding
-        val components = Vector(s"/$defaultNamespace/$pkgWithBinding/$actionName").map(stringToFullyQualifiedName(_))
-        val content = WhiskActionPut(Some(sequence(components)))
-
-        // create an action sequence
-        Put(s"$collectionPath/${seqName.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[String]
-        }
+    // add namespace to component names
+    val components = componentNames map { c =>
+      stringToFullyQualifiedName(s"/$ns/$c")
     }
+    // create wsk action for the sequence
+    WhiskAction(namespace, EntityName(sequenceName), sequence(components))
+  }
 
-    it should "reject update of sequence with cycle through bindings" in {
-        implicit val tid = transid()
-        val seqName = EntityName(s"${aname()}_cycle_binding")
-
-        // put the action in the entity store so it's found
-        val component = WhiskAction(namespace, aname(), jsDefault("??"))
-        put(entityStore, component)
-        val components = for (i <- 1 to 2) yield stringToFullyQualifiedName(component.docid.asString)
-
-        // create package
-        val pkg = s"${aname()}_pkg"
-        val wp = WhiskPackage(namespace, EntityName(pkg), None, publish = true)
-        put(entityStore, wp)
-
-        // create an action sequence
-        val namespaceWithPkg = EntityPath(s"/$namespace/$pkg")
-        val content = WhiskActionPut(Some(sequence(components.toVector)))
-        Put(s"$collectionPath/$pkg/${seqName.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-        }
-
-        // create binding
-        val pkgWithBinding = s"${aname()}_pkgbinding"
-        val wpBinding = WhiskPackage(namespace, EntityName(pkgWithBinding), wp.bind)
-        put(entityStore, wpBinding)
-
-        // now update the sequence to refer to itself through the binding
-        val seqNameWithBinding = stringToFullyQualifiedName(s"/$namespace/$pkgWithBinding/${seqName.name}")
-        val updatedSeq = components.updated(1, seqNameWithBinding)
-        val updatedContent = WhiskActionPut(Some(sequence(updatedSeq.toVector)))
-
-        // update the sequence
-        Put(s"$collectionPath/$pkg/${seqName.name}?overwrite=true", updatedContent) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[ErrorResponse].error shouldBe Messages.sequenceIsCyclic
-        }
-    }
-
-    it should "reject creation of a sequence with components that don't have at least namespace and action name" in {
-        implicit val tid = transid()
-        val content = JsObject("exec" -> JsObject("kind" -> Exec.SEQUENCE.toJson, "components" -> Vector("a", "b").toJson))
-
-        Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            // the content will fail to deserialize on the route directive,
-            // and without a custom rejection, the response will be a string
-            responseAs[String] shouldBe s"The request content was malformed:\nrequirement failed: ${Messages.malformedFullyQualifiedEntityName}"
-        }
-    }
-
-    it should "reject update of a sequence with components that don't have at least namespace and action name" in {
-        implicit val tid = transid()
-        val content = JsObject("exec" -> JsObject("kind" -> Exec.SEQUENCE.toJson, "components" -> Vector("a", "b").toJson))
-
-        // update an action sequence
-        Put(s"$collectionPath/${aname()}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            // the content will fail to deserialize on the route directive,
-            // and without a custom rejection, the response will be a string
-            responseAs[String] shouldBe s"The request content was malformed:\nrequirement failed: ${Messages.malformedFullyQualifiedEntityName}"
-        }
-    }
-
-    it should "create a sequence of type s -> (x, x) where x is a sequence and correctly count the atomic actions" in {
-        implicit val tid = transid()
-        val actionCnt = 2
-
-        // make sequence x and install it in db
-        val xSeqName = s"${aname()}_x"
-        val components = for (i <- 1 to actionCnt) yield s"${aname()}_p"
-        putSimpleSequenceInDB(xSeqName, namespace, components.toVector)
-
-        // create an action sequence s
-        val sSeqName = s"${aname()}_s"
-        val sSeq = makeSimpleSequence(sSeqName, namespace, Vector(xSeqName, xSeqName), false) // x is installed in the db already
-        val content = WhiskActionPut(Some(sSeq.exec))
-
-        Console.withOut(stream) {
-            Put(s"$collectionPath/$sSeqName", content) ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                logContains(s"atomic action count ${2 * actionCnt}")(stream)
-            }
-        }
-    }
-
-    /**
-     * Tests the following sequence:
-     * y -> a
-     * x -> b, z
-     * s -> a, x, y
-     *
-     * Update z -> s should not work
-     * Update s -> a, s, b should not work
-     * Update z -> y should work (no cycle) act cnt 1
-     * Update s -> a, x, y, a, b should work (no cycle) act cnt 6
-     */
-    it should "create a complex sequence, allow updates with no cycle and reject updates with cycle" in {
-        val limit = whiskConfig.actionSequenceLimit.toInt
-        assert(whiskConfig.actionSequenceLimit.toInt >= 6)
-        implicit val tid = transid()
-        val actionCnt = 4
-        val aAct = s"${aname()}_a"
-        val yAct = s"${aname()}_y"
-        val yComp = Vector(aAct)
-        // make seq y and store it in the db
-        putSimpleSequenceInDB(yAct, namespace, yComp)
-        val bAct = s"${aname()}_b"
-        val zAct = s"${aname()}_z"
-        val xAct = s"${aname()}_x"
-        val xComp = Vector(bAct, zAct)
-        // make sequence x and install it in db
-        putSimpleSequenceInDB(xAct, namespace, xComp)
-        val sAct = s"${aname()}_s"
-        val sSeq = makeSimpleSequence(sAct, namespace, Vector(s"$aAct", s"$xAct", s"$yAct"), false) // a, x, y  in the db already
-        // create an action sequence s
-        val content = WhiskActionPut(Some(sSeq.exec))
-
-        stream.reset()
-        Console.withOut(stream) {
-            Put(s"$collectionPath/$sAct", content) ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-            }
-            logContains("atomic action count 4")(stream)
-        }
-
-        // update action z to point to s --- should be rejected
-        val zUpdate = makeSimpleSequence(zAct, namespace, Vector(s"$sAct"), false) // s in the db already
-        val zUpdateContent = WhiskActionPut(Some(zUpdate.exec))
-        Put(s"$collectionPath/$zAct?overwrite=true", zUpdateContent) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[ErrorResponse].error shouldBe Messages.sequenceIsCyclic
-        }
-
-        // update action s to point to a, s, b --- should be rejected
-        val sUpdate = makeSimpleSequence(sAct, namespace, Vector(s"$aAct", s"$sAct", s"$bAct"), false) // s in the db already
-        val sUpdateContent = WhiskActionPut(Some(sUpdate.exec))
-        Put(s"$collectionPath/$sAct?overwrite=true", sUpdateContent) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[ErrorResponse].error shouldBe Messages.sequenceIsCyclic
-        }
-
-        // update action z to point to y
-        val zSeq = makeSimpleSequence(zAct, namespace, Vector(s"$yAct"), false) // y  in the db already
-        val updateContent = WhiskActionPut(Some(zSeq.exec))
-        stream.reset()
-        Console.withOut(stream) {
-            Put(s"$collectionPath/$zAct?overwrite=true", updateContent) ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-            }
-            logContains("atomic action count 1")(stream)
-        }
-        // update sequence s to s -> a, x, y, a, b
-        val newS = makeSimpleSequence(sAct, namespace, Vector(s"$aAct", s"$xAct", s"$yAct", s"$aAct", s"$bAct"), false) // a, x, y, b  in the db already
-        val newSContent = WhiskActionPut(Some(newS.exec))
-        stream.reset()
-        Console.withOut(stream) {
-            Put(s"${collectionPath}/$sAct?overwrite=true", newSContent) ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-            }
-            logContains("atomic action count 6")(stream)
-        }
-    }
-
-    /**
-     * Makes a simple sequence action and installs it in the db (no call to wsk api/cli).
-     * All actions are in the default package.
-     *
-     * @param sequenceName the name of the sequence
-     * @param ns the namespace to be used when creating the component actions and the sequence action
-     * @param components the names of the actions (entity names, no namespace)
-     */
-    private def putSimpleSequenceInDB(sequenceName: String, ns: EntityPath, components: Vector[String])(
-        implicit tid: TransactionId) = {
-        val seqAction = makeSimpleSequence(sequenceName, ns, components)
-        put(entityStore, seqAction)
-    }
-
-    /**
-     * Returns a WhiskAction that can be used to create/update a sequence.
-     * If instructed to do so, installs the component actions in the db.
-     * All actions are in the default package.
-     *
-     * @param sequenceName the name of the sequence
-     * @param ns the namespace to be used when creating the component actions and the sequence action
-     * @param componentNames the names of the actions (entity names, no namespace)
-     * @param installDB if true, installs the component actions in the db (default true)
-     */
-    private def makeSimpleSequence(sequenceName: String, ns: EntityPath, componentNames: Vector[String], installDB: Boolean = true)(
-        implicit tid: TransactionId): WhiskAction = {
-        if (installDB) {
-            // create bogus wsk actions
-            val wskActions = componentNames.toSet[String] map { c => WhiskAction(ns, EntityName(c), jsDefault("??")) }
-            // add them to the db
-            wskActions.foreach { put(entityStore, _) }
-        }
-        // add namespace to component names
-        val components = componentNames map { c => stringToFullyQualifiedName(s"/$ns/$c") }
-        // create wsk action for the sequence
-        WhiskAction(namespace, EntityName(sequenceName), sequence(components))
-    }
-
-    private def logContains(w: String)(implicit stream: java.io.ByteArrayOutputStream): Boolean = {
-        whisk.utils.retry({
-            val log = stream.toString()
-            val result = log.contains(w)
-            assert(result) // throws exception required to retry
-            result
-        }, 10, Some(100 milliseconds))
-    }
+  private def logContains(w: String)(implicit stream: java.io.ByteArrayOutputStream): Boolean = {
+    whisk.utils.retry({
+      val log = stream.toString()
+      val result = log.contains(w)
+      assert(result) // throws exception required to retry
+      result
+    }, 10, Some(100 milliseconds))
+  }
 }

--- a/tests/src/test/scala/whisk/core/controller/test/SwaggerRoutesTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/SwaggerRoutesTests.scala
@@ -43,19 +43,19 @@ import whisk.core.controller.SwaggerDocs
 @RunWith(classOf[JUnitRunner])
 class SwaggerRoutesTests extends ControllerTestCommon with BeforeAndAfterEach {
 
-    behavior of "Swagger routes"
+  behavior of "Swagger routes"
 
-    it should "server docs" in {
-        implicit val tid = transid()
-        val swagger = new SwaggerDocs(Uri.Path.Empty, "infoswagger.json")
-        Get("/docs") ~> Route.seal(swagger.swaggerRoutes) ~> check {
-            status shouldBe PermanentRedirect
-            header("location").get.value shouldBe "docs/index.html?url=/api-docs"
-        }
-
-        Get("/api-docs") ~> Route.seal(swagger.swaggerRoutes) ~> check {
-            status shouldBe OK
-            responseAs[JsObject].fields("swagger") shouldBe JsString("2.0")
-        }
+  it should "server docs" in {
+    implicit val tid = transid()
+    val swagger = new SwaggerDocs(Uri.Path.Empty, "infoswagger.json")
+    Get("/docs") ~> Route.seal(swagger.swaggerRoutes) ~> check {
+      status shouldBe PermanentRedirect
+      header("location").get.value shouldBe "docs/index.html?url=/api-docs"
     }
+
+    Get("/api-docs") ~> Route.seal(swagger.swaggerRoutes) ~> check {
+      status shouldBe OK
+      responseAs[JsObject].fields("swagger") shouldBe JsString("2.0")
+    }
+  }
 }

--- a/tests/src/test/scala/whisk/core/controller/test/TriggersApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/TriggersApiTests.scala
@@ -55,330 +55,348 @@ import whisk.http.Messages
 @RunWith(classOf[JUnitRunner])
 class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
 
-    /** Triggers API tests */
-    behavior of "Triggers API"
+  /** Triggers API tests */
+  behavior of "Triggers API"
 
-    val creds = WhiskAuthHelpers.newIdentity()
-    val namespace = EntityPath(creds.subject.asString)
-    val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
-    def aname = MakeName.next("triggers_tests")
-    val parametersLimit = Parameters.sizeLimit
+  val creds = WhiskAuthHelpers.newIdentity()
+  val namespace = EntityPath(creds.subject.asString)
+  val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
+  def aname = MakeName.next("triggers_tests")
+  val parametersLimit = Parameters.sizeLimit
 
-    //// GET /triggers
-    it should "list triggers by default/explicit namespace" in {
-        implicit val tid = transid()
-        val triggers = (1 to 2).map { i =>
-            WhiskTrigger(namespace, aname, Parameters("x", "b"))
-        }.toList
-        triggers foreach { put(entityStore, _) }
-        waitOnView(entityStore, WhiskTrigger, namespace, 2)
-        Get(s"$collectionPath") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[List[JsObject]]
-            triggers.length should be(response.length)
-            triggers forall { a => response contains a.summaryAsJson } should be(true)
-        }
-
-        // it should "list triggers with explicit namespace owned by subject" in {
-        Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[List[JsObject]]
-            triggers.length should be(response.length)
-            triggers forall { a => response contains a.summaryAsJson } should be(true)
-        }
-
-        // it should "reject list triggers with explicit namespace not owned by subject" in {
-        val auser = WhiskAuthHelpers.newIdentity()
-        Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden)
-        }
+  //// GET /triggers
+  it should "list triggers by default/explicit namespace" in {
+    implicit val tid = transid()
+    val triggers = (1 to 2).map { i =>
+      WhiskTrigger(namespace, aname, Parameters("x", "b"))
+    }.toList
+    triggers foreach { put(entityStore, _) }
+    waitOnView(entityStore, WhiskTrigger, namespace, 2)
+    Get(s"$collectionPath") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[List[JsObject]]
+      triggers.length should be(response.length)
+      triggers forall { a =>
+        response contains a.summaryAsJson
+      } should be(true)
     }
 
-    // ?docs disabled
-    ignore should "list triggers by default namespace with full docs" in {
-        implicit val tid = transid()
-        val triggers = (1 to 2).map { i =>
-            WhiskTrigger(namespace, aname, Parameters("x", "b"))
-        }.toList
-        triggers foreach { put(entityStore, _) }
-        waitOnView(entityStore, WhiskTrigger, namespace, 2)
-        Get(s"$collectionPath?docs=true") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[List[WhiskTrigger]]
-            triggers.length should be(response.length)
-            triggers forall { a => response contains a } should be(true)
-        }
+    // it should "list triggers with explicit namespace owned by subject" in {
+    Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[List[JsObject]]
+      triggers.length should be(response.length)
+      triggers forall { a =>
+        response contains a.summaryAsJson
+      } should be(true)
     }
 
-    //// GET /triggers/name
-    it should "get trigger by name in default/explicit namespace" in {
-        implicit val tid = transid()
-        val trigger = WhiskTrigger(namespace, aname, Parameters("x", "b"))
-        put(entityStore, trigger)
-        Get(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskTrigger]
-            response should be(trigger.withoutRules)
-        }
+    // it should "reject list triggers with explicit namespace not owned by subject" in {
+    val auser = WhiskAuthHelpers.newIdentity()
+    Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden)
+    }
+  }
 
-        // it should "get trigger by name in explicit namespace owned by subject" in
-        Get(s"/$namespace/${collection.path}/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskTrigger]
-            response should be(trigger.withoutRules)
-        }
+  // ?docs disabled
+  ignore should "list triggers by default namespace with full docs" in {
+    implicit val tid = transid()
+    val triggers = (1 to 2).map { i =>
+      WhiskTrigger(namespace, aname, Parameters("x", "b"))
+    }.toList
+    triggers foreach { put(entityStore, _) }
+    waitOnView(entityStore, WhiskTrigger, namespace, 2)
+    Get(s"$collectionPath?docs=true") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[List[WhiskTrigger]]
+      triggers.length should be(response.length)
+      triggers forall { a =>
+        response contains a
+      } should be(true)
+    }
+  }
 
-        // it should "reject get trigger by name in explicit namespace not owned by subject" in
-        val auser = WhiskAuthHelpers.newIdentity()
-        Get(s"/$namespace/${collection.path}/${trigger.name}") ~> Route.seal(routes(auser)) ~> check {
-            status should be(Forbidden)
-        }
+  //// GET /triggers/name
+  it should "get trigger by name in default/explicit namespace" in {
+    implicit val tid = transid()
+    val trigger = WhiskTrigger(namespace, aname, Parameters("x", "b"))
+    put(entityStore, trigger)
+    Get(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskTrigger]
+      response should be(trigger.withoutRules)
     }
 
-    it should "report Conflict if the name was of a different type" in {
-        implicit val tid = transid()
-        val rule = WhiskRule(namespace, aname, FullyQualifiedEntityName(namespace, aname), FullyQualifiedEntityName(namespace, aname))
-        put(entityStore, rule)
-        Get(s"/$namespace/${collection.path}/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(Conflict)
-        }
+    // it should "get trigger by name in explicit namespace owned by subject" in
+    Get(s"/$namespace/${collection.path}/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskTrigger]
+      response should be(trigger.withoutRules)
     }
 
-    //// DEL /triggers/name
-    it should "delete trigger by name" in {
-        implicit val tid = transid()
-        val trigger = WhiskTrigger(namespace, aname, Parameters("x", "b"))
-        put(entityStore, trigger)
-        Delete(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskTrigger]
-            response should be(trigger.withoutRules)
-        }
+    // it should "reject get trigger by name in explicit namespace not owned by subject" in
+    val auser = WhiskAuthHelpers.newIdentity()
+    Get(s"/$namespace/${collection.path}/${trigger.name}") ~> Route.seal(routes(auser)) ~> check {
+      status should be(Forbidden)
     }
+  }
 
-    //// PUT /triggers/name
-    it should "put should accept request with missing optional properties" in {
-        implicit val tid = transid()
-        val trigger = WhiskTrigger(namespace, aname)
-        val content = WhiskTriggerPut()
-        Put(s"$collectionPath/${trigger.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            deleteTrigger(trigger.docid)
-            status should be(OK)
-            val response = responseAs[WhiskTrigger]
-            response should be(trigger.withoutRules)
-        }
+  it should "report Conflict if the name was of a different type" in {
+    implicit val tid = transid()
+    val rule = WhiskRule(
+      namespace,
+      aname,
+      FullyQualifiedEntityName(namespace, aname),
+      FullyQualifiedEntityName(namespace, aname))
+    put(entityStore, rule)
+    Get(s"/$namespace/${collection.path}/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(Conflict)
     }
+  }
 
-    it should "put should accept request with valid feed parameter" in {
-        implicit val tid = transid()
-        val trigger = WhiskTrigger(namespace, aname, annotations = Parameters(Parameters.Feed, "xyz"))
-        val content = WhiskTriggerPut(annotations = Some(trigger.annotations))
-        Put(s"$collectionPath/${trigger.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            deleteTrigger(trigger.docid)
-            status should be(OK)
-            val response = responseAs[WhiskTrigger]
-            response should be(trigger.withoutRules)
-        }
+  //// DEL /triggers/name
+  it should "delete trigger by name" in {
+    implicit val tid = transid()
+    val trigger = WhiskTrigger(namespace, aname, Parameters("x", "b"))
+    put(entityStore, trigger)
+    Delete(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskTrigger]
+      response should be(trigger.withoutRules)
     }
+  }
 
-    it should "put should reject request with undefined feed parameter" in {
-        implicit val tid = transid()
-        val trigger = WhiskTrigger(namespace, aname, annotations = Parameters(Parameters.Feed, ""))
-        val content = WhiskTriggerPut(annotations = Some(trigger.annotations))
-        Put(s"$collectionPath/${trigger.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-        }
+  //// PUT /triggers/name
+  it should "put should accept request with missing optional properties" in {
+    implicit val tid = transid()
+    val trigger = WhiskTrigger(namespace, aname)
+    val content = WhiskTriggerPut()
+    Put(s"$collectionPath/${trigger.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      deleteTrigger(trigger.docid)
+      status should be(OK)
+      val response = responseAs[WhiskTrigger]
+      response should be(trigger.withoutRules)
     }
+  }
 
-    it should "put should reject request with bad feed parameters" in {
-        implicit val tid = transid()
-        val trigger = WhiskTrigger(namespace, aname, annotations = Parameters(Parameters.Feed, "a,b"))
-        val content = WhiskTriggerPut(annotations = Some(trigger.annotations))
-        Put(s"$collectionPath/${trigger.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-        }
+  it should "put should accept request with valid feed parameter" in {
+    implicit val tid = transid()
+    val trigger = WhiskTrigger(namespace, aname, annotations = Parameters(Parameters.Feed, "xyz"))
+    val content = WhiskTriggerPut(annotations = Some(trigger.annotations))
+    Put(s"$collectionPath/${trigger.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      deleteTrigger(trigger.docid)
+      status should be(OK)
+      val response = responseAs[WhiskTrigger]
+      response should be(trigger.withoutRules)
     }
+  }
 
-    it should "reject activation with entity which is too big" in {
-        implicit val tid = transid()
-        val code = "a" * (allowedActivationEntitySize.toInt + 1)
-        val content = s"""{"a":"$code"}""".stripMargin
-        Post(s"$collectionPath/${aname}", content.parseJson.asJsObject) ~> Route.seal(routes(creds)) ~> check {
-            status should be(RequestEntityTooLarge)
-            responseAs[String] should include {
-                Messages.entityTooBig(SizeError(fieldDescriptionForSizeError, (content.length).B, allowedActivationEntitySize.B))
-            }
-        }
+  it should "put should reject request with undefined feed parameter" in {
+    implicit val tid = transid()
+    val trigger = WhiskTrigger(namespace, aname, annotations = Parameters(Parameters.Feed, ""))
+    val content = WhiskTriggerPut(annotations = Some(trigger.annotations))
+    Put(s"$collectionPath/${trigger.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
     }
+  }
 
-    it should "reject create with parameters which are too big" in {
-        implicit val tid = transid()
-        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
-        val parameters = keys map { key =>
-            Parameters(key.toString, "a" * 10)
-        } reduce (_ ++ _)
-        val content = s"""{"parameters":$parameters}""".parseJson.asJsObject
-        Put(s"$collectionPath/${aname}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(RequestEntityTooLarge)
-            responseAs[String] should include {
-                Messages.entityTooBig(SizeError(WhiskEntity.paramsFieldName, parameters.size, Parameters.sizeLimit))
-            }
-        }
+  it should "put should reject request with bad feed parameters" in {
+    implicit val tid = transid()
+    val trigger = WhiskTrigger(namespace, aname, annotations = Parameters(Parameters.Feed, "a,b"))
+    val content = WhiskTriggerPut(annotations = Some(trigger.annotations))
+    Put(s"$collectionPath/${trigger.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
     }
+  }
 
-    it should "reject create with annotations which are too big" in {
-        implicit val tid = transid()
-        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
-        val annotations = keys map { key =>
-            Parameters(key.toString, "a" * 10)
-        } reduce (_ ++ _)
-        val content = s"""{"annotations":$annotations}""".parseJson.asJsObject
-        Put(s"$collectionPath/${aname}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(RequestEntityTooLarge)
-            responseAs[String] should include {
-                Messages.entityTooBig(SizeError(WhiskEntity.annotationsFieldName, annotations.size, Parameters.sizeLimit))
-            }
-        }
+  it should "reject activation with entity which is too big" in {
+    implicit val tid = transid()
+    val code = "a" * (allowedActivationEntitySize.toInt + 1)
+    val content = s"""{"a":"$code"}""".stripMargin
+    Post(s"$collectionPath/${aname}", content.parseJson.asJsObject) ~> Route.seal(routes(creds)) ~> check {
+      status should be(RequestEntityTooLarge)
+      responseAs[String] should include {
+        Messages.entityTooBig(
+          SizeError(fieldDescriptionForSizeError, (content.length).B, allowedActivationEntitySize.B))
+      }
     }
+  }
 
-    it should "reject update with parameters which are too big" in {
-        implicit val tid = transid()
-        val trigger = WhiskTrigger(namespace, aname)
-        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
-        val parameters = keys map { key =>
-            Parameters(key.toString, "a" * 10)
-        } reduce (_ ++ _)
-        val content = s"""{"parameters":$parameters}""".parseJson.asJsObject
-        put(entityStore, trigger)
-        Put(s"$collectionPath/${trigger.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(RequestEntityTooLarge)
-            responseAs[String] should include {
-                Messages.entityTooBig(SizeError(WhiskEntity.paramsFieldName, parameters.size, Parameters.sizeLimit))
-            }
-        }
+  it should "reject create with parameters which are too big" in {
+    implicit val tid = transid()
+    val keys: List[Long] =
+      List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
+    val parameters = keys map { key =>
+      Parameters(key.toString, "a" * 10)
+    } reduce (_ ++ _)
+    val content = s"""{"parameters":$parameters}""".parseJson.asJsObject
+    Put(s"$collectionPath/${aname}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(RequestEntityTooLarge)
+      responseAs[String] should include {
+        Messages.entityTooBig(SizeError(WhiskEntity.paramsFieldName, parameters.size, Parameters.sizeLimit))
+      }
     }
+  }
 
-    it should "put should accept update request with missing optional properties" in {
-        implicit val tid = transid()
-        val trigger = WhiskTrigger(namespace, aname, Parameters("x", "b"))
-        val content = WhiskTriggerPut()
-        put(entityStore, trigger)
-        Put(s"$collectionPath/${trigger.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            deleteTrigger(trigger.docid)
-            status should be(OK)
-            val response = responseAs[WhiskTrigger]
-            response should be(WhiskTrigger(trigger.namespace, trigger.name, trigger.parameters, version = trigger.version.upPatch).withoutRules)
-        }
+  it should "reject create with annotations which are too big" in {
+    implicit val tid = transid()
+    val keys: List[Long] =
+      List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
+    val annotations = keys map { key =>
+      Parameters(key.toString, "a" * 10)
+    } reduce (_ ++ _)
+    val content = s"""{"annotations":$annotations}""".parseJson.asJsObject
+    Put(s"$collectionPath/${aname}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(RequestEntityTooLarge)
+      responseAs[String] should include {
+        Messages.entityTooBig(SizeError(WhiskEntity.annotationsFieldName, annotations.size, Parameters.sizeLimit))
+      }
     }
+  }
 
-    it should "put should reject update request for trigger with existing feed" in {
-        implicit val tid = transid()
-        val trigger = WhiskTrigger(namespace, aname, annotations = Parameters(Parameters.Feed, "xyz"))
-        val content = WhiskTriggerPut(annotations = Some(trigger.annotations))
-        put(entityStore, trigger)
-        Put(s"$collectionPath/${trigger.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-        }
+  it should "reject update with parameters which are too big" in {
+    implicit val tid = transid()
+    val trigger = WhiskTrigger(namespace, aname)
+    val keys: List[Long] =
+      List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
+    val parameters = keys map { key =>
+      Parameters(key.toString, "a" * 10)
+    } reduce (_ ++ _)
+    val content = s"""{"parameters":$parameters}""".parseJson.asJsObject
+    put(entityStore, trigger)
+    Put(s"$collectionPath/${trigger.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(RequestEntityTooLarge)
+      responseAs[String] should include {
+        Messages.entityTooBig(SizeError(WhiskEntity.paramsFieldName, parameters.size, Parameters.sizeLimit))
+      }
     }
+  }
 
-    it should "put should reject update request for trigger with new feed" in {
-        implicit val tid = transid()
-        val trigger = WhiskTrigger(namespace, aname)
-        val content = WhiskTriggerPut(annotations = Some(Parameters(Parameters.Feed, "xyz")))
-        put(entityStore, trigger)
-        Put(s"$collectionPath/${trigger.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(BadRequest)
-        }
+  it should "put should accept update request with missing optional properties" in {
+    implicit val tid = transid()
+    val trigger = WhiskTrigger(namespace, aname, Parameters("x", "b"))
+    val content = WhiskTriggerPut()
+    put(entityStore, trigger)
+    Put(s"$collectionPath/${trigger.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      deleteTrigger(trigger.docid)
+      status should be(OK)
+      val response = responseAs[WhiskTrigger]
+      response should be(WhiskTrigger(
+        trigger.namespace,
+        trigger.name,
+        trigger.parameters,
+        version = trigger.version.upPatch).withoutRules)
     }
+  }
 
-    //// POST /triggers/name
-    it should "fire a trigger" in {
-        implicit val tid = transid()
-        val trigger = WhiskTrigger(namespace, aname, Parameters("x", "b"))
-        val content = JsObject("xxx" -> "yyy".toJson)
-        put(entityStore, trigger)
-        Post(s"$collectionPath/${trigger.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[JsObject]
-            val JsString(id) = response.fields("activationId")
-            val activationId = ActivationId(id)
-            response.fields("activationId") should not be None
-
-            val activationDoc = DocId(WhiskEntity.qualifiedName(namespace, activationId))
-            val activation = get(activationStore, activationDoc, WhiskActivation, garbageCollect = false)
-            del(activationStore, DocId(WhiskEntity.qualifiedName(namespace, activationId)), WhiskActivation)
-            activation.end should be(Instant.EPOCH)
-            activation.response.result should be(Some(content))
-        }
+  it should "put should reject update request for trigger with existing feed" in {
+    implicit val tid = transid()
+    val trigger = WhiskTrigger(namespace, aname, annotations = Parameters(Parameters.Feed, "xyz"))
+    val content = WhiskTriggerPut(annotations = Some(trigger.annotations))
+    put(entityStore, trigger)
+    Put(s"$collectionPath/${trigger.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
     }
+  }
 
-    it should "fire a trigger without args" in {
-        implicit val tid = transid()
-        val trigger = WhiskTrigger(namespace, aname, Parameters("x", "b"))
-        put(entityStore, trigger)
-        Post(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
-            val response = responseAs[JsObject]
-            val JsString(id) = response.fields("activationId")
-            val activationId = ActivationId(id)
-            del(activationStore, DocId(WhiskEntity.qualifiedName(namespace, activationId)), WhiskActivation)
-            response.fields("activationId") should not be None
-        }
+  it should "put should reject update request for trigger with new feed" in {
+    implicit val tid = transid()
+    val trigger = WhiskTrigger(namespace, aname)
+    val content = WhiskTriggerPut(annotations = Some(Parameters(Parameters.Feed, "xyz")))
+    put(entityStore, trigger)
+    Put(s"$collectionPath/${trigger.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
     }
+  }
 
-    //// invalid resource
-    it should "reject invalid resource" in {
-        implicit val tid = transid()
-        val trigger = WhiskTrigger(namespace, aname)
-        put(entityStore, trigger)
-        Get(s"$collectionPath/${trigger.name}/bar") ~> Route.seal(routes(creds)) ~> check {
-            status should be(NotFound)
-        }
+  //// POST /triggers/name
+  it should "fire a trigger" in {
+    implicit val tid = transid()
+    val trigger = WhiskTrigger(namespace, aname, Parameters("x", "b"))
+    val content = JsObject("xxx" -> "yyy".toJson)
+    put(entityStore, trigger)
+    Post(s"$collectionPath/${trigger.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[JsObject]
+      val JsString(id) = response.fields("activationId")
+      val activationId = ActivationId(id)
+      response.fields("activationId") should not be None
+
+      val activationDoc = DocId(WhiskEntity.qualifiedName(namespace, activationId))
+      val activation = get(activationStore, activationDoc, WhiskActivation, garbageCollect = false)
+      del(activationStore, DocId(WhiskEntity.qualifiedName(namespace, activationId)), WhiskActivation)
+      activation.end should be(Instant.EPOCH)
+      activation.response.result should be(Some(content))
     }
+  }
 
-    // migration path
-    it should "be able to handle a trigger as of the old schema" in {
-        implicit val tid = transid()
-        val trigger = OldWhiskTrigger(namespace, aname)
-        put(entityStore, trigger)
-        Get(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
-            val response = responseAs[WhiskTrigger]
-            status should be(OK)
-
-            response should be(trigger.toWhiskTrigger)
-        }
+  it should "fire a trigger without args" in {
+    implicit val tid = transid()
+    val trigger = WhiskTrigger(namespace, aname, Parameters("x", "b"))
+    put(entityStore, trigger)
+    Post(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
+      val response = responseAs[JsObject]
+      val JsString(id) = response.fields("activationId")
+      val activationId = ActivationId(id)
+      del(activationStore, DocId(WhiskEntity.qualifiedName(namespace, activationId)), WhiskActivation)
+      response.fields("activationId") should not be None
     }
+  }
 
-    it should "report proper error when record is corrupted on delete" in {
-        implicit val tid = transid()
-        val entity = BadEntity(namespace, aname)
-        put(entityStore, entity)
-
-        Delete(s"$collectionPath/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(InternalServerError)
-            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-        }
+  //// invalid resource
+  it should "reject invalid resource" in {
+    implicit val tid = transid()
+    val trigger = WhiskTrigger(namespace, aname)
+    put(entityStore, trigger)
+    Get(s"$collectionPath/${trigger.name}/bar") ~> Route.seal(routes(creds)) ~> check {
+      status should be(NotFound)
     }
+  }
 
-    it should "report proper error when record is corrupted on get" in {
-        implicit val tid = transid()
-        val entity = BadEntity(namespace, aname)
-        put(entityStore, entity)
+  // migration path
+  it should "be able to handle a trigger as of the old schema" in {
+    implicit val tid = transid()
+    val trigger = OldWhiskTrigger(namespace, aname)
+    put(entityStore, trigger)
+    Get(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
+      val response = responseAs[WhiskTrigger]
+      status should be(OK)
 
-        Get(s"$collectionPath/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(InternalServerError)
-            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-        }
+      response should be(trigger.toWhiskTrigger)
     }
+  }
 
-    it should "report proper error when record is corrupted on put" in {
-        implicit val tid = transid()
-        val entity = BadEntity(namespace, aname)
-        put(entityStore, entity)
+  it should "report proper error when record is corrupted on delete" in {
+    implicit val tid = transid()
+    val entity = BadEntity(namespace, aname)
+    put(entityStore, entity)
 
-        val content = WhiskTriggerPut()
-        Put(s"$collectionPath/${entity.name}", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(InternalServerError)
-            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-        }
+    Delete(s"$collectionPath/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(InternalServerError)
+      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
     }
+  }
+
+  it should "report proper error when record is corrupted on get" in {
+    implicit val tid = transid()
+    val entity = BadEntity(namespace, aname)
+    put(entityStore, entity)
+
+    Get(s"$collectionPath/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(InternalServerError)
+      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
+    }
+  }
+
+  it should "report proper error when record is corrupted on put" in {
+    implicit val tid = transid()
+    val entity = BadEntity(namespace, aname)
+    put(entityStore, entity)
+
+    val content = WhiskTriggerPut()
+    Put(s"$collectionPath/${entity.name}", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(InternalServerError)
+      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
+    }
+  }
 }

--- a/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
@@ -81,1307 +81,1293 @@ import whisk.http.Messages
 
 @RunWith(classOf[JUnitRunner])
 class WebActionsApiPropertiesTests extends FlatSpec with Matchers with WebActionsApiTests {
-    override lazy val webInvokePathSegments = Seq("web")
-    override lazy val webApiDirectives = new WebApiDirectives()
+  override lazy val webInvokePathSegments = Seq("web")
+  override lazy val webApiDirectives = new WebApiDirectives()
 
-    "properties" should "match verion" in {
-        webApiDirectives.method shouldBe "__ow_method"
-        webApiDirectives.headers shouldBe "__ow_headers"
-        webApiDirectives.path shouldBe "__ow_path"
-        webApiDirectives.namespace shouldBe "__ow_user"
-        webApiDirectives.query shouldBe "__ow_query"
-        webApiDirectives.body shouldBe "__ow_body"
-        webApiDirectives.statusCode shouldBe "statusCode"
-        webApiDirectives.enforceExtension shouldBe false
-        webApiDirectives.reservedProperties shouldBe {
-            Set("__ow_method", "__ow_headers", "__ow_path", "__ow_user",
-                "__ow_query", "__ow_body")
-        }
+  "properties" should "match verion" in {
+    webApiDirectives.method shouldBe "__ow_method"
+    webApiDirectives.headers shouldBe "__ow_headers"
+    webApiDirectives.path shouldBe "__ow_path"
+    webApiDirectives.namespace shouldBe "__ow_user"
+    webApiDirectives.query shouldBe "__ow_query"
+    webApiDirectives.body shouldBe "__ow_body"
+    webApiDirectives.statusCode shouldBe "statusCode"
+    webApiDirectives.enforceExtension shouldBe false
+    webApiDirectives.reservedProperties shouldBe {
+      Set("__ow_method", "__ow_headers", "__ow_path", "__ow_user", "__ow_query", "__ow_body")
     }
+  }
 }
 
 @RunWith(classOf[JUnitRunner])
 class WebActionsApiCommonTests extends FlatSpec with Matchers {
-    "extension splitter" should "split action name and extension" in {
-        Seq(".http", ".json", ".text", ".html", ".svg").foreach { ext =>
-            Seq(s"t$ext", s"tt$ext", s"t.wxyz$ext", s"tt.wxyz$ext").foreach { s =>
-                Seq(true, false).foreach { enforce =>
-                    val (n, e) = WhiskWebActionsApi.mediaTranscoderForName(s, enforce)
-                    val i = s.lastIndexOf(".")
-                    n shouldBe s.substring(0, i)
-                    e.get.extension shouldBe ext
-                }
-            }
+  "extension splitter" should "split action name and extension" in {
+    Seq(".http", ".json", ".text", ".html", ".svg").foreach { ext =>
+      Seq(s"t$ext", s"tt$ext", s"t.wxyz$ext", s"tt.wxyz$ext").foreach { s =>
+        Seq(true, false).foreach { enforce =>
+          val (n, e) = WhiskWebActionsApi.mediaTranscoderForName(s, enforce)
+          val i = s.lastIndexOf(".")
+          n shouldBe s.substring(0, i)
+          e.get.extension shouldBe ext
         }
-
-        Seq(s"t", "tt", "abcde", "abcdef", "t.wxyz").foreach { s =>
-            val (n, e) = WhiskWebActionsApi.mediaTranscoderForName(s, false)
-            n shouldBe s
-            e.get.extension shouldBe ".http"
-        }
-
-        Seq(s"t", "tt", "abcde", "abcdef", "t.wxyz").foreach { s =>
-            val (n, e) = WhiskWebActionsApi.mediaTranscoderForName(s, true)
-            n shouldBe s
-            e shouldBe empty
-        }
+      }
     }
+
+    Seq(s"t", "tt", "abcde", "abcdef", "t.wxyz").foreach { s =>
+      val (n, e) = WhiskWebActionsApi.mediaTranscoderForName(s, false)
+      n shouldBe s
+      e.get.extension shouldBe ".http"
+    }
+
+    Seq(s"t", "tt", "abcde", "abcdef", "t.wxyz").foreach { s =>
+      val (n, e) = WhiskWebActionsApi.mediaTranscoderForName(s, true)
+      n shouldBe s
+      e shouldBe empty
+    }
+  }
 }
 
 trait WebActionsApiTests extends ControllerTestCommon with BeforeAndAfterEach with WhiskWebActionsApi {
-    val systemId = Subject()
-    val systemKey = AuthKey()
-    val systemIdentity = Future.successful(Identity(systemId, EntityName(systemId.asString), systemKey, Privilege.ALL))
-    override lazy val entitlementProvider = new TestingEntitlementProvider(whiskConfig, loadBalancer)
-    protected val testRoutePath = webInvokePathSegments.mkString("/", "/", "")
+  val systemId = Subject()
+  val systemKey = AuthKey()
+  val systemIdentity = Future.successful(Identity(systemId, EntityName(systemId.asString), systemKey, Privilege.ALL))
+  override lazy val entitlementProvider = new TestingEntitlementProvider(whiskConfig, loadBalancer)
+  protected val testRoutePath = webInvokePathSegments.mkString("/", "/", "")
 
-    behavior of "Web actions API"
+  behavior of "Web actions API"
 
-    var failActionLookup = false // toggle to cause action lookup to fail
-    var failActivation = 0 // toggle to cause action to fail
-    var failThrottleForSubject: Option[Subject] = None // toggle to cause throttle to fail for subject
-    var actionResult: Option[JsObject] = None
-    var requireAuthentication = false // toggle require-whisk-auth annotation on action
-    var customOptions = true // toogle web-custom-options annotation on action
-    var invocationCount = 0
-    var invocationsAllowed = 0
+  var failActionLookup = false // toggle to cause action lookup to fail
+  var failActivation = 0 // toggle to cause action to fail
+  var failThrottleForSubject: Option[Subject] = None // toggle to cause throttle to fail for subject
+  var actionResult: Option[JsObject] = None
+  var requireAuthentication = false // toggle require-whisk-auth annotation on action
+  var customOptions = true // toogle web-custom-options annotation on action
+  var invocationCount = 0
+  var invocationsAllowed = 0
 
-    override def beforeEach() = {
-        invocationCount = 0
-        invocationsAllowed = 0
+  override def beforeEach() = {
+    invocationCount = 0
+    invocationsAllowed = 0
+  }
+
+  override def afterEach() = {
+    failActionLookup = false
+    failActivation = 0
+    failThrottleForSubject = None
+    actionResult = None
+    requireAuthentication = false
+    customOptions = true
+    assert(invocationsAllowed == invocationCount, "allowed invoke count did not match actual")
+  }
+
+  val allowedMethodsWithEntity = {
+    val nonModifierMethods = Seq(Get, Options)
+    val modifierMethods = Seq(Post, Put, Delete, Patch)
+    modifierMethods ++ nonModifierMethods
+  }
+
+  val allowedMethods = {
+    allowedMethodsWithEntity ++ Seq(Head)
+  }
+
+  // there is only one package that is predefined 'proxy'
+  val packages = Seq(
+    WhiskPackage(
+      EntityPath(systemId.asString),
+      EntityName("proxy"),
+      parameters = Parameters("x", JsString("X")) ++ Parameters("z", JsString("z"))))
+
+  override protected def getPackage(pkgName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
+    Future {
+      packages.find(_.fullyQualifiedName(false) == pkgName).get
+    } recoverWith {
+      case _: NoSuchElementException => Future.failed(NoDocumentException("does not exist"))
     }
+  }
 
-    override def afterEach() = {
-        failActionLookup = false
-        failActivation = 0
-        failThrottleForSubject = None
-        actionResult = None
-        requireAuthentication = false
-        customOptions = true
-        assert(invocationsAllowed == invocationCount, "allowed invoke count did not match actual")
+  val defaultActionParameters = {
+    Parameters("y", JsString("Y")) ++ Parameters("z", JsString("Z")) ++ Parameters("empty", JsNull)
+  }
+
+  // action names that start with 'export_' will automatically have an web-export annotation added by the test harness
+  override protected def getAction(actionName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
+    if (!failActionLookup) {
+      def theAction = {
+        val annotations = Parameters(WhiskAction.finalParamsAnnotationName, JsBoolean(true))
+
+        WhiskAction(
+          actionName.path,
+          actionName.name,
+          jsDefault("??"),
+          defaultActionParameters,
+          annotations = {
+            if (actionName.name.asString.startsWith("export_")) {
+              annotations ++
+                Parameters("web-export", JsBoolean(true)) ++ {
+                if (requireAuthentication) {
+                  Parameters("require-whisk-auth", JsBoolean(true))
+                } else Parameters()
+              } ++ {
+                if (customOptions) {
+                  Parameters("web-custom-options", JsBoolean(true))
+                } else Parameters()
+              }
+            } else if (actionName.name.asString.startsWith("raw_export_")) {
+              annotations ++
+                Parameters("web-export", JsBoolean(true)) ++
+                Parameters("raw-http", JsBoolean(true)) ++ {
+                if (requireAuthentication) {
+                  Parameters("require-whisk-auth", JsBoolean(true))
+                } else Parameters()
+              } ++ {
+                if (customOptions) {
+                  Parameters("web-custom-options", JsBoolean(true))
+                } else Parameters()
+              }
+            } else annotations
+          })
+      }
+
+      if (actionName.path.defaultPackage) {
+        Future.successful(theAction)
+      } else {
+        getPackage(actionName.path.toFullyQualifiedEntityName) map (_ => theAction)
+      }
+    } else {
+      Future.failed(NoDocumentException("doesn't exist"))
     }
+  }
 
-    val allowedMethodsWithEntity = {
-        val nonModifierMethods = Seq(Get, Options)
-        val modifierMethods = Seq(Post, Put, Delete, Patch)
-        modifierMethods ++ nonModifierMethods
+  // there is only one identity defined for the fully qualified name of the web action: 'systemId'
+  override protected def getIdentity(namespace: EntityName)(implicit transid: TransactionId): Future[Identity] = {
+    if (namespace.asString == systemId.asString) {
+      systemIdentity
+    } else {
+      logging.info(this, s"namespace has no identity")
+      Future.failed(RejectRequest(BadRequest))
     }
+  }
 
-    val allowedMethods = {
-        allowedMethodsWithEntity ++ Seq(Head)
-    }
+  override protected[controller] def invokeAction(
+    user: Identity,
+    action: WhiskAction,
+    payload: Option[JsObject],
+    waitForResponse: Option[FiniteDuration],
+    cause: Option[ActivationId])(implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
+    invocationCount = invocationCount + 1
 
-    // there is only one package that is predefined 'proxy'
-    val packages = Seq(
-        WhiskPackage(
-            EntityPath(systemId.asString),
-            EntityName("proxy"),
-            parameters = Parameters("x", JsString("X")) ++ Parameters("z", JsString("z"))))
+    if (failActivation == 0) {
+      // construct a result stub that includes:
+      // 1. the package name for the action (to confirm that this resolved to systemId)
+      // 2. the action name (to confirm that this resolved to the expected action)
+      // 3. the payload received by the action which consists of the action.params + payload
+      val result = actionResult getOrElse JsObject(
+        "pkg" -> action.namespace.toJson,
+        "action" -> action.name.toJson,
+        "content" -> action.parameters.merge(payload).get)
 
-    override protected def getPackage(pkgName: FullyQualifiedEntityName)(
-        implicit transid: TransactionId) = {
-        Future {
-            packages.find(_.fullyQualifiedName(false) == pkgName).get
-        } recoverWith {
-            case _: NoSuchElementException => Future.failed(NoDocumentException("does not exist"))
+      val activation = WhiskActivation(
+        action.namespace,
+        action.name,
+        user.subject,
+        ActivationId(),
+        start = Instant.now,
+        end = Instant.now,
+        response = {
+          actionResult.flatMap { r =>
+            r.fields.get("application_error").map { e =>
+              ActivationResponse.applicationError(e)
+            } orElse r.fields.get("developer_error").map { e =>
+              ActivationResponse.containerError(e)
+            } orElse r.fields.get("whisk_error").map { e =>
+              ActivationResponse.whiskError(e)
+            } orElse None // for clarity
+          } getOrElse ActivationResponse.success(Some(result))
+        })
+
+      // check that action parameters were merged with package
+      // all actions have default parameters (see actionLookup stub)
+      if (!action.namespace.defaultPackage) {
+        getPackage(action.namespace.toFullyQualifiedEntityName) foreach { pkg =>
+          action.parameters shouldBe (pkg.parameters ++ defaultActionParameters)
         }
+      } else {
+        action.parameters shouldBe defaultActionParameters
+      }
+      action.parameters.get("z") shouldBe defaultActionParameters.get("z")
+
+      Future.successful(Right(activation))
+    } else if (failActivation == 1) {
+      Future.successful(Left(ActivationId()))
+    } else {
+      Future.failed(new IllegalStateException("bad activation"))
+    }
+  }
+
+  def metaPayload(method: String,
+                  params: JsObject,
+                  identity: Option[Identity],
+                  path: String = "",
+                  body: Option[JsObject] = None,
+                  pkgName: String = null,
+                  headers: List[HttpHeader] = List()) = {
+    val packageActionParams = Option(pkgName)
+      .filter(_ != null)
+      .flatMap(n => packages.find(_.name == EntityName(n)))
+      .map(_.parameters)
+      .getOrElse(Parameters())
+
+    (packageActionParams ++ defaultActionParameters).merge {
+      Some {
+        JsObject(
+          params.fields ++
+            body.map(_.fields).getOrElse(Map()) ++
+            Context(webApiDirectives, HttpMethods.getForKey(method.toUpperCase).get, headers, path, Query.Empty)
+              .metadata(identity))
+      }
+    }.get
+  }
+
+  def confirmErrorWithTid(error: JsObject, message: Option[String] = None) = {
+    error.fields.size shouldBe 2
+    error.fields.get("error") shouldBe defined
+    message.foreach { m =>
+      error.fields.get("error").get shouldBe JsString(m)
+    }
+    error.fields.get("code") shouldBe defined
+    error.fields.get("code").get shouldBe an[JsNumber]
+  }
+
+  Seq(None, Some(WhiskAuthHelpers.newIdentity())).foreach { creds =>
+    it should s"not match invalid routes (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+
+      // none of these should match a route
+      Seq("a", "a/b", "/a", s"$systemId/c", s"$systemId/export_c").foreach { path =>
+        allowedMethods.foreach { m =>
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            status should be(NotFound)
+          }
+        }
+      }
     }
 
-    val defaultActionParameters = {
-        Parameters("y", JsString("Y")) ++ Parameters("z", JsString("Z")) ++ Parameters("empty", JsNull)
-    }
+    it should s"reject requests when identity, package or action lookup fail or missing annotation (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
 
-    // action names that start with 'export_' will automatically have an web-export annotation added by the test harness
-    override protected def getAction(actionName: FullyQualifiedEntityName)(
-        implicit transid: TransactionId) = {
-        if (!failActionLookup) {
-            def theAction = {
-                val annotations = Parameters(WhiskAction.finalParamsAnnotationName, JsBoolean(true))
+      // the first of these fails in the identity lookup,
+      // the second in the package lookup (does not exist),
+      // the third fails the annotation check (no web-export annotation because name doesn't start with export_c)
+      // the fourth fails the action lookup
+      Seq("guest/proxy/c", s"$systemId/doesnotexist/c", s"$systemId/default/c", s"$systemId/proxy/export_fail")
+        .foreach { path =>
+          allowedMethods.foreach { m =>
+            failActionLookup = path.endsWith("fail")
 
-                WhiskAction(actionName.path, actionName.name, jsDefault("??"), defaultActionParameters, annotations = {
-                    if (actionName.name.asString.startsWith("export_")) {
-                        annotations ++
-                            Parameters("web-export", JsBoolean(true)) ++ {
-                                if (requireAuthentication) {
-                                    Parameters("require-whisk-auth", JsBoolean(true))
-                                } else Parameters()
-                            } ++ {
-                                if (customOptions) {
-                                    Parameters("web-custom-options", JsBoolean(true))
-                                } else Parameters()
-                            }
-                    } else if (actionName.name.asString.startsWith("raw_export_")) {
-                        annotations ++
-                            Parameters("web-export", JsBoolean(true)) ++
-                            Parameters("raw-http", JsBoolean(true)) ++ {
-                                if (requireAuthentication) {
-                                    Parameters("require-whisk-auth", JsBoolean(true))
-                                } else Parameters()
-                            } ++ {
-                                if (customOptions) {
-                                    Parameters("web-custom-options", JsBoolean(true))
-                                } else Parameters()
-                            }
-                    } else annotations
-                })
+            m(s"$testRoutePath/${path}.json") ~> Route.seal(routes(creds)) ~> check {
+              status should be(NotFound)
             }
 
-            if (actionName.path.defaultPackage) {
-                Future.successful(theAction)
-            } else {
-                getPackage(actionName.path.toFullyQualifiedEntityName) map (_ => theAction)
+            m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+              if (webApiDirectives.enforceExtension) {
+                status should be(NotAcceptable)
+                confirmErrorWithTid(
+                  responseAs[JsObject],
+                  Some(Messages.contentTypeExtensionNotSupported(WhiskWebActionsApi.allowedExtensions)))
+              } else {
+                status should be(NotFound)
+              }
             }
-        } else {
-            Future.failed(NoDocumentException("doesn't exist"))
+          }
         }
     }
 
-    // there is only one identity defined for the fully qualified name of the web action: 'systemId'
-    override protected def getIdentity(namespace: EntityName)(
-        implicit transid: TransactionId): Future[Identity] = {
-        if (namespace.asString == systemId.asString) {
-            systemIdentity
-        } else {
-            logging.info(this, s"namespace has no identity")
-            Future.failed(RejectRequest(BadRequest))
+    it should s"reject requests when authentication is required but none given (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+
+      Seq(s"$systemId/proxy/export_auth").foreach { path =>
+        allowedMethods.foreach { m =>
+          if (creds.isDefined)
+            invocationsAllowed += 1
+          requireAuthentication = true
+
+          m(s"$testRoutePath/${path}.json") ~> Route.seal(routes(creds)) ~> check {
+            creds match {
+              case None => status should be(Unauthorized)
+              case Some(user) =>
+                status should be(OK)
+                val response = responseAs[JsObject]
+                response shouldBe JsObject(
+                  "pkg" -> s"$systemId/proxy".toJson,
+                  "action" -> "export_auth".toJson,
+                  "content" -> metaPayload(m.method.name.toLowerCase, JsObject(), creds, pkgName = "proxy"))
+                response.fields("content").asJsObject.fields(webApiDirectives.namespace) shouldBe user.namespace.toJson
+            }
+          }
         }
+      }
     }
 
-    override protected[controller] def invokeAction(
-        user: Identity,
-        action: WhiskAction,
-        payload: Option[JsObject],
-        waitForResponse: Option[FiniteDuration],
-        cause: Option[ActivationId])(
-            implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
-        invocationCount = invocationCount + 1
+    it should s"invoke action that times out and provide a code (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+      failActivation = 1
 
-        if (failActivation == 0) {
-            // construct a result stub that includes:
-            // 1. the package name for the action (to confirm that this resolved to systemId)
-            // 2. the action name (to confirm that this resolved to the expected action)
-            // 3. the payload received by the action which consists of the action.params + payload
-            val result = actionResult getOrElse JsObject(
-                "pkg" -> action.namespace.toJson,
-                "action" -> action.name.toJson,
-                "content" -> action.parameters.merge(payload).get)
+      allowedMethods.foreach { m =>
+        invocationsAllowed += 1
 
-            val activation = WhiskActivation(
-                action.namespace,
-                action.name,
-                user.subject,
-                ActivationId(),
-                start = Instant.now,
-                end = Instant.now,
-                response = {
-                    actionResult.flatMap { r =>
-                        r.fields.get("application_error").map {
-                            e => ActivationResponse.applicationError(e)
-                        } orElse r.fields.get("developer_error").map {
-                            e => ActivationResponse.containerError(e)
-                        } orElse r.fields.get("whisk_error").map {
-                            e => ActivationResponse.whiskError(e)
-                        } orElse None // for clarity
-                    } getOrElse ActivationResponse.success(Some(result))
-                })
-
-            // check that action parameters were merged with package
-            // all actions have default parameters (see actionLookup stub)
-            if (!action.namespace.defaultPackage) {
-                getPackage(action.namespace.toFullyQualifiedEntityName) foreach { pkg =>
-                    action.parameters shouldBe (pkg.parameters ++ defaultActionParameters)
-                }
-            } else {
-                action.parameters shouldBe defaultActionParameters
-            }
-            action.parameters.get("z") shouldBe defaultActionParameters.get("z")
-
-            Future.successful(Right(activation))
-        } else if (failActivation == 1) {
-            Future.successful(Left(ActivationId()))
-        } else {
-            Future.failed(new IllegalStateException("bad activation"))
+        m(s"$testRoutePath/$systemId/proxy/export_c.json") ~> Route.seal(routes(creds)) ~> check {
+          status should be(Accepted)
+          val response = responseAs[JsObject]
+          confirmErrorWithTid(response, Some("Response not yet ready."))
         }
+      }
     }
 
-    def metaPayload(method: String, params: JsObject, identity: Option[Identity], path: String = "", body: Option[JsObject] = None, pkgName: String = null, headers: List[HttpHeader] = List()) = {
-        val packageActionParams = Option(pkgName).filter(_ != null).flatMap(n => packages.find(_.name == EntityName(n)))
-            .map(_.parameters)
-            .getOrElse(Parameters())
+    it should s"invoke action that errors and respond with error and code (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+      failActivation = 2
 
-        (packageActionParams ++ defaultActionParameters).merge {
-            Some {
-                JsObject(
-                    params.fields ++
-                        body.map(_.fields).getOrElse(Map()) ++
-                        Context(webApiDirectives, HttpMethods.getForKey(method.toUpperCase).get, headers, path, Query.Empty).metadata(identity))
-            }
-        }.get
+      allowedMethods.foreach { m =>
+        invocationsAllowed += 1
+
+        m(s"$testRoutePath/$systemId/proxy/export_c.json") ~> Route.seal(routes(creds)) ~> check {
+          status should be(InternalServerError)
+          val response = responseAs[JsObject]
+          confirmErrorWithTid(response)
+        }
+      }
     }
 
-    def confirmErrorWithTid(error: JsObject, message: Option[String] = None) = {
-        error.fields.size shouldBe 2
-        error.fields.get("error") shouldBe defined
-        message.foreach { m => error.fields.get("error").get shouldBe JsString(m) }
-        error.fields.get("code") shouldBe defined
-        error.fields.get("code").get shouldBe an[JsNumber]
+    it should s"invoke action and merge query parameters (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+
+      Seq(s"$systemId/proxy/export_c.json?a=b&c=d").foreach { path =>
+        allowedMethods.foreach { m =>
+          invocationsAllowed += 1
+
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            val response = responseAs[JsObject]
+            response shouldBe JsObject(
+              "pkg" -> s"$systemId/proxy".toJson,
+              "action" -> "export_c".toJson,
+              "content" -> metaPayload(
+                m.method.name.toLowerCase,
+                Map("a" -> "b", "c" -> "d").toJson.asJsObject,
+                creds,
+                pkgName = "proxy"))
+          }
+        }
+      }
     }
 
-    Seq(None, Some(WhiskAuthHelpers.newIdentity())).foreach { creds =>
+    it should s"invoke action and merge body parameters (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
 
-        it should s"not match invalid routes (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            // none of these should match a route
-            Seq("a", "a/b", "/a", s"$systemId/c", s"$systemId/export_c").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            status should be(NotFound)
-                        }
-                    }
-                }
+      // both of these should produce full result objects (trailing slash is ok)
+      Seq(s"$systemId/proxy/export_c.json", s"$systemId/proxy/export_c.json/").foreach { path =>
+        allowedMethodsWithEntity.foreach { m =>
+          val content = JsObject("extra" -> "read all about it".toJson, "yummy" -> true.toJson)
+          val p = if (path.endsWith("/")) "/" else ""
+          invocationsAllowed += 1
+          m(s"$testRoutePath/$path", content) ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            val response = responseAs[JsObject]
+            response shouldBe JsObject(
+              "pkg" -> s"$systemId/proxy".toJson,
+              "action" -> "export_c".toJson,
+              "content" -> metaPayload(
+                m.method.name.toLowerCase,
+                JsObject(),
+                creds,
+                body = Some(content),
+                path = p,
+                pkgName = "proxy"))
+          }
         }
+      }
+    }
 
-        it should s"reject requests when identity, package or action lookup fail or missing annotation (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
+    it should s"invoke action and merge query and body parameters (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
 
-            // the first of these fails in the identity lookup,
-            // the second in the package lookup (does not exist),
-            // the third fails the annotation check (no web-export annotation because name doesn't start with export_c)
-            // the fourth fails the action lookup
-            Seq("guest/proxy/c", s"$systemId/doesnotexist/c", s"$systemId/default/c", s"$systemId/proxy/export_fail").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        failActionLookup = path.endsWith("fail")
+      Seq(s"$systemId/proxy/export_c.json?a=b&c=d").foreach { path =>
+        allowedMethodsWithEntity.foreach { m =>
+          val content = JsObject("extra" -> "read all about it".toJson, "yummy" -> true.toJson)
+          invocationsAllowed += 1
 
-                        m(s"$testRoutePath/${path}.json") ~> Route.seal(routes(creds)) ~> check {
-                            status should be(NotFound)
-                        }
-
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            if (webApiDirectives.enforceExtension) {
-                                status should be(NotAcceptable)
-                                confirmErrorWithTid(responseAs[JsObject], Some(Messages.contentTypeExtensionNotSupported(WhiskWebActionsApi.allowedExtensions)))
-                            } else {
-                                status should be(NotFound)
-                            }
-                        }
-                    }
-                }
+          m(s"$testRoutePath/$path", content) ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            val response = responseAs[JsObject]
+            response shouldBe JsObject(
+              "pkg" -> s"$systemId/proxy".toJson,
+              "action" -> "export_c".toJson,
+              "content" -> metaPayload(
+                m.method.name.toLowerCase,
+                Map("a" -> "b", "c" -> "d").toJson.asJsObject,
+                creds,
+                body = Some(content),
+                pkgName = "proxy"))
+          }
         }
+      }
+    }
 
-        it should s"reject requests when authentication is required but none given (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
+    it should s"invoke action in default package (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
 
-            Seq(s"$systemId/proxy/export_auth").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        if (creds.isDefined)
-                            invocationsAllowed += 1
-                        requireAuthentication = true
+      Seq(s"$systemId/default/export_c.json").foreach { path =>
+        allowedMethods.foreach { m =>
+          invocationsAllowed += 1
 
-                        m(s"$testRoutePath/${path}.json") ~> Route.seal(routes(creds)) ~> check {
-                            creds match {
-                                case None => status should be(Unauthorized)
-                                case Some(user) =>
-                                    status should be(OK)
-                                    val response = responseAs[JsObject]
-                                    response shouldBe JsObject(
-                                        "pkg" -> s"$systemId/proxy".toJson,
-                                        "action" -> "export_auth".toJson,
-                                        "content" -> metaPayload(m.method.name.toLowerCase, JsObject(), creds, pkgName = "proxy"))
-                                    response.fields("content").asJsObject.fields(webApiDirectives.namespace) shouldBe user.namespace.toJson
-                            }
-                        }
-                    }
-                }
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            val response = responseAs[JsObject]
+            response shouldBe JsObject(
+              "pkg" -> s"$systemId".toJson,
+              "action" -> "export_c".toJson,
+              "content" -> metaPayload(m.method.name.toLowerCase, JsObject(), creds))
+          }
         }
+      }
+    }
 
-        it should s"invoke action that times out and provide a code (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-            failActivation = 1
+    it should s"project a field from the result object (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
 
-            allowedMethods.foreach { m =>
-                invocationsAllowed += 1
+      Seq(s"$systemId/proxy/export_c.json/content").foreach { path =>
+        allowedMethods.foreach { m =>
+          invocationsAllowed += 1
 
-                m(s"$testRoutePath/$systemId/proxy/export_c.json") ~> Route.seal(routes(creds)) ~> check {
-                    status should be(Accepted)
-                    val response = responseAs[JsObject]
-                    confirmErrorWithTid(response, Some("Response not yet ready."))
-                }
-            }
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            val response = responseAs[JsObject]
+            response shouldBe metaPayload(
+              m.method.name.toLowerCase,
+              JsObject(),
+              creds,
+              path = "/content",
+              pkgName = "proxy")
+          }
         }
+      }
 
-        it should s"invoke action that errors and respond with error and code (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-            failActivation = 2
+      Seq(
+        s"$systemId/proxy/export_c.text/content/z",
+        s"$systemId/proxy/export_c.text/content/z/",
+        s"$systemId/proxy/export_c.text/content/z//").foreach { path =>
+        allowedMethods.foreach { m =>
+          invocationsAllowed += 1
 
-            allowedMethods.foreach { m =>
-                invocationsAllowed += 1
-
-                m(s"$testRoutePath/$systemId/proxy/export_c.json") ~> Route.seal(routes(creds)) ~> check {
-                    status should be(InternalServerError)
-                    val response = responseAs[JsObject]
-                    confirmErrorWithTid(response)
-                }
-            }
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            val response = responseAs[String]
+            response shouldBe "Z"
+          }
         }
+      }
+    }
 
-        it should s"invoke action and merge query parameters (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
+    it should s"reject when projecting a result which does not match expected type (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
 
-            Seq(s"$systemId/proxy/export_c.json?a=b&c=d").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        invocationsAllowed += 1
+      // these project a result which does not match expected type
+      Seq(s"$systemId/proxy/export_c.json/a").foreach { path =>
+        allowedMethods.foreach { m =>
+          invocationsAllowed += 1
+          actionResult = Some(JsObject("a" -> JsString("b")))
 
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            status should be(OK)
-                            val response = responseAs[JsObject]
-                            response shouldBe JsObject(
-                                "pkg" -> s"$systemId/proxy".toJson,
-                                "action" -> "export_c".toJson,
-                                "content" -> metaPayload(
-                                    m.method.name.toLowerCase,
-                                    Map("a" -> "b", "c" -> "d").toJson.asJsObject,
-                                    creds,
-                                    pkgName = "proxy"))
-                        }
-                    }
-                }
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            status should be(BadRequest)
+            confirmErrorWithTid(responseAs[JsObject], Some(Messages.invalidMedia(MediaTypes.`application/json`)))
+          }
         }
+      }
+    }
 
-        it should s"invoke action and merge body parameters (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
+    it should s"reject when projecting a field from the result object that does not exist (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
 
-            // both of these should produce full result objects (trailing slash is ok)
-            Seq(s"$systemId/proxy/export_c.json", s"$systemId/proxy/export_c.json/").
-                foreach { path =>
-                    allowedMethodsWithEntity.foreach { m =>
-                        val content = JsObject("extra" -> "read all about it".toJson, "yummy" -> true.toJson)
-                        val p = if (path.endsWith("/")) "/" else ""
-                        invocationsAllowed += 1
-                        m(s"$testRoutePath/$path", content) ~> Route.seal(routes(creds)) ~> check {
-                            status should be(OK)
-                            val response = responseAs[JsObject]
-                            response shouldBe JsObject(
-                                "pkg" -> s"$systemId/proxy".toJson,
-                                "action" -> "export_c".toJson,
-                                "content" -> metaPayload(
-                                    m.method.name.toLowerCase,
-                                    JsObject(),
-                                    creds,
-                                    body = Some(content),
-                                    path = p,
-                                    pkgName = "proxy"))
-                        }
-                    }
-                }
+      Seq(s"$systemId/proxy/export_c.text/foobar", s"$systemId/proxy/export_c.text/content/z/x").foreach { path =>
+        allowedMethods.foreach { m =>
+          invocationsAllowed += 1
+
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            status should be(NotFound)
+            confirmErrorWithTid(responseAs[JsObject], Some(Messages.propertyNotFound))
+            // ensure that error message is pretty printed as { error, code }
+            responseAs[String].lines should have size 4
+          }
         }
+      }
+    }
 
-        it should s"invoke action and merge query and body parameters (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
+    it should s"not project an http response (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
 
-            Seq(s"$systemId/proxy/export_c.json?a=b&c=d").
-                foreach { path =>
-                    allowedMethodsWithEntity.foreach { m =>
-                        val content = JsObject("extra" -> "read all about it".toJson, "yummy" -> true.toJson)
-                        invocationsAllowed += 1
+      // http extension does not project
+      Seq(s"$systemId/proxy/export_c.http/content/response").foreach { path =>
+        allowedMethods.foreach { m =>
+          actionResult = Some(
+            JsObject(
+              "headers" -> JsObject("location" -> "http://openwhisk.org".toJson),
+              webApiDirectives.statusCode -> Found.intValue.toJson))
+          invocationsAllowed += 1
 
-                        m(s"$testRoutePath/$path", content) ~> Route.seal(routes(creds)) ~> check {
-                            status should be(OK)
-                            val response = responseAs[JsObject]
-                            response shouldBe JsObject(
-                                "pkg" -> s"$systemId/proxy".toJson,
-                                "action" -> "export_c".toJson,
-                                "content" -> metaPayload(
-                                    m.method.name.toLowerCase,
-                                    Map("a" -> "b", "c" -> "d").toJson.asJsObject,
-                                    creds,
-                                    body = Some(content),
-                                    pkgName = "proxy"))
-                        }
-                    }
-                }
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            status should be(Found)
+            header("location").get.toString shouldBe "location: http://openwhisk.org"
+          }
         }
+      }
+    }
 
-        it should s"invoke action in default package (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
+    it should s"use default projection for extension (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
 
-            Seq(s"$systemId/default/export_c.json").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        invocationsAllowed += 1
+      Seq(s"$systemId/proxy/export_c.http").foreach { path =>
+        allowedMethods.foreach { m =>
+          invocationsAllowed += 1
+          actionResult = Some(
+            JsObject(
+              "headers" -> JsObject("location" -> "http://openwhisk.org".toJson),
+              webApiDirectives.statusCode -> Found.intValue.toJson))
 
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            status should be(OK)
-                            val response = responseAs[JsObject]
-                            response shouldBe JsObject(
-                                "pkg" -> s"$systemId".toJson,
-                                "action" -> "export_c".toJson,
-                                "content" -> metaPayload(m.method.name.toLowerCase, JsObject(), creds))
-                        }
-                    }
-                }
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            status should be(Found)
+            header("location").get.toString shouldBe "location: http://openwhisk.org"
+          }
         }
+      }
 
-        it should s"project a field from the result object (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
+      Seq(s"$systemId/proxy/export_c.text").foreach { path =>
+        allowedMethods.foreach { m =>
+          val text = "default text"
+          invocationsAllowed += 1
+          actionResult = Some(JsObject("text" -> JsString(text)))
 
-            Seq(s"$systemId/proxy/export_c.json/content").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        invocationsAllowed += 1
-
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            status should be(OK)
-                            val response = responseAs[JsObject]
-                            response shouldBe metaPayload(m.method.name.toLowerCase, JsObject(), creds, path = "/content", pkgName = "proxy")
-                        }
-                    }
-                }
-
-            Seq(s"$systemId/proxy/export_c.text/content/z", s"$systemId/proxy/export_c.text/content/z/", s"$systemId/proxy/export_c.text/content/z//").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        invocationsAllowed += 1
-
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            status should be(OK)
-                            val response = responseAs[String]
-                            response shouldBe "Z"
-                        }
-                    }
-                }
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            contentType shouldBe MediaTypes.`text/plain`.withCharset(HttpCharsets.`UTF-8`)
+            val response = responseAs[String]
+            response shouldBe text
+          }
         }
+      }
 
-        it should s"reject when projecting a result which does not match expected type (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
+      Seq(s"$systemId/proxy/export_c.json").foreach { path =>
+        allowedMethods.foreach { m =>
+          invocationsAllowed += 1
+          actionResult = Some(JsObject("foobar" -> JsString("foobar")))
 
-            // these project a result which does not match expected type
-            Seq(s"$systemId/proxy/export_c.json/a").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        invocationsAllowed += 1
-                        actionResult = Some(JsObject("a" -> JsString("b")))
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            val response = responseAs[JsObject]
+            response shouldBe actionResult.get
 
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            status should be(BadRequest)
-                            confirmErrorWithTid(responseAs[JsObject], Some(Messages.invalidMedia(MediaTypes.`application/json`)))
-                        }
-                    }
-                }
-        }
-
-        it should s"reject when projecting a field from the result object that does not exist (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            Seq(s"$systemId/proxy/export_c.text/foobar", s"$systemId/proxy/export_c.text/content/z/x").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        invocationsAllowed += 1
-
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            status should be(NotFound)
-                            confirmErrorWithTid(responseAs[JsObject], Some(Messages.propertyNotFound))
-                            // ensure that error message is pretty printed as { error, code }
-                            responseAs[String].lines should have size 4
-                        }
-                    }
-                }
-        }
-
-        it should s"not project an http response (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            // http extension does not project
-            Seq(s"$systemId/proxy/export_c.http/content/response").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        actionResult = Some(JsObject("headers" -> JsObject("location" -> "http://openwhisk.org".toJson), webApiDirectives.statusCode -> Found.intValue.toJson))
-                        invocationsAllowed += 1
-
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            status should be(Found)
-                            header("location").get.toString shouldBe "location: http://openwhisk.org"
-                        }
-                    }
-                }
-        }
-
-        it should s"use default projection for extension (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            Seq(s"$systemId/proxy/export_c.http").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        invocationsAllowed += 1
-                        actionResult = Some(JsObject("headers" -> JsObject("location" -> "http://openwhisk.org".toJson), webApiDirectives.statusCode -> Found.intValue.toJson))
-
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            status should be(Found)
-                            header("location").get.toString shouldBe "location: http://openwhisk.org"
-                        }
-                    }
-                }
-
-            Seq(s"$systemId/proxy/export_c.text").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        val text = "default text"
-                        invocationsAllowed += 1
-                        actionResult = Some(JsObject("text" -> JsString(text)))
-
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            status should be(OK)
-                            contentType shouldBe MediaTypes.`text/plain`.withCharset(HttpCharsets.`UTF-8`)
-                            val response = responseAs[String]
-                            response shouldBe text
-                        }
-                    }
-                }
-
-            Seq(s"$systemId/proxy/export_c.json").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        invocationsAllowed += 1
-                        actionResult = Some(JsObject("foobar" -> JsString("foobar")))
-
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            status should be(OK)
-                            val response = responseAs[JsObject]
-                            response shouldBe actionResult.get
-
-                            // ensure response is pretty printed
-                            responseAs[String] shouldBe {
-                                """{
+            // ensure response is pretty printed
+            responseAs[String] shouldBe {
+              """{
                                   |  "foobar": "foobar"
                                   |}""".stripMargin
-                            }
-                        }
-                    }
-                }
-
-            Seq(s"$systemId/proxy/export_c.html").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        val html = "<html>hi</htlml>"
-                        invocationsAllowed += 1
-                        actionResult = Some(JsObject("html" -> JsString(html)))
-
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            status should be(OK)
-                            contentType shouldBe MediaTypes.`text/html`.withCharset(HttpCharsets.`UTF-8`)
-                            val response = responseAs[String]
-                            response shouldBe html
-                        }
-                    }
-                }
-
-            Seq(s"$systemId/proxy/export_c.svg").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        val svg = """<svg><circle cx="3" cy="3" r="3" fill="blue"/></svg>"""
-                        invocationsAllowed += 1
-                        actionResult = Some(JsObject("svg" -> JsString(svg)))
-
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            status should be(OK)
-                            //contentType shouldBe MediaTypes.`image/svg+xml`.withCharset(HttpCharsets.`UTF-8`)
-                            val response = responseAs[String]
-                            response shouldBe svg
-                        }
-                    }
-                }
-        }
-
-        it should s"handle http web action and provide defaults (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            Seq(s"$systemId/proxy/export_c.http").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        invocationsAllowed += 1
-                        actionResult = Some(JsObject())
-
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            status should be(OK)
-                            response.entity shouldBe HttpEntity.Empty
-                            withClue(headers) {
-                                headers.length shouldBe 0
-                            }
-                        }
-                    }
-                }
-        }
-
-        it should s"handle all JSON values with .text extension (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            Seq(JsObject("a" -> "A".toJson), JsArray("a".toJson), JsString("a"), JsBoolean(true), JsNumber(1), JsNull).
-                foreach { jsval =>
-                    val path = s"$systemId/proxy/export_c.text/res"
-                    allowedMethods.foreach { m =>
-                        invocationsAllowed += 1
-                        actionResult = Some(JsObject("res" -> jsval))
-
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            responseAs[String] shouldBe {
-                                jsval match {
-                                    case _: JsObject  => jsval.prettyPrint
-                                    case _: JsArray   => jsval.prettyPrint
-                                    case JsString(s)  => s
-                                    case JsBoolean(b) => b.toString
-                                    case JsNumber(n)  => n.toString
-                                    case _            => "null"
-                                }
-                            }
-                        }
-                    }
-                }
-        }
-
-        it should s"handle http web action with base64 encoded JSON response (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            Seq(s"$systemId/proxy/export_c.http").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        invocationsAllowed += 1
-                        actionResult = Some(JsObject(
-                            "headers" -> JsObject(
-                                "content-type" -> "application/json".toJson),
-                            webApiDirectives.statusCode -> OK.intValue.toJson,
-                            "body" -> Base64.getEncoder.encodeToString {
-                                JsObject("field" -> "value".toJson).compactPrint.getBytes
-                            }.toJson))
-
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            status should be(OK)
-                            responseAs[JsObject] shouldBe JsObject("field" -> "value".toJson)
-                        }
-                    }
-                }
-        }
-
-        it should s"handle http web action without base64 encoded JSON response (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            Seq((JsObject("content-type" -> "application/json".toJson), OK),
-                (JsObject(), OK),
-                (JsObject("content-type" -> "text/html".toJson), BadRequest)).foreach {
-                    case (headers, expectedCode) =>
-                        Seq(s"$systemId/proxy/export_c.http").
-                            foreach { path =>
-                                allowedMethods.foreach { m =>
-                                    invocationsAllowed += 1
-                                    actionResult = Some(JsObject(
-                                        "headers" -> headers,
-                                        webApiDirectives.statusCode -> OK.intValue.toJson,
-                                        "body" -> JsObject("field" -> "value".toJson)))
-
-                                    m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                                        status should be(expectedCode)
-
-                                        if (expectedCode == OK) {
-                                            header("content-type").map(_.toString shouldBe "content-type: application/json")
-                                            responseAs[JsObject] shouldBe JsObject("field" -> "value".toJson)
-                                        } else {
-                                            confirmErrorWithTid(responseAs[JsObject], Some(Messages.httpContentTypeError))
-                                        }
-                                    }
-                                }
-                            }
-                }
-
-            Seq(s"$systemId/proxy/export_c.http").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        invocationsAllowed += 1
-                        actionResult = Some(JsObject(
-                            webApiDirectives.statusCode -> OK.intValue.toJson,
-                            "body" -> JsNumber(3)))
-
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            status should be(OK)
-                            header("content-type").map(_.toString shouldBe "content-type: application/json")
-                            responseAs[String].toInt shouldBe 3
-                        }
-                    }
-                }
-        }
-
-        it should s"handle http web action with base64 encoded binary response (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-            val png = "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAGCAYAAAD68A/GAAAA/klEQVQYGWNgAAEHBxaG//+ZQMyyn581Pfas+cRQnf1LfF" +
-                "Ljf+62smUgcUbt0FA2Zh7drf/ffMy9vLn3RurrW9e5hCU11i2azfD4zu1/DHz8TAy/foUxsXBrFzHzC7r8+M9S1vn1qxQT07dDjL" +
-                "9fdemrqKxlYGT6z8AIMo6hgeUfA0PUvy9fGFh5GWK3z7vNxSWt++jX99+8SoyiGQwsW38w8PJEM7x5v5SJ8f+/xv8MDAzffv9hev" +
-                "fkWjiXBGMpMx+j2awovjcMjFztDO8+7GF49LkbZDCDeXLTWnZO7qDfn1/+5jbw/8pjYWS4wZLztXnuEuYTk2M+MzIw/AcA36Vewa" +
-                "D6fzsAAAAASUVORK5CYII="
-            val expectedEntity = HttpEntity(ContentType(MediaTypes.`image/png`), Base64.getDecoder().decode(png))
-
-            Seq(s"$systemId/proxy/export_c.http").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        invocationsAllowed += 1
-                        actionResult = Some(JsObject(
-                            "headers" -> JsObject(`Content-Type`.lowercaseName -> MediaTypes.`image/png`.toString.toJson),
-                            "body" -> png.toJson))
-
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            status should be(OK)
-                            response.entity shouldBe expectedEntity
-                        }
-                    }
-                }
-        }
-
-        it should s"handle http web action with html/text response (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            Seq(s"$systemId/proxy/export_c.http").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        invocationsAllowed += 1
-                        actionResult = Some(JsObject(
-                            webApiDirectives.statusCode -> OK.intValue.toJson,
-                            "body" -> "hello world".toJson))
-
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            status should be(OK)
-                            responseAs[String] shouldBe "hello world"
-                        }
-                    }
-                }
-        }
-
-        it should s"reject http web action with mismatch between header and response (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            Seq(s"$systemId/proxy/export_c.http").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        invocationsAllowed += 1
-                        actionResult = Some(JsObject(
-                            "headers" -> JsObject(
-                                "content-type" -> "application/json".toJson),
-                            webApiDirectives.statusCode -> OK.intValue.toJson,
-                            "body" -> "hello world".toJson))
-
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            status should be(BadRequest)
-                            confirmErrorWithTid(responseAs[JsObject], Some(Messages.httpContentTypeError))
-                        }
-                    }
-                }
-        }
-
-        it should s"reject http web action with unknown header (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            Seq(s"$systemId/proxy/export_c.http").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        invocationsAllowed += 1
-                        actionResult = Some(JsObject(
-                            "headers" -> JsObject(
-                                "content-type" -> "xyz/bar".toJson),
-                            webApiDirectives.statusCode -> OK.intValue.toJson,
-                            "body" -> "hello world".toJson))
-
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            status should be(BadRequest)
-                            confirmErrorWithTid(responseAs[JsObject], Some(Messages.httpUnknownContentType))
-                        }
-                    }
-                }
-        }
-
-        it should s"handle an activation that results in application error and response matches extension (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            Seq(s"$systemId/proxy/export_c.http", s"$systemId/proxy/export_c.http/ignoreme").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        invocationsAllowed += 1
-                        actionResult = Some(JsObject(
-                            "application_error" -> JsObject(
-                                webApiDirectives.statusCode -> OK.intValue.toJson,
-                                "body" -> "no hello for you".toJson)))
-
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            status should be(OK)
-                            responseAs[String] shouldBe "no hello for you"
-                        }
-                    }
-                }
-        }
-
-        it should s"handle an activation that results in application error but where response does not match extension (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            Seq(s"$systemId/proxy/export_c.json", s"$systemId/proxy/export_c.json/ignoreme").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        invocationsAllowed += 1
-                        actionResult = Some(JsObject("application_error" -> "bad response type".toJson))
-
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            status should be(BadRequest)
-                            confirmErrorWithTid(responseAs[JsObject], Some(Messages.invalidMedia(MediaTypes.`application/json`)))
-                        }
-                    }
-                }
-        }
-
-        it should s"handle an activation that results in developer or system error (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            Seq(s"$systemId/proxy/export_c.json", s"$systemId/proxy/export_c.json/ignoreme", s"$systemId/proxy/export_c.text").
-                foreach { path =>
-                    Seq("developer_error", "whisk_error").foreach { e =>
-                        allowedMethods.foreach { m =>
-                            invocationsAllowed += 1
-                            actionResult = Some(JsObject(e -> "bad response type".toJson))
-
-                            m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                                status should be(BadRequest)
-                                if (e == "application_error") {
-                                    confirmErrorWithTid(responseAs[JsObject], Some(Messages.invalidMedia(MediaTypes.`application/json`)))
-                                } else {
-                                    confirmErrorWithTid(responseAs[JsObject], Some(Messages.errorProcessingRequest))
-                                }
-                            }
-                        }
-                    }
-                }
-        }
-
-        it should s"support formdata (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            Seq(s"$systemId/proxy/export_c.text/content/field1", s"$systemId/proxy/export_c.text/content/field2").
-                foreach { path =>
-
-                    val form = FormData(Map("field1" -> "value1", "field2" -> "value2"))
-                    invocationsAllowed += 2
-
-                    Post(s"$testRoutePath/$path", form.toEntity) ~> Route.seal(routes(creds)) ~> check {
-                        status should be(OK)
-                        responseAs[String] should (be("value1") or be("value2"))
-                    }
-
-                    Post(s"$testRoutePath/$path", form.toEntity(HttpCharsets.`US-ASCII`)) ~> Route.seal(routes(creds)) ~> check {
-                        status should be(OK)
-                        responseAs[String] should (be("value1") or be("value2"))
-                    }
-                }
-        }
-
-        it should s"reject requests when entity size exceeds allowed limit (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            Seq(s"$systemId/proxy/export_c.json").
-                foreach { path =>
-                    val largeEntity = "a" * (allowedActivationEntitySize.toInt + 1)
-
-                    val content = s"""{"a":"$largeEntity"}"""
-                    Post(s"$testRoutePath/$path", content.parseJson.asJsObject) ~> Route.seal(routes(creds)) ~> check {
-                        status should be(RequestEntityTooLarge)
-                        val expectedErrorMsg = Messages.entityTooBig(SizeError(
-                            fieldDescriptionForSizeError,
-                            (largeEntity.length + 8).B,
-                            allowedActivationEntitySize.B))
-                        confirmErrorWithTid(responseAs[JsObject], Some(expectedErrorMsg))
-                    }
-
-                    val form = FormData(Map("a" -> largeEntity))
-                    Post(s"$testRoutePath/$path", form) ~> Route.seal(routes(creds)) ~> check {
-                        status should be(RequestEntityTooLarge)
-                        val expectedErrorMsg = Messages.entityTooBig(SizeError(
-                            fieldDescriptionForSizeError,
-                            (largeEntity.length + 2).B,
-                            allowedActivationEntitySize.B))
-                        confirmErrorWithTid(responseAs[JsObject], Some(expectedErrorMsg))
-                    }
-                }
-        }
-
-        it should s"reject unknown extensions (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            Seq(s"$systemId/proxy/export_c.xyz", s"$systemId/proxy/export_c.xyz/", s"$systemId/proxy/export_c.xyz/content",
-                s"$systemId/proxy/export_c.xyzz", s"$systemId/proxy/export_c.xyzz/", s"$systemId/proxy/export_c.xyzz/content").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        actionResult = Some(JsObject("statusCode" -> 201.toJson))
-
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            if (webApiDirectives.enforceExtension) {
-                                status should be(NotAcceptable)
-                                confirmErrorWithTid(responseAs[JsObject], Some(Messages.contentTypeExtensionNotSupported(WhiskWebActionsApi.allowedExtensions)))
-                            } else {
-                                invocationsAllowed += 1
-                                status should be(Created)
-                            }
-                        }
-                    }
-                }
-        }
-
-        it should s"reject request that tries to override reserved properties (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            allowedMethodsWithEntity.foreach { m =>
-                webApiDirectives.reservedProperties.foreach { p =>
-                    m(s"$testRoutePath/$systemId/proxy/export_c.json?$p=YYY") ~> Route.seal(routes(creds)) ~> check {
-                        status should be(BadRequest)
-                        responseAs[ErrorResponse].error shouldBe Messages.parametersNotAllowed
-                    }
-
-                    m(s"$testRoutePath/$systemId/proxy/export_c.json", JsObject(p -> "YYY".toJson)) ~> Route.seal(routes(creds)) ~> check {
-                        status should be(BadRequest)
-                        responseAs[ErrorResponse].error shouldBe Messages.parametersNotAllowed
-                    }
-                }
             }
+          }
         }
+      }
 
-        it should s"reject request that tries to override final parameters (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-            val contentX = JsObject("x" -> "overriden".toJson)
-            val contentZ = JsObject("z" -> "overriden".toJson)
+      Seq(s"$systemId/proxy/export_c.html").foreach { path =>
+        allowedMethods.foreach { m =>
+          val html = "<html>hi</htlml>"
+          invocationsAllowed += 1
+          actionResult = Some(JsObject("html" -> JsString(html)))
 
-            allowedMethodsWithEntity.foreach { m =>
-                invocationsAllowed += 1
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            contentType shouldBe MediaTypes.`text/html`.withCharset(HttpCharsets.`UTF-8`)
+            val response = responseAs[String]
+            response shouldBe html
+          }
+        }
+      }
 
-                m(s"$testRoutePath/$systemId/proxy/export_c.json?x=overriden") ~> Route.seal(routes(creds)) ~> check {
-                    status should be(BadRequest)
-                    responseAs[ErrorResponse].error shouldBe Messages.parametersNotAllowed
-                }
+      Seq(s"$systemId/proxy/export_c.svg").foreach { path =>
+        allowedMethods.foreach { m =>
+          val svg = """<svg><circle cx="3" cy="3" r="3" fill="blue"/></svg>"""
+          invocationsAllowed += 1
+          actionResult = Some(JsObject("svg" -> JsString(svg)))
 
-                m(s"$testRoutePath/$systemId/proxy/export_c.json?y=overriden") ~> Route.seal(routes(creds)) ~> check {
-                    status should be(BadRequest)
-                    responseAs[ErrorResponse].error shouldBe Messages.parametersNotAllowed
-                }
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            //contentType shouldBe MediaTypes.`image/svg+xml`.withCharset(HttpCharsets.`UTF-8`)
+            val response = responseAs[String]
+            response shouldBe svg
+          }
+        }
+      }
+    }
 
-                m(s"$testRoutePath/$systemId/proxy/export_c.json", contentX) ~> Route.seal(routes(creds)) ~> check {
-                    status should be(BadRequest)
-                    responseAs[ErrorResponse].error shouldBe Messages.parametersNotAllowed
-                }
+    it should s"handle http web action and provide defaults (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
 
-                m(s"$testRoutePath/$systemId/proxy/export_c.json?y=overriden", contentZ) ~> Route.seal(routes(creds)) ~> check {
-                    status should be(BadRequest)
-                    responseAs[ErrorResponse].error shouldBe Messages.parametersNotAllowed
-                }
+      Seq(s"$systemId/proxy/export_c.http").foreach { path =>
+        allowedMethods.foreach { m =>
+          invocationsAllowed += 1
+          actionResult = Some(JsObject())
 
-                m(s"$testRoutePath/$systemId/proxy/export_c.json?empty=overriden") ~> Route.seal(routes(creds)) ~> check {
-                    status should be(OK)
-                    val response = responseAs[JsObject]
-                    response shouldBe JsObject(
-                        "pkg" -> s"$systemId/proxy".toJson,
-                        "action" -> "export_c".toJson,
-                        "content" -> metaPayload(
-                            m.method.name.toLowerCase,
-                            Map("empty" -> "overriden").toJson.asJsObject,
-                            creds,
-                            pkgName = "proxy"))
-                }
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            response.entity shouldBe HttpEntity.Empty
+            withClue(headers) {
+              headers.length shouldBe 0
             }
+          }
+        }
+      }
+    }
+
+    it should s"handle all JSON values with .text extension (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+
+      Seq(JsObject("a" -> "A".toJson), JsArray("a".toJson), JsString("a"), JsBoolean(true), JsNumber(1), JsNull)
+        .foreach { jsval =>
+          val path = s"$systemId/proxy/export_c.text/res"
+          allowedMethods.foreach { m =>
+            invocationsAllowed += 1
+            actionResult = Some(JsObject("res" -> jsval))
+
+            m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+              responseAs[String] shouldBe {
+                jsval match {
+                  case _: JsObject  => jsval.prettyPrint
+                  case _: JsArray   => jsval.prettyPrint
+                  case JsString(s)  => s
+                  case JsBoolean(b) => b.toString
+                  case JsNumber(n)  => n.toString
+                  case _            => "null"
+                }
+              }
+            }
+          }
+        }
+    }
+
+    it should s"handle http web action with base64 encoded JSON response (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+
+      Seq(s"$systemId/proxy/export_c.http").foreach { path =>
+        allowedMethods.foreach { m =>
+          invocationsAllowed += 1
+          actionResult = Some(
+            JsObject(
+              "headers" -> JsObject("content-type" -> "application/json".toJson),
+              webApiDirectives.statusCode -> OK.intValue.toJson,
+              "body" -> Base64.getEncoder.encodeToString {
+                JsObject("field" -> "value".toJson).compactPrint.getBytes
+              }.toJson))
+
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            responseAs[JsObject] shouldBe JsObject("field" -> "value".toJson)
+          }
+        }
+      }
+    }
+
+    it should s"handle http web action without base64 encoded JSON response (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+
+      Seq(
+        (JsObject("content-type" -> "application/json".toJson), OK),
+        (JsObject(), OK),
+        (JsObject("content-type" -> "text/html".toJson), BadRequest)).foreach {
+        case (headers, expectedCode) =>
+          Seq(s"$systemId/proxy/export_c.http").foreach { path =>
+            allowedMethods.foreach { m =>
+              invocationsAllowed += 1
+              actionResult = Some(
+                JsObject(
+                  "headers" -> headers,
+                  webApiDirectives.statusCode -> OK.intValue.toJson,
+                  "body" -> JsObject("field" -> "value".toJson)))
+
+              m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+                status should be(expectedCode)
+
+                if (expectedCode == OK) {
+                  header("content-type").map(_.toString shouldBe "content-type: application/json")
+                  responseAs[JsObject] shouldBe JsObject("field" -> "value".toJson)
+                } else {
+                  confirmErrorWithTid(responseAs[JsObject], Some(Messages.httpContentTypeError))
+                }
+              }
+            }
+          }
+      }
+
+      Seq(s"$systemId/proxy/export_c.http").foreach { path =>
+        allowedMethods.foreach { m =>
+          invocationsAllowed += 1
+          actionResult = Some(JsObject(webApiDirectives.statusCode -> OK.intValue.toJson, "body" -> JsNumber(3)))
+
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            header("content-type").map(_.toString shouldBe "content-type: application/json")
+            responseAs[String].toInt shouldBe 3
+          }
+        }
+      }
+    }
+
+    it should s"handle http web action with base64 encoded binary response (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+      val png = "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAGCAYAAAD68A/GAAAA/klEQVQYGWNgAAEHBxaG//+ZQMyyn581Pfas+cRQnf1LfF" +
+        "Ljf+62smUgcUbt0FA2Zh7drf/ffMy9vLn3RurrW9e5hCU11i2azfD4zu1/DHz8TAy/foUxsXBrFzHzC7r8+M9S1vn1qxQT07dDjL" +
+        "9fdemrqKxlYGT6z8AIMo6hgeUfA0PUvy9fGFh5GWK3z7vNxSWt++jX99+8SoyiGQwsW38w8PJEM7x5v5SJ8f+/xv8MDAzffv9hev" +
+        "fkWjiXBGMpMx+j2awovjcMjFztDO8+7GF49LkbZDCDeXLTWnZO7qDfn1/+5jbw/8pjYWS4wZLztXnuEuYTk2M+MzIw/AcA36Vewa" +
+        "D6fzsAAAAASUVORK5CYII="
+      val expectedEntity = HttpEntity(ContentType(MediaTypes.`image/png`), Base64.getDecoder().decode(png))
+
+      Seq(s"$systemId/proxy/export_c.http").foreach { path =>
+        allowedMethods.foreach { m =>
+          invocationsAllowed += 1
+          actionResult = Some(
+            JsObject(
+              "headers" -> JsObject(`Content-Type`.lowercaseName -> MediaTypes.`image/png`.toString.toJson),
+              "body" -> png.toJson))
+
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            response.entity shouldBe expectedEntity
+          }
+        }
+      }
+    }
+
+    it should s"handle http web action with html/text response (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+
+      Seq(s"$systemId/proxy/export_c.http").foreach { path =>
+        allowedMethods.foreach { m =>
+          invocationsAllowed += 1
+          actionResult =
+            Some(JsObject(webApiDirectives.statusCode -> OK.intValue.toJson, "body" -> "hello world".toJson))
+
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            responseAs[String] shouldBe "hello world"
+          }
+        }
+      }
+    }
+
+    it should s"reject http web action with mismatch between header and response (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+
+      Seq(s"$systemId/proxy/export_c.http").foreach { path =>
+        allowedMethods.foreach { m =>
+          invocationsAllowed += 1
+          actionResult = Some(
+            JsObject(
+              "headers" -> JsObject("content-type" -> "application/json".toJson),
+              webApiDirectives.statusCode -> OK.intValue.toJson,
+              "body" -> "hello world".toJson))
+
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            status should be(BadRequest)
+            confirmErrorWithTid(responseAs[JsObject], Some(Messages.httpContentTypeError))
+          }
+        }
+      }
+    }
+
+    it should s"reject http web action with unknown header (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+
+      Seq(s"$systemId/proxy/export_c.http").foreach { path =>
+        allowedMethods.foreach { m =>
+          invocationsAllowed += 1
+          actionResult = Some(
+            JsObject(
+              "headers" -> JsObject("content-type" -> "xyz/bar".toJson),
+              webApiDirectives.statusCode -> OK.intValue.toJson,
+              "body" -> "hello world".toJson))
+
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            status should be(BadRequest)
+            confirmErrorWithTid(responseAs[JsObject], Some(Messages.httpUnknownContentType))
+          }
+        }
+      }
+    }
+
+    it should s"handle an activation that results in application error and response matches extension (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+
+      Seq(s"$systemId/proxy/export_c.http", s"$systemId/proxy/export_c.http/ignoreme").foreach { path =>
+        allowedMethods.foreach { m =>
+          invocationsAllowed += 1
+          actionResult = Some(
+            JsObject(
+              "application_error" -> JsObject(
+                webApiDirectives.statusCode -> OK.intValue.toJson,
+                "body" -> "no hello for you".toJson)))
+
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            responseAs[String] shouldBe "no hello for you"
+          }
+        }
+      }
+    }
+
+    it should s"handle an activation that results in application error but where response does not match extension (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+
+      Seq(s"$systemId/proxy/export_c.json", s"$systemId/proxy/export_c.json/ignoreme").foreach { path =>
+        allowedMethods.foreach { m =>
+          invocationsAllowed += 1
+          actionResult = Some(JsObject("application_error" -> "bad response type".toJson))
+
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            status should be(BadRequest)
+            confirmErrorWithTid(responseAs[JsObject], Some(Messages.invalidMedia(MediaTypes.`application/json`)))
+          }
+        }
+      }
+    }
+
+    it should s"handle an activation that results in developer or system error (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+
+      Seq(s"$systemId/proxy/export_c.json", s"$systemId/proxy/export_c.json/ignoreme", s"$systemId/proxy/export_c.text")
+        .foreach { path =>
+          Seq("developer_error", "whisk_error").foreach { e =>
+            allowedMethods.foreach { m =>
+              invocationsAllowed += 1
+              actionResult = Some(JsObject(e -> "bad response type".toJson))
+
+              m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+                status should be(BadRequest)
+                if (e == "application_error") {
+                  confirmErrorWithTid(responseAs[JsObject], Some(Messages.invalidMedia(MediaTypes.`application/json`)))
+                } else {
+                  confirmErrorWithTid(responseAs[JsObject], Some(Messages.errorProcessingRequest))
+                }
+              }
+            }
+          }
+        }
+    }
+
+    it should s"support formdata (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+
+      Seq(s"$systemId/proxy/export_c.text/content/field1", s"$systemId/proxy/export_c.text/content/field2").foreach {
+        path =>
+          val form = FormData(Map("field1" -> "value1", "field2" -> "value2"))
+          invocationsAllowed += 2
+
+          Post(s"$testRoutePath/$path", form.toEntity) ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            responseAs[String] should (be("value1") or be("value2"))
+          }
+
+          Post(s"$testRoutePath/$path", form.toEntity(HttpCharsets.`US-ASCII`)) ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            responseAs[String] should (be("value1") or be("value2"))
+          }
+      }
+    }
+
+    it should s"reject requests when entity size exceeds allowed limit (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+
+      Seq(s"$systemId/proxy/export_c.json").foreach { path =>
+        val largeEntity = "a" * (allowedActivationEntitySize.toInt + 1)
+
+        val content = s"""{"a":"$largeEntity"}"""
+        Post(s"$testRoutePath/$path", content.parseJson.asJsObject) ~> Route.seal(routes(creds)) ~> check {
+          status should be(RequestEntityTooLarge)
+          val expectedErrorMsg = Messages.entityTooBig(
+            SizeError(fieldDescriptionForSizeError, (largeEntity.length + 8).B, allowedActivationEntitySize.B))
+          confirmErrorWithTid(responseAs[JsObject], Some(expectedErrorMsg))
         }
 
-        it should s"inline body when receiving entity that is not a JsObject (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-            val str = "1,2,3"
-            invocationsAllowed = 3
+        val form = FormData(Map("a" -> largeEntity))
+        Post(s"$testRoutePath/$path", form) ~> Route.seal(routes(creds)) ~> check {
+          status should be(RequestEntityTooLarge)
+          val expectedErrorMsg = Messages.entityTooBig(
+            SizeError(fieldDescriptionForSizeError, (largeEntity.length + 2).B, allowedActivationEntitySize.B))
+          confirmErrorWithTid(responseAs[JsObject], Some(expectedErrorMsg))
+        }
+      }
+    }
 
-            /*
-             * Now supporting all content types with inlined "body".
-             *
+    it should s"reject unknown extensions (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+
+      Seq(
+        s"$systemId/proxy/export_c.xyz",
+        s"$systemId/proxy/export_c.xyz/",
+        s"$systemId/proxy/export_c.xyz/content",
+        s"$systemId/proxy/export_c.xyzz",
+        s"$systemId/proxy/export_c.xyzz/",
+        s"$systemId/proxy/export_c.xyzz/content").foreach { path =>
+        allowedMethods.foreach { m =>
+          actionResult = Some(JsObject("statusCode" -> 201.toJson))
+
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            if (webApiDirectives.enforceExtension) {
+              status should be(NotAcceptable)
+              confirmErrorWithTid(
+                responseAs[JsObject],
+                Some(Messages.contentTypeExtensionNotSupported(WhiskWebActionsApi.allowedExtensions)))
+            } else {
+              invocationsAllowed += 1
+              status should be(Created)
+            }
+          }
+        }
+      }
+    }
+
+    it should s"reject request that tries to override reserved properties (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+
+      allowedMethodsWithEntity.foreach { m =>
+        webApiDirectives.reservedProperties.foreach { p =>
+          m(s"$testRoutePath/$systemId/proxy/export_c.json?$p=YYY") ~> Route.seal(routes(creds)) ~> check {
+            status should be(BadRequest)
+            responseAs[ErrorResponse].error shouldBe Messages.parametersNotAllowed
+          }
+
+          m(s"$testRoutePath/$systemId/proxy/export_c.json", JsObject(p -> "YYY".toJson)) ~> Route.seal(routes(creds)) ~> check {
+            status should be(BadRequest)
+            responseAs[ErrorResponse].error shouldBe Messages.parametersNotAllowed
+          }
+        }
+      }
+    }
+
+    it should s"reject request that tries to override final parameters (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+      val contentX = JsObject("x" -> "overriden".toJson)
+      val contentZ = JsObject("z" -> "overriden".toJson)
+
+      allowedMethodsWithEntity.foreach { m =>
+        invocationsAllowed += 1
+
+        m(s"$testRoutePath/$systemId/proxy/export_c.json?x=overriden") ~> Route.seal(routes(creds)) ~> check {
+          status should be(BadRequest)
+          responseAs[ErrorResponse].error shouldBe Messages.parametersNotAllowed
+        }
+
+        m(s"$testRoutePath/$systemId/proxy/export_c.json?y=overriden") ~> Route.seal(routes(creds)) ~> check {
+          status should be(BadRequest)
+          responseAs[ErrorResponse].error shouldBe Messages.parametersNotAllowed
+        }
+
+        m(s"$testRoutePath/$systemId/proxy/export_c.json", contentX) ~> Route.seal(routes(creds)) ~> check {
+          status should be(BadRequest)
+          responseAs[ErrorResponse].error shouldBe Messages.parametersNotAllowed
+        }
+
+        m(s"$testRoutePath/$systemId/proxy/export_c.json?y=overriden", contentZ) ~> Route.seal(routes(creds)) ~> check {
+          status should be(BadRequest)
+          responseAs[ErrorResponse].error shouldBe Messages.parametersNotAllowed
+        }
+
+        m(s"$testRoutePath/$systemId/proxy/export_c.json?empty=overriden") ~> Route.seal(routes(creds)) ~> check {
+          status should be(OK)
+          val response = responseAs[JsObject]
+          response shouldBe JsObject(
+            "pkg" -> s"$systemId/proxy".toJson,
+            "action" -> "export_c".toJson,
+            "content" -> metaPayload(
+              m.method.name.toLowerCase,
+              Map("empty" -> "overriden").toJson.asJsObject,
+              creds,
+              pkgName = "proxy"))
+        }
+      }
+    }
+
+    it should s"inline body when receiving entity that is not a JsObject (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+      val str = "1,2,3"
+      invocationsAllowed = 3
+
+      /*
+       * Now supporting all content types with inlined "body".
+       *
              Post(s"$testRoutePath/$systemId/proxy/export_c.json?a=b&c=d", "1,2,3") ~> Route.seal(routes(creds)) ~> check {
                  status should be(BadRequest)
                  confirmErrorWithTid(responseAs[JsObject], Some(Messages.contentTypeNotSupported))
              }
-             *
-             */
+       *
+       */
 
-            Post(s"$testRoutePath/$systemId/proxy/export_c.json", str) ~> addHeader("Content-type", ContentTypes.`text/html(UTF-8)`.value) ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                val response = responseAs[JsObject]
-                response shouldBe JsObject(
-                    "pkg" -> s"$systemId/proxy".toJson,
-                    "action" -> "export_c".toJson,
-                    "content" -> metaPayload(
-                        Post.method.name.toLowerCase,
-                        JsObject(webApiDirectives.body -> str.toJson),
-                        creds,
-                        pkgName = "proxy",
-                        headers = List(`Content-Type`(ContentTypes.`text/html(UTF-8)`))))
-            }
+      Post(s"$testRoutePath/$systemId/proxy/export_c.json", str) ~> addHeader(
+        "Content-type",
+        ContentTypes.`text/html(UTF-8)`.value) ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[JsObject]
+        response shouldBe JsObject(
+          "pkg" -> s"$systemId/proxy".toJson,
+          "action" -> "export_c".toJson,
+          "content" -> metaPayload(
+            Post.method.name.toLowerCase,
+            JsObject(webApiDirectives.body -> str.toJson),
+            creds,
+            pkgName = "proxy",
+            headers = List(`Content-Type`(ContentTypes.`text/html(UTF-8)`))))
+      }
 
-            Post(s"$testRoutePath/$systemId/proxy/export_c.json?a=b&c=d") ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                val response = responseAs[JsObject]
-                response shouldBe JsObject(
-                    "pkg" -> s"$systemId/proxy".toJson,
-                    "action" -> "export_c".toJson,
-                    "content" -> metaPayload(
-                        Post.method.name.toLowerCase,
-                        Map("a" -> "b", "c" -> "d").toJson.asJsObject,
-                        creds,
-                        pkgName = "proxy"))
-            }
+      Post(s"$testRoutePath/$systemId/proxy/export_c.json?a=b&c=d") ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[JsObject]
+        response shouldBe JsObject(
+          "pkg" -> s"$systemId/proxy".toJson,
+          "action" -> "export_c".toJson,
+          "content" -> metaPayload(
+            Post.method.name.toLowerCase,
+            Map("a" -> "b", "c" -> "d").toJson.asJsObject,
+            creds,
+            pkgName = "proxy"))
+      }
 
-            Post(s"$testRoutePath/$systemId/proxy/export_c.json?a=b&c=d", JsObject()) ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                val response = responseAs[JsObject]
-                response shouldBe JsObject(
-                    "pkg" -> s"$systemId/proxy".toJson,
-                    "action" -> "export_c".toJson,
-                    "content" -> metaPayload(
-                        Post.method.name.toLowerCase,
-                        Map("a" -> "b", "c" -> "d").toJson.asJsObject,
-                        creds,
-                        pkgName = "proxy"))
-            }
-        }
-
-        it should s"throttle subject owning namespace for web action (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            // this should fail for exceeding quota
-            Seq(s"$systemId/proxy/export_c.text/content/z").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        failThrottleForSubject = Some(systemId)
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            status should be(TooManyRequests)
-                            confirmErrorWithTid(responseAs[JsObject], Some(Messages.tooManyRequests))
-                        }
-                        failThrottleForSubject = None
-                    }
-                }
-        }
-
-        it should s"invoke action with options verb with custom options (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            Seq(s"$systemId/proxy/export_c.http").
-                foreach { path =>
-                    invocationsAllowed += 1
-                    actionResult = Some(
-                        JsObject(
-                            "headers" -> JsObject(
-                                "Access-Control-Allow-Methods" -> "OPTIONS, GET, PATCH".toJson)))
-
-                    Options(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                        header("Access-Control-Allow-Origin") shouldBe None
-                        header("Access-Control-Allow-Methods").get.toString shouldBe "Access-Control-Allow-Methods: OPTIONS, GET, PATCH"
-                    }
-                }
-        }
-
-        it should s"support multiple values for headers (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            Seq(s"$systemId/proxy/export_c.http").
-                foreach { path =>
-                    invocationsAllowed += 1
-                    actionResult = Some(
-                        JsObject(
-                            "headers" -> JsObject(
-                                "Set-Cookie" -> JsArray(JsString("a=b"), JsString("c=d; Path = /")))))
-
-                    Options(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                        headers should contain allOf (
-                            RawHeader("Set-Cookie", "a=b"),
-                            RawHeader("Set-Cookie", "c=d; Path = /"))
-                    }
-                }
-        }
-
-        it should s"invoke action with options verb without custom options (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-            customOptions = false
-
-            Seq(s"$systemId/proxy/export_c.http", s"$systemId/proxy/export_c.json").
-                foreach { path =>
-                    allowedMethods.foreach { m =>
-                        invocationsAllowed += 1
-                        m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                            header("Access-Control-Allow-Origin").get.toString shouldBe "Access-Control-Allow-Origin: *"
-                            header("Access-Control-Allow-Methods").get.toString shouldBe "Access-Control-Allow-Methods: OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH"
-                            header("Access-Control-Allow-Headers").get.toString shouldBe "Access-Control-Allow-Headers: Authorization, Content-Type"
-                        }
-                    }
-                }
-
-            invocationsAllowed -= 2 // Options request does not cause invocation of an action
-        }
-
-        it should s"invoke action with head verb (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            Seq(s"$systemId/proxy/export_c.http").
-                foreach { path =>
-                    invocationsAllowed += 1
-                    actionResult = Some(
-                        JsObject(
-                            "headers" -> JsObject(
-                                "location" -> "http://openwhisk.org".toJson)))
-
-                    Head(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
-                        header("location").get.toString shouldBe "location: http://openwhisk.org"
-                    }
-                }
-        }
-
-        it should s"handle html web action with text/xml response (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            Seq(s"$systemId/proxy/export_c.html").
-                foreach { path =>
-                    val html = """<html><body>test</body></html>"""
-                    val xml = """<?xml version="1.0" encoding="UTF-8"?><note><from>test</from></note>"""
-                    invocationsAllowed += 2
-                    actionResult = Some(JsObject("html" -> xml.toJson))
-
-                    Seq((html, MediaTypes.`text/html`), (xml, MediaTypes.`text/html`)).
-                        foreach {
-                            case (res, expectedMediaType) =>
-                                actionResult = Some(JsObject("html" -> res.toJson))
-
-                                Get(s"$testRoutePath/$path") ~> addHeader("Accept", expectedMediaType.value) ~> Route.seal(routes(creds)) ~> check {
-                                    status should be(OK)
-                                    responseAs[String] shouldBe res
-                                    mediaType shouldBe expectedMediaType
-                                }
-                        }
-                }
-        }
-
-        it should s"not fail a raw http action when query or body parameters overlap with final action parameters (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-            invocationsAllowed = 2
-
-            val queryString = "x=overriden&key2=value2"
-            Post(s"$testRoutePath/$systemId/proxy/raw_export_c.json?$queryString") ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                val response = responseAs[JsObject]
-                response shouldBe JsObject(
-                    "pkg" -> s"$systemId/proxy".toJson,
-                    "action" -> "raw_export_c".toJson,
-                    "content" -> metaPayload(
-                        Post.method.name.toLowerCase,
-                        Map(webApiDirectives.body -> JsObject(),
-                            webApiDirectives.query -> queryString.toJson).toJson.asJsObject,
-                        creds,
-                        pkgName = "proxy"))
-            }
-
-            Post(s"$testRoutePath/$systemId/proxy/raw_export_c.json", JsObject("x" -> "overriden".toJson, "key2" -> "value2".toJson)) ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                val response = responseAs[JsObject]
-                response shouldBe JsObject(
-                    "pkg" -> s"$systemId/proxy".toJson,
-                    "action" -> "raw_export_c".toJson,
-                    "content" -> metaPayload(
-                        Post.method.name.toLowerCase,
-                        Map(webApiDirectives.query -> "".toJson,
-                            webApiDirectives.body -> Base64.getEncoder.encodeToString {
-                                JsObject("x" -> JsString("overriden"), "key2" -> JsString("value2")).compactPrint.getBytes
-                            }.toJson).toJson.asJsObject,
-                        creds,
-                        pkgName = "proxy"))
-            }
-        }
-
-        it should s"invoke raw action ensuring body and query arguments are set properly (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-            val str = "1,2,3"
-            invocationsAllowed = 1
-
-            val queryString = "key1=value1&key2=value2"
-            Post(s"$testRoutePath/$systemId/proxy/raw_export_c.json?$queryString", str) ~> addHeader("Content-type", MediaTypes.`application/json`.value) ~> Route.seal(routes(creds)) ~> check {
-                status should be(OK)
-                val response = responseAs[JsObject]
-                response shouldBe JsObject(
-                    "pkg" -> s"$systemId/proxy".toJson,
-                    "action" -> "raw_export_c".toJson,
-                    "content" -> metaPayload(
-                        Post.method.name.toLowerCase,
-                        Map(webApiDirectives.body -> str.toJson,
-                            webApiDirectives.query -> queryString.toJson).toJson.asJsObject,
-                        creds,
-                        pkgName = "proxy",
-                        headers = List(`Content-Type`(ContentTypes.`application/json`))))
-            }
-        }
-
-        it should s"reject invocation of web action with invalid accept header (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            Seq(s"$systemId/proxy/export_c.http").
-                foreach { path =>
-                    actionResult = Some(JsObject("body" -> "Plain text".toJson))
-                    invocationsAllowed += 1
-
-                    Get(s"$testRoutePath/$path") ~> addHeader("Accept", "application/json") ~> Route.seal(routes(creds)) ~> check {
-                        status should be(NotAcceptable)
-                        response shouldBe HttpResponse(NotAcceptable, entity = "Resource representation is only available with these types:\ntext/html; charset=UTF-8")
-                    }
-                }
-        }
-
-        it should s"not invoke an action more than once when determining entity type (auth? ${creds.isDefined})" in {
-            implicit val tid = transid()
-
-            Seq(s"$systemId/proxy/export_c.html").
-                foreach { path =>
-                    val html = """<html><body>test</body></html>"""
-                    val xml = """<?xml version="1.0" encoding="UTF-8"?><note><from>test</from></note>"""
-                    invocationsAllowed += 1
-                    actionResult = Some(JsObject("html" -> xml.toJson))
-
-                    Get(s"$testRoutePath/$path") ~> addHeader("Accept", MediaTypes.`text/xml`.value) ~> Route.seal(routes(creds)) ~> check {
-                        status should be(NotAcceptable)
-                    }
-                }
-
-            withClue(s"allowed invoke count did not match actual") {
-                invocationsAllowed shouldBe invocationCount
-            }
-        }
+      Post(s"$testRoutePath/$systemId/proxy/export_c.json?a=b&c=d", JsObject()) ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[JsObject]
+        response shouldBe JsObject(
+          "pkg" -> s"$systemId/proxy".toJson,
+          "action" -> "export_c".toJson,
+          "content" -> metaPayload(
+            Post.method.name.toLowerCase,
+            Map("a" -> "b", "c" -> "d").toJson.asJsObject,
+            creds,
+            pkgName = "proxy"))
+      }
     }
 
-    class TestingEntitlementProvider(
-        config: WhiskConfig,
-        loadBalancer: LoadBalancer)
-        extends EntitlementProvider(config, loadBalancer) {
+    it should s"throttle subject owning namespace for web action (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
 
-        protected[core] override def checkThrottles(user: Identity)(
-            implicit transid: TransactionId): Future[Unit] = {
-            val subject = user.subject
-            logging.debug(this, s"test throttle is checking user '$subject' has not exceeded activation quota")
+      // this should fail for exceeding quota
+      Seq(s"$systemId/proxy/export_c.text/content/z").foreach { path =>
+        allowedMethods.foreach { m =>
+          failThrottleForSubject = Some(systemId)
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            status should be(TooManyRequests)
+            confirmErrorWithTid(responseAs[JsObject], Some(Messages.tooManyRequests))
+          }
+          failThrottleForSubject = None
+        }
+      }
+    }
 
-            failThrottleForSubject match {
-                case Some(subject) if subject == user.subject =>
-                    Future.failed(RejectRequest(TooManyRequests, Messages.tooManyRequests))
-                case _ => Future.successful({})
+    it should s"invoke action with options verb with custom options (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+
+      Seq(s"$systemId/proxy/export_c.http").foreach { path =>
+        invocationsAllowed += 1
+        actionResult =
+          Some(JsObject("headers" -> JsObject("Access-Control-Allow-Methods" -> "OPTIONS, GET, PATCH".toJson)))
+
+        Options(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+          header("Access-Control-Allow-Origin") shouldBe None
+          header("Access-Control-Allow-Methods").get.toString shouldBe "Access-Control-Allow-Methods: OPTIONS, GET, PATCH"
+        }
+      }
+    }
+
+    it should s"support multiple values for headers (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+
+      Seq(s"$systemId/proxy/export_c.http").foreach { path =>
+        invocationsAllowed += 1
+        actionResult =
+          Some(JsObject("headers" -> JsObject("Set-Cookie" -> JsArray(JsString("a=b"), JsString("c=d; Path = /")))))
+
+        Options(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+          headers should contain allOf (RawHeader("Set-Cookie", "a=b"),
+          RawHeader("Set-Cookie", "c=d; Path = /"))
+        }
+      }
+    }
+
+    it should s"invoke action with options verb without custom options (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+      customOptions = false
+
+      Seq(s"$systemId/proxy/export_c.http", s"$systemId/proxy/export_c.json").foreach { path =>
+        allowedMethods.foreach { m =>
+          invocationsAllowed += 1
+          m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+            header("Access-Control-Allow-Origin").get.toString shouldBe "Access-Control-Allow-Origin: *"
+            header("Access-Control-Allow-Methods").get.toString shouldBe "Access-Control-Allow-Methods: OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH"
+            header("Access-Control-Allow-Headers").get.toString shouldBe "Access-Control-Allow-Headers: Authorization, Content-Type"
+          }
+        }
+      }
+
+      invocationsAllowed -= 2 // Options request does not cause invocation of an action
+    }
+
+    it should s"invoke action with head verb (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+
+      Seq(s"$systemId/proxy/export_c.http").foreach { path =>
+        invocationsAllowed += 1
+        actionResult = Some(JsObject("headers" -> JsObject("location" -> "http://openwhisk.org".toJson)))
+
+        Head(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
+          header("location").get.toString shouldBe "location: http://openwhisk.org"
+        }
+      }
+    }
+
+    it should s"handle html web action with text/xml response (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+
+      Seq(s"$systemId/proxy/export_c.html").foreach { path =>
+        val html = """<html><body>test</body></html>"""
+        val xml = """<?xml version="1.0" encoding="UTF-8"?><note><from>test</from></note>"""
+        invocationsAllowed += 2
+        actionResult = Some(JsObject("html" -> xml.toJson))
+
+        Seq((html, MediaTypes.`text/html`), (xml, MediaTypes.`text/html`)).foreach {
+          case (res, expectedMediaType) =>
+            actionResult = Some(JsObject("html" -> res.toJson))
+
+            Get(s"$testRoutePath/$path") ~> addHeader("Accept", expectedMediaType.value) ~> Route.seal(routes(creds)) ~> check {
+              status should be(OK)
+              responseAs[String] shouldBe res
+              mediaType shouldBe expectedMediaType
             }
         }
-
-        protected[core] override def grant(subject: Subject, right: Privilege, resource: Resource)(
-            implicit transid: TransactionId) = ???
-
-        /** Revokes subject right to resource by removing them from the entitlement matrix. */
-        protected[core] override def revoke(subject: Subject, right: Privilege, resource: Resource)(
-            implicit transid: TransactionId) = ???
-
-        /** Checks if subject has explicit grant for a resource. */
-        protected override def entitled(subject: Subject, right: Privilege, resource: Resource)(
-            implicit transid: TransactionId) = ???
+      }
     }
+
+    it should s"not fail a raw http action when query or body parameters overlap with final action parameters (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+      invocationsAllowed = 2
+
+      val queryString = "x=overriden&key2=value2"
+      Post(s"$testRoutePath/$systemId/proxy/raw_export_c.json?$queryString") ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[JsObject]
+        response shouldBe JsObject(
+          "pkg" -> s"$systemId/proxy".toJson,
+          "action" -> "raw_export_c".toJson,
+          "content" -> metaPayload(
+            Post.method.name.toLowerCase,
+            Map(webApiDirectives.body -> JsObject(), webApiDirectives.query -> queryString.toJson).toJson.asJsObject,
+            creds,
+            pkgName = "proxy"))
+      }
+
+      Post(
+        s"$testRoutePath/$systemId/proxy/raw_export_c.json",
+        JsObject("x" -> "overriden".toJson, "key2" -> "value2".toJson)) ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[JsObject]
+        response shouldBe JsObject(
+          "pkg" -> s"$systemId/proxy".toJson,
+          "action" -> "raw_export_c".toJson,
+          "content" -> metaPayload(
+            Post.method.name.toLowerCase,
+            Map(webApiDirectives.query -> "".toJson, webApiDirectives.body -> Base64.getEncoder.encodeToString {
+              JsObject("x" -> JsString("overriden"), "key2" -> JsString("value2")).compactPrint.getBytes
+            }.toJson).toJson.asJsObject,
+            creds,
+            pkgName = "proxy"))
+      }
+    }
+
+    it should s"invoke raw action ensuring body and query arguments are set properly (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+      val str = "1,2,3"
+      invocationsAllowed = 1
+
+      val queryString = "key1=value1&key2=value2"
+      Post(s"$testRoutePath/$systemId/proxy/raw_export_c.json?$queryString", str) ~> addHeader(
+        "Content-type",
+        MediaTypes.`application/json`.value) ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[JsObject]
+        response shouldBe JsObject(
+          "pkg" -> s"$systemId/proxy".toJson,
+          "action" -> "raw_export_c".toJson,
+          "content" -> metaPayload(
+            Post.method.name.toLowerCase,
+            Map(webApiDirectives.body -> str.toJson, webApiDirectives.query -> queryString.toJson).toJson.asJsObject,
+            creds,
+            pkgName = "proxy",
+            headers = List(`Content-Type`(ContentTypes.`application/json`))))
+      }
+    }
+
+    it should s"reject invocation of web action with invalid accept header (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+
+      Seq(s"$systemId/proxy/export_c.http").foreach { path =>
+        actionResult = Some(JsObject("body" -> "Plain text".toJson))
+        invocationsAllowed += 1
+
+        Get(s"$testRoutePath/$path") ~> addHeader("Accept", "application/json") ~> Route.seal(routes(creds)) ~> check {
+          status should be(NotAcceptable)
+          response shouldBe HttpResponse(
+            NotAcceptable,
+            entity = "Resource representation is only available with these types:\ntext/html; charset=UTF-8")
+        }
+      }
+    }
+
+    it should s"not invoke an action more than once when determining entity type (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+
+      Seq(s"$systemId/proxy/export_c.html").foreach { path =>
+        val html = """<html><body>test</body></html>"""
+        val xml = """<?xml version="1.0" encoding="UTF-8"?><note><from>test</from></note>"""
+        invocationsAllowed += 1
+        actionResult = Some(JsObject("html" -> xml.toJson))
+
+        Get(s"$testRoutePath/$path") ~> addHeader("Accept", MediaTypes.`text/xml`.value) ~> Route.seal(routes(creds)) ~> check {
+          status should be(NotAcceptable)
+        }
+      }
+
+      withClue(s"allowed invoke count did not match actual") {
+        invocationsAllowed shouldBe invocationCount
+      }
+    }
+  }
+
+  class TestingEntitlementProvider(config: WhiskConfig, loadBalancer: LoadBalancer)
+      extends EntitlementProvider(config, loadBalancer) {
+
+    protected[core] override def checkThrottles(user: Identity)(implicit transid: TransactionId): Future[Unit] = {
+      val subject = user.subject
+      logging.debug(this, s"test throttle is checking user '$subject' has not exceeded activation quota")
+
+      failThrottleForSubject match {
+        case Some(subject) if subject == user.subject =>
+          Future.failed(RejectRequest(TooManyRequests, Messages.tooManyRequests))
+        case _ => Future.successful({})
+      }
+    }
+
+    protected[core] override def grant(subject: Subject, right: Privilege, resource: Resource)(
+      implicit transid: TransactionId) = ???
+
+    /** Revokes subject right to resource by removing them from the entitlement matrix. */
+    protected[core] override def revoke(subject: Subject, right: Privilege, resource: Resource)(
+      implicit transid: TransactionId) = ???
+
+    /** Checks if subject has explicit grant for a resource. */
+    protected override def entitled(subject: Subject, right: Privilege, resource: Resource)(
+      implicit transid: TransactionId) = ???
+  }
 
 }

--- a/tests/src/test/scala/whisk/core/controller/test/WhiskAuthHelpers.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/WhiskAuthHelpers.scala
@@ -24,11 +24,11 @@ import whisk.core.entitlement.Privilege
 import whisk.core.entity.Identity
 
 object WhiskAuthHelpers {
-    def newAuth(s: Subject = Subject(), k: AuthKey = AuthKey()) = {
-        WhiskAuth(s, Set(WhiskNamespace(EntityName(s.asString), k)))
-    }
+  def newAuth(s: Subject = Subject(), k: AuthKey = AuthKey()) = {
+    WhiskAuth(s, Set(WhiskNamespace(EntityName(s.asString), k)))
+  }
 
-    def newIdentity(s: Subject = Subject(), k: AuthKey = AuthKey()) = {
-        Identity(s, EntityName(s.asString), k, Privilege.ALL)
-    }
+  def newIdentity(s: Subject = Subject(), k: AuthKey = AuthKey()) = {
+    Identity(s, EntityName(s.asString), k, Privilege.ALL)
+  }
 }

--- a/tests/src/test/scala/whisk/core/controller/test/migration/SequenceActionApiMigrationTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/migration/SequenceActionApiMigrationTests.scala
@@ -41,135 +41,140 @@ import whisk.core.entity._
  * Tests migration of a new implementation of sequences: old style sequences can be updated and retrieved - standalone tests
  */
 @RunWith(classOf[JUnitRunner])
-class SequenceActionApiMigrationTests extends ControllerTestCommon
+class SequenceActionApiMigrationTests
+    extends ControllerTestCommon
     with WhiskActionsApi
     with TestHelpers
     with WskTestHelpers {
 
-    behavior of "Sequence Action API Migration"
+  behavior of "Sequence Action API Migration"
 
-    val creds = WhiskAuthHelpers.newIdentity()
-    val namespace = EntityPath(creds.subject.asString)
-    val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
-    def aname = MakeName.next("seq_migration_tests")
+  val creds = WhiskAuthHelpers.newIdentity()
+  val namespace = EntityPath(creds.subject.asString)
+  val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
+  def aname = MakeName.next("seq_migration_tests")
 
-    private def seqParameters(seq: Vector[String]) = Parameters("_actions", seq.toJson)
+  private def seqParameters(seq: Vector[String]) = Parameters("_actions", seq.toJson)
 
-    it should "list old-style sequence action with explicit namespace" in {
-        implicit val tid = transid()
-        val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c").map(stringToFullyQualifiedName(_))
-        val actions = (1 to 2).map { i =>
-            WhiskAction(namespace, aname, sequence(components))
-        }.toList
-        actions foreach { put(entityStore, _) }
-        waitOnView(entityStore, WhiskAction, namespace, 2)
-        Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[List[JsObject]]
+  it should "list old-style sequence action with explicit namespace" in {
+    implicit val tid = transid()
+    val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c").map(stringToFullyQualifiedName(_))
+    val actions = (1 to 2).map { i =>
+      WhiskAction(namespace, aname, sequence(components))
+    }.toList
+    actions foreach { put(entityStore, _) }
+    waitOnView(entityStore, WhiskAction, namespace, 2)
+    Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[List[JsObject]]
 
-            actions.length should be(response.length)
-            actions forall { a => response contains a.summaryAsJson } should be(true)
-        }
+      actions.length should be(response.length)
+      actions forall { a =>
+        response contains a.summaryAsJson
+      } should be(true)
     }
+  }
 
-    it should "get old-style sequence action by name in default namespace" in {
-        implicit val tid = transid()
-        val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c").map(stringToFullyQualifiedName(_))
-        val action = WhiskAction(namespace, aname, sequence(components))
-        put(entityStore, action)
-        Get(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskAction]
-            response should be(action)
-        }
+  it should "get old-style sequence action by name in default namespace" in {
+    implicit val tid = transid()
+    val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c").map(stringToFullyQualifiedName(_))
+    val action = WhiskAction(namespace, aname, sequence(components))
+    put(entityStore, action)
+    Get(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response should be(action)
     }
+  }
 
-    // this test is a repeat from ActionsApiTest BUT with old style sequence
-    it should "preserve new parameters when changing old-style sequence action to non sequence" in {
-        implicit val tid = transid()
-        val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c")
-        val seqComponents = components.map(stringToFullyQualifiedName(_))
-        val action = WhiskAction(namespace, aname, sequence(seqComponents), seqParameters(components))
-        val content = WhiskActionPut(Some(jsDefault("")), parameters = Some(Parameters("a", "A")))
-        put(entityStore, action, false)
+  // this test is a repeat from ActionsApiTest BUT with old style sequence
+  it should "preserve new parameters when changing old-style sequence action to non sequence" in {
+    implicit val tid = transid()
+    val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c")
+    val seqComponents = components.map(stringToFullyQualifiedName(_))
+    val action = WhiskAction(namespace, aname, sequence(seqComponents), seqParameters(components))
+    val content = WhiskActionPut(Some(jsDefault("")), parameters = Some(Parameters("a", "A")))
+    put(entityStore, action, false)
 
-        // create an action sequence
-        Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            deleteAction(action.docid)
-            status should be(OK)
-            val response = responseAs[WhiskAction]
-            response.exec.kind should be(NODEJS6)
-            response.parameters should be(Parameters("a", "A"))
-        }
+    // create an action sequence
+    Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      deleteAction(action.docid)
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response.exec.kind should be(NODEJS6)
+      response.parameters should be(Parameters("a", "A"))
     }
+  }
 
-    // this test is a repeat from ActionsApiTest BUT with old style sequence
-    it should "reset parameters when changing old-style sequence action to non sequence" in {
-        implicit val tid = transid()
-        val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c")
-        val seqComponents = components.map(stringToFullyQualifiedName(_))
-        val action = WhiskAction(namespace, aname, sequence(seqComponents), seqParameters(components))
-        val content = WhiskActionPut(Some(jsDefault("")))
-        put(entityStore, action, false)
+  // this test is a repeat from ActionsApiTest BUT with old style sequence
+  it should "reset parameters when changing old-style sequence action to non sequence" in {
+    implicit val tid = transid()
+    val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c")
+    val seqComponents = components.map(stringToFullyQualifiedName(_))
+    val action = WhiskAction(namespace, aname, sequence(seqComponents), seqParameters(components))
+    val content = WhiskActionPut(Some(jsDefault("")))
+    put(entityStore, action, false)
 
-        // create an action sequence
-        Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            deleteAction(action.docid)
-            status should be(OK)
-            val response = responseAs[WhiskAction]
-            response.exec.kind should be(NODEJS6)
-            response.parameters shouldBe Parameters()
-        }
+    // create an action sequence
+    Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      deleteAction(action.docid)
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response.exec.kind should be(NODEJS6)
+      response.parameters shouldBe Parameters()
     }
+  }
 
-    it should "update old-style sequence action with new annotations" in {
-        implicit val tid = transid()
-        val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c")
-        val seqComponents = components.map(stringToFullyQualifiedName(_))
-        val action = WhiskAction(namespace, aname, sequence(seqComponents))
-        val content = """{"annotations":[{"key":"old","value":"new"}]}""".parseJson.asJsObject
-        put(entityStore, action, false)
+  it should "update old-style sequence action with new annotations" in {
+    implicit val tid = transid()
+    val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c")
+    val seqComponents = components.map(stringToFullyQualifiedName(_))
+    val action = WhiskAction(namespace, aname, sequence(seqComponents))
+    val content = """{"annotations":[{"key":"old","value":"new"}]}""".parseJson.asJsObject
+    put(entityStore, action, false)
 
-        // create an action sequence
-        Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            deleteAction(action.docid)
-            status should be(OK)
-            val response = responseAs[String]
-            // contains the action
-            components map {c => response should include(c)}
-            // contains the annotations
-            response should include("old")
-            response should include("new")
-        }
+    // create an action sequence
+    Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      deleteAction(action.docid)
+      status should be(OK)
+      val response = responseAs[String]
+      // contains the action
+      components map { c =>
+        response should include(c)
+      }
+      // contains the annotations
+      response should include("old")
+      response should include("new")
     }
+  }
 
-    it should "update an old-style sequence with new sequence" in {
-        implicit val tid = transid()
-        // old sequence
-        val seqName = EntityName(s"${aname}_new")
-        val oldComponents = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c").map(stringToFullyQualifiedName(_))
-        val oldSequence = WhiskAction(namespace, seqName, sequence(oldComponents))
-        put(entityStore, oldSequence)
+  it should "update an old-style sequence with new sequence" in {
+    implicit val tid = transid()
+    // old sequence
+    val seqName = EntityName(s"${aname}_new")
+    val oldComponents = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c").map(stringToFullyQualifiedName(_))
+    val oldSequence = WhiskAction(namespace, seqName, sequence(oldComponents))
+    put(entityStore, oldSequence)
 
-        // new sequence
-        val limit = 5 // count of bogus actions in sequence
-        val bogus = s"${aname}_bogus"
-        val bogusActionName = s"/_/${bogus}"   // test that default namespace gets properly replaced
-        // put the action in the entity store so it exists
-        val bogusAction = WhiskAction(namespace, EntityName(bogus), jsDefault("??"), Parameters("x", "y"))
-        put(entityStore, bogusAction)
-        val seqComponents = for (i <- 1 to limit) yield stringToFullyQualifiedName(bogusActionName)
-        val seqAction = WhiskAction(namespace, seqName, sequence(seqComponents.toVector))
-        val content = WhiskActionPut(Some(seqAction.exec), Some(Parameters()))
+    // new sequence
+    val limit = 5 // count of bogus actions in sequence
+    val bogus = s"${aname}_bogus"
+    val bogusActionName = s"/_/${bogus}" // test that default namespace gets properly replaced
+    // put the action in the entity store so it exists
+    val bogusAction = WhiskAction(namespace, EntityName(bogus), jsDefault("??"), Parameters("x", "y"))
+    put(entityStore, bogusAction)
+    val seqComponents = for (i <- 1 to limit) yield stringToFullyQualifiedName(bogusActionName)
+    val seqAction = WhiskAction(namespace, seqName, sequence(seqComponents.toVector))
+    val content = WhiskActionPut(Some(seqAction.exec), Some(Parameters()))
 
-        // update an action sequence
-        Put(s"$collectionPath/${seqName}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[WhiskAction]
-            response.exec.kind should be(Exec.SEQUENCE)
-            response.limits should be(seqAction.limits)
-            response.publish should be(seqAction.publish)
-            response.version should be(seqAction.version.upPatch)
-        }
+    // update an action sequence
+    Put(s"$collectionPath/${seqName}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response.exec.kind should be(Exec.SEQUENCE)
+      response.limits should be(seqAction.limits)
+      response.publish should be(seqAction.publish)
+      response.version should be(seqAction.version.upPatch)
     }
+  }
 }

--- a/tests/src/test/scala/whisk/core/database/test/CleanUpActivationsTest.scala
+++ b/tests/src/test/scala/whisk/core/database/test/CleanUpActivationsTest.scala
@@ -41,7 +41,8 @@ import spray.json.JsObject
 import spray.json.pimpAny
 
 @RunWith(classOf[JUnitRunner])
-class CleanUpActivationsTest extends FlatSpec
+class CleanUpActivationsTest
+    extends FlatSpec
     with Matchers
     with ScalaFutures
     with WskActorSystem
@@ -49,79 +50,98 @@ class CleanUpActivationsTest extends FlatSpec
     with StreamLogging
     with DatabaseScriptTestUtils {
 
-    val testDbPrefix = s"cleanuptest_${dbPrefix}"
-    val cleanUpTool = WhiskProperties.getFileRelativeToWhiskHome("tools/db/cleanUpActivations.py").getAbsolutePath
-    val designDocPath = WhiskProperties.getFileRelativeToWhiskHome("ansible/files/activations_design_document_for_activations_db.json").getAbsolutePath
+  val testDbPrefix = s"cleanuptest_${dbPrefix}"
+  val cleanUpTool = WhiskProperties.getFileRelativeToWhiskHome("tools/db/cleanUpActivations.py").getAbsolutePath
+  val designDocPath = WhiskProperties
+    .getFileRelativeToWhiskHome("ansible/files/activations_design_document_for_activations_db.json")
+    .getAbsolutePath
 
-    implicit def toDuration(dur: FiniteDuration) = java.time.Duration.ofMillis(dur.toMillis)
+  implicit def toDuration(dur: FiniteDuration) = java.time.Duration.ofMillis(dur.toMillis)
 
-    /** Runs the clean up script to delete old activations */
-    def runCleanUpTool(dbUrl: String, dbName: String, days: Int, docsPerRequest: Int = 200) = {
-        println(s"Running clean up tool: $dbUrl, $dbName, $days, $docsPerRequest")
+  /** Runs the clean up script to delete old activations */
+  def runCleanUpTool(dbUrl: String, dbName: String, days: Int, docsPerRequest: Int = 200) = {
+    println(s"Running clean up tool: $dbUrl, $dbName, $days, $docsPerRequest")
 
-        val cmd = Seq(python, cleanUpTool, "--dbUrl", dbUrl, "--dbName", dbName, "--days", days.toString, "--docsPerRequest", docsPerRequest.toString)
-        val rr = TestUtils.runCmd(0, new File("."), cmd: _*)
+    val cmd = Seq(
+      python,
+      cleanUpTool,
+      "--dbUrl",
+      dbUrl,
+      "--dbName",
+      dbName,
+      "--days",
+      days.toString,
+      "--docsPerRequest",
+      docsPerRequest.toString)
+    val rr = TestUtils.runCmd(0, new File("."), cmd: _*)
+  }
+
+  behavior of "Database clean up script"
+
+  it should "delete old activations and keep new ones" in {
+    // Create a database
+    val dbName = testDbPrefix + "database_to_clean_old_and_keep_new"
+    val client = createDatabase(dbName, Some(designDocPath))
+
+    println(s"Creating testdocuments")
+    val oldDocument =
+      JsObject("start" -> Instant.now.minus(6.days).toEpochMilli.toJson, "activationId" -> "abcde0123".toJson)
+    val newDocument = JsObject("start" -> Instant.now.toEpochMilli.toJson, "activationId" -> "0123abcde".toJson)
+    client.putDoc("testId1", oldDocument).futureValue
+    client.putDoc("testId2", newDocument).futureValue
+    waitForView(client, "activations", "byDate", 2)
+
+    // Trigger clean up script and verify that old document is deleted and the new one not
+    runCleanUpTool(dbUrl, dbName, 5)
+    val resultOld = client.getDoc("testId1").futureValue
+    resultOld shouldBe 'left
+    resultOld.left.get shouldBe StatusCodes.NotFound
+
+    val resultNew = client.getDoc("testId2").futureValue
+    resultNew shouldBe 'right
+    resultNew.right.get.fields
+      .filterNot(current => current._1 == "_id" || current._1 == "_rev")
+      .toJson shouldBe newDocument
+
+    // Remove created database
+    removeDatabase(dbName)
+  }
+
+  it should "delete old activations in several iterations" in {
+    // Create a database
+    val dbName = testDbPrefix + "database_to_clean_in_iterations"
+    val client = createDatabase(dbName, Some(designDocPath))
+    println(s"Creating testdocuments")
+    val ids = (1 to 5).map { current =>
+      client
+        .putDoc(
+          s"testId_$current",
+          JsObject(
+            "start" -> Instant.now.minus(2.days).toEpochMilli.toJson,
+            "activationId" -> s"abcde0123$current".toJson))
+        .futureValue
+      s"testId_$current"
     }
 
-    behavior of "Database clean up script"
+    val newDocument = JsObject("start" -> Instant.now.toEpochMilli.toJson, "activationId" -> "0123abcde".toJson)
+    client.putDoc("testIdNew", newDocument).futureValue
+    waitForView(client, "activations", "byDate", 6)
 
-    it should "delete old activations and keep new ones" in {
-        // Create a database
-        val dbName = testDbPrefix + "database_to_clean_old_and_keep_new"
-        val client = createDatabase(dbName, Some(designDocPath))
-
-        println(s"Creating testdocuments")
-        val oldDocument = JsObject("start" -> Instant.now.minus(6.days).toEpochMilli.toJson,
-            "activationId" -> "abcde0123".toJson)
-        val newDocument = JsObject("start" -> Instant.now.toEpochMilli.toJson,
-            "activationId" -> "0123abcde".toJson)
-        client.putDoc("testId1", oldDocument).futureValue
-        client.putDoc("testId2", newDocument).futureValue
-        waitForView(client, "activations", "byDate", 2)
-
-        // Trigger clean up script and verify that old document is deleted and the new one not
-        runCleanUpTool(dbUrl, dbName, 5)
-        val resultOld = client.getDoc("testId1").futureValue
-        resultOld shouldBe 'left
-        resultOld.left.get shouldBe StatusCodes.NotFound
-
-        val resultNew = client.getDoc("testId2").futureValue
-        resultNew shouldBe 'right
-        resultNew.right.get.fields.filterNot(current => current._1 == "_id" || current._1 == "_rev").toJson shouldBe newDocument
-
-        // Remove created database
-        removeDatabase(dbName)
+    // Trigger clean up script and verify that old document is deleted and the new one not
+    runCleanUpTool(dbUrl, dbName, 1, 2)
+    ids.foreach { id =>
+      val resultOld = client.getDoc(id).futureValue
+      resultOld shouldBe 'left
+      resultOld.left.get shouldBe StatusCodes.NotFound
     }
 
-    it should "delete old activations in several iterations" in {
-        // Create a database
-        val dbName = testDbPrefix + "database_to_clean_in_iterations"
-        val client = createDatabase(dbName, Some(designDocPath))
-        println(s"Creating testdocuments")
-        val ids = (1 to 5).map { current =>
-            client.putDoc(s"testId_$current", JsObject("start" -> Instant.now.minus(2.days).toEpochMilli.toJson,
-                "activationId" -> s"abcde0123$current".toJson)).futureValue
-            s"testId_$current"
-        }
+    val resultNew = client.getDoc("testIdNew").futureValue
+    resultNew shouldBe 'right
+    resultNew.right.get.fields
+      .filterNot(current => current._1 == "_id" || current._1 == "_rev")
+      .toJson shouldBe newDocument
 
-        val newDocument = JsObject("start" -> Instant.now.toEpochMilli.toJson,
-            "activationId" -> "0123abcde".toJson)
-        client.putDoc("testIdNew", newDocument).futureValue
-        waitForView(client, "activations", "byDate", 6)
-
-        // Trigger clean up script and verify that old document is deleted and the new one not
-        runCleanUpTool(dbUrl, dbName, 1, 2)
-        ids.foreach { id =>
-            val resultOld = client.getDoc(id).futureValue
-            resultOld shouldBe 'left
-            resultOld.left.get shouldBe StatusCodes.NotFound
-        }
-
-        val resultNew = client.getDoc("testIdNew").futureValue
-        resultNew shouldBe 'right
-        resultNew.right.get.fields.filterNot(current => current._1 == "_id" || current._1 == "_rev").toJson shouldBe newDocument
-
-        // Remove created database
-        removeDatabase(dbName)
-    }
+    // Remove created database
+    removeDatabase(dbName)
+  }
 }

--- a/tests/src/test/scala/whisk/core/database/test/CouchDbRestClientTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/CouchDbRestClientTests.scala
@@ -45,7 +45,8 @@ import whisk.core.WhiskConfig._
 import whisk.test.http.RESTProxy
 
 @RunWith(classOf[JUnitRunner])
-class CouchDbRestClientTests extends FlatSpec
+class CouchDbRestClientTests
+    extends FlatSpec
     with Matchers
     with ScalaFutures
     with BeforeAndAfterAll
@@ -53,207 +54,219 @@ class CouchDbRestClientTests extends FlatSpec
     with DbUtils
     with StreamLogging {
 
-    override implicit val patienceConfig = PatienceConfig(timeout = 10.seconds, interval = 0.5.seconds)
+  override implicit val patienceConfig = PatienceConfig(timeout = 10.seconds, interval = 0.5.seconds)
 
-    private def someId(prefix: String): String = s"${prefix}${Random.nextInt().abs.toInt}"
+  private def someId(prefix: String): String = s"${prefix}${Random.nextInt().abs.toInt}"
 
-    val config = new WhiskConfig(Map(
-        dbProvider -> null,
-        dbProtocol -> null,
-        dbUsername -> null,
-        dbPassword -> null,
-        dbHost -> null,
-        dbPort -> null))
+  val config = new WhiskConfig(
+    Map(dbProvider -> null, dbProtocol -> null, dbUsername -> null, dbPassword -> null, dbHost -> null, dbPort -> null))
 
-    // We assume this DB does not exist.
-    val dbName = someId("whisk_test_db_")
+  // We assume this DB does not exist.
+  val dbName = someId("whisk_test_db_")
 
-    val client = new ExtendedCouchDbRestClient(config.dbProtocol, config.dbHost, config.dbPort.toInt, config.dbUsername, config.dbPassword, dbName)
+  val client = new ExtendedCouchDbRestClient(
+    config.dbProtocol,
+    config.dbHost,
+    config.dbPort.toInt,
+    config.dbUsername,
+    config.dbPassword,
+    dbName)
 
-    override def beforeAll() {
-        super.beforeAll()
-        whenReady(client.createDb()) { r =>
-            assert(r.isRight)
-        }
+  override def beforeAll() {
+    super.beforeAll()
+    whenReady(client.createDb()) { r =>
+      assert(r.isRight)
+    }
+  }
+
+  override def afterAll() {
+    whenReady(client.deleteDb()) { r =>
+      assert(r.isRight)
+    }
+    super.afterAll()
+  }
+
+  def checkInstanceInfoResponse(response: Either[StatusCode, JsObject]): Unit = response match {
+    case Right(obj) =>
+      assert(obj.fields.contains("couchdb"), "response object doesn't contain 'couchdb'")
+
+    case Left(code) =>
+      assert(false, s"unsuccessful response (code ${code.intValue})")
+  }
+
+  behavior of "CouchDbRestClient"
+
+  it should "successfully access the DB instance info" in {
+    assume(config.dbProvider == "Cloudant" || config.dbProvider == "CouchDB")
+    val f = client.instanceInfo()
+    whenReady(f) { e =>
+      checkInstanceInfoResponse(e)
+    }
+  }
+
+  it should "successfully read and write documents containing unicode" in {
+    val docId = someId("unicode_doc_")
+    val doc = JsObject("winter" -> JsString("❄ ☃ ❄"))
+    val f1 = client.putDoc(docId, doc)
+
+    whenReady(f1) { e1 =>
+      assert(e1.isRight)
+
+      val f2 = client.getDoc(docId)
+      whenReady(f2) { e2 =>
+        assert(e2.isRight)
+        assert(JsObject(e2.right.get.fields.filter(_._1 == "winter")) === doc)
+      }
+    }
+  }
+
+  ignore /* it */ should "successfully access the DB despite transient connection failures" in {
+    assume(config.dbProvider == "Cloudant" || config.dbProvider == "CouchDB")
+
+    val dbAuthority = Uri.Authority(host = Uri.Host(config.dbHost), port = config.dbPort.toInt)
+
+    val proxyPort = 15975
+    val proxyActor =
+      actorSystem.actorOf(Props(new RESTProxy("0.0.0.0", proxyPort)(dbAuthority, config.dbProtocol == "https")))
+
+    val proxiedClient =
+      new ExtendedCouchDbRestClient("http", "localhost", proxyPort, config.dbUsername, config.dbPassword, dbName)
+
+    // sprays the client with requests, makes sure they are all answered
+    // despite temporary connection failure.
+    val numRequests = 30
+    val timeSpan = 5.seconds
+    val delta = timeSpan / numRequests
+
+    val promises = Vector.fill(numRequests)(Promise[Either[StatusCode, JsObject]])
+
+    for (i <- 0 until numRequests) {
+      actorSystem.scheduler.scheduleOnce(delta * (i + 1)) {
+        proxiedClient.instanceInfo().andThen({ case r => promises(i).tryComplete(r) })
+      }
     }
 
-    override def afterAll() {
-        whenReady(client.deleteDb()) { r =>
-            assert(r.isRight)
-        }
-        super.afterAll()
+    // Mayhem! Havoc!
+    actorSystem.scheduler.scheduleOnce(2.5.seconds, proxyActor, RESTProxy.UnbindFor(1.second))
+
+    // What a type!
+    val futures: Vector[Future[Try[Either[StatusCode, JsObject]]]] =
+      promises.map(_.future.map(e => Success(e)).recover { case t: Throwable => Failure(t) })
+
+    whenReady(Future.sequence(futures), Timeout(timeSpan * 2)) { results =>
+      // We check that the first result was OK
+      // (i.e. the service worked before the disruption)
+      results.head.toOption shouldBe defined
+      checkInstanceInfoResponse(results.head.get)
+
+      // We check that the last result was OK
+      // (i.e. the service worked again after the disruption)
+      results.last.toOption shouldBe defined
+      checkInstanceInfoResponse(results.last.get)
+
+      // We check that there was at least one error
+      // (i.e. we did manage to unbind for a while)
+      results.find(_.isFailure) shouldBe defined
     }
+  }
 
-    def checkInstanceInfoResponse(response: Either[StatusCode, JsObject]): Unit = response match {
-        case Right(obj) =>
-            assert(obj.fields.contains("couchdb"), "response object doesn't contain 'couchdb'")
+  it should "upload then download an attachment" in {
+    assume(config.dbProvider == "Cloudant" || config.dbProvider == "CouchDB")
 
-        case Left(code) =>
-            assert(false, s"unsuccessful response (code ${code.intValue})")
-    }
-
-    behavior of "CouchDbRestClient"
-
-    it should "successfully access the DB instance info" in {
-        assume(config.dbProvider == "Cloudant" || config.dbProvider == "CouchDB")
-        val f = client.instanceInfo()
-        whenReady(f) { e => checkInstanceInfoResponse(e) }
-    }
-
-    it should "successfully read and write documents containing unicode" in {
-        val docId = someId("unicode_doc_")
-        val doc = JsObject("winter" -> JsString("❄ ☃ ❄"))
-        val f1 = client.putDoc(docId, doc)
-
-        whenReady(f1) { e1 =>
-            assert(e1.isRight)
-
-            val f2 = client.getDoc(docId)
-            whenReady(f2) { e2 =>
-                assert(e2.isRight)
-                assert(JsObject(e2.right.get.fields.filter(_._1 == "winter")) === doc)
-            }
-        }
-    }
-
-    ignore /* it */ should "successfully access the DB despite transient connection failures" in {
-        assume(config.dbProvider == "Cloudant" || config.dbProvider == "CouchDB")
-
-        val dbAuthority = Uri.Authority(
-            host = Uri.Host(config.dbHost),
-            port = config.dbPort.toInt)
-
-        val proxyPort = 15975
-        val proxyActor = actorSystem.actorOf(Props(new RESTProxy("0.0.0.0", proxyPort)(dbAuthority, config.dbProtocol == "https")))
-
-        val proxiedClient = new ExtendedCouchDbRestClient("http", "localhost", proxyPort, config.dbUsername, config.dbPassword, dbName)
-
-        // sprays the client with requests, makes sure they are all answered
-        // despite temporary connection failure.
-        val numRequests = 30
-        val timeSpan = 5.seconds
-        val delta = timeSpan / numRequests
-
-        val promises = Vector.fill(numRequests)(Promise[Either[StatusCode, JsObject]])
-
-        for (i <- 0 until numRequests) {
-            actorSystem.scheduler.scheduleOnce(delta * (i + 1)) {
-                proxiedClient.instanceInfo().andThen({ case r => promises(i).tryComplete(r) })
-            }
-        }
-
-        // Mayhem! Havoc!
-        actorSystem.scheduler.scheduleOnce(2.5.seconds, proxyActor, RESTProxy.UnbindFor(1.second))
-
-        // What a type!
-        val futures: Vector[Future[Try[Either[StatusCode, JsObject]]]] =
-            promises.map(_.future.map(e => Success(e)).recover { case t: Throwable => Failure(t) })
-
-        whenReady(Future.sequence(futures), Timeout(timeSpan * 2)) { results =>
-            // We check that the first result was OK
-            // (i.e. the service worked before the disruption)
-            results.head.toOption shouldBe defined
-            checkInstanceInfoResponse(results.head.get)
-
-            // We check that the last result was OK
-            // (i.e. the service worked again after the disruption)
-            results.last.toOption shouldBe defined
-            checkInstanceInfoResponse(results.last.get)
-
-            // We check that there was at least one error
-            // (i.e. we did manage to unbind for a while)
-            results.find(_.isFailure) shouldBe defined
-        }
-    }
-
-    it should "upload then download an attachment" in {
-        assume(config.dbProvider == "Cloudant" || config.dbProvider == "CouchDB")
-
-        val docId = "some_doc"
-        val doc = JsObject("greeting" -> JsString("hello"))
-        val attachmentName = "misc"
-        val attachmentType = ContentTypes.`text/plain(UTF-8)`
-        val attachment = ("""
+    val docId = "some_doc"
+    val doc = JsObject("greeting" -> JsString("hello"))
+    val attachmentName = "misc"
+    val attachmentType = ContentTypes.`text/plain(UTF-8)`
+    val attachment = ("""
             | This could have been poetry.
             | But it isn't.
         """).stripMargin
 
-        val attachmentSource = Source.single(ByteString.fromString(attachment))
+    val attachmentSource = Source.single(ByteString.fromString(attachment))
 
-        val retrievalSink = Sink.fold[String, ByteString]("")((s, bs) => s + bs.decodeString("UTF-8"))
+    val retrievalSink = Sink.fold[String, ByteString]("")((s, bs) => s + bs.decodeString("UTF-8"))
 
-        val insertAndRetrieveResult: Future[(ContentType, String)] = for (
-            docResponse <- client.putDoc(docId, doc);
-            Right(d) = docResponse;
-            rev1 = d.fields("rev").convertTo[String];
-            attResponse <- client.putAttachment(docId, rev1, attachmentName, attachmentType, attachmentSource);
-            Right(a) = attResponse;
-            rev2 = a.fields("rev").convertTo[String];
-            retResponse <- client.getAttachment[String](docId, rev2, attachmentName, retrievalSink);
-            Right(pair) = retResponse
-        ) yield pair
+    val insertAndRetrieveResult: Future[(ContentType, String)] = for (docResponse <- client.putDoc(docId, doc);
+                                                                      Right(d) = docResponse;
+                                                                      rev1 = d.fields("rev").convertTo[String];
+                                                                      attResponse <- client.putAttachment(
+                                                                        docId,
+                                                                        rev1,
+                                                                        attachmentName,
+                                                                        attachmentType,
+                                                                        attachmentSource);
+                                                                      Right(a) = attResponse;
+                                                                      rev2 = a.fields("rev").convertTo[String];
+                                                                      retResponse <- client.getAttachment[String](
+                                                                        docId,
+                                                                        rev2,
+                                                                        attachmentName,
+                                                                        retrievalSink);
+                                                                      Right(pair) = retResponse) yield pair
 
-        whenReady(insertAndRetrieveResult) {
-            case (t, r) =>
-                assert(t === ContentTypes.`text/plain(UTF-8)`)
-                assert(r === attachment)
-        }
+    whenReady(insertAndRetrieveResult) {
+      case (t, r) =>
+        assert(t === ContentTypes.`text/plain(UTF-8)`)
+        assert(r === attachment)
+    }
+  }
+
+  it should "fail if group=true is used together with reduce=false" in {
+    intercept[IllegalArgumentException] {
+      Await.result(client.executeView("", "")(reduce = false, group = true), 15.seconds)
+    }
+  }
+
+  it should "check group Parameter on view-execution" in {
+    assume(config.dbProvider == "Cloudant" || config.dbProvider == "CouchDB")
+
+    val ids = List("some_doc_1", "some_doc_2", "some_doc_3", "some_doc_4", "some_doc_5")
+    val docs = Map(
+      ids(0) -> JsObject("key" -> JsString("a"), "value" -> JsNumber(1)),
+      ids(1) -> JsObject("key" -> JsString("a"), "value" -> JsNumber(2)),
+      ids(2) -> JsObject("key" -> JsString("b"), "value" -> JsNumber(3)),
+      ids(3) -> JsObject("key" -> JsString("b"), "value" -> JsNumber(4)),
+      ids(4) -> JsObject("key" -> JsString("c"), "value" -> JsNumber(5)))
+    val designDocName = "testDocument"
+    val viewName = "sumOfValues"
+    val designDoc = JsObject(
+      "views" -> JsObject(viewName -> JsObject(
+        "reduce" -> JsString("_sum"),
+        "map" -> JsString("function (doc) {\n  if(doc.key && doc.value) {\n    emit([doc.key], doc.value);\n  }\n}"))),
+      "language" -> JsString("javascript"))
+
+    Await.result(client.putDoc(s"_design/$designDocName", designDoc), 15.seconds)
+    docs.map {
+      case (id, doc) =>
+        Await.result(client.putDoc(id, doc), 15.seconds)
     }
 
-    it should "fail if group=true is used together with reduce=false" in {
-        intercept[IllegalArgumentException] {
-            Await.result(client.executeView("", "")(reduce = false, group = true), 15.seconds)
-        }
-    }
+    waitOnView(client, designDocName, viewName, docs.size)
 
-    it should "check group Parameter on view-execution" in {
-        assume(config.dbProvider == "Cloudant" || config.dbProvider == "CouchDB")
+    val resultGroupedTrue =
+      Await.result(client.executeView(designDocName, viewName)(reduce = true, group = true), 15.seconds)
+    resultGroupedTrue should be('right)
+    val jsObjectTrue = resultGroupedTrue.right.get
+    var rows = jsObjectTrue.fields("rows").convertTo[List[JsObject]]
+    rows.length should equal(3)
+    rows(0) shouldBe JsObject("key" -> JsArray(JsString("a")), "value" -> JsNumber(3))
+    rows(1) shouldBe JsObject("key" -> JsArray(JsString("b")), "value" -> JsNumber(7))
+    rows(2) shouldBe JsObject("key" -> JsArray(JsString("c")), "value" -> JsNumber(5))
 
-        val ids = List("some_doc_1", "some_doc_2", "some_doc_3", "some_doc_4", "some_doc_5")
-        val docs = Map(
-            ids(0) -> JsObject("key" -> JsString("a"), "value" -> JsNumber(1)),
-            ids(1) -> JsObject("key" -> JsString("a"), "value" -> JsNumber(2)),
-            ids(2) -> JsObject("key" -> JsString("b"), "value" -> JsNumber(3)),
-            ids(3) -> JsObject("key" -> JsString("b"), "value" -> JsNumber(4)),
-            ids(4) -> JsObject("key" -> JsString("c"), "value" -> JsNumber(5)))
-        val designDocName = "testDocument"
-        val viewName = "sumOfValues"
-        val designDoc = JsObject(
-            "views" -> JsObject(viewName -> JsObject(
-                "reduce" -> JsString("_sum"),
-                "map" -> JsString("function (doc) {\n  if(doc.key && doc.value) {\n    emit([doc.key], doc.value);\n  }\n}"))),
-            "language" -> JsString("javascript"))
+    val resultGroupedFalse =
+      Await.result(client.executeView(designDocName, viewName)(reduce = true, group = false), 15.seconds)
+    resultGroupedFalse should be('right)
+    val jsObjectFalse = resultGroupedFalse.right.get
+    rows = jsObjectFalse.fields("rows").convertTo[List[JsObject]]
+    rows.length should equal(1)
+    rows(0).fields("value") should equal(JsNumber(15))
 
-        Await.result(client.putDoc(s"_design/$designDocName", designDoc), 15.seconds)
-        docs.map {
-            case (id, doc) =>
-                Await.result(client.putDoc(id, doc), 15.seconds)
-        }
+    val resultGroupedWithout = Await.result(client.executeView(designDocName, viewName)(reduce = true), 15.seconds)
+    resultGroupedWithout should be('right)
+    val jsObjectWithout = resultGroupedWithout.right.get
+    rows = jsObjectWithout.fields("rows").convertTo[List[JsObject]]
+    rows.length should equal(1)
+    rows(0).fields("value") should equal(JsNumber(15))
 
-        waitOnView(client, designDocName, viewName, docs.size)
-
-        val resultGroupedTrue = Await.result(client.executeView(designDocName, viewName)(reduce = true, group = true), 15.seconds)
-        resultGroupedTrue should be('right)
-        val jsObjectTrue = resultGroupedTrue.right.get
-        var rows = jsObjectTrue.fields("rows").convertTo[List[JsObject]]
-        rows.length should equal(3)
-        rows(0) shouldBe JsObject("key" -> JsArray(JsString("a")), "value" -> JsNumber(3))
-        rows(1) shouldBe JsObject("key" -> JsArray(JsString("b")), "value" -> JsNumber(7))
-        rows(2) shouldBe JsObject("key" -> JsArray(JsString("c")), "value" -> JsNumber(5))
-
-        val resultGroupedFalse = Await.result(client.executeView(designDocName, viewName)(reduce = true, group = false), 15.seconds)
-        resultGroupedFalse should be('right)
-        val jsObjectFalse = resultGroupedFalse.right.get
-        rows = jsObjectFalse.fields("rows").convertTo[List[JsObject]]
-        rows.length should equal(1)
-        rows(0).fields("value") should equal(JsNumber(15))
-
-        val resultGroupedWithout = Await.result(client.executeView(designDocName, viewName)(reduce = true), 15.seconds)
-        resultGroupedWithout should be('right)
-        val jsObjectWithout = resultGroupedWithout.right.get
-        rows = jsObjectWithout.fields("rows").convertTo[List[JsObject]]
-        rows.length should equal(1)
-        rows(0).fields("value") should equal(JsNumber(15))
-
-    }
+  }
 }

--- a/tests/src/test/scala/whisk/core/database/test/DbUtils.scala
+++ b/tests/src/test/scala/whisk/core/database/test/DbUtils.scala
@@ -57,164 +57,190 @@ import whisk.core.entity.types.EntityStore
  * names in tests, and defer all cleanup to the end of a test suite.
  */
 trait DbUtils extends TransactionCounter {
-    implicit val dbOpTimeout = 15 seconds
-    override val numberOfInstances = 1
-    override val instance = InstanceId(0)
-    val docsToDelete = ListBuffer[(ArtifactStore[_], DocInfo)]()
-    case class RetryOp() extends Throwable
+  implicit val dbOpTimeout = 15 seconds
+  override val numberOfInstances = 1
+  override val instance = InstanceId(0)
+  val docsToDelete = ListBuffer[(ArtifactStore[_], DocInfo)]()
+  case class RetryOp() extends Throwable
 
-    /**
-     * Retry an operation 'step()' awaiting its result up to 'timeout'.
-     * Attempt the operation up to 'count' times. The future from the
-     * step is not aborted --- TODO fix this.
-     */
-    def retry[T](step: () => Future[T], timeout: Duration, count: Int = 5): Try[T] = {
-        val future = step()
-        if (count > 0) try {
-            val result = Await.result(future, timeout)
-            Success(result)
-        } catch {
-            case n: NoDocumentException =>
-                println("no document exception, retrying")
-                retry(step, timeout, count - 1)
-            case RetryOp() =>
-                println("condition not met, retrying")
-                retry(step, timeout, count - 1)
-            case t: TimeoutException =>
-                println("timed out, retrying")
-                retry(step, timeout, count - 1)
-            case t: Throwable =>
-                println(s"unexpected failure $t")
-                Failure(t)
+  /**
+   * Retry an operation 'step()' awaiting its result up to 'timeout'.
+   * Attempt the operation up to 'count' times. The future from the
+   * step is not aborted --- TODO fix this.
+   */
+  def retry[T](step: () => Future[T], timeout: Duration, count: Int = 5): Try[T] = {
+    val future = step()
+    if (count > 0) try {
+      val result = Await.result(future, timeout)
+      Success(result)
+    } catch {
+      case n: NoDocumentException =>
+        println("no document exception, retrying")
+        retry(step, timeout, count - 1)
+      case RetryOp() =>
+        println("condition not met, retrying")
+        retry(step, timeout, count - 1)
+      case t: TimeoutException =>
+        println("timed out, retrying")
+        retry(step, timeout, count - 1)
+      case t: Throwable =>
+        println(s"unexpected failure $t")
+        Failure(t)
+    } else Failure(new NoDocumentException("timed out"))
+  }
+
+  /**
+   * Wait on a view to update with documents added to namespace. This uses retry above,
+   * where the step performs a direct db query to retrieve the view and check the count
+   * matches the given value.
+   */
+  def waitOnView[Au](db: ArtifactStore[Au], namespace: EntityPath, count: Int)(implicit context: ExecutionContext,
+                                                                               transid: TransactionId,
+                                                                               timeout: Duration) = {
+    val success = retry(
+      () => {
+        val startKey = List(namespace.toString)
+        val endKey = List(namespace.toString, WhiskEntityQueries.TOP)
+        db.query(
+          WhiskEntityQueries.viewname(WhiskEntityQueries.ALL),
+          startKey,
+          endKey,
+          0,
+          0,
+          false,
+          true,
+          false,
+          StaleParameter.No) map { l =>
+          if (l.length != count) {
+            throw RetryOp()
+          } else true
         }
-        else Failure(new NoDocumentException("timed out"))
-    }
+      },
+      timeout)
+    assert(success.isSuccess, "wait aborted")
+  }
 
-    /**
-     * Wait on a view to update with documents added to namespace. This uses retry above,
-     * where the step performs a direct db query to retrieve the view and check the count
-     * matches the given value.
-     */
-    def waitOnView[Au](db: ArtifactStore[Au], namespace: EntityPath, count: Int)(
-        implicit context: ExecutionContext, transid: TransactionId, timeout: Duration) = {
-        val success = retry(() => {
-            val startKey = List(namespace.toString)
-            val endKey = List(namespace.toString, WhiskEntityQueries.TOP)
-            db.query(WhiskEntityQueries.viewname(WhiskEntityQueries.ALL), startKey, endKey, 0, 0, false, true, false, StaleParameter.No) map { l =>
-                if (l.length != count) {
-                    throw RetryOp()
-                } else true
-            }
-        }, timeout)
-        assert(success.isSuccess, "wait aborted")
-    }
+  /**
+   * Wait on a view specific to a collection to update with documents added to that collection in namespace.
+   * This uses retry above, where the step performs a collection-specific view query using the collection
+   * factory. The result count from the view is checked against the given value.
+   */
+  def waitOnView(db: EntityStore, factory: WhiskEntityQueries[_], namespace: EntityPath, count: Int)(
+    implicit context: ExecutionContext,
+    transid: TransactionId,
+    timeout: Duration) = {
+    val success = retry(() => {
+      factory.listCollectionInNamespace(db, namespace, 0, 0) map { l =>
+        if (l.left.get.length < count) {
+          throw RetryOp()
+        } else true
+      }
+    }, timeout)
+    assert(success.isSuccess, "wait aborted")
+  }
 
-    /**
-     * Wait on a view specific to a collection to update with documents added to that collection in namespace.
-     * This uses retry above, where the step performs a collection-specific view query using the collection
-     * factory. The result count from the view is checked against the given value.
-     */
-    def waitOnView(db: EntityStore, factory: WhiskEntityQueries[_], namespace: EntityPath, count: Int)(
-        implicit context: ExecutionContext, transid: TransactionId, timeout: Duration) = {
-        val success = retry(() => {
-            factory.listCollectionInNamespace(db, namespace, 0, 0) map { l =>
-                if (l.left.get.length < count) {
-                    throw RetryOp()
-                } else true
-            }
-        }, timeout)
-        assert(success.isSuccess, "wait aborted")
-    }
+  /**
+   * Wait on view for the authentication table. This is like the other waitOnViews but
+   * specific to the WhiskAuth records.
+   */
+  def waitOnView(db: AuthStore, authkey: AuthKey, count: Int)(implicit context: ExecutionContext,
+                                                              transid: TransactionId,
+                                                              timeout: Duration) = {
+    val success = retry(() => {
+      Identity.list(db, List(authkey.uuid.asString, authkey.key.asString)) map { l =>
+        if (l.length != count) {
+          throw RetryOp()
+        } else true
+      }
+    }, timeout)
+    assert(success.isSuccess, "wait aborted after: " + timeout + ": " + success)
+  }
 
-    /**
-     * Wait on view for the authentication table. This is like the other waitOnViews but
-     * specific to the WhiskAuth records.
-     */
-    def waitOnView(db: AuthStore, authkey: AuthKey, count: Int)(
-        implicit context: ExecutionContext, transid: TransactionId, timeout: Duration) = {
-        val success = retry(() => {
-            Identity.list(db, List(authkey.uuid.asString, authkey.key.asString)) map { l =>
-                if (l.length != count) {
-                    throw RetryOp()
-                } else true
-            }
-        }, timeout)
-        assert(success.isSuccess, "wait aborted after: " + timeout + ": " + success)
-    }
+  /**
+   * Wait on view using the CouchDbRestClient. This is like the other waitOnViews.
+   */
+  def waitOnView(db: CouchDbRestClient, designDocName: String, viewName: String, count: Int)(
+    implicit context: ExecutionContext,
+    timeout: Duration) = {
+    val success = retry(
+      () => {
+        db.executeView(designDocName, viewName)().map {
+          case Right(doc) =>
+            val length = doc.fields("rows").convertTo[List[JsObject]].length
+            if (length != count) {
+              throw RetryOp()
+            } else true
+          case Left(_) =>
+            throw RetryOp()
+        }
+      },
+      timeout)
+    assert(success.isSuccess, "wait aborted after: " + timeout + ": " + success)
+  }
 
-    /**
-     * Wait on view using the CouchDbRestClient. This is like the other waitOnViews.
-     */
-    def waitOnView(db: CouchDbRestClient, designDocName: String, viewName: String, count: Int)(
-        implicit context: ExecutionContext, timeout: Duration) = {
-        val success = retry(() => {
-            db.executeView(designDocName, viewName)().map {
-                case Right(doc) =>
-                    val length = doc.fields("rows").convertTo[List[JsObject]].length
-                    if (length != count) {
-                        throw RetryOp()
-                    } else true
-                case Left(_) =>
-                    throw RetryOp()
-            }
-        }, timeout)
-        assert(success.isSuccess, "wait aborted after: " + timeout + ": " + success)
-    }
+  /**
+   * Puts document 'w' in datastore, and add it to gc queue to delete after the test completes.
+   */
+  def put[A, Au >: A](db: ArtifactStore[Au], w: A, garbageCollect: Boolean = true)(
+    implicit transid: TransactionId,
+    timeout: Duration = 10 seconds): DocInfo = {
+    val docFuture = db.put(w)
+    val doc = Await.result(docFuture, timeout)
+    assert(doc != null)
+    if (garbageCollect) docsToDelete += ((db, doc))
+    doc
+  }
 
-    /**
-     * Puts document 'w' in datastore, and add it to gc queue to delete after the test completes.
-     */
-    def put[A, Au >: A](db: ArtifactStore[Au], w: A, garbageCollect: Boolean = true)(
-        implicit transid: TransactionId, timeout: Duration = 10 seconds): DocInfo = {
-        val docFuture = db.put(w)
-        val doc = Await.result(docFuture, timeout)
-        assert(doc != null)
-        if (garbageCollect) docsToDelete += ((db, doc))
-        doc
-    }
+  /**
+   * Gets document by id from datastore, and add it to gc queue to delete after the test completes.
+   */
+  def get[A, Au >: A](db: ArtifactStore[Au], docid: DocId, factory: DocumentFactory[A], garbageCollect: Boolean = true)(
+    implicit transid: TransactionId,
+    timeout: Duration = 10 seconds,
+    ma: Manifest[A]): A = {
+    val docFuture = factory.get(db, docid)
+    val doc = Await.result(docFuture, timeout)
+    assert(doc != null)
+    if (garbageCollect) docsToDelete += ((db, docid.asDocInfo))
+    doc
+  }
 
-    /**
-     * Gets document by id from datastore, and add it to gc queue to delete after the test completes.
-     */
-    def get[A, Au >: A](db: ArtifactStore[Au], docid: DocId, factory: DocumentFactory[A], garbageCollect: Boolean = true)(
-        implicit transid: TransactionId, timeout: Duration = 10 seconds, ma: Manifest[A]): A = {
-        val docFuture = factory.get(db, docid)
-        val doc = Await.result(docFuture, timeout)
-        assert(doc != null)
-        if (garbageCollect) docsToDelete += ((db, docid.asDocInfo))
-        doc
-    }
+  /**
+   * Deletes document by id from datastore.
+   */
+  def del[A <: WhiskDocument, Au >: A](db: ArtifactStore[Au], docid: DocId, factory: DocumentFactory[A])(
+    implicit transid: TransactionId,
+    timeout: Duration = 10 seconds,
+    ma: Manifest[A]) = {
+    val docFuture = factory.get(db, docid)
+    val doc = Await.result(docFuture, timeout)
+    assert(doc != null)
+    Await.result(db.del(doc.docinfo), timeout)
+  }
 
-    /**
-     * Deletes document by id from datastore.
-     */
-    def del[A <: WhiskDocument, Au >: A](db: ArtifactStore[Au], docid: DocId, factory: DocumentFactory[A])(
-        implicit transid: TransactionId, timeout: Duration = 10 seconds, ma: Manifest[A]) = {
-        val docFuture = factory.get(db, docid)
-        val doc = Await.result(docFuture, timeout)
-        assert(doc != null)
-        Await.result(db.del(doc.docinfo), timeout)
-    }
+  /**
+   * Puts a document 'entity' into the datastore, then do a get to retrieve it and confirm the identity.
+   */
+  def putGetCheck[A, Au >: A](db: ArtifactStore[Au], entity: A, factory: DocumentFactory[A], gc: Boolean = true)(
+    implicit transid: TransactionId,
+    timeout: Duration = 10 seconds,
+    ma: Manifest[A]): (DocInfo, A) = {
+    val doc = put(db, entity, gc)
+    assert(doc != null && doc.id.asString != null && doc.rev.asString != null)
+    val future = factory.get(db, doc.id, doc.rev)
+    val dbEntity = Await.result(future, timeout)
+    assert(dbEntity != null)
+    assert(dbEntity == entity)
+    (doc, dbEntity)
+  }
 
-    /**
-     * Puts a document 'entity' into the datastore, then do a get to retrieve it and confirm the identity.
-     */
-    def putGetCheck[A, Au >: A](db: ArtifactStore[Au], entity: A, factory: DocumentFactory[A], gc: Boolean = true)(
-        implicit transid: TransactionId, timeout: Duration = 10 seconds, ma: Manifest[A]): (DocInfo, A) = {
-        val doc = put(db, entity, gc)
-        assert(doc != null && doc.id.asString != null && doc.rev.asString != null)
-        val future = factory.get(db, doc.id, doc.rev)
-        val dbEntity = Await.result(future, timeout)
-        assert(dbEntity != null)
-        assert(dbEntity == entity)
-        (doc, dbEntity)
+  /**
+   * Deletes all documents added to gc queue.
+   */
+  def cleanup()(implicit timeout: Duration = 10 seconds) = {
+    docsToDelete.map { e =>
+      Try(Await.result(e._1.del(e._2)(TransactionId.testing), timeout))
     }
-
-    /**
-     * Deletes all documents added to gc queue.
-     */
-    def cleanup()(implicit timeout: Duration = 10 seconds) = {
-        docsToDelete.map { e => Try(Await.result(e._1.del(e._2)(TransactionId.testing), timeout)) }
-        docsToDelete.clear()
-    }
+    docsToDelete.clear()
+  }
 }

--- a/tests/src/test/scala/whisk/core/database/test/RemoveLogsTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/RemoveLogsTests.scala
@@ -37,69 +37,78 @@ import whisk.core.entity.WhiskActivation
 import whisk.core.entity.ActivationLogs
 
 @RunWith(classOf[JUnitRunner])
-class RemoveLogsTests
-    extends FlatSpec
-    with DatabaseScriptTestUtils
-    with StreamLogging
-    with WskActorSystem {
+class RemoveLogsTests extends FlatSpec with DatabaseScriptTestUtils with StreamLogging with WskActorSystem {
 
-    val designDocPath = WhiskProperties.getFileRelativeToWhiskHome("ansible/files/logCleanup_design_document_for_activations_db.json").getAbsolutePath
-    val removeLogsToolPath = WhiskProperties.getFileRelativeToWhiskHome("tools/db/deleteLogsFromActivations.py").getAbsolutePath
+  val designDocPath = WhiskProperties
+    .getFileRelativeToWhiskHome("ansible/files/logCleanup_design_document_for_activations_db.json")
+    .getAbsolutePath
+  val removeLogsToolPath =
+    WhiskProperties.getFileRelativeToWhiskHome("tools/db/deleteLogsFromActivations.py").getAbsolutePath
 
-    /** Runs the clean up script to delete old activations */
-    def removeLogsTool(dbUrl: String, dbName: String, days: Int, docsPerRequest: Int = 20) = {
-        println(s"Running removeLogs tool: $dbUrl, $dbName, $days, $docsPerRequest")
+  /** Runs the clean up script to delete old activations */
+  def removeLogsTool(dbUrl: String, dbName: String, days: Int, docsPerRequest: Int = 20) = {
+    println(s"Running removeLogs tool: $dbUrl, $dbName, $days, $docsPerRequest")
 
-        val cmd = Seq(python, removeLogsToolPath, "--dbUrl", dbUrl, "--dbName", dbName, "--days", days.toString, "--docsPerRequest", docsPerRequest.toString)
-        val rr = TestUtils.runCmd(0, new File("."), cmd: _*)
+    val cmd = Seq(
+      python,
+      removeLogsToolPath,
+      "--dbUrl",
+      dbUrl,
+      "--dbName",
+      dbName,
+      "--days",
+      days.toString,
+      "--docsPerRequest",
+      docsPerRequest.toString)
+    val rr = TestUtils.runCmd(0, new File("."), cmd: _*)
+  }
+
+  behavior of "Activation Log Cleanup Script"
+
+  it should "delete logs in old activation and keep log in new activation" in {
+    val dbName = dbPrefix + "test_log_cleanup_1"
+    val db = createDatabase(dbName, Some(designDocPath))
+
+    try {
+      // Create an old and a new activation
+      val oldActivation = WhiskActivation(
+        namespace = EntityPath("testns1"),
+        name = EntityName("testname1"),
+        subject = Subject("test-sub1"),
+        activationId = ActivationId(),
+        start = Instant.now.minus(2, ChronoUnit.DAYS),
+        end = Instant.now,
+        logs = ActivationLogs(Vector("first line1", "second line1")))
+
+      val newActivation = WhiskActivation(
+        namespace = EntityPath("testns2"),
+        name = EntityName("testname2"),
+        subject = Subject("test-sub2"),
+        activationId = ActivationId(),
+        start = Instant.now,
+        end = Instant.now,
+        logs = ActivationLogs(Vector("first line2", "second line2")))
+
+      db.putDoc(oldActivation.docid.asString, oldActivation.toJson).futureValue shouldBe 'right
+      db.putDoc(newActivation.docid.asString, newActivation.toJson).futureValue shouldBe 'right
+
+      // Run the tool to delete logs from activations that are older than 1 day
+      removeLogsTool(dbUrl, dbName, 1)
+
+      // Check, that the new activation is untouched and the old activation is without logs now
+      val newActivationRequest = db.getDoc(newActivation.docid.asString).futureValue
+      newActivationRequest shouldBe 'right
+      val newActivationFromDb = newActivationRequest.right.get.convertTo[WhiskActivation]
+      // Compare the Json of the Whiskactivations in case the test fails -> better log output
+      newActivationFromDb.toJson shouldBe newActivation.toJson
+
+      val oldActivationRequest = db.getDoc(oldActivation.docid.asString).futureValue
+      oldActivationRequest shouldBe 'right
+      val oldActivationFromDb = oldActivationRequest.right.get.convertTo[WhiskActivation]
+      // Compare the Json of the Whiskactivations in case the test fails -> better log output
+      oldActivationFromDb.toJson shouldBe oldActivation.withoutLogs.toJson
+    } finally {
+      removeDatabase(dbName)
     }
-
-    behavior of "Activation Log Cleanup Script"
-
-    it should "delete logs in old activation and keep log in new activation" in {
-        val dbName = dbPrefix + "test_log_cleanup_1"
-        val db = createDatabase(dbName, Some(designDocPath))
-
-        try {
-            // Create an old and a new activation
-            val oldActivation = WhiskActivation(
-                namespace = EntityPath("testns1"),
-                name = EntityName("testname1"),
-                subject = Subject("test-sub1"),
-                activationId = ActivationId(),
-                start = Instant.now.minus(2, ChronoUnit.DAYS),
-                end = Instant.now,
-                logs = ActivationLogs(Vector("first line1", "second line1")))
-
-            val newActivation = WhiskActivation(
-                namespace = EntityPath("testns2"),
-                name = EntityName("testname2"),
-                subject = Subject("test-sub2"),
-                activationId = ActivationId(),
-                start = Instant.now,
-                end = Instant.now,
-                logs = ActivationLogs(Vector("first line2", "second line2")))
-
-            db.putDoc(oldActivation.docid.asString, oldActivation.toJson).futureValue shouldBe 'right
-            db.putDoc(newActivation.docid.asString, newActivation.toJson).futureValue shouldBe 'right
-
-            // Run the tool to delete logs from activations that are older than 1 day
-            removeLogsTool(dbUrl, dbName, 1)
-
-            // Check, that the new activation is untouched and the old activation is without logs now
-            val newActivationRequest = db.getDoc(newActivation.docid.asString).futureValue
-            newActivationRequest shouldBe 'right
-            val newActivationFromDb = newActivationRequest.right.get.convertTo[WhiskActivation]
-            // Compare the Json of the Whiskactivations in case the test fails -> better log output
-            newActivationFromDb.toJson shouldBe newActivation.toJson
-
-            val oldActivationRequest = db.getDoc(oldActivation.docid.asString).futureValue
-            oldActivationRequest shouldBe 'right
-            val oldActivationFromDb = oldActivationRequest.right.get.convertTo[WhiskActivation]
-            // Compare the Json of the Whiskactivations in case the test fails -> better log output
-            oldActivationFromDb.toJson shouldBe oldActivation.withoutLogs.toJson
-        } finally {
-            removeDatabase(dbName)
-        }
-    }
+  }
 }

--- a/tests/src/test/scala/whisk/core/database/test/ReplicatorTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/ReplicatorTests.scala
@@ -39,7 +39,8 @@ import spray.json._
 import spray.json.DefaultJsonProtocol._
 
 @RunWith(classOf[JUnitRunner])
-class ReplicatorTests extends FlatSpec
+class ReplicatorTests
+    extends FlatSpec
     with Matchers
     with ScalaFutures
     with WskActorSystem
@@ -47,371 +48,406 @@ class ReplicatorTests extends FlatSpec
     with StreamLogging
     with DatabaseScriptTestUtils {
 
-    val testDbPrefix = s"replicatortest_${dbPrefix}"
+  val testDbPrefix = s"replicatortest_${dbPrefix}"
 
-    val replicatorClient = new ExtendedCouchDbRestClient(dbProtocol, dbHost, dbPort.toInt, dbUsername, dbPassword, "_replicator")
+  val replicatorClient =
+    new ExtendedCouchDbRestClient(dbProtocol, dbHost, dbPort.toInt, dbUsername, dbPassword, "_replicator")
 
-    val replicator = WhiskProperties.getFileRelativeToWhiskHome("tools/db/replicateDbs.py").getAbsolutePath
-    val designDocPath = WhiskProperties.getFileRelativeToWhiskHome("ansible/files/filter_design_document.json").getAbsolutePath
+  val replicator = WhiskProperties.getFileRelativeToWhiskHome("tools/db/replicateDbs.py").getAbsolutePath
+  val designDocPath =
+    WhiskProperties.getFileRelativeToWhiskHome("ansible/files/filter_design_document.json").getAbsolutePath
 
-    implicit def toDuration(dur: FiniteDuration) = java.time.Duration.ofMillis(dur.toMillis)
-    def toEpochSeconds(i: Instant) = i.toEpochMilli / 1000
+  implicit def toDuration(dur: FiniteDuration) = java.time.Duration.ofMillis(dur.toMillis)
+  def toEpochSeconds(i: Instant) = i.toEpochMilli / 1000
 
-    /** Removes a document from the _replicator-database */
-    def removeReplicationDoc(id: String) = {
-        println(s"Removing replication doc: $id")
-        val response = replicatorClient.getDoc(id).futureValue
-        val rev = response.right.toOption.map(_.fields("_rev").convertTo[String])
-        rev.map(replicatorClient.deleteDoc(id, _).futureValue)
-    }
+  /** Removes a document from the _replicator-database */
+  def removeReplicationDoc(id: String) = {
+    println(s"Removing replication doc: $id")
+    val response = replicatorClient.getDoc(id).futureValue
+    val rev = response.right.toOption.map(_.fields("_rev").convertTo[String])
+    rev.map(replicatorClient.deleteDoc(id, _).futureValue)
+  }
 
-    /** Runs the replicator script to replicate databases */
-    def runReplicator(sourceDbUrl: String, targetDbUrl: String, dbPrefix: String, expires: FiniteDuration, continuous: Boolean = false, exclude: List[String] = List()) = {
-        println(s"Running replicator: $sourceDbUrl, $targetDbUrl, $dbPrefix, $expires, $continuous, $exclude")
+  /** Runs the replicator script to replicate databases */
+  def runReplicator(sourceDbUrl: String,
+                    targetDbUrl: String,
+                    dbPrefix: String,
+                    expires: FiniteDuration,
+                    continuous: Boolean = false,
+                    exclude: List[String] = List()) = {
+    println(s"Running replicator: $sourceDbUrl, $targetDbUrl, $dbPrefix, $expires, $continuous, $exclude")
 
-        val continuousFlag = if (continuous) Some("--continuous") else None
-        val excludeFlag = Seq(exclude.mkString(",")).filter(_.nonEmpty).flatMap(ex => Seq("--exclude", ex))
-        val cmd = Seq(python, replicator, "--sourceDbUrl", sourceDbUrl, "--targetDbUrl", targetDbUrl, "replicate", "--dbPrefix", dbPrefix, "--expires", expires.toSeconds.toString) ++ continuousFlag ++ excludeFlag
-        val rr = TestUtils.runCmd(0, new File("."), cmd: _*)
+    val continuousFlag = if (continuous) Some("--continuous") else None
+    val excludeFlag = Seq(exclude.mkString(",")).filter(_.nonEmpty).flatMap(ex => Seq("--exclude", ex))
+    val cmd = Seq(
+      python,
+      replicator,
+      "--sourceDbUrl",
+      sourceDbUrl,
+      "--targetDbUrl",
+      targetDbUrl,
+      "replicate",
+      "--dbPrefix",
+      dbPrefix,
+      "--expires",
+      expires.toSeconds.toString) ++ continuousFlag ++ excludeFlag
+    val rr = TestUtils.runCmd(0, new File("."), cmd: _*)
 
-        val Seq(created, deletedDoc, deleted) = Seq("create backup: ", "deleting backup document: ", "deleting backup: ").map { prefix =>
-            rr.stdout.lines.collect {
-                case line if line.startsWith(prefix) => line.replace(prefix, "")
-            }.toList
-        }
-
-        println(s"Created: $created")
-        println(s"DeletedDocs: $deletedDoc")
-        println(s"Deleted: $deleted")
-
-        (created, deletedDoc, deleted)
-    }
-
-    /** Runs the replicator script to replay databases */
-    def runReplay(sourceDbUrl: String, targetDbUrl: String, dbPrefix: String) = {
-        println(s"Running replay: $sourceDbUrl, $targetDbUrl, $dbPrefix")
-        val rr = TestUtils.runCmd(0, new File("."), WhiskProperties.python, WhiskProperties.getFileRelativeToWhiskHome("tools/db/replicateDbs.py").getAbsolutePath, "--sourceDbUrl", sourceDbUrl, "--targetDbUrl", targetDbUrl, "replay", "--dbPrefix", dbPrefix)
-
-        val line = """([\w-]+) -> ([\w-]+) \(([\w-]+)\)""".r.unanchored
-        val replays = rr.stdout.lines.collect {
-            case line(backup, target, id) => (backup, target, id)
+    val Seq(created, deletedDoc, deleted) =
+      Seq("create backup: ", "deleting backup document: ", "deleting backup: ").map { prefix =>
+        rr.stdout.lines.collect {
+          case line if line.startsWith(prefix) => line.replace(prefix, "")
         }.toList
+      }
 
-        println(s"Replays created: $replays")
+    println(s"Created: $created")
+    println(s"DeletedDocs: $deletedDoc")
+    println(s"Deleted: $deleted")
 
-        replays
+    (created, deletedDoc, deleted)
+  }
+
+  /** Runs the replicator script to replay databases */
+  def runReplay(sourceDbUrl: String, targetDbUrl: String, dbPrefix: String) = {
+    println(s"Running replay: $sourceDbUrl, $targetDbUrl, $dbPrefix")
+    val rr = TestUtils.runCmd(
+      0,
+      new File("."),
+      WhiskProperties.python,
+      WhiskProperties.getFileRelativeToWhiskHome("tools/db/replicateDbs.py").getAbsolutePath,
+      "--sourceDbUrl",
+      sourceDbUrl,
+      "--targetDbUrl",
+      targetDbUrl,
+      "replay",
+      "--dbPrefix",
+      dbPrefix)
+
+    val line = """([\w-]+) -> ([\w-]+) \(([\w-]+)\)""".r.unanchored
+    val replays = rr.stdout.lines.collect {
+      case line(backup, target, id) => (backup, target, id)
+    }.toList
+
+    println(s"Replays created: $replays")
+
+    replays
+  }
+
+  /** Wait for a replication to finish */
+  def waitForReplication(dbName: String) = {
+    val timeout = 5.minutes
+    val replicationResult = waitfor(() => {
+      val replicatorDoc = replicatorClient.getDoc(dbName).futureValue
+      replicatorDoc shouldBe 'right
+
+      val state = replicatorDoc.right.get.fields.get("_replication_state")
+      println(s"Waiting for replication, state: $state")
+
+      state.contains("completed".toJson)
+    }, totalWait = timeout)
+
+    assert(replicationResult, s"replication did not finish in $timeout")
+  }
+
+  /** Compares to databases to full equality */
+  def compareDatabases(sourceDb: String, targetDb: String, filterUsed: Boolean) = {
+    val originalDocs = getAllDocs(sourceDb)
+    val replicatedDocs = getAllDocs(targetDb)
+
+    if (!filterUsed) {
+      replicatedDocs shouldBe originalDocs
+    } else {
+      val filteredReplicatedDocs = replicatedDocs.fields("rows").convertTo[List[JsObject]]
+      val filteredOriginalDocs = originalDocs
+        .fields("rows")
+        .convertTo[List[JsObject]]
+        .filterNot(_.fields("id").convertTo[String].startsWith("_design/"))
+
+      filteredReplicatedDocs shouldBe filteredOriginalDocs
+    }
+  }
+
+  // Do cleanups of possibly existing databases
+  val dbs = replicatorClient.dbs().futureValue
+  dbs shouldBe 'right
+  dbs.right.get.filter(dbname => dbname.contains(testDbPrefix)).map(dbName => removeDatabase(dbName))
+
+  val docs = replicatorClient.getAllDocs().futureValue
+  docs shouldBe 'right
+  docs.right.get
+    .fields("rows")
+    .convertTo[List[JsObject]]
+    .filter(_.fields("id").convertTo[String].contains(testDbPrefix))
+    .map(doc =>
+      replicatorClient
+        .deleteDoc(doc.fields("id").convertTo[String], doc.fields("value").asJsObject.fields("rev").convertTo[String]))
+
+  behavior of "Database replication script"
+
+  it should "replicate a database (snapshot)" in {
+    // Create a database to backup
+    val dbName = testDbPrefix + "database_for_single_replication"
+    val client = createDatabase(dbName, Some(designDocPath))
+
+    println(s"Creating testdocument")
+    val testDocument = JsObject("testKey" -> "testValue".toJson)
+    client.putDoc("testId", testDocument).futureValue
+
+    // Trigger replication and verify the created databases have the correct format
+    val (createdBackupDbs, _, _) = runReplicator(dbUrl, dbUrl, testDbPrefix, 10.minutes)
+    createdBackupDbs should have size 1
+    val backupDbName = createdBackupDbs.head
+    backupDbName should fullyMatch regex s"backup_\\d+_$dbName"
+
+    // Wait for the replication to finish
+    waitForReplication(backupDbName)
+
+    // Verify the replicated database is equal to the original database
+    compareDatabases(dbName, backupDbName, true)
+
+    // Remove all created databases
+    createdBackupDbs.foreach(removeDatabase(_))
+    createdBackupDbs.foreach(removeReplicationDoc(_))
+    removeDatabase(dbName)
+  }
+
+  it should "do not replicate a database that is excluded" in {
+    // Create a database to backup
+    val dbNameToBackup = testDbPrefix + "database_for_single_replication_with_exclude"
+    val nExClient = createDatabase(dbNameToBackup, Some(designDocPath))
+
+    val excludedName = "some_excluded_name"
+    val exClient = createDatabase(testDbPrefix + excludedName, Some(designDocPath))
+
+    // Trigger replication and verify the created databases have the correct format
+    val (createdBackupDbs, _, _) = runReplicator(dbUrl, dbUrl, testDbPrefix, 10.minutes, exclude = List(excludedName))
+    createdBackupDbs should have size 1
+    val backupDbName = createdBackupDbs.head
+    backupDbName should fullyMatch regex s"backup_\\d+_$dbNameToBackup"
+
+    // Wait for the replication to finish
+    waitForReplication(backupDbName)
+
+    // Remove all created databases
+    createdBackupDbs.foreach(removeDatabase(_))
+    createdBackupDbs.foreach(removeReplicationDoc(_))
+    removeDatabase(dbNameToBackup)
+    removeDatabase(testDbPrefix + excludedName)
+  }
+
+  it should "replicate a database (snapshot) even if the filter is not available" in {
+    // Create a db to backup
+    val dbName = testDbPrefix + "database_for_snapshout_without_filter"
+    val client = createDatabase(dbName, None)
+
+    println("Creating testdocuments")
+    val testDocuments = Seq(
+      JsObject("testKey" -> "testValue".toJson, "_id" -> "doc1".toJson),
+      JsObject("testKey" -> "testValue".toJson, "_id" -> "_design/doc1".toJson))
+    val documents = testDocuments.map { doc =>
+      val res = client.putDoc(doc.fields("_id").convertTo[String], doc).futureValue
+      res shouldBe 'right
+      res.right.get
     }
 
-    /** Wait for a replication to finish */
-    def waitForReplication(dbName: String) = {
-        val timeout = 5.minutes
-        val replicationResult = waitfor(() => {
-            val replicatorDoc = replicatorClient.getDoc(dbName).futureValue
-            replicatorDoc shouldBe 'right
+    // Trigger replication and verify the created databases have the correct format
+    val (createdBackupDbs, _, _) = runReplicator(dbUrl, dbUrl, testDbPrefix, 10.minutes)
+    createdBackupDbs should have size 1
+    val backupDbName = createdBackupDbs.head
+    backupDbName should fullyMatch regex s"backup_\\d+_$dbName"
 
-            val state = replicatorDoc.right.get.fields.get("_replication_state")
-            println(s"Waiting for replication, state: $state")
+    // Wait for the replication to finish
+    waitForReplication(backupDbName)
 
-            state.contains("completed".toJson)
-        }, totalWait = timeout)
+    // Verify the replicated database is equal to the original database
+    compareDatabases(dbName, backupDbName, false)
 
-        assert(replicationResult, s"replication did not finish in $timeout")
+    // Remove all created databases
+    createdBackupDbs.foreach(removeDatabase(_))
+    createdBackupDbs.foreach(removeReplicationDoc(_))
+    removeDatabase(dbName)
+  }
+
+  it should "replicate a database (snapshot) and deleted documents and design documents should not be in the snapshot" in {
+    // Create a database to backup
+    val dbName = testDbPrefix + "database_for_single_replication_design_and_deleted_docs"
+    val client = createDatabase(dbName, Some(designDocPath))
+
+    println(s"Creating testdocument")
+    val testDocuments = Seq(
+      JsObject("testKey" -> "testValue".toJson, "_id" -> "doc1".toJson),
+      JsObject("testKey" -> "testValue".toJson, "_id" -> "doc2".toJson),
+      JsObject("testKey" -> "testValue".toJson, "_id" -> "_design/doc1".toJson))
+    val documents = testDocuments.map { doc =>
+      val res = client.putDoc(doc.fields("_id").convertTo[String], doc).futureValue
+      res shouldBe 'right
+      res.right.get
     }
 
-    /** Compares to databases to full equality */
-    def compareDatabases(sourceDb: String, targetDb: String, filterUsed: Boolean) = {
-        val originalDocs = getAllDocs(sourceDb)
-        val replicatedDocs = getAllDocs(targetDb)
+    // Delete second document again
+    val indexOfDocumentToDelete = 1
+    val idOfDeletedDocument = documents(indexOfDocumentToDelete).fields("id").convertTo[String]
+    client.deleteDoc(idOfDeletedDocument, documents(indexOfDocumentToDelete).fields("rev").convertTo[String])
 
-        if (!filterUsed) {
-            replicatedDocs shouldBe originalDocs
-        } else {
-            val filteredReplicatedDocs = replicatedDocs.fields("rows").convertTo[List[JsObject]]
-            val filteredOriginalDocs = originalDocs.fields("rows").convertTo[List[JsObject]].filterNot(_.fields("id").convertTo[String].startsWith("_design/"))
+    // Trigger replication and verify the created databases have the correct format
+    val (createdBackupDbs, _, _) = runReplicator(dbUrl, dbUrl, testDbPrefix, 10.minutes)
+    createdBackupDbs should have size 1
+    val backupDbName = createdBackupDbs.head
+    backupDbName should fullyMatch regex s"backup_\\d+_$dbName"
 
-            filteredReplicatedDocs shouldBe filteredOriginalDocs
-        }
-    }
+    // Wait for the replication to finish
+    waitForReplication(backupDbName)
 
-    // Do cleanups of possibly existing databases
-    val dbs = replicatorClient.dbs().futureValue
-    dbs shouldBe 'right
-    dbs.right.get.filter(dbname => dbname.contains(testDbPrefix)).map(dbName => removeDatabase(dbName))
+    // Verify the replicated database is equal to the original database
+    compareDatabases(dbName, backupDbName, true)
 
-    val docs = replicatorClient.getAllDocs().futureValue
-    docs shouldBe 'right
-    docs.right.get.fields("rows").convertTo[List[JsObject]]
-        .filter(_.fields("id").convertTo[String].contains(testDbPrefix))
-        .map(doc => replicatorClient.deleteDoc(doc.fields("id").convertTo[String], doc.fields("value").asJsObject.fields("rev").convertTo[String]))
+    // Check that deleted doc has not been copied to snapshot
+    val snapshotClient =
+      new ExtendedCouchDbRestClient(dbProtocol, dbHost, dbPort.toInt, dbUsername, dbPassword, backupDbName)
+    val snapshotResponse = snapshotClient.getAllDocs(keys = Some(List(idOfDeletedDocument))).futureValue
+    snapshotResponse shouldBe 'right
+    val results = snapshotResponse.right.get.fields("rows").convertTo[List[JsObject]]
+    results should have size 1
+    // If deleted doc would be in db, the document id and rev would have been returned
+    results(0) shouldBe JsObject("key" -> idOfDeletedDocument.toJson, "error" -> "not_found".toJson)
 
-    behavior of "Database replication script"
+    // Remove all created databases
+    createdBackupDbs.foreach(removeDatabase(_))
+    createdBackupDbs.foreach(removeReplicationDoc(_))
+    removeDatabase(dbName)
+  }
 
-    it should "replicate a database (snapshot)" in {
-        // Create a database to backup
-        val dbName = testDbPrefix + "database_for_single_replication"
-        val client = createDatabase(dbName, Some(designDocPath))
+  it should "continuously update a database" in {
+    // Create a database to backup
+    val dbName = testDbPrefix + "database_for_continous_replication"
+    val client = createDatabase(dbName, Some(designDocPath))
 
-        println(s"Creating testdocument")
-        val testDocument = JsObject("testKey" -> "testValue".toJson)
-        client.putDoc("testId", testDocument).futureValue
+    // Trigger replication and verify the created databases have the correct format
+    val (createdBackupDbs, _, _) = runReplicator(dbUrl, dbUrl, testDbPrefix, 10.minutes, true)
+    createdBackupDbs should have size 1
+    val backupDbName = createdBackupDbs.head
+    backupDbName shouldBe s"continuous_$dbName"
 
-        // Trigger replication and verify the created databases have the correct format
-        val (createdBackupDbs, _, _) = runReplicator(dbUrl, dbUrl, testDbPrefix, 10.minutes)
-        createdBackupDbs should have size 1
-        val backupDbName = createdBackupDbs.head
-        backupDbName should fullyMatch regex s"backup_\\d+_$dbName"
+    // Wait for the replicated database to appear
+    val backupClient = waitForDatabase(backupDbName)
 
-        // Wait for the replication to finish
-        waitForReplication(backupDbName)
+    // Create a document in the old database
+    println(s"Creating testdocument")
+    val docId = "testId"
+    val testDocument = JsObject("testKey" -> "testValue".toJson)
+    client.putDoc(docId, testDocument).futureValue
 
-        // Verify the replicated database is equal to the original database
-        compareDatabases(dbName, backupDbName, true)
+    // Wait for the document to appear
+    waitForDocument(backupClient, docId)
 
-        // Remove all created databases
-        createdBackupDbs.foreach(removeDatabase(_))
-        createdBackupDbs.foreach(removeReplicationDoc(_))
-        removeDatabase(dbName)
-    }
+    // Verify the replicated database is equal to the original database
+    compareDatabases(backupDbName, dbName, false)
 
-    it should "do not replicate a database that is excluded" in {
-        // Create a database to backup
-        val dbNameToBackup = testDbPrefix + "database_for_single_replication_with_exclude"
-        val nExClient = createDatabase(dbNameToBackup, Some(designDocPath))
+    // Stop the replication
+    val replication = replicatorClient.getDoc(backupDbName).futureValue
+    replication shouldBe 'right
+    val replicationDoc = replication.right.get
+    replicatorClient.deleteDoc(
+      replicationDoc.fields("_id").convertTo[String],
+      replicationDoc.fields("_rev").convertTo[String])
 
-        val excludedName = "some_excluded_name"
-        val exClient = createDatabase(testDbPrefix + excludedName, Some(designDocPath))
+    // Remove all created databases
+    createdBackupDbs.foreach(removeDatabase(_))
+    createdBackupDbs.foreach(removeReplicationDoc(_))
+    removeDatabase(dbName)
+  }
 
-        // Trigger replication and verify the created databases have the correct format
-        val (createdBackupDbs, _, _) = runReplicator(dbUrl, dbUrl, testDbPrefix, 10.minutes, exclude = List(excludedName))
-        createdBackupDbs should have size 1
-        val backupDbName = createdBackupDbs.head
-        backupDbName should fullyMatch regex s"backup_\\d+_$dbNameToBackup"
+  it should "remove outdated databases and replicationDocs" in {
+    val now = Instant.now()
+    val expires = 10.minutes
 
-        // Wait for the replication to finish
-        waitForReplication(backupDbName)
+    println(s"Now is: ${toEpochSeconds(now)}")
 
-        // Remove all created databases
-        createdBackupDbs.foreach(removeDatabase(_))
-        createdBackupDbs.foreach(removeReplicationDoc(_))
-        removeDatabase(dbNameToBackup)
-        removeDatabase(testDbPrefix + excludedName)
-    }
+    // Create a database that is already expired
+    val expired = now.minus(expires + 5.minutes)
+    val expiredName = s"backup_${toEpochSeconds(expired)}_${testDbPrefix}expired_backup"
+    val expiredClient = createDatabase(expiredName, Some(designDocPath))
+    replicatorClient.putDoc(expiredName, JsObject("source" -> "".toJson, "target" -> "".toJson)).futureValue
 
-    it should "replicate a database (snapshot) even if the filter is not available" in {
-        // Create a db to backup
-        val dbName = testDbPrefix + "database_for_snapshout_without_filter"
-        val client = createDatabase(dbName, None)
+    // Create a database that is not yet expired
+    val notExpired = now.plus(expires - 5.minutes)
+    val notExpiredName = s"backup_${toEpochSeconds(notExpired)}_${testDbPrefix}notexpired_backup"
+    val notExpiredClient = createDatabase(notExpiredName, Some(designDocPath))
+    replicatorClient.putDoc(notExpiredName, JsObject("source" -> "".toJson, "target" -> "".toJson)).futureValue
 
-        println("Creating testdocuments")
-        val testDocuments = Seq(
-            JsObject(
-                "testKey" -> "testValue".toJson,
-                "_id" -> "doc1".toJson),
-            JsObject("testKey" -> "testValue".toJson,
-                "_id" -> "_design/doc1".toJson))
-        val documents = testDocuments.map { doc =>
-            val res = client.putDoc(doc.fields("_id").convertTo[String], doc).futureValue
-            res shouldBe 'right
-            res.right.get
-        }
+    // Trigger replication and verify the expired database is deleted while the unexpired one is kept
+    val (createdDatabases, deletedReplicationDocs, deletedDatabases) =
+      runReplicator(dbUrl, dbUrl, testDbPrefix, expires)
+    deletedReplicationDocs should (contain(expiredName) and not contain (notExpiredName))
+    deletedDatabases should (contain(expiredName) and not contain (notExpiredName))
 
-        // Trigger replication and verify the created databases have the correct format
-        val (createdBackupDbs, _, _) = runReplicator(dbUrl, dbUrl, testDbPrefix, 10.minutes)
-        createdBackupDbs should have size 1
-        val backupDbName = createdBackupDbs.head
-        backupDbName should fullyMatch regex s"backup_\\d+_$dbName"
+    expiredClient.getAllDocs().futureValue shouldBe Left(StatusCodes.NotFound)
+    notExpiredClient.getAllDocs().futureValue shouldBe 'right
 
-        // Wait for the replication to finish
-        waitForReplication(backupDbName)
+    // Cleanup backup database
+    createdDatabases.foreach(removeDatabase(_))
+    createdDatabases.foreach(removeReplicationDoc(_))
+    removeReplicationDoc(notExpiredName)
+    removeDatabase(notExpiredName)
+  }
 
-        // Verify the replicated database is equal to the original database
-        compareDatabases(dbName, backupDbName, false)
+  it should "not remove outdated databases with other prefix" in {
+    val now = Instant.now()
+    val expires = 10.minutes
 
-        // Remove all created databases
-        createdBackupDbs.foreach(removeDatabase(_))
-        createdBackupDbs.foreach(removeReplicationDoc(_))
-        removeDatabase(dbName)
-    }
+    println(s"Now is: ${toEpochSeconds(now)}")
 
-    it should "replicate a database (snapshot) and deleted documents and design documents should not be in the snapshot" in {
-        // Create a database to backup
-        val dbName = testDbPrefix + "database_for_single_replication_design_and_deleted_docs"
-        val client = createDatabase(dbName, Some(designDocPath))
+    val expired = now.minus(expires + 5.minutes)
 
-        println(s"Creating testdocument")
-        val testDocuments = Seq(
-            JsObject(
-                "testKey" -> "testValue".toJson,
-                "_id" -> "doc1".toJson),
-            JsObject("testKey" -> "testValue".toJson,
-                "_id" -> "doc2".toJson),
-            JsObject("testKey" -> "testValue".toJson,
-                "_id" -> "_design/doc1".toJson))
-        val documents = testDocuments.map { doc =>
-            val res = client.putDoc(doc.fields("_id").convertTo[String], doc).futureValue
-            res shouldBe 'right
-            res.right.get
-        }
+    // Create a database that is expired with correct prefix
+    val correctPrefixName = s"backup_${toEpochSeconds(expired)}_${testDbPrefix}expired_backup_correct_prefix"
+    val correctPrefixClient = createDatabase(correctPrefixName, Some(designDocPath))
+    replicatorClient.putDoc(correctPrefixName, JsObject("source" -> "".toJson, "target" -> "".toJson)).futureValue
 
-        // Delete second document again
-        val indexOfDocumentToDelete = 1
-        val idOfDeletedDocument = documents(indexOfDocumentToDelete).fields("id").convertTo[String]
-        client.deleteDoc(idOfDeletedDocument, documents(indexOfDocumentToDelete).fields("rev").convertTo[String])
+    // Create a database that is expired with wrong prefix
+    val wrongPrefix = s"replicatortest_wrongprefix_${dbPrefix}"
+    val wrongPrefixName = s"backup_${toEpochSeconds(expired)}_${wrongPrefix}expired_backup_wrong_prefix"
+    val wrongPrefixClient = createDatabase(wrongPrefixName, Some(designDocPath))
+    replicatorClient.putDoc(wrongPrefixName, JsObject("source" -> "".toJson, "target" -> "".toJson)).futureValue
 
-        // Trigger replication and verify the created databases have the correct format
-        val (createdBackupDbs, _, _) = runReplicator(dbUrl, dbUrl, testDbPrefix, 10.minutes)
-        createdBackupDbs should have size 1
-        val backupDbName = createdBackupDbs.head
-        backupDbName should fullyMatch regex s"backup_\\d+_$dbName"
+    // Trigger replication and verify the expired database with correct prefix is deleted while the db with the wrong prefix is kept
+    val (createdDatabases, deletedReplicationDocs, deletedDatabases) =
+      runReplicator(dbUrl, dbUrl, testDbPrefix, expires)
+    deletedReplicationDocs should (contain(correctPrefixName) and not contain (wrongPrefixName))
+    deletedDatabases should (contain(correctPrefixName) and not contain (wrongPrefixName))
 
-        // Wait for the replication to finish
-        waitForReplication(backupDbName)
+    correctPrefixClient.getAllDocs().futureValue shouldBe Left(StatusCodes.NotFound)
+    wrongPrefixClient.getAllDocs().futureValue shouldBe 'right
 
-        // Verify the replicated database is equal to the original database
-        compareDatabases(dbName, backupDbName, true)
+    // Cleanup backup database
+    createdDatabases.foreach(removeDatabase(_))
+    createdDatabases.foreach(removeReplicationDoc(_))
+    removeReplicationDoc(wrongPrefixName)
+    removeDatabase(wrongPrefixName)
+  }
 
-        // Check that deleted doc has not been copied to snapshot
-        val snapshotClient = new ExtendedCouchDbRestClient(dbProtocol, dbHost, dbPort.toInt, dbUsername, dbPassword, backupDbName)
-        val snapshotResponse = snapshotClient.getAllDocs(keys = Some(List(idOfDeletedDocument))).futureValue
-        snapshotResponse shouldBe 'right
-        val results = snapshotResponse.right.get.fields("rows").convertTo[List[JsObject]]
-        results should have size 1
-        // If deleted doc would be in db, the document id and rev would have been returned
-        results(0) shouldBe JsObject("key" -> idOfDeletedDocument.toJson, "error" -> "not_found".toJson)
+  it should "replay a database" in {
+    val now = Instant.now()
+    val dbName = testDbPrefix + "database_to_be_restored"
+    val backupPrefix = s"backup_${toEpochSeconds(now)}_"
+    val backupDbName = backupPrefix + dbName
 
-        // Remove all created databases
-        createdBackupDbs.foreach(removeDatabase(_))
-        createdBackupDbs.foreach(removeReplicationDoc(_))
-        removeDatabase(dbName)
-    }
+    // Create a database that looks like a backup
+    val backupClient = createDatabase(backupDbName, Some(designDocPath))
+    println(s"Creating testdocument")
+    backupClient.putDoc("testId", JsObject("testKey" -> "testValue".toJson)).futureValue
 
-    it should "continuously update a database" in {
-        // Create a database to backup
-        val dbName = testDbPrefix + "database_for_continous_replication"
-        val client = createDatabase(dbName, Some(designDocPath))
+    // Run the replay script
+    val (_, _, replicationId) = runReplay(dbUrl, dbUrl, backupPrefix).head
 
-        // Trigger replication and verify the created databases have the correct format
-        val (createdBackupDbs, _, _) = runReplicator(dbUrl, dbUrl, testDbPrefix, 10.minutes, true)
-        createdBackupDbs should have size 1
-        val backupDbName = createdBackupDbs.head
-        backupDbName shouldBe s"continuous_$dbName"
+    // Wait for the replication to finish
+    waitForReplication(replicationId)
 
-        // Wait for the replicated database to appear
-        val backupClient = waitForDatabase(backupDbName)
+    // Verify the replicated database is equal to the original database
+    compareDatabases(backupDbName, dbName, false)
 
-        // Create a document in the old database
-        println(s"Creating testdocument")
-        val docId = "testId"
-        val testDocument = JsObject("testKey" -> "testValue".toJson)
-        client.putDoc(docId, testDocument).futureValue
-
-        // Wait for the document to appear
-        waitForDocument(backupClient, docId)
-
-        // Verify the replicated database is equal to the original database
-        compareDatabases(backupDbName, dbName, false)
-
-        // Stop the replication
-        val replication = replicatorClient.getDoc(backupDbName).futureValue
-        replication shouldBe 'right
-        val replicationDoc = replication.right.get
-        replicatorClient.deleteDoc(replicationDoc.fields("_id").convertTo[String], replicationDoc.fields("_rev").convertTo[String])
-
-        // Remove all created databases
-        createdBackupDbs.foreach(removeDatabase(_))
-        createdBackupDbs.foreach(removeReplicationDoc(_))
-        removeDatabase(dbName)
-    }
-
-    it should "remove outdated databases and replicationDocs" in {
-        val now = Instant.now()
-        val expires = 10.minutes
-
-        println(s"Now is: ${toEpochSeconds(now)}")
-
-        // Create a database that is already expired
-        val expired = now.minus(expires + 5.minutes)
-        val expiredName = s"backup_${toEpochSeconds(expired)}_${testDbPrefix}expired_backup"
-        val expiredClient = createDatabase(expiredName, Some(designDocPath))
-        replicatorClient.putDoc(expiredName, JsObject("source" -> "".toJson, "target" -> "".toJson)).futureValue
-
-        // Create a database that is not yet expired
-        val notExpired = now.plus(expires - 5.minutes)
-        val notExpiredName = s"backup_${toEpochSeconds(notExpired)}_${testDbPrefix}notexpired_backup"
-        val notExpiredClient = createDatabase(notExpiredName, Some(designDocPath))
-        replicatorClient.putDoc(notExpiredName, JsObject("source" -> "".toJson, "target" -> "".toJson)).futureValue
-
-        // Trigger replication and verify the expired database is deleted while the unexpired one is kept
-        val (createdDatabases, deletedReplicationDocs, deletedDatabases) = runReplicator(dbUrl, dbUrl, testDbPrefix, expires)
-        deletedReplicationDocs should (contain(expiredName) and not contain (notExpiredName))
-        deletedDatabases should (contain(expiredName) and not contain (notExpiredName))
-
-        expiredClient.getAllDocs().futureValue shouldBe Left(StatusCodes.NotFound)
-        notExpiredClient.getAllDocs().futureValue shouldBe 'right
-
-        // Cleanup backup database
-        createdDatabases.foreach(removeDatabase(_))
-        createdDatabases.foreach(removeReplicationDoc(_))
-        removeReplicationDoc(notExpiredName)
-        removeDatabase(notExpiredName)
-    }
-
-    it should "not remove outdated databases with other prefix" in {
-        val now = Instant.now()
-        val expires = 10.minutes
-
-        println(s"Now is: ${toEpochSeconds(now)}")
-
-        val expired = now.minus(expires + 5.minutes)
-
-        // Create a database that is expired with correct prefix
-        val correctPrefixName = s"backup_${toEpochSeconds(expired)}_${testDbPrefix}expired_backup_correct_prefix"
-        val correctPrefixClient = createDatabase(correctPrefixName, Some(designDocPath))
-        replicatorClient.putDoc(correctPrefixName, JsObject("source" -> "".toJson, "target" -> "".toJson)).futureValue
-
-        // Create a database that is expired with wrong prefix
-        val wrongPrefix = s"replicatortest_wrongprefix_${dbPrefix}"
-        val wrongPrefixName = s"backup_${toEpochSeconds(expired)}_${wrongPrefix}expired_backup_wrong_prefix"
-        val wrongPrefixClient = createDatabase(wrongPrefixName, Some(designDocPath))
-        replicatorClient.putDoc(wrongPrefixName, JsObject("source" -> "".toJson, "target" -> "".toJson)).futureValue
-
-        // Trigger replication and verify the expired database with correct prefix is deleted while the db with the wrong prefix is kept
-        val (createdDatabases, deletedReplicationDocs, deletedDatabases) = runReplicator(dbUrl, dbUrl, testDbPrefix, expires)
-        deletedReplicationDocs should (contain(correctPrefixName) and not contain (wrongPrefixName))
-        deletedDatabases should (contain(correctPrefixName) and not contain (wrongPrefixName))
-
-        correctPrefixClient.getAllDocs().futureValue shouldBe Left(StatusCodes.NotFound)
-        wrongPrefixClient.getAllDocs().futureValue shouldBe 'right
-
-        // Cleanup backup database
-        createdDatabases.foreach(removeDatabase(_))
-        createdDatabases.foreach(removeReplicationDoc(_))
-        removeReplicationDoc(wrongPrefixName)
-        removeDatabase(wrongPrefixName)
-    }
-
-    it should "replay a database" in {
-        val now = Instant.now()
-        val dbName = testDbPrefix + "database_to_be_restored"
-        val backupPrefix = s"backup_${toEpochSeconds(now)}_"
-        val backupDbName = backupPrefix + dbName
-
-        // Create a database that looks like a backup
-        val backupClient = createDatabase(backupDbName, Some(designDocPath))
-        println(s"Creating testdocument")
-        backupClient.putDoc("testId", JsObject("testKey" -> "testValue".toJson)).futureValue
-
-        // Run the replay script
-        val (_, _, replicationId) = runReplay(dbUrl, dbUrl, backupPrefix).head
-
-        // Wait for the replication to finish
-        waitForReplication(replicationId)
-
-        // Verify the replicated database is equal to the original database
-        compareDatabases(backupDbName, dbName, false)
-
-        // Cleanup databases
-        removeDatabase(backupDbName)
-        removeDatabase(dbName)
-    }
+    // Cleanup databases
+    removeDatabase(backupDbName)
+    removeDatabase(dbName)
+  }
 }

--- a/tests/src/test/scala/whisk/core/entity/test/ActivationResponseTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ActivationResponseTests.scala
@@ -34,159 +34,163 @@ import scala.Right
 @RunWith(classOf[JUnitRunner])
 class ActivationResponseTests extends FlatSpec with Matchers {
 
-    behavior of "ActivationResponse"
+  behavior of "ActivationResponse"
 
-    val logger = new PrintStreamLogging()
+  val logger = new PrintStreamLogging()
 
-    it should "interpret truncated response" in {
-        val max = 5.B
-        Seq("abcdef", """{"msg":"abcedf"}""", """["a","b","c","d","e"]""").foreach { m =>
-            {
-                val response = ContainerResponse(okStatus = false, m.take(max.toBytes.toInt - 1), Some(m.length.B, max))
-                val init = processInitResponseContent(Right(response), logger)
-                init.statusCode shouldBe ContainerError
-                init.result.get.asJsObject.fields(ERROR_FIELD) shouldBe truncatedResponse(response.entity, m.length.B, max).toJson
-            }
-            {
-                val response = ContainerResponse(okStatus = true, m.take(max.toBytes.toInt - 1), Some(m.length.B, max))
-                val run = processRunResponseContent(Right(response), logger)
-                run.statusCode shouldBe ContainerError
-                run.result.get.asJsObject.fields(ERROR_FIELD) shouldBe truncatedResponse(response.entity, m.length.B, max).toJson
-            }
-        }
+  it should "interpret truncated response" in {
+    val max = 5.B
+    Seq("abcdef", """{"msg":"abcedf"}""", """["a","b","c","d","e"]""").foreach { m =>
+      {
+        val response = ContainerResponse(okStatus = false, m.take(max.toBytes.toInt - 1), Some(m.length.B, max))
+        val init = processInitResponseContent(Right(response), logger)
+        init.statusCode shouldBe ContainerError
+        init.result.get.asJsObject
+          .fields(ERROR_FIELD) shouldBe truncatedResponse(response.entity, m.length.B, max).toJson
+      }
+      {
+        val response = ContainerResponse(okStatus = true, m.take(max.toBytes.toInt - 1), Some(m.length.B, max))
+        val run = processRunResponseContent(Right(response), logger)
+        run.statusCode shouldBe ContainerError
+        run.result.get.asJsObject
+          .fields(ERROR_FIELD) shouldBe truncatedResponse(response.entity, m.length.B, max).toJson
+      }
     }
+  }
 
-    it should "interpret failed init that does not response" in {
-        Seq(NoHost(), ConnectionError(new Throwable()), NoResponseReceived(), Timeout())
-            .map(Left(_)).foreach { e =>
-                val ar = processInitResponseContent(e, logger)
-                ar.statusCode shouldBe ContainerError
-                ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe abnormalInitialization.toJson
-            }
-    }
-
-    it should "interpret failed init that responds with null string" in {
-        val response = ContainerResponse(okStatus = false, null)
-        val ar = processInitResponseContent(Right(response), logger)
+  it should "interpret failed init that does not response" in {
+    Seq(NoHost(), ConnectionError(new Throwable()), NoResponseReceived(), Timeout())
+      .map(Left(_))
+      .foreach { e =>
+        val ar = processInitResponseContent(e, logger)
         ar.statusCode shouldBe ContainerError
-        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.entity).toJson
-        ar.result.get.toString should not include regex("null")
-    }
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe abnormalInitialization.toJson
+      }
+  }
 
-    it should "interpret failed init that responds with empty string" in {
-        val response = ContainerResponse(okStatus = false, "")
-        val ar = processInitResponseContent(Right(response), logger)
+  it should "interpret failed init that responds with null string" in {
+    val response = ContainerResponse(okStatus = false, null)
+    val ar = processInitResponseContent(Right(response), logger)
+    ar.statusCode shouldBe ContainerError
+    ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.entity).toJson
+    ar.result.get.toString should not include regex("null")
+  }
+
+  it should "interpret failed init that responds with empty string" in {
+    val response = ContainerResponse(okStatus = false, "")
+    val ar = processInitResponseContent(Right(response), logger)
+    ar.statusCode shouldBe ContainerError
+    ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.entity).toJson
+    ar.result.get.asJsObject.fields(ERROR_FIELD).toString.endsWith(".\"") shouldBe true
+  }
+
+  it should "interpret failed init that responds with non-empty string" in {
+    val response = ContainerResponse(okStatus = false, "string")
+    val ar = processInitResponseContent(Right(response), logger)
+    ar.statusCode shouldBe ContainerError
+    ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.entity).toJson
+    ar.result.get.toString should include(response.entity)
+  }
+
+  it should "interpret failed init that responds with JSON string not object" in {
+    val response = ContainerResponse(okStatus = false, Vector(1).toJson.compactPrint)
+    val ar = processInitResponseContent(Right(response), logger)
+    ar.statusCode shouldBe ContainerError
+    ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.entity).toJson
+    ar.result.get.toString should include(response.entity)
+  }
+
+  it should "interpret failed init that responds with JSON object containing error" in {
+    val response = ContainerResponse(okStatus = false, Map(ERROR_FIELD -> "foobar").toJson.compactPrint)
+    val ar = processInitResponseContent(Right(response), logger)
+    ar.statusCode shouldBe ContainerError
+    ar.result.get shouldBe response.entity.parseJson
+  }
+
+  it should "interpret failed init that responds with JSON object" in {
+    val response = ContainerResponse(okStatus = false, Map("foobar" -> "baz").toJson.compactPrint)
+    val ar = processInitResponseContent(Right(response), logger)
+    ar.statusCode shouldBe ContainerError
+    ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.entity).toJson
+    ar.result.get.toString should include("baz")
+  }
+
+  it should "not interpret successful init" in {
+    val response = ContainerResponse(okStatus = true, "")
+    an[IllegalArgumentException] should be thrownBy {
+      processInitResponseContent(Right(response), logger)
+    }
+  }
+
+  it should "interpret failed run that does not response" in {
+    Seq(NoHost(), ConnectionError(new Throwable()), NoResponseReceived(), Timeout())
+      .map(Left(_))
+      .foreach { e =>
+        val ar = processRunResponseContent(e, logger)
         ar.statusCode shouldBe ContainerError
-        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.entity).toJson
-        ar.result.get.asJsObject.fields(ERROR_FIELD).toString.endsWith(".\"") shouldBe true
-    }
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe abnormalRun.toJson
+      }
+  }
 
-    it should "interpret failed init that responds with non-empty string" in {
-        val response = ContainerResponse(okStatus = false, "string")
-        val ar = processInitResponseContent(Right(response), logger)
-        ar.statusCode shouldBe ContainerError
-        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.entity).toJson
-        ar.result.get.toString should include(response.entity)
-    }
+  it should "interpret failed run that responds with null string" in {
+    val response = ContainerResponse(okStatus = false, null)
+    val ar = processRunResponseContent(Right(response), logger)
+    ar.statusCode shouldBe ContainerError
+    ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.entity).toJson
+    ar.result.get.toString should not include regex("null")
+  }
 
-    it should "interpret failed init that responds with JSON string not object" in {
-        val response = ContainerResponse(okStatus = false, Vector(1).toJson.compactPrint)
-        val ar = processInitResponseContent(Right(response), logger)
-        ar.statusCode shouldBe ContainerError
-        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.entity).toJson
-        ar.result.get.toString should include(response.entity)
-    }
+  it should "interpret failed run that responds with empty string" in {
+    val response = ContainerResponse(okStatus = false, "")
+    val ar = processRunResponseContent(Right(response), logger)
+    ar.statusCode shouldBe ContainerError
+    ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.entity).toJson
+    ar.result.get.asJsObject.fields(ERROR_FIELD).toString.endsWith(".\"") shouldBe true
+  }
 
-    it should "interpret failed init that responds with JSON object containing error" in {
-        val response = ContainerResponse(okStatus = false, Map(ERROR_FIELD -> "foobar").toJson.compactPrint)
-        val ar = processInitResponseContent(Right(response), logger)
-        ar.statusCode shouldBe ContainerError
-        ar.result.get shouldBe response.entity.parseJson
-    }
+  it should "interpret failed run that responds with non-empty string" in {
+    val response = ContainerResponse(okStatus = false, "string")
+    val ar = processRunResponseContent(Right(response), logger)
+    ar.statusCode shouldBe ContainerError
+    ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.entity).toJson
+    ar.result.get.toString should include(response.entity)
+  }
 
-    it should "interpret failed init that responds with JSON object" in {
-        val response = ContainerResponse(okStatus = false, Map("foobar" -> "baz").toJson.compactPrint)
-        val ar = processInitResponseContent(Right(response), logger)
-        ar.statusCode shouldBe ContainerError
-        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.entity).toJson
-        ar.result.get.toString should include("baz")
-    }
+  it should "interpret failed run that responds with JSON string not object" in {
+    val response = ContainerResponse(okStatus = false, Vector(1).toJson.compactPrint)
+    val ar = processRunResponseContent(Right(response), logger)
+    ar.statusCode shouldBe ContainerError
+    ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.entity).toJson
+    ar.result.get.toString should include(response.entity)
+  }
 
-    it should "not interpret successful init" in {
-        val response = ContainerResponse(okStatus = true, "")
-        an[IllegalArgumentException] should be thrownBy {
-            processInitResponseContent(Right(response), logger)
-        }
-    }
+  it should "interpret failed run that responds with JSON object containing error" in {
+    val response = ContainerResponse(okStatus = false, Map(ERROR_FIELD -> "foobar").toJson.compactPrint)
+    val ar = processRunResponseContent(Right(response), logger)
+    ar.statusCode shouldBe ContainerError
+    ar.result.get shouldBe response.entity.parseJson
+  }
 
-    it should "interpret failed run that does not response" in {
-        Seq(NoHost(), ConnectionError(new Throwable()), NoResponseReceived(), Timeout())
-            .map(Left(_)).foreach { e =>
-                val ar = processRunResponseContent(e, logger)
-                ar.statusCode shouldBe ContainerError
-                ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe abnormalRun.toJson
-            }
-    }
+  it should "interpret failed run that responds with JSON object" in {
+    val response = ContainerResponse(okStatus = false, Map("foobar" -> "baz").toJson.compactPrint)
+    val ar = processRunResponseContent(Right(response), logger)
+    ar.statusCode shouldBe ContainerError
+    ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.entity).toJson
+    ar.result.get.toString should include("baz")
+  }
 
-    it should "interpret failed run that responds with null string" in {
-        val response = ContainerResponse(okStatus = false, null)
-        val ar = processRunResponseContent(Right(response), logger)
-        ar.statusCode shouldBe ContainerError
-        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.entity).toJson
-        ar.result.get.toString should not include regex("null")
-    }
+  it should "interpret successful run that responds with JSON object containing error" in {
+    val response = ContainerResponse(okStatus = true, Map(ERROR_FIELD -> "foobar").toJson.compactPrint)
+    val ar = processRunResponseContent(Right(response), logger)
+    ar.statusCode shouldBe ApplicationError
+    ar.result.get shouldBe response.entity.parseJson
+  }
 
-    it should "interpret failed run that responds with empty string" in {
-        val response = ContainerResponse(okStatus = false, "")
-        val ar = processRunResponseContent(Right(response), logger)
-        ar.statusCode shouldBe ContainerError
-        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.entity).toJson
-        ar.result.get.asJsObject.fields(ERROR_FIELD).toString.endsWith(".\"") shouldBe true
-    }
-
-    it should "interpret failed run that responds with non-empty string" in {
-        val response = ContainerResponse(okStatus = false, "string")
-        val ar = processRunResponseContent(Right(response), logger)
-        ar.statusCode shouldBe ContainerError
-        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.entity).toJson
-        ar.result.get.toString should include(response.entity)
-    }
-
-    it should "interpret failed run that responds with JSON string not object" in {
-        val response = ContainerResponse(okStatus = false, Vector(1).toJson.compactPrint)
-        val ar = processRunResponseContent(Right(response), logger)
-        ar.statusCode shouldBe ContainerError
-        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.entity).toJson
-        ar.result.get.toString should include(response.entity)
-    }
-
-    it should "interpret failed run that responds with JSON object containing error" in {
-        val response = ContainerResponse(okStatus = false, Map(ERROR_FIELD -> "foobar").toJson.compactPrint)
-        val ar = processRunResponseContent(Right(response), logger)
-        ar.statusCode shouldBe ContainerError
-        ar.result.get shouldBe response.entity.parseJson
-    }
-
-    it should "interpret failed run that responds with JSON object" in {
-        val response = ContainerResponse(okStatus = false, Map("foobar" -> "baz").toJson.compactPrint)
-        val ar = processRunResponseContent(Right(response), logger)
-        ar.statusCode shouldBe ContainerError
-        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.entity).toJson
-        ar.result.get.toString should include("baz")
-    }
-
-    it should "interpret successful run that responds with JSON object containing error" in {
-        val response = ContainerResponse(okStatus = true, Map(ERROR_FIELD -> "foobar").toJson.compactPrint)
-        val ar = processRunResponseContent(Right(response), logger)
-        ar.statusCode shouldBe ApplicationError
-        ar.result.get shouldBe response.entity.parseJson
-    }
-
-    it should "interpret successful run that responds with JSON object" in {
-        val response = ContainerResponse(okStatus = true, Map("foobar" -> "baz").toJson.compactPrint)
-        val ar = processRunResponseContent(Right(response), logger)
-        ar.statusCode shouldBe Success
-        ar.result.get shouldBe response.entity.parseJson
-    }
+  it should "interpret successful run that responds with JSON object" in {
+    val response = ContainerResponse(okStatus = true, Map("foobar" -> "baz").toJson.compactPrint)
+    val ar = processRunResponseContent(Right(response), logger)
+    ar.statusCode shouldBe Success
+    ar.result.get shouldBe response.entity.parseJson
+  }
 
 }

--- a/tests/src/test/scala/whisk/core/entity/test/DatastoreTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/DatastoreTests.scala
@@ -38,7 +38,8 @@ import whisk.core.database.test.DbUtils
 import whisk.core.entity._
 
 @RunWith(classOf[JUnitRunner])
-class DatastoreTests extends FlatSpec
+class DatastoreTests
+    extends FlatSpec
     with BeforeAndAfter
     with BeforeAndAfterAll
     with WskActorSystem
@@ -46,271 +47,300 @@ class DatastoreTests extends FlatSpec
     with ExecHelpers
     with StreamLogging {
 
-    val namespace = EntityPath("test namespace")
-    val config = new WhiskConfig(WhiskAuthStore.requiredProperties ++ WhiskEntityStore.requiredProperties)
-    val datastore = WhiskEntityStore.datastore(config)
-    val authstore = WhiskAuthStore.datastore(config)
+  val namespace = EntityPath("test namespace")
+  val config = new WhiskConfig(WhiskAuthStore.requiredProperties ++ WhiskEntityStore.requiredProperties)
+  val datastore = WhiskEntityStore.datastore(config)
+  val authstore = WhiskAuthStore.datastore(config)
 
-    implicit val cacheUpdateNotifier: Option[CacheChangeNotification] = None
+  implicit val cacheUpdateNotifier: Option[CacheChangeNotification] = None
 
-    override def afterAll() {
-        println("Shutting down store connections")
-        datastore.shutdown()
-        authstore.shutdown()
-        super.afterAll()
+  override def afterAll() {
+    println("Shutting down store connections")
+    datastore.shutdown()
+    authstore.shutdown()
+    super.afterAll()
+  }
+
+  @volatile var counter = 0
+  def aname(implicit n: EntityName) = {
+    counter = counter + 1
+    EntityName(s"$n$counter")
+  }
+
+  def afullname(implicit namespace: EntityPath, name: String) = FullyQualifiedEntityName(namespace, EntityName(name))
+
+  after {
+    cleanup()
+  }
+
+  behavior of "Datastore"
+
+  it should "CRD action blackbox" in {
+    implicit val tid = transid()
+    implicit val basename = EntityName("create action blackbox")
+    val exec = bb("image")
+    val actions = Seq(
+      WhiskAction(namespace, aname, exec),
+      WhiskAction(namespace, aname, exec, Parameters("x", "y")),
+      WhiskAction(namespace, aname, exec, Parameters("x", "y")),
+      WhiskAction(namespace, aname, exec, Parameters("x", "y") ++ Parameters("x", "y")),
+      WhiskAction(namespace, aname, exec, Parameters("x", "y") ++ Parameters("y", "x")))
+    val docs = actions.map { entity =>
+      putGetCheck(datastore, entity, WhiskAction)
     }
+  }
 
-    @volatile var counter = 0
-    def aname(implicit n: EntityName) = {
-        counter = counter + 1
-        EntityName(s"$n$counter")
+  it should "CRD action js" in {
+    implicit val tid = transid()
+    implicit val basename = EntityName("create action js")
+    val exec = jsDefault("code")
+    val actions = Seq(
+      WhiskAction(namespace, aname, exec, Parameters()),
+      WhiskAction(namespace, aname, exec, Parameters("x", "y")),
+      WhiskAction(namespace, aname, exec, Parameters("x", "y")),
+      WhiskAction(namespace, aname, exec, Parameters("x", "y") ++ Parameters("x", "y")),
+      WhiskAction(namespace, aname, exec, Parameters("x", "y") ++ Parameters("y", "x")))
+    val docs = actions.map { entity =>
+      putGetCheck(datastore, entity, WhiskAction)
     }
+  }
 
-    def afullname(implicit namespace: EntityPath, name: String) = FullyQualifiedEntityName(namespace, EntityName(name))
-
-    after {
-        cleanup()
+  it should "CRD trigger" in {
+    implicit val tid = transid()
+    implicit val basename = EntityName("create trigger")
+    val triggers = Seq(
+      WhiskTrigger(namespace, aname),
+      WhiskTrigger(namespace, aname, Parameters("x", "y")),
+      WhiskTrigger(namespace, aname, Parameters("x", "y")))
+    val docs = triggers.map { entity =>
+      putGetCheck(datastore, entity, WhiskTrigger)
     }
+  }
 
-    behavior of "Datastore"
-
-    it should "CRD action blackbox" in {
-        implicit val tid = transid()
-        implicit val basename = EntityName("create action blackbox")
-        val exec = bb("image")
-        val actions = Seq(
-            WhiskAction(namespace, aname, exec),
-            WhiskAction(namespace, aname, exec, Parameters("x", "y")),
-            WhiskAction(namespace, aname, exec, Parameters("x", "y")),
-            WhiskAction(namespace, aname, exec, Parameters("x", "y") ++ Parameters("x", "y")),
-            WhiskAction(namespace, aname, exec, Parameters("x", "y") ++ Parameters("y", "x")))
-        val docs = actions.map { entity =>
-            putGetCheck(datastore, entity, WhiskAction)
-        }
+  it should "CRD rule" in {
+    implicit val tid = transid()
+    implicit val basename = EntityName("create rule")
+    val rules = Seq(
+      WhiskRule(namespace, aname, afullname(namespace, "a trigger"), afullname(namespace, "an action")),
+      WhiskRule(namespace, aname, afullname(namespace, "a trigger"), afullname(namespace, "an action")))
+    val docs = rules.map { entity =>
+      putGetCheck(datastore, entity, WhiskRule)
     }
+  }
 
-    it should "CRD action js" in {
-        implicit val tid = transid()
-        implicit val basename = EntityName("create action js")
-        val exec = jsDefault("code")
-        val actions = Seq(
-            WhiskAction(namespace, aname, exec, Parameters()),
-            WhiskAction(namespace, aname, exec, Parameters("x", "y")),
-            WhiskAction(namespace, aname, exec, Parameters("x", "y")),
-            WhiskAction(namespace, aname, exec, Parameters("x", "y") ++ Parameters("x", "y")),
-            WhiskAction(namespace, aname, exec, Parameters("x", "y") ++ Parameters("y", "x")))
-        val docs = actions.map { entity =>
-            putGetCheck(datastore, entity, WhiskAction)
-        }
+  it should "CRD activation" in {
+    implicit val tid = transid()
+    implicit val basename = EntityName("create action blackbox")
+    val activations = Seq(
+      WhiskActivation(namespace, aname, Subject(), ActivationId(), start = Instant.now, end = Instant.now),
+      WhiskActivation(namespace, aname, Subject(), ActivationId(), start = Instant.now, end = Instant.now))
+    val docs = activations.map { entity =>
+      putGetCheck(datastore, entity, WhiskActivation)
     }
+  }
 
-    it should "CRD trigger" in {
-        implicit val tid = transid()
-        implicit val basename = EntityName("create trigger")
-        val triggers = Seq(
-            WhiskTrigger(namespace, aname),
-            WhiskTrigger(namespace, aname, Parameters("x", "y")),
-            WhiskTrigger(namespace, aname, Parameters("x", "y")))
-        val docs = triggers.map { entity =>
-            putGetCheck(datastore, entity, WhiskTrigger)
-        }
+  it should "CRD activation with utf8 characters" in {
+    implicit val tid = transid()
+    implicit val basename = EntityName("create action blackbox")
+    val activations = Seq(
+      WhiskActivation(
+        namespace,
+        aname,
+        Subject(),
+        ActivationId(),
+        start = Instant.now,
+        end = Instant.now,
+        logs = ActivationLogs(Vector("Prote\u00EDna"))))
+    val docs = activations.map { entity =>
+      putGetCheck(datastore, entity, WhiskActivation)
     }
+  }
 
-    it should "CRD rule" in {
-        implicit val tid = transid()
-        implicit val basename = EntityName("create rule")
-        val rules = Seq(
-            WhiskRule(namespace, aname, afullname(namespace, "a trigger"), afullname(namespace, "an action")),
-            WhiskRule(namespace, aname, afullname(namespace, "a trigger"), afullname(namespace, "an action")))
-        val docs = rules.map { entity =>
-            putGetCheck(datastore, entity, WhiskRule)
-        }
+  it should "reject action with null arguments" in {
+    val name = EntityName("bad action")
+    intercept[IllegalArgumentException] {
+      WhiskAction(namespace, name, bb("i"), Parameters(), null)
     }
+  }
 
-    it should "CRD activation" in {
-        implicit val tid = transid()
-        implicit val basename = EntityName("create action blackbox")
-        val activations = Seq(
-            WhiskActivation(namespace, aname, Subject(), ActivationId(), start = Instant.now, end = Instant.now),
-            WhiskActivation(namespace, aname, Subject(), ActivationId(), start = Instant.now, end = Instant.now))
-        val docs = activations.map { entity =>
-            putGetCheck(datastore, entity, WhiskActivation)
-        }
+  it should "reject trigger with null arguments" in {
+    val name = EntityName("bad trigger")
+    intercept[IllegalArgumentException] {
+      WhiskTrigger(namespace, name, Parameters(), null)
     }
+  }
 
-    it should "CRD activation with utf8 characters" in {
-        implicit val tid = transid()
-        implicit val basename = EntityName("create action blackbox")
-        val activations = Seq(
-            WhiskActivation(namespace, aname, Subject(), ActivationId(), start = Instant.now, end = Instant.now, logs = ActivationLogs(Vector("Prote\u00EDna"))))
-        val docs = activations.map { entity =>
-            putGetCheck(datastore, entity, WhiskActivation)
-        }
+  it should "reject rule with null arguments" in {
+    val name = EntityName("bad rule")
+    intercept[IllegalArgumentException] {
+      WhiskRule(
+        namespace,
+        name,
+        FullyQualifiedEntityName(namespace, EntityName(null)),
+        FullyQualifiedEntityName(namespace, EntityName(null)))
     }
+    intercept[IllegalArgumentException] {
+      WhiskRule(
+        namespace,
+        name,
+        FullyQualifiedEntityName(namespace, EntityName("")),
+        FullyQualifiedEntityName(namespace, EntityName(null)))
+    }
+    intercept[IllegalArgumentException] {
+      WhiskRule(
+        namespace,
+        name,
+        FullyQualifiedEntityName(namespace, EntityName(" ")),
+        FullyQualifiedEntityName(namespace, EntityName(null)))
+    }
+  }
 
-    it should "reject action with null arguments" in {
-        val name = EntityName("bad action")
-        intercept[IllegalArgumentException] {
-            WhiskAction(namespace, name, bb("i"), Parameters(), null)
-        }
-    }
+  it should "update action with a revision" in {
+    implicit val tid = transid()
+    implicit val basename = EntityName("update action")
+    val exec = jsDefault("update")
+    val action = WhiskAction(namespace, aname, exec, Parameters(), ActionLimits())
+    val docinfo = putGetCheck(datastore, action, WhiskAction, false)._2.docinfo
+    val revAction =
+      WhiskAction(namespace, action.name, exec, Parameters(), ActionLimits()).revision[WhiskAction](docinfo.rev)
+    putGetCheck(datastore, revAction, WhiskAction)
+  }
 
-    it should "reject trigger with null arguments" in {
-        val name = EntityName("bad trigger")
-        intercept[IllegalArgumentException] {
-            WhiskTrigger(namespace, name, Parameters(), null)
-        }
-    }
+  it should "update trigger with a revision" in {
+    implicit val tid = transid()
+    implicit val basename = EntityName("update trigger")
+    val trigger = WhiskTrigger(namespace, aname)
+    val docinfo = putGetCheck(datastore, trigger, WhiskTrigger, false)._2.docinfo
+    val revTrigger = WhiskTrigger(namespace, trigger.name).revision[WhiskTrigger](docinfo.rev)
+    putGetCheck(datastore, revTrigger, WhiskTrigger)
+  }
 
-    it should "reject rule with null arguments" in {
-        val name = EntityName("bad rule")
-        intercept[IllegalArgumentException] {
-            WhiskRule(namespace, name, FullyQualifiedEntityName(namespace, EntityName(null)), FullyQualifiedEntityName(namespace, EntityName(null)))
-        }
-        intercept[IllegalArgumentException] {
-            WhiskRule(namespace, name, FullyQualifiedEntityName(namespace, EntityName("")), FullyQualifiedEntityName(namespace, EntityName(null)))
-        }
-        intercept[IllegalArgumentException] {
-            WhiskRule(namespace, name, FullyQualifiedEntityName(namespace, EntityName(" ")), FullyQualifiedEntityName(namespace, EntityName(null)))
-        }
-    }
+  it should "update rule with a revision" in {
+    implicit val tid = transid()
+    implicit val basename = EntityName("update rule")
+    val rule = WhiskRule(namespace, aname, afullname(namespace, "a trigger"), afullname(namespace, "an action"))
+    val docinfo = putGetCheck(datastore, rule, WhiskRule, false)._2.docinfo
+    val revRule = WhiskRule(namespace, rule.name, rule.trigger, rule.action).revision[WhiskRule](docinfo.rev)
+    putGetCheck(datastore, revRule, WhiskRule)
+  }
 
-    it should "update action with a revision" in {
-        implicit val tid = transid()
-        implicit val basename = EntityName("update action")
-        val exec = jsDefault("update")
-        val action = WhiskAction(namespace, aname, exec, Parameters(), ActionLimits())
-        val docinfo = putGetCheck(datastore, action, WhiskAction, false)._2.docinfo
-        val revAction = WhiskAction(namespace, action.name, exec, Parameters(), ActionLimits()).revision[WhiskAction](docinfo.rev)
-        putGetCheck(datastore, revAction, WhiskAction)
-    }
+  it should "update activation with a revision" in {
+    implicit val tid = transid()
+    implicit val basename = EntityName("update activation")
+    val activation =
+      WhiskActivation(namespace, aname, Subject(), ActivationId(), start = Instant.now, end = Instant.now)
+    val docinfo = putGetCheck(datastore, activation, WhiskActivation, false)._2.docinfo
+    val revActivation = WhiskActivation(
+      namespace,
+      aname,
+      activation.subject,
+      activation.activationId,
+      start = Instant.now,
+      end = Instant.now).revision[WhiskActivation](docinfo.rev)
+    putGetCheck(datastore, revActivation, WhiskActivation)
+  }
 
-    it should "update trigger with a revision" in {
-        implicit val tid = transid()
-        implicit val basename = EntityName("update trigger")
-        val trigger = WhiskTrigger(namespace, aname)
-        val docinfo = putGetCheck(datastore, trigger, WhiskTrigger, false)._2.docinfo
-        val revTrigger = WhiskTrigger(namespace, trigger.name).revision[WhiskTrigger](docinfo.rev)
-        putGetCheck(datastore, revTrigger, WhiskTrigger)
+  it should "fail with document conflict when trying to write the same action twice without a revision" in {
+    implicit val tid = transid()
+    implicit val basename = EntityName("create action twice")
+    val exec = jsDefault("twice")
+    val action = WhiskAction(namespace, aname, exec)
+    putGetCheck(datastore, action, WhiskAction)
+    intercept[DocumentConflictException] {
+      putGetCheck(datastore, action, WhiskAction)
     }
+  }
 
-    it should "update rule with a revision" in {
-        implicit val tid = transid()
-        implicit val basename = EntityName("update rule")
-        val rule = WhiskRule(namespace, aname, afullname(namespace, "a trigger"), afullname(namespace, "an action"))
-        val docinfo = putGetCheck(datastore, rule, WhiskRule, false)._2.docinfo
-        val revRule = WhiskRule(namespace, rule.name, rule.trigger, rule.action).revision[WhiskRule](docinfo.rev)
-        putGetCheck(datastore, revRule, WhiskRule)
+  it should "fail with document conflict when trying to write the same trigger twice without a revision" in {
+    implicit val tid = transid()
+    implicit val basename = EntityName("create trigger twice")
+    val trigger = WhiskTrigger(namespace, aname, Parameters("x", "y"))
+    putGetCheck(datastore, trigger, WhiskTrigger)
+    intercept[DocumentConflictException] {
+      putGetCheck(datastore, trigger, WhiskTrigger)
     }
+  }
 
-    it should "update activation with a revision" in {
-        implicit val tid = transid()
-        implicit val basename = EntityName("update activation")
-        val activation = WhiskActivation(namespace, aname, Subject(), ActivationId(), start = Instant.now, end = Instant.now)
-        val docinfo = putGetCheck(datastore, activation, WhiskActivation, false)._2.docinfo
-        val revActivation = WhiskActivation(namespace, aname, activation.subject, activation.activationId, start = Instant.now, end = Instant.now).revision[WhiskActivation](docinfo.rev)
-        putGetCheck(datastore, revActivation, WhiskActivation)
+  it should "fail with document conflict when trying to write the same rule twice without a revision" in {
+    implicit val tid = transid()
+    implicit val basename = EntityName("create rule twice")
+    val rule = WhiskRule(namespace, aname, afullname(namespace, "a trigger"), afullname(namespace, "an action"))
+    putGetCheck(datastore, rule, WhiskRule)
+    intercept[DocumentConflictException] {
+      putGetCheck(datastore, rule, WhiskRule)
     }
+  }
 
-    it should "fail with document conflict when trying to write the same action twice without a revision" in {
-        implicit val tid = transid()
-        implicit val basename = EntityName("create action twice")
-        val exec = jsDefault("twice")
-        val action = WhiskAction(namespace, aname, exec)
-        putGetCheck(datastore, action, WhiskAction)
-        intercept[DocumentConflictException] {
-            putGetCheck(datastore, action, WhiskAction)
-        }
+  it should "fail with document conflict when trying to write the same activation twice without a revision" in {
+    implicit val tid = transid()
+    implicit val basename = EntityName("create activation twice")
+    val activation =
+      WhiskActivation(namespace, aname, Subject(), ActivationId(), start = Instant.now, end = Instant.now)
+    putGetCheck(datastore, activation, WhiskActivation)
+    intercept[DocumentConflictException] {
+      putGetCheck(datastore, activation, WhiskActivation)
     }
+  }
 
-    it should "fail with document conflict when trying to write the same trigger twice without a revision" in {
-        implicit val tid = transid()
-        implicit val basename = EntityName("create trigger twice")
-        val trigger = WhiskTrigger(namespace, aname, Parameters("x", "y"))
-        putGetCheck(datastore, trigger, WhiskTrigger)
-        intercept[DocumentConflictException] {
-            putGetCheck(datastore, trigger, WhiskTrigger)
-        }
+  it should "fail with document does not exist when trying to delete the same action twice" in {
+    implicit val tid = transid()
+    implicit val basename = EntityName("delete action twice")
+    val exec = jsDefault("twice")
+    val action = WhiskAction(namespace, aname, exec)
+    val doc = putGetCheck(datastore, action, WhiskAction, false)._1
+    assert(Await.result(WhiskAction.del(datastore, doc), dbOpTimeout))
+    intercept[NoDocumentException] {
+      Await.result(WhiskAction.del(datastore, doc), dbOpTimeout)
+      assert(false)
     }
+  }
 
-    it should "fail with document conflict when trying to write the same rule twice without a revision" in {
-        implicit val tid = transid()
-        implicit val basename = EntityName("create rule twice")
-        val rule = WhiskRule(namespace, aname, afullname(namespace, "a trigger"), afullname(namespace, "an action"))
-        putGetCheck(datastore, rule, WhiskRule)
-        intercept[DocumentConflictException] {
-            putGetCheck(datastore, rule, WhiskRule)
-        }
+  it should "fail with document does not exist when trying to delete the same trigger twice" in {
+    implicit val tid = transid()
+    implicit val basename = EntityName("delete trigger twice")
+    val trigger = WhiskTrigger(namespace, aname, Parameters("x", "y"))
+    val doc = putGetCheck(datastore, trigger, WhiskTrigger, false)._1
+    assert(Await.result(WhiskTrigger.del(datastore, doc), dbOpTimeout))
+    intercept[NoDocumentException] {
+      Await.result(WhiskTrigger.del(datastore, doc), dbOpTimeout)
+      assert(false)
     }
+  }
 
-    it should "fail with document conflict when trying to write the same activation twice without a revision" in {
-        implicit val tid = transid()
-        implicit val basename = EntityName("create activation twice")
-        val activation = WhiskActivation(namespace, aname, Subject(), ActivationId(), start = Instant.now, end = Instant.now)
-        putGetCheck(datastore, activation, WhiskActivation)
-        intercept[DocumentConflictException] {
-            putGetCheck(datastore, activation, WhiskActivation)
-        }
+  it should "fail with document does not exist when trying to delete the same rule twice" in {
+    implicit val tid = transid()
+    implicit val basename = EntityName("delete rule twice")
+    val rule = WhiskRule(namespace, aname, afullname(namespace, "a trigger"), afullname(namespace, "an action"))
+    val doc = putGetCheck(datastore, rule, WhiskRule, false)._1
+    assert(Await.result(WhiskRule.del(datastore, doc), dbOpTimeout))
+    intercept[NoDocumentException] {
+      Await.result(WhiskRule.del(datastore, doc), dbOpTimeout)
+      assert(false)
     }
+  }
 
-    it should "fail with document does not exist when trying to delete the same action twice" in {
-        implicit val tid = transid()
-        implicit val basename = EntityName("delete action twice")
-        val exec = jsDefault("twice")
-        val action = WhiskAction(namespace, aname, exec)
-        val doc = putGetCheck(datastore, action, WhiskAction, false)._1
-        assert(Await.result(WhiskAction.del(datastore, doc), dbOpTimeout))
-        intercept[NoDocumentException] {
-            Await.result(WhiskAction.del(datastore, doc), dbOpTimeout)
-            assert(false)
-        }
+  it should "fail with document does not exist when trying to delete the same activation twice" in {
+    implicit val tid = transid()
+    implicit val basename = EntityName("delete activation twice")
+    val activation =
+      WhiskActivation(namespace, aname, Subject(), ActivationId(), start = Instant.now, end = Instant.now)
+    val doc = putGetCheck(datastore, activation, WhiskActivation, false)._1
+    assert(Await.result(WhiskActivation.del(datastore, doc), dbOpTimeout))
+    intercept[NoDocumentException] {
+      Await.result(WhiskActivation.del(datastore, doc), dbOpTimeout)
+      assert(false)
     }
+  }
 
-    it should "fail with document does not exist when trying to delete the same trigger twice" in {
-        implicit val tid = transid()
-        implicit val basename = EntityName("delete trigger twice")
-        val trigger = WhiskTrigger(namespace, aname, Parameters("x", "y"))
-        val doc = putGetCheck(datastore, trigger, WhiskTrigger, false)._1
-        assert(Await.result(WhiskTrigger.del(datastore, doc), dbOpTimeout))
-        intercept[NoDocumentException] {
-            Await.result(WhiskTrigger.del(datastore, doc), dbOpTimeout)
-            assert(false)
-        }
+  it should "fail to CRD with undefined argument" in {
+    implicit val tid = transid()
+    intercept[IllegalArgumentException] {
+      Await.result(WhiskAction.del(null, null), dbOpTimeout)
+      assert(false)
     }
-
-    it should "fail with document does not exist when trying to delete the same rule twice" in {
-        implicit val tid = transid()
-        implicit val basename = EntityName("delete rule twice")
-        val rule = WhiskRule(namespace, aname, afullname(namespace, "a trigger"), afullname(namespace, "an action"))
-        val doc = putGetCheck(datastore, rule, WhiskRule, false)._1
-        assert(Await.result(WhiskRule.del(datastore, doc), dbOpTimeout))
-        intercept[NoDocumentException] {
-            Await.result(WhiskRule.del(datastore, doc), dbOpTimeout)
-            assert(false)
-        }
+    intercept[IllegalArgumentException] {
+      Await.result(WhiskAction.put(null, null), dbOpTimeout)
+      assert(false)
     }
-
-    it should "fail with document does not exist when trying to delete the same activation twice" in {
-        implicit val tid = transid()
-        implicit val basename = EntityName("delete activation twice")
-        val activation = WhiskActivation(namespace, aname, Subject(), ActivationId(), start = Instant.now, end = Instant.now)
-        val doc = putGetCheck(datastore, activation, WhiskActivation, false)._1
-        assert(Await.result(WhiskActivation.del(datastore, doc), dbOpTimeout))
-        intercept[NoDocumentException] {
-            Await.result(WhiskActivation.del(datastore, doc), dbOpTimeout)
-            assert(false)
-        }
-    }
-
-    it should "fail to CRD with undefined argument" in {
-        implicit val tid = transid()
-        intercept[IllegalArgumentException] {
-            Await.result(WhiskAction.del(null, null), dbOpTimeout)
-            assert(false)
-        }
-        intercept[IllegalArgumentException] {
-            Await.result(WhiskAction.put(null, null), dbOpTimeout)
-            assert(false)
-        }
-    }
+  }
 }

--- a/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
@@ -27,48 +27,52 @@ import whisk.core.entity._
 import whisk.core.entity.ArgNormalizer.trim
 import whisk.core.entity.ExecManifest._
 
-trait ExecHelpers
-    extends Matchers
-    with WskActorSystem
-    with StreamLogging {
-    self: Suite =>
+trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
+  self: Suite =>
 
-    private val config = new WhiskConfig(ExecManifest.requiredProperties)
-    ExecManifest.initialize(config) should be a 'success
+  private val config = new WhiskConfig(ExecManifest.requiredProperties)
+  ExecManifest.initialize(config) should be a 'success
 
-    protected val NODEJS = "nodejs"
-    protected val NODEJS6 = "nodejs:6"
-    protected val SWIFT = "swift"
-    protected val SWIFT3 = "swift:3"
+  protected val NODEJS = "nodejs"
+  protected val NODEJS6 = "nodejs:6"
+  protected val SWIFT = "swift"
+  protected val SWIFT3 = "swift:3"
 
-    protected def imagename(name: String) = ExecManifest.ImageName(s"${name}action".replace(":", ""), Some("openwhisk"), Some("latest"))
+  protected def imagename(name: String) =
+    ExecManifest.ImageName(s"${name}action".replace(":", ""), Some("openwhisk"), Some("latest"))
 
-    protected def js(code: String, main: Option[String] = None) = {
-        CodeExecAsString(RuntimeManifest(NODEJS, imagename(NODEJS), deprecated = Some(true)), trim(code), main.map(_.trim))
-    }
+  protected def js(code: String, main: Option[String] = None) = {
+    CodeExecAsString(RuntimeManifest(NODEJS, imagename(NODEJS), deprecated = Some(true)), trim(code), main.map(_.trim))
+  }
 
-    protected def js6(code: String, main: Option[String] = None) = {
-        CodeExecAsString(RuntimeManifest(NODEJS6, imagename(NODEJS6), default = Some(true), deprecated = Some(false)), trim(code), main.map(_.trim))
-    }
+  protected def js6(code: String, main: Option[String] = None) = {
+    CodeExecAsString(
+      RuntimeManifest(NODEJS6, imagename(NODEJS6), default = Some(true), deprecated = Some(false)),
+      trim(code),
+      main.map(_.trim))
+  }
 
-    protected def jsDefault(code: String, main: Option[String] = None) = {
-        js6(code, main)
-    }
+  protected def jsDefault(code: String, main: Option[String] = None) = {
+    js6(code, main)
+  }
 
-    protected def swift(code: String, main: Option[String] = None) = {
-        CodeExecAsString(RuntimeManifest(SWIFT, imagename(SWIFT), deprecated = Some(true)), trim(code), main.map(_.trim))
-    }
+  protected def swift(code: String, main: Option[String] = None) = {
+    CodeExecAsString(RuntimeManifest(SWIFT, imagename(SWIFT), deprecated = Some(true)), trim(code), main.map(_.trim))
+  }
 
-    protected def swift3(code: String, main: Option[String] = None) = {
-        val default = ExecManifest.runtimesManifest.resolveDefaultRuntime(SWIFT3).flatMap(_.default)
-        CodeExecAsString(RuntimeManifest(SWIFT3, imagename(SWIFT3), default = default, deprecated = Some(false)), trim(code), main.map(_.trim))
-    }
+  protected def swift3(code: String, main: Option[String] = None) = {
+    val default = ExecManifest.runtimesManifest.resolveDefaultRuntime(SWIFT3).flatMap(_.default)
+    CodeExecAsString(
+      RuntimeManifest(SWIFT3, imagename(SWIFT3), default = default, deprecated = Some(false)),
+      trim(code),
+      main.map(_.trim))
+  }
 
-    protected def sequence(components: Vector[FullyQualifiedEntityName]) = SequenceExec(components)
+  protected def sequence(components: Vector[FullyQualifiedEntityName]) = SequenceExec(components)
 
-    protected def bb(image: String) = BlackBoxExec(ExecManifest.ImageName(trim(image)), None, None, false)
+  protected def bb(image: String) = BlackBoxExec(ExecManifest.ImageName(trim(image)), None, None, false)
 
-    protected def bb(image: String, code: String, main: Option[String] = None) = {
-        BlackBoxExec(ExecManifest.ImageName(trim(image)), Some(trim(code)).filter(_.nonEmpty), main, false)
-    }
+  protected def bb(image: String, code: String, main: Option[String] = None) = {
+    BlackBoxExec(ExecManifest.ImageName(trim(image)), Some(trim(code)).filter(_.nonEmpty), main, false)
+  }
 }

--- a/tests/src/test/scala/whisk/core/entity/test/ExecManifestTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecManifestTests.scala
@@ -34,165 +34,162 @@ import common.StreamLogging
 import common.WskActorSystem
 
 @RunWith(classOf[JUnitRunner])
-class ExecManifestTests
-    extends FlatSpec
-    with WskActorSystem
-    with StreamLogging
-    with Matchers {
+class ExecManifestTests extends FlatSpec with WskActorSystem with StreamLogging with Matchers {
 
-    behavior of "ExecManifest"
+  behavior of "ExecManifest"
 
-    private def manifestFactory(runtimes: JsObject) = {
-        JsObject("runtimes" -> runtimes)
+  private def manifestFactory(runtimes: JsObject) = {
+    JsObject("runtimes" -> runtimes)
+  }
+
+  it should "parse an image name" in {
+    Map(
+      "i" -> ImageName("i"),
+      "i:t" -> ImageName("i", tag = Some("t")),
+      "i:tt" -> ImageName("i", tag = Some("tt")),
+      "ii" -> ImageName("ii"),
+      "ii:t" -> ImageName("ii", tag = Some("t")),
+      "ii:tt" -> ImageName("ii", tag = Some("tt")),
+      "p/i" -> ImageName("i", Some("p")),
+      "pre/img" -> ImageName("img", Some("pre")),
+      "pre/img:t" -> ImageName("img", Some("pre"), Some("t")),
+      "pre1/pre2/img:t" -> ImageName("img", Some("pre1/pre2"), Some("t")),
+      "pre1/pre2/img" -> ImageName("img", Some("pre1/pre2")))
+      .foreach {
+        case (s, v) => ImageName.fromString(s) shouldBe Success(v)
+      }
+
+    Seq("ABC", "x:8080/abc", "p/a:x:y").foreach { s =>
+      a[DeserializationException] should be thrownBy ImageName.fromString(s).get
+    }
+  }
+
+  it should "read a valid configuration without default prefix, default tag or blackbox images" in {
+    val k1 = RuntimeManifest("k1", ImageName("???"))
+    val k2 = RuntimeManifest("k2", ImageName("???"), default = Some(true))
+    val p1 = RuntimeManifest("p1", ImageName("???"))
+    val mf = manifestFactory(JsObject("ks" -> Set(k1, k2).toJson, "p1" -> Set(p1).toJson))
+    val runtimes = ExecManifest.runtimes(mf).get
+
+    Seq("k1", "k2", "p1").foreach {
+      runtimes.knownContainerRuntimes.contains(_) shouldBe true
     }
 
-    it should "parse an image name" in {
-        Map("i" -> ImageName("i"),
-            "i:t" -> ImageName("i", tag = Some("t")),
-            "i:tt" -> ImageName("i", tag = Some("tt")),
-            "ii" -> ImageName("ii"),
-            "ii:t" -> ImageName("ii", tag = Some("t")),
-            "ii:tt" -> ImageName("ii", tag = Some("tt")),
-            "p/i" -> ImageName("i", Some("p")),
-            "pre/img" -> ImageName("img", Some("pre")),
-            "pre/img:t" -> ImageName("img", Some("pre"), Some("t")),
-            "pre1/pre2/img:t" -> ImageName("img", Some("pre1/pre2"), Some("t")),
-            "pre1/pre2/img" -> ImageName("img", Some("pre1/pre2")))
-            .foreach {
-                case (s, v) => ImageName.fromString(s) shouldBe Success(v)
-            }
+    runtimes.knownContainerRuntimes.contains("k3") shouldBe false
 
-        Seq("ABC", "x:8080/abc", "p/a:x:y").foreach { s =>
-            a[DeserializationException] should be thrownBy ImageName.fromString(s).get
-        }
+    runtimes.resolveDefaultRuntime("k1") shouldBe Some(k1)
+    runtimes.resolveDefaultRuntime("k2") shouldBe Some(k2)
+    runtimes.resolveDefaultRuntime("p1") shouldBe Some(p1)
+
+    runtimes.resolveDefaultRuntime("ks:default") shouldBe Some(k2)
+    runtimes.resolveDefaultRuntime("p1:default") shouldBe Some(p1)
+  }
+
+  it should "read a valid configuration without default prefix, default tag" in {
+    val i1 = RuntimeManifest("i1", ImageName("???"))
+    val i2 = RuntimeManifest("i2", ImageName("???", Some("ppp")), default = Some(true))
+    val j1 = RuntimeManifest("j1", ImageName("???", Some("ppp"), Some("ttt")))
+    val k1 = RuntimeManifest("k1", ImageName("???", None, Some("ttt")))
+
+    val mf = JsObject(
+      "defaultImagePrefix" -> "pre".toJson,
+      "defaultImageTag" -> "test".toJson,
+      "runtimes" -> JsObject("is" -> Set(i1, i2).toJson, "js" -> Set(j1).toJson, "ks" -> Set(k1).toJson))
+    val runtimes = ExecManifest.runtimes(mf).get
+
+    runtimes.resolveDefaultRuntime("i1").get.image.publicImageName shouldBe "pre/???:test"
+    runtimes.resolveDefaultRuntime("i2").get.image.publicImageName shouldBe "ppp/???:test"
+    runtimes.resolveDefaultRuntime("j1").get.image.publicImageName shouldBe "ppp/???:ttt"
+    runtimes.resolveDefaultRuntime("k1").get.image.publicImageName shouldBe "pre/???:ttt"
+  }
+
+  it should "read a valid configuration with blackbox images but without default prefix or tag" in {
+    val imgs = Set(
+      ImageName("???"),
+      ImageName("???", Some("ppp")),
+      ImageName("???", Some("ppp"), Some("ttt")),
+      ImageName("???", None, Some("ttt")))
+
+    val mf = JsObject("runtimes" -> JsObject(), "blackboxes" -> imgs.toJson)
+    val runtimes = ExecManifest.runtimes(mf).get
+    runtimes.blackboxImages shouldBe imgs
+  }
+
+  it should "read a valid configuration with blackbox images, default prefix and tag" in {
+    val imgs = Set(
+      ImageName("???"),
+      ImageName("???", Some("ppp")),
+      ImageName("???", Some("ppp"), Some("ttt")),
+      ImageName("???", None, Some("ttt")))
+
+    val mf = JsObject(
+      "defaultImagePrefix" -> "pre".toJson,
+      "defaultImageTag" -> "test".toJson,
+      "runtimes" -> JsObject(),
+      "blackboxes" -> imgs.toJson)
+    val runtimes = ExecManifest.runtimes(mf).get
+
+    runtimes.blackboxImages shouldBe {
+      Set(
+        ImageName("???", Some("pre"), Some("test")),
+        ImageName("???", Some("ppp"), Some("test")),
+        ImageName("???", Some("ppp"), Some("ttt")),
+        ImageName("???", Some("pre"), Some("ttt")))
     }
 
-    it should "read a valid configuration without default prefix, default tag or blackbox images" in {
-        val k1 = RuntimeManifest("k1", ImageName("???"))
-        val k2 = RuntimeManifest("k2", ImageName("???"), default = Some(true))
-        val p1 = RuntimeManifest("p1", ImageName("???"))
-        val mf = manifestFactory(JsObject("ks" -> Set(k1, k2).toJson, "p1" -> Set(p1).toJson))
-        val runtimes = ExecManifest.runtimes(mf).get
+  }
 
-        Seq("k1", "k2", "p1").foreach {
-            runtimes.knownContainerRuntimes.contains(_) shouldBe true
-        }
+  it should "reject runtimes with multiple defaults" in {
+    val k1 = RuntimeManifest("k1", ImageName("???"), default = Some(true))
+    val k2 = RuntimeManifest("k2", ImageName("???"), default = Some(true))
+    val mf = manifestFactory(JsObject("ks" -> Set(k1, k2).toJson))
 
-        runtimes.knownContainerRuntimes.contains("k3") shouldBe false
+    an[IllegalArgumentException] should be thrownBy ExecManifest.runtimes(mf).get
+  }
 
-        runtimes.resolveDefaultRuntime("k1") shouldBe Some(k1)
-        runtimes.resolveDefaultRuntime("k2") shouldBe Some(k2)
-        runtimes.resolveDefaultRuntime("p1") shouldBe Some(p1)
+  it should "reject finding a default when none is specified for multiple versions" in {
+    val k1 = RuntimeManifest("k1", ImageName("???"))
+    val k2 = RuntimeManifest("k2", ImageName("???"))
+    val mf = manifestFactory(JsObject("ks" -> Set(k1, k2).toJson))
 
-        runtimes.resolveDefaultRuntime("ks:default") shouldBe Some(k2)
-        runtimes.resolveDefaultRuntime("p1:default") shouldBe Some(p1)
+    an[IllegalArgumentException] should be thrownBy ExecManifest.runtimes(mf).get
+  }
+
+  it should "prefix image name with overrides" in {
+    val name = "xyz"
+    ExecManifest.ImageName(name, Some(""), Some("")).publicImageName shouldBe name
+
+    Seq(
+      (ExecManifest.ImageName(name), name),
+      (ExecManifest.ImageName(name, Some("pre")), s"pre/$name"),
+      (ExecManifest.ImageName(name, None, Some("t")), s"$name:t"),
+      (ExecManifest.ImageName(name, Some("pre"), Some("t")), s"pre/$name:t")).foreach {
+      case (image, exp) =>
+        image.publicImageName shouldBe exp
+
+        image.localImageName("", "", None) shouldBe image.tag.map(t => s"$name:$t").getOrElse(s"$name:latest")
+        image.localImageName("", "p", None) shouldBe image.tag.map(t => s"p/$name:$t").getOrElse(s"p/$name:latest")
+        image.localImageName("r", "", None) shouldBe image.tag.map(t => s"r/$name:$t").getOrElse(s"r/$name:latest")
+        image.localImageName("r", "p", None) shouldBe image.tag.map(t => s"r/p/$name:$t").getOrElse(s"r/p/$name:latest")
+        image.localImageName("r", "p", Some("tag")) shouldBe s"r/p/$name:tag"
     }
+  }
 
-    it should "read a valid configuration without default prefix, default tag" in {
-        val i1 = RuntimeManifest("i1", ImageName("???"))
-        val i2 = RuntimeManifest("i2", ImageName("???", Some("ppp")), default = Some(true))
-        val j1 = RuntimeManifest("j1", ImageName("???", Some("ppp"), Some("ttt")))
-        val k1 = RuntimeManifest("k1", ImageName("???", None, Some("ttt")))
+  it should "throw an error when configured manifest is a valid JSON, but with a missing key" in {
+    val config_manifest = """{"nodejs":[{"kind":"nodejs:6","default":true,"image":{"name":"nodejs6action"}}]}"""
+    val file = File.createTempFile("cxt", ".txt")
+    file.deleteOnExit()
 
-        val mf = JsObject(
-            "defaultImagePrefix" -> "pre".toJson,
-            "defaultImageTag" -> "test".toJson,
-            "runtimes" -> JsObject("is" -> Set(i1, i2).toJson, "js" -> Set(j1).toJson, "ks" -> Set(k1).toJson))
-        val runtimes = ExecManifest.runtimes(mf).get
+    val bw = new BufferedWriter(new FileWriter(file))
+    bw.write("runtimes.manifest=" + config_manifest + "\n")
+    bw.close()
 
-        runtimes.resolveDefaultRuntime("i1").get.image.publicImageName shouldBe "pre/???:test"
-        runtimes.resolveDefaultRuntime("i2").get.image.publicImageName shouldBe "ppp/???:test"
-        runtimes.resolveDefaultRuntime("j1").get.image.publicImageName shouldBe "ppp/???:ttt"
-        runtimes.resolveDefaultRuntime("k1").get.image.publicImageName shouldBe "pre/???:ttt"
-    }
+    val result = ExecManifest.initialize(new WhiskConfig(Map("runtimes.manifest" -> null), Set(), file), true)
 
-    it should "read a valid configuration with blackbox images but without default prefix or tag" in {
-        val imgs = Set(
-            ImageName("???"),
-            ImageName("???", Some("ppp")),
-            ImageName("???", Some("ppp"), Some("ttt")),
-            ImageName("???", None, Some("ttt")))
+    result should be a 'failure
 
-        val mf = JsObject(
-            "runtimes" -> JsObject(),
-            "blackboxes" -> imgs.toJson)
-        val runtimes = ExecManifest.runtimes(mf).get
-        runtimes.blackboxImages shouldBe imgs
-    }
-
-    it should "read a valid configuration with blackbox images, default prefix and tag" in {
-        val imgs = Set(
-            ImageName("???"),
-            ImageName("???", Some("ppp")),
-            ImageName("???", Some("ppp"), Some("ttt")),
-            ImageName("???", None, Some("ttt")))
-
-        val mf = JsObject(
-            "defaultImagePrefix" -> "pre".toJson,
-            "defaultImageTag" -> "test".toJson,
-            "runtimes" -> JsObject(),
-            "blackboxes" -> imgs.toJson)
-        val runtimes = ExecManifest.runtimes(mf).get
-
-        runtimes.blackboxImages shouldBe {
-            Set(ImageName("???", Some("pre"), Some("test")),
-                ImageName("???", Some("ppp"), Some("test")),
-                ImageName("???", Some("ppp"), Some("ttt")),
-                ImageName("???", Some("pre"), Some("ttt")))
-        }
-
-    }
-
-    it should "reject runtimes with multiple defaults" in {
-        val k1 = RuntimeManifest("k1", ImageName("???"), default = Some(true))
-        val k2 = RuntimeManifest("k2", ImageName("???"), default = Some(true))
-        val mf = manifestFactory(JsObject("ks" -> Set(k1, k2).toJson))
-
-        an[IllegalArgumentException] should be thrownBy ExecManifest.runtimes(mf).get
-    }
-
-    it should "reject finding a default when none is specified for multiple versions" in {
-        val k1 = RuntimeManifest("k1", ImageName("???"))
-        val k2 = RuntimeManifest("k2", ImageName("???"))
-        val mf = manifestFactory(JsObject("ks" -> Set(k1, k2).toJson))
-
-        an[IllegalArgumentException] should be thrownBy ExecManifest.runtimes(mf).get
-    }
-
-    it should "prefix image name with overrides" in {
-        val name = "xyz"
-        ExecManifest.ImageName(name, Some(""), Some("")).publicImageName shouldBe name
-
-        Seq((ExecManifest.ImageName(name), name),
-            (ExecManifest.ImageName(name, Some("pre")), s"pre/$name"),
-            (ExecManifest.ImageName(name, None, Some("t")), s"$name:t"),
-            (ExecManifest.ImageName(name, Some("pre"), Some("t")), s"pre/$name:t")).foreach {
-                case (image, exp) =>
-                    image.publicImageName shouldBe exp
-
-                    image.localImageName("", "", None) shouldBe image.tag.map(t => s"$name:$t").getOrElse(s"$name:latest")
-                    image.localImageName("", "p", None) shouldBe image.tag.map(t => s"p/$name:$t").getOrElse(s"p/$name:latest")
-                    image.localImageName("r", "", None) shouldBe image.tag.map(t => s"r/$name:$t").getOrElse(s"r/$name:latest")
-                    image.localImageName("r", "p", None) shouldBe image.tag.map(t => s"r/p/$name:$t").getOrElse(s"r/p/$name:latest")
-                    image.localImageName("r", "p", Some("tag")) shouldBe s"r/p/$name:tag"
-            }
-    }
-
-    it should "throw an error when configured manifest is a valid JSON, but with a missing key" in {
-        val config_manifest = """{"nodejs":[{"kind":"nodejs:6","default":true,"image":{"name":"nodejs6action"}}]}"""
-        val file = File.createTempFile("cxt", ".txt")
-        file.deleteOnExit()
-
-        val bw = new BufferedWriter(new FileWriter(file))
-        bw.write("runtimes.manifest=" + config_manifest + "\n")
-        bw.close()
-
-        val result = ExecManifest.initialize(new WhiskConfig(Map("runtimes.manifest" -> null), Set(), file), true)
-
-        result should be a 'failure
-
-        the [NoSuchElementException] thrownBy {
-            result.get
-        } should have message ("key not found: runtimes")
-    }
+    the[NoSuchElementException] thrownBy {
+      result.get
+    } should have message ("key not found: runtimes")
+  }
 }

--- a/tests/src/test/scala/whisk/core/entity/test/MigrationEntities.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/MigrationEntities.scala
@@ -25,30 +25,32 @@ import whisk.core.entity._
  * Contains types which represent former versions of database schemas
  * to be able to test migration path
  */
-
 /**
  * Old schema of rules, containing the rules' status in the rule record
  * itself
  */
-case class OldWhiskRule(
-    namespace: EntityPath,
-    override val name: EntityName,
-    trigger: EntityName,
-    action: EntityName,
-    status: Status,
-    version: SemVer = SemVer(),
-    publish: Boolean = false,
-    annotations: Parameters = Parameters())
+case class OldWhiskRule(namespace: EntityPath,
+                        override val name: EntityName,
+                        trigger: EntityName,
+                        action: EntityName,
+                        status: Status,
+                        version: SemVer = SemVer(),
+                        publish: Boolean = false,
+                        annotations: Parameters = Parameters())
     extends WhiskEntity(name) {
 
-    def toJson = OldWhiskRule.serdes.write(this).asJsObject
+  def toJson = OldWhiskRule.serdes.write(this).asJsObject
 
-    def toWhiskRule = {
-        WhiskRule(namespace, name,
-            FullyQualifiedEntityName(namespace, trigger),
-            FullyQualifiedEntityName(namespace, action),
-            version, publish, annotations)
-    }
+  def toWhiskRule = {
+    WhiskRule(
+      namespace,
+      name,
+      FullyQualifiedEntityName(namespace, trigger),
+      FullyQualifiedEntityName(namespace, action),
+      version,
+      publish,
+      annotations)
+  }
 }
 
 object OldWhiskRule
@@ -56,26 +58,25 @@ object OldWhiskRule
     with WhiskEntityQueries[OldWhiskRule]
     with DefaultJsonProtocol {
 
-    override val collectionName = "rules"
-    override implicit val serdes = jsonFormat8(OldWhiskRule.apply)
+  override val collectionName = "rules"
+  override implicit val serdes = jsonFormat8(OldWhiskRule.apply)
 }
 
 /**
  * Old schema of triggers, not containing a map of ReducedRules
  */
-case class OldWhiskTrigger(
-    namespace: EntityPath,
-    override val name: EntityName,
-    parameters: Parameters = Parameters(),
-    limits: TriggerLimits = TriggerLimits(),
-    version: SemVer = SemVer(),
-    publish: Boolean = false,
-    annotations: Parameters = Parameters())
+case class OldWhiskTrigger(namespace: EntityPath,
+                           override val name: EntityName,
+                           parameters: Parameters = Parameters(),
+                           limits: TriggerLimits = TriggerLimits(),
+                           version: SemVer = SemVer(),
+                           publish: Boolean = false,
+                           annotations: Parameters = Parameters())
     extends WhiskEntity(name) {
 
-    def toJson = OldWhiskTrigger.serdes.write(this).asJsObject
+  def toJson = OldWhiskTrigger.serdes.write(this).asJsObject
 
-    def toWhiskTrigger = WhiskTrigger(namespace, name, parameters, limits, version, publish, annotations)
+  def toWhiskTrigger = WhiskTrigger(namespace, name, parameters, limits, version, publish, annotations)
 }
 
 object OldWhiskTrigger
@@ -83,6 +84,6 @@ object OldWhiskTrigger
     with WhiskEntityQueries[OldWhiskTrigger]
     with DefaultJsonProtocol {
 
-    override val collectionName = "triggers"
-    override implicit val serdes = jsonFormat7(OldWhiskTrigger.apply)
+  override val collectionName = "triggers"
+  override implicit val serdes = jsonFormat7(OldWhiskTrigger.apply)
 }

--- a/tests/src/test/scala/whisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/SchemaTests.scala
@@ -43,580 +43,710 @@ import whisk.http.Messages
 import whisk.utils.JsHelpers
 
 @RunWith(classOf[JUnitRunner])
-class SchemaTests
-    extends FlatSpec
-    with BeforeAndAfter
-    with ExecHelpers
-    with Matchers {
+class SchemaTests extends FlatSpec with BeforeAndAfter with ExecHelpers with Matchers {
 
-    behavior of "AuthKey"
+  behavior of "AuthKey"
 
-    it should "accept well formed keys" in {
-        val uuid = UUID()
-        val secret = Secret()
-        Seq(s"$uuid:$secret", s" $uuid: $secret", s"$uuid:$secret ", s" $uuid : $secret ").foreach { i =>
-            val k = AuthKey(i)
-            assert(k.uuid == uuid)
-            assert(k.key == secret)
+  it should "accept well formed keys" in {
+    val uuid = UUID()
+    val secret = Secret()
+    Seq(s"$uuid:$secret", s" $uuid: $secret", s"$uuid:$secret ", s" $uuid : $secret ").foreach { i =>
+      val k = AuthKey(i)
+      assert(k.uuid == uuid)
+      assert(k.key == secret)
+    }
+  }
+
+  it should "reject malformed ids" in {
+    Seq(null, "", " ", ":", " : ", " :", ": ", "a:b").foreach { i =>
+      an[IllegalArgumentException] should be thrownBy AuthKey(i)
+    }
+  }
+
+  behavior of "Privilege"
+
+  it should "serdes a right" in {
+    Privilege.serdes.read("READ".toJson) shouldBe Privilege.READ
+    Privilege.serdes.read("read".toJson) shouldBe Privilege.READ
+    a[DeserializationException] should be thrownBy Privilege.serdes.read("???".toJson)
+  }
+
+  behavior of "Identity"
+
+  it should "serdes an identity" in {
+    val i = WhiskAuthHelpers.newIdentity()
+    val expected = JsObject(
+      "subject" -> i.subject.asString.toJson,
+      "namespace" -> i.namespace.toJson,
+      "authkey" -> i.authkey.compact.toJson,
+      "rights" -> Array("READ", "PUT", "DELETE", "ACTIVATE").toJson,
+      "limits" -> JsObject())
+    Identity.serdes.write(i) shouldBe expected
+    Identity.serdes.read(expected) shouldBe i
+  }
+
+  behavior of "DocInfo"
+
+  it should "accept well formed doc info" in {
+    Seq("a", " a", "a ").foreach { i =>
+      val d = DocInfo(i)
+      assert(d.id.asString == i.trim)
+    }
+  }
+
+  it should "accept any string as doc revision" in {
+    Seq("a", " a", "a ", "", null).foreach { i =>
+      val d = DocRevision(i)
+      assert(d.rev == (if (i != null) i.trim else null))
+    }
+
+    DocRevision.serdes.read(JsNull) shouldBe DocRevision.empty
+    DocRevision.serdes.read(JsString("")) shouldBe DocRevision("")
+    DocRevision.serdes.read(JsString("a")) shouldBe DocRevision("a")
+    DocRevision.serdes.read(JsString(" a")) shouldBe DocRevision("a")
+    DocRevision.serdes.read(JsString("a ")) shouldBe DocRevision("a")
+    a[DeserializationException] should be thrownBy DocRevision.serdes.read(JsNumber(1))
+  }
+
+  it should "reject malformed doc info" in {
+    Seq(null, "", " ").foreach { i =>
+      an[IllegalArgumentException] should be thrownBy DocInfo(i)
+    }
+  }
+
+  it should "reject malformed doc ids" in {
+    Seq(null, "", " ").foreach { i =>
+      an[IllegalArgumentException] should be thrownBy DocId(i)
+    }
+  }
+
+  behavior of "EntityPath"
+
+  it should "accept well formed paths" in {
+    val paths = Seq(
+      "/a",
+      "//a",
+      "//a//",
+      "//a//b//c",
+      "//a//b/c//",
+      "a",
+      "a/b",
+      "a/b/",
+      "a@b.c",
+      "a@b.c/",
+      "a@b.c/d",
+      "_a/",
+      "_ _",
+      "a/b/c")
+    val expected =
+      Seq("a", "a", "a", "a/b/c", "a/b/c", "a", "a/b", "a/b", "a@b.c", "a@b.c", "a@b.c/d", "_a", "_ _", "a/b/c")
+    val spaces = paths.zip(expected).foreach { p =>
+      EntityPath(p._1).namespace shouldBe p._2
+    }
+
+    EntityPath.DEFAULT.addPath(EntityName("a")).toString shouldBe "_/a"
+
+    EntityPath.DEFAULT.addPath(EntityPath("a")).toString shouldBe "_/a"
+    EntityPath.DEFAULT.addPath(EntityPath("a/b")).toString shouldBe "_/a/b"
+
+    EntityPath.DEFAULT.resolveNamespace(EntityName("a")) shouldBe EntityPath("a")
+    EntityPath("a").resolveNamespace(EntityName("b")) shouldBe EntityPath("a")
+
+    EntityPath("a").defaultPackage shouldBe true
+    EntityPath("a/b").defaultPackage shouldBe false
+
+    EntityPath("a").root shouldBe EntityName("a")
+    EntityPath("a").last shouldBe EntityName("a")
+    EntityPath("a/b").root shouldBe EntityName("a")
+    EntityPath("a/b").last shouldBe EntityName("b")
+
+    EntityPath("a").relativePath shouldBe empty
+    EntityPath("a/b").relativePath shouldBe Some(EntityPath("b"))
+    EntityPath("a/b/c").relativePath shouldBe Some(EntityPath("b/c"))
+
+    EntityPath("a/b").toFullyQualifiedEntityName shouldBe FullyQualifiedEntityName(EntityPath("a"), EntityName("b"))
+  }
+
+  it should "reject malformed paths" in {
+    val paths = Seq(
+      null,
+      "",
+      " ",
+      "a/ ",
+      "a/b/c ",
+      " xxx",
+      "xxx ",
+      " xxx",
+      "xxx/ ",
+      "/",
+      " /",
+      "/ ",
+      "//",
+      "///",
+      " / / / ",
+      "a/b/ c",
+      "a/ /b",
+      " a/ b")
+    paths.foreach { p =>
+      an[IllegalArgumentException] should be thrownBy EntityPath(p)
+    }
+
+    an[IllegalArgumentException] should be thrownBy EntityPath("a").toFullyQualifiedEntityName
+  }
+
+  behavior of "EntityName"
+
+  it should "accept well formed names" in {
+    val paths = Seq(
+      "a",
+      "a b",
+      "a@b.c",
+      "_a",
+      "_",
+      "_ _",
+      "a0",
+      "a 0",
+      "a.0",
+      "a@@",
+      "0",
+      "0.0",
+      "0.0.0",
+      "0a",
+      "0.a",
+      "a" * EntityName.ENTITY_NAME_MAX_LENGTH)
+    paths.foreach { n =>
+      assert(EntityName(n).toString == n)
+    }
+  }
+
+  it should "reject malformed names" in {
+    val paths = Seq(
+      null,
+      "",
+      " ",
+      " xxx",
+      "xxx ",
+      "/",
+      " /",
+      "/ ",
+      "0 ",
+      "_ ",
+      "a  ",
+      "a \t",
+      "a\n",
+      "a" * (EntityName.ENTITY_NAME_MAX_LENGTH + 1))
+    paths.foreach { p =>
+      an[IllegalArgumentException] should be thrownBy EntityName(p)
+    }
+  }
+
+  behavior of "FullyQualifiedEntityName"
+
+  it should "work with paths" in {
+    FullyQualifiedEntityName(EntityPath("a"), EntityName("b")).add(EntityName("c")) shouldBe
+      FullyQualifiedEntityName(EntityPath("a/b"), EntityName("c"))
+
+    FullyQualifiedEntityName(EntityPath("a"), EntityName("b")).fullPath shouldBe EntityPath("a/b")
+  }
+
+  it should "deserialize a fully qualified name without a version" in {
+    val names = Seq(
+      JsObject("path" -> "a".toJson, "name" -> "b".toJson),
+      JsObject("path" -> "a".toJson, "name" -> "b".toJson, "version" -> "0.0.1".toJson),
+      JsString("a/b"),
+      JsString("n/a/b"),
+      JsString("/a/b"),
+      JsString("/n/a/b"),
+      JsString("b")) //JsObject("namespace" -> "a".toJson, "name" -> "b".toJson))
+
+    FullyQualifiedEntityName.serdes.read(names(0)) shouldBe FullyQualifiedEntityName(EntityPath("a"), EntityName("b"))
+    FullyQualifiedEntityName.serdes.read(names(1)) shouldBe FullyQualifiedEntityName(
+      EntityPath("a"),
+      EntityName("b"),
+      Some(SemVer()))
+    FullyQualifiedEntityName.serdes.read(names(2)) shouldBe FullyQualifiedEntityName(EntityPath("a"), EntityName("b"))
+    FullyQualifiedEntityName.serdes.read(names(3)) shouldBe FullyQualifiedEntityName(EntityPath("n/a"), EntityName("b"))
+    FullyQualifiedEntityName.serdes.read(names(4)) shouldBe FullyQualifiedEntityName(EntityPath("a"), EntityName("b"))
+    FullyQualifiedEntityName.serdes.read(names(5)) shouldBe FullyQualifiedEntityName(EntityPath("n/a"), EntityName("b"))
+    a[DeserializationException] should be thrownBy FullyQualifiedEntityName.serdes.read(names(6))
+
+    a[DeserializationException] should be thrownBy FullyQualifiedEntityName.serdesAsDocId.read(names(0))
+    a[DeserializationException] should be thrownBy FullyQualifiedEntityName.serdesAsDocId.read(names(1))
+    FullyQualifiedEntityName.serdesAsDocId.read(names(2)) shouldBe FullyQualifiedEntityName(
+      EntityPath("a"),
+      EntityName("b"))
+    FullyQualifiedEntityName.serdesAsDocId.read(names(3)) shouldBe FullyQualifiedEntityName(
+      EntityPath("n/a"),
+      EntityName("b"))
+    FullyQualifiedEntityName.serdesAsDocId.read(names(4)) shouldBe FullyQualifiedEntityName(
+      EntityPath("a"),
+      EntityName("b"))
+    FullyQualifiedEntityName.serdesAsDocId.read(names(5)) shouldBe FullyQualifiedEntityName(
+      EntityPath("n/a"),
+      EntityName("b"))
+    a[DeserializationException] should be thrownBy FullyQualifiedEntityName.serdesAsDocId.read(names(6))
+  }
+
+  behavior of "Binding"
+
+  it should "desiarilize legacy format" in {
+    val names =
+      Seq(JsObject("namespace" -> "a".toJson, "name" -> "b".toJson), JsObject(), JsObject("name" -> "b".toJson), JsNull)
+
+    Binding.optionalBindingDeserializer.read(names(0)) shouldBe Some(Binding(EntityName("a"), EntityName("b")))
+    Binding.optionalBindingDeserializer.read(names(1)) shouldBe None
+    a[DeserializationException] should be thrownBy Binding.optionalBindingDeserializer.read(names(2))
+    a[DeserializationException] should be thrownBy Binding.optionalBindingDeserializer.read(names(3))
+  }
+
+  it should "serialize optional binding to empty object" in {
+    Binding.optionalBindingSerializer.write(None) shouldBe JsObject()
+  }
+
+  behavior of "WhiskPackagePut"
+
+  it should "deserialize empty request" in {
+    WhiskPackagePut.serdes.read(JsObject()) shouldBe WhiskPackagePut()
+    //WhiskPackagePut.serdes.read(JsObject("binding" -> JsNull)) shouldBe WhiskPackagePut()
+    WhiskPackagePut.serdes.read(JsObject("binding" -> JsObject())) shouldBe WhiskPackagePut()
+    //WhiskPackagePut.serdes.read(JsObject("binding" -> "a/b".toJson)) shouldBe WhiskPackagePut(binding = Some(Binding(EntityPath("a"), EntityName("b"))))
+    a[DeserializationException] should be thrownBy WhiskPackagePut.serdes.read(JsObject("binding" -> JsNull))
+  }
+
+  behavior of "WhiskPackage"
+
+  it should "not deserialize package without binding property" in {
+    val pkg = WhiskPackage(EntityPath("a"), EntityName("b"))
+    WhiskPackage.serdes.read(JsObject(pkg.toJson.fields + ("binding" -> JsObject()))) shouldBe pkg
+    a[DeserializationException] should be thrownBy WhiskPackage.serdes.read(JsObject(pkg.toJson.fields - "binding"))
+  }
+
+  it should "serialize package with empty binding property" in {
+    val pkg = WhiskPackage(EntityPath("a"), EntityName("b"))
+    WhiskPackage.serdes.write(pkg) shouldBe JsObject(
+      "namespace" -> "a".toJson,
+      "name" -> "b".toJson,
+      "binding" -> JsObject(),
+      "parameters" -> Parameters().toJson,
+      "version" -> SemVer().toJson,
+      "publish" -> JsBoolean(false),
+      "annotations" -> Parameters().toJson)
+  }
+
+  it should "serialize and deserialize package binding" in {
+    val pkg = WhiskPackage(EntityPath("a"), EntityName("b"), Some(Binding(EntityName("x"), EntityName("y"))))
+    val pkgAsJson = JsObject(
+      "namespace" -> "a".toJson,
+      "name" -> "b".toJson,
+      "binding" -> JsObject("namespace" -> "x".toJson, "name" -> "y".toJson),
+      "parameters" -> Parameters().toJson,
+      "version" -> SemVer().toJson,
+      "publish" -> JsBoolean(false),
+      "annotations" -> Parameters().toJson)
+    //val legacyPkgAsJson = JsObject(pkgAsJson.fields + ("binding" -> JsObject("namespace" -> "x".toJson, "name" -> "y".toJson)))
+    WhiskPackage.serdes.write(pkg) shouldBe pkgAsJson
+    WhiskPackage.serdes.read(pkgAsJson) shouldBe pkg
+    //WhiskPackage.serdes.read(legacyPkgAsJson) shouldBe pkg
+  }
+
+  behavior of "SemVer"
+
+  it should "parse semantic versions" in {
+    val semvers = Seq("0.0.1", "1", "1.2", "1.2.3.").map { SemVer(_) }
+    assert(semvers(0) == SemVer(0, 0, 1) && semvers(0).toString == "0.0.1")
+    assert(semvers(1) == SemVer(1, 0, 0) && semvers(1).toString == "1.0.0")
+    assert(semvers(2) == SemVer(1, 2, 0) && semvers(2).toString == "1.2.0")
+    assert(semvers(3) == SemVer(1, 2, 3) && semvers(3).toString == "1.2.3")
+
+  }
+
+  it should "permit leading zeros but strip them away" in {
+    val semvers = Seq("0.0.01", "01", "01.02", "01.02.003.").map { SemVer(_) }
+    assert(semvers(0) == SemVer(0, 0, 1))
+    assert(semvers(1) == SemVer(1, 0, 0))
+    assert(semvers(2) == SemVer(1, 2, 0))
+    assert(semvers(3) == SemVer(1, 2, 3))
+  }
+
+  it should "reject malformed semantic version" in {
+    val semvers = Seq("0", "0.0.0", "00.00.00", ".1", "-1", "0.-1.0", "0.0.-1", "xyz", "", null)
+    semvers.foreach { v =>
+      val thrown = intercept[IllegalArgumentException] {
+        SemVer(v)
+      }
+      assert(thrown.getMessage.contains("bad semantic version"))
+    }
+  }
+
+  it should "reject negative values" in {
+    an[IllegalArgumentException] should be thrownBy SemVer(-1, 0, 0)
+    an[IllegalArgumentException] should be thrownBy SemVer(0, -1, 0)
+    an[IllegalArgumentException] should be thrownBy SemVer(0, 0, -1)
+    an[IllegalArgumentException] should be thrownBy SemVer(0, 0, 0)
+  }
+
+  behavior of "Exec"
+
+  it should "initialize exec manifest" in {
+    val runtimes = ExecManifest.runtimesManifest
+    runtimes.resolveDefaultRuntime("nodejs:default").get.kind shouldBe "nodejs:6"
+    runtimes.resolveDefaultRuntime("swift").get.deprecated shouldBe Some(true)
+  }
+
+  it should "properly deserialize and reserialize JSON" in {
+    val b64Body = """ZnVuY3Rpb24gbWFpbihhcmdzKSB7IHJldHVybiBhcmdzOyB9Cg=="""
+
+    val json = Seq[JsObject](
+      JsObject("kind" -> "nodejs:6".toJson, "code" -> "js1".toJson, "binary" -> false.toJson),
+      JsObject("kind" -> "nodejs:6".toJson, "code" -> "js2".toJson, "binary" -> false.toJson, "foo" -> "bar".toJson),
+      JsObject("kind" -> "swift".toJson, "code" -> "swift1".toJson, "binary" -> false.toJson),
+      JsObject("kind" -> "swift:3".toJson, "code" -> b64Body.toJson, "binary" -> true.toJson),
+      JsObject("kind" -> "nodejs:6".toJson, "code" -> b64Body.toJson, "binary" -> true.toJson))
+
+    val execs = json.map { e =>
+      Exec.serdes.read(e)
+    }
+
+    assert(execs(0) == jsDefault("js1") && json(0).compactPrint == jsDefault("js1").toString)
+    assert(execs(1) == jsDefault("js2") && json(1).compactPrint != jsDefault("js2").toString) // ignores unknown properties
+    assert(execs(2) == swift("swift1") && json(2).compactPrint == swift("swift1").toString)
+    assert(execs(3) == swift3(b64Body) && json(3).compactPrint == swift3(b64Body).toString)
+    assert(execs(4) == jsDefault(b64Body) && json(4).compactPrint == jsDefault(b64Body).toString)
+  }
+
+  it should "properly deserialize and reserialize JSON blackbox" in {
+    val b64 = Base64.getEncoder()
+    val contents = b64.encodeToString("tarball".getBytes)
+    val json = Seq[JsObject](
+      JsObject("kind" -> "blackbox".toJson, "image" -> "container1".toJson, "binary" -> false.toJson),
+      JsObject(
+        "kind" -> "blackbox".toJson,
+        "image" -> "container1".toJson,
+        "binary" -> true.toJson,
+        "code" -> contents.toJson),
+      JsObject(
+        "kind" -> "blackbox".toJson,
+        "image" -> "container1".toJson,
+        "binary" -> true.toJson,
+        "code" -> contents.toJson,
+        "main" -> "naim".toJson))
+
+    val execs = json.map { e =>
+      Exec.serdes.read(e)
+    }
+
+    execs(0) shouldBe bb("container1")
+    execs(1) shouldBe bb("container1", contents)
+    execs(2) shouldBe bb("container1", contents, Some("naim"))
+
+    json(0).compactPrint shouldBe bb("container1").toString
+    json(1).compactPrint shouldBe bb("container1", contents).toString
+    json(2).compactPrint shouldBe bb("container1", contents, Some("naim")).toString
+
+    execs(0) shouldBe Exec.serdes.read(
+      JsObject(
+        "kind" -> "blackbox".toJson,
+        "image" -> "container1".toJson,
+        "binary" -> false.toJson,
+        "code" -> " ".toJson))
+    execs(0) shouldBe Exec.serdes.read(
+      JsObject(
+        "kind" -> "blackbox".toJson,
+        "image" -> "container1".toJson,
+        "binary" -> false.toJson,
+        "code" -> "".toJson))
+  }
+
+  it should "exclude undefined code in whisk action initializer" in {
+    ExecutableWhiskAction(EntityPath("a"), EntityName("b"), bb("container1")).containerInitializer shouldBe {
+      JsObject("name" -> "b".toJson, "binary" -> false.toJson, "main" -> "main".toJson)
+    }
+    ExecutableWhiskAction(EntityPath("a"), EntityName("b"), bb("container1", "xyz")).containerInitializer shouldBe {
+      JsObject("name" -> "b".toJson, "binary" -> false.toJson, "main" -> "main".toJson, "code" -> "xyz".toJson)
+    }
+    ExecutableWhiskAction(EntityPath("a"), EntityName("b"), bb("container1", "", Some("naim"))).containerInitializer shouldBe {
+      JsObject("name" -> "b".toJson, "binary" -> false.toJson, "main" -> "naim".toJson)
+    }
+  }
+
+  it should "reject malformed JSON" in {
+    val b64 = Base64.getEncoder()
+    val contents = b64.encodeToString("tarball".getBytes)
+
+    val execs = Seq[JsValue](
+      null,
+      JsObject(),
+      JsNull,
+      JsObject("init" -> "zipfile".toJson),
+      JsObject("kind" -> "nodejs:6".toJson, "code" -> JsNumber(42)),
+      JsObject("kind" -> "nodejs:6".toJson, "init" -> "zipfile".toJson),
+      JsObject("kind" -> "turbopascal".toJson, "code" -> "BEGIN1".toJson),
+      JsObject("kind" -> "blackbox".toJson, "code" -> "js".toJson),
+      JsObject("kind" -> "swift".toJson, "swiftcode" -> "swift".toJson))
+
+    execs.foreach { e =>
+      withClue(if (e != null) e else "null") {
+        val thrown = intercept[Throwable] {
+          Exec.serdes.read(e)
         }
-    }
-
-    it should "reject malformed ids" in {
-        Seq(null, "", " ", ":", " : ", " :", ": ", "a:b").foreach {
-            i => an[IllegalArgumentException] should be thrownBy AuthKey(i)
+        thrown match {
+          case _: DeserializationException =>
+          case _: IllegalArgumentException =>
+          case t                           => assert(false, "Unexpected exception:" + t)
         }
+      }
     }
+  }
 
-    behavior of "Privilege"
+  it should "reject null code/image arguments" in {
+    an[IllegalArgumentException] should be thrownBy Exec.serdes.read(null)
+    a[DeserializationException] should be thrownBy Exec.serdes.read("{}" parseJson)
+    a[DeserializationException] should be thrownBy Exec.serdes.read(JsString(""))
+  }
 
-    it should "serdes a right" in {
-        Privilege.serdes.read("READ".toJson) shouldBe Privilege.READ
-        Privilege.serdes.read("read".toJson) shouldBe Privilege.READ
-        a[DeserializationException] should be thrownBy Privilege.serdes.read("???".toJson)
+  it should "serialize to json" in {
+    val execs = Seq(bb("container"), jsDefault("js"), jsDefault("js"), swift("swift")).map { _.toString }
+    assert(
+      execs(0) == JsObject("kind" -> "blackbox".toJson, "image" -> "container".toJson, "binary" -> false.toJson).compactPrint)
+    assert(
+      execs(1) == JsObject("kind" -> "nodejs:6".toJson, "code" -> "js".toJson, "binary" -> false.toJson).compactPrint)
+    assert(
+      execs(2) == JsObject("kind" -> "nodejs:6".toJson, "code" -> "js".toJson, "binary" -> false.toJson).compactPrint)
+    assert(
+      execs(3) == JsObject("kind" -> "swift".toJson, "code" -> "swift".toJson, "binary" -> false.toJson).compactPrint)
+  }
+
+  behavior of "Parameter"
+  it should "properly deserialize and reserialize JSON" in {
+    val json = Seq[JsValue](
+      JsArray(JsObject("key" -> "k".toJson, "value" -> "v".toJson)),
+      JsArray(JsObject("key" -> "k".toJson, "value" -> "v".toJson, "foo" -> "bar".toJson)),
+      JsArray(JsObject("key" -> "k".toJson, "value" -> 3.toJson)),
+      JsArray(JsObject("key" -> "k".toJson, "value" -> Vector(false, true).toJson)))
+    val params = json.map { p =>
+      Parameters.serdes.read(p)
     }
+    assert(params(0) == Parameters("k", "v"))
+    assert(params(1) == Parameters("k", "v"))
+    assert(params(0).toString == json(0).compactPrint)
+    assert(params(1).toString == json(0).compactPrint) // drops unknown prop "foo"
+    assert(params(1).toString != json(1).compactPrint) // drops unknown prop "foo"
+    assert(params(2).toString == json(2).compactPrint) // drops unknown prop "foo"
+    assert(params(3).toString == json(3).compactPrint) // drops unknown prop "foo"
+  }
 
-    behavior of "Identity"
+  it should "filter immutable parameters" in {
+    val params = Parameters("k", "v") ++ Parameters("ns", null: String) ++ Parameters("njs", JsNull)
+    params.definedParameters shouldBe Set("k")
+  }
 
-    it should "serdes an identity" in {
-        val i = WhiskAuthHelpers.newIdentity()
-        val expected = JsObject(
-            "subject" -> i.subject.asString.toJson,
-            "namespace" -> i.namespace.toJson,
-            "authkey" -> i.authkey.compact.toJson,
-            "rights" -> Array("READ", "PUT", "DELETE", "ACTIVATE").toJson,
-            "limits" -> JsObject())
-        Identity.serdes.write(i) shouldBe expected
-        Identity.serdes.read(expected) shouldBe i
+  it should "reject malformed JSON" in {
+    val params = Seq[JsValue](
+      null,
+      JsObject(),
+      JsObject("key" -> "k".toJson),
+      JsObject("value" -> "v".toJson),
+      JsObject("key" -> JsNull, "value" -> "v".toJson),
+      JsObject("key" -> "k".toJson, ("value" -> JsNull)),
+      JsObject("key" -> JsNull, "value" -> JsNull),
+      JsObject("KEY" -> "k".toJson, "VALUE" -> "v".toJson),
+      JsObject("key" -> "k".toJson, "value" -> 0.toJson))
+
+    params.foreach { p =>
+      a[DeserializationException] should be thrownBy Parameters.serdes.read(p)
     }
+  }
 
-    behavior of "DocInfo"
+  it should "reject undefined key" in {
+    a[DeserializationException] should be thrownBy Parameters.serdes.read(null: JsValue)
+    an[IllegalArgumentException] should be thrownBy Parameters(null, null: String)
+    an[IllegalArgumentException] should be thrownBy Parameters("", null: JsValue)
+    an[IllegalArgumentException] should be thrownBy Parameters(" ", null: String)
+    an[IllegalArgumentException] should be thrownBy Parameters(null, "")
+    an[IllegalArgumentException] should be thrownBy Parameters(null, " ")
+    an[IllegalArgumentException] should be thrownBy Parameters(null)
 
-    it should "accept well formed doc info" in {
-        Seq("a", " a", "a ").foreach { i =>
-            val d = DocInfo(i)
-            assert(d.id.asString == i.trim)
+  }
+
+  it should "serialize to json" in {
+    assert(
+      Parameters("k", null: String).toString == JsArray(JsObject("key" -> "k".toJson, "value" -> JsNull)).compactPrint)
+    assert(Parameters("k", "").toString == JsArray(JsObject("key" -> "k".toJson, "value" -> "".toJson)).compactPrint)
+    assert(Parameters("k", " ").toString == JsArray(JsObject("key" -> "k".toJson, "value" -> "".toJson)).compactPrint)
+    assert(Parameters("k", "v").toString == JsArray(JsObject("key" -> "k".toJson, "value" -> "v".toJson)).compactPrint)
+  }
+
+  behavior of "ActionLimits"
+
+  it should "properly deserialize JSON" in {
+    val json = Seq[JsValue](
+      JsObject(
+        "timeout" -> TimeLimit.STD_DURATION.toMillis.toInt.toJson,
+        "memory" -> MemoryLimit.STD_MEMORY.toMB.toInt.toJson,
+        "logs" -> LogLimit.STD_LOGSIZE.toMB.toInt.toJson),
+      JsObject(
+        "timeout" -> TimeLimit.STD_DURATION.toMillis.toInt.toJson,
+        "memory" -> MemoryLimit.STD_MEMORY.toMB.toInt.toJson,
+        "logs" -> LogLimit.STD_LOGSIZE.toMB.toInt.toJson,
+        "foo" -> "bar".toJson),
+      JsObject(
+        "timeout" -> TimeLimit.STD_DURATION.toMillis.toInt.toJson,
+        "memory" -> MemoryLimit.STD_MEMORY.toMB.toInt.toJson))
+    val limits = json.map(ActionLimits.serdes.read)
+    assert(limits(0) == ActionLimits())
+    assert(limits(1) == ActionLimits())
+    assert(limits(2) == ActionLimits())
+    assert(limits(0).toJson == json(0))
+    assert(limits(1).toJson == json(0)) // drops unknown prop "foo"
+    assert(limits(1).toJson != json(1)) // drops unknown prop "foo"
+  }
+
+  it should "reject malformed JSON" in {
+    val limits = Seq[JsValue](
+      null,
+      JsObject(),
+      JsNull,
+      JsObject("timeout" -> TimeLimit.STD_DURATION.toMillis.toInt.toJson),
+      JsObject("memory" -> MemoryLimit.STD_MEMORY.toMB.toInt.toJson),
+      JsObject("logs" -> (LogLimit.STD_LOGSIZE.toMB.toInt + 1).toJson),
+      JsObject(
+        "TIMEOUT" -> TimeLimit.STD_DURATION.toMillis.toInt.toJson,
+        "MEMORY" -> MemoryLimit.STD_MEMORY.toMB.toInt.toJson),
+      JsObject(
+        "timeout" -> (TimeLimit.STD_DURATION.toMillis.toDouble + .01).toJson,
+        "memory" -> (MemoryLimit.STD_MEMORY.toMB.toDouble + .01).toJson),
+      JsObject("timeout" -> null, "memory" -> null),
+      JsObject("timeout" -> JsNull, "memory" -> JsNull),
+      JsObject(
+        "timeout" -> TimeLimit.STD_DURATION.toMillis.toString.toJson,
+        "memory" -> MemoryLimit.STD_MEMORY.toMB.toInt.toString.toJson))
+
+    limits.foreach { p =>
+      a[DeserializationException] should be thrownBy ActionLimits.serdes.read(p)
+    }
+  }
+
+  it should "pass the correct error message through" in {
+    val serdes = Seq(TimeLimit.serdes, MemoryLimit.serdes, LogLimit.serdes)
+
+    serdes foreach { s =>
+      withClue(s"serializer $s") {
+        if (s != LogLimit.serdes) {
+          val lb = the[DeserializationException] thrownBy s.read(JsNumber(0))
+          lb.getMessage should include("below allowed threshold")
+        } else {
+          val lb = the[DeserializationException] thrownBy s.read(JsNumber(-1))
+          lb.getMessage should include("a negative size of an object is not allowed")
         }
+
+        val ub = the[DeserializationException] thrownBy s.read(JsNumber(Int.MaxValue))
+        ub.getMessage should include("exceeds allowed threshold")
+
+        val int = the[DeserializationException] thrownBy s.read(JsNumber(2.5))
+        int.getMessage should include("limit must be whole number")
+      }
     }
+  }
 
-    it should "accept any string as doc revision" in {
-        Seq("a", " a", "a ", "", null).foreach { i =>
-            val d = DocRevision(i)
-            assert(d.rev == (if (i != null) i.trim else null))
-        }
+  it should "reject bad limit values" in {
+    an[IllegalArgumentException] should be thrownBy ActionLimits(
+      TimeLimit(TimeLimit.MIN_DURATION - 1.millisecond),
+      MemoryLimit(),
+      LogLimit())
+    an[IllegalArgumentException] should be thrownBy ActionLimits(
+      TimeLimit(),
+      MemoryLimit(MemoryLimit.MIN_MEMORY - 1.B),
+      LogLimit())
+    an[IllegalArgumentException] should be thrownBy ActionLimits(
+      TimeLimit(),
+      MemoryLimit(),
+      LogLimit(LogLimit.MIN_LOGSIZE - 1.B))
 
-        DocRevision.serdes.read(JsNull) shouldBe DocRevision.empty
-        DocRevision.serdes.read(JsString("")) shouldBe DocRevision("")
-        DocRevision.serdes.read(JsString("a")) shouldBe DocRevision("a")
-        DocRevision.serdes.read(JsString(" a")) shouldBe DocRevision("a")
-        DocRevision.serdes.read(JsString("a ")) shouldBe DocRevision("a")
-        a[DeserializationException] should be thrownBy DocRevision.serdes.read(JsNumber(1))
+    an[IllegalArgumentException] should be thrownBy ActionLimits(
+      TimeLimit(TimeLimit.MAX_DURATION + 1.millisecond),
+      MemoryLimit(),
+      LogLimit())
+    an[IllegalArgumentException] should be thrownBy ActionLimits(
+      TimeLimit(),
+      MemoryLimit(MemoryLimit.MAX_MEMORY + 1.B),
+      LogLimit())
+    an[IllegalArgumentException] should be thrownBy ActionLimits(
+      TimeLimit(),
+      MemoryLimit(),
+      LogLimit(LogLimit.MAX_LOGSIZE + 1.B))
+  }
+
+  it should "parse activation id as uuid" in {
+    val id = "213174381920559471141441e1111111"
+    val aid = ActivationId.unapply(id)
+    assert(aid.isDefined)
+    assert(aid.get.toString == id)
+  }
+
+  it should "parse activation id as uuid when made up of no numbers" in {
+    val id = "a" * 32
+    val aid = ActivationId.unapply(id)
+    assert(aid.isDefined)
+    assert(aid.get.toString == id)
+  }
+
+  it should "parse activation id as uuid when made up of no letters" in {
+    val id = "1" * 32
+    val aid = ActivationId.unapply(id)
+    assert(aid.isDefined)
+    assert(aid.get.toString == id)
+  }
+
+  it should "parse an activation id as uuid when it is a number" in {
+    val id = "1" * 32
+    val aid = Try { ActivationId.serdes.read(BigInt(id).toJson) }
+    assert(aid.isSuccess)
+    assert(aid.get.toString == id)
+  }
+
+  it should "not parse invalid activation id" in {
+    val id = "213174381920559471141441e111111z"
+    assert(ActivationId.unapply(id).isEmpty)
+    Try(ActivationId.serdes.read(JsString(id))) shouldBe Failure {
+      DeserializationException(Messages.activationIdIllegal)
     }
+  }
 
-    it should "reject malformed doc info" in {
-        Seq(null, "", " ").foreach {
-            i => an[IllegalArgumentException] should be thrownBy DocInfo(i)
-        }
+  it should "not parse activation id if longer than uuid" in {
+    val id = "213174381920559471141441e1111111abc"
+    assert(ActivationId.unapply(id).isEmpty)
+    Try(ActivationId.serdes.read(JsString(id))) shouldBe Failure {
+      DeserializationException(Messages.activationIdLengthError(SizeError("Activation id", id.length.B, 32.B)))
     }
+  }
 
-    it should "reject malformed doc ids" in {
-        Seq(null, "", " ").foreach {
-            i => an[IllegalArgumentException] should be thrownBy DocId(i)
-        }
+  it should "not parse activation id if shorter than uuid" in {
+    val id = "213174381920559471141441e1"
+    ActivationId.unapply(id) shouldBe empty
+    Try(ActivationId.serdes.read(JsString(id))) shouldBe Failure {
+      DeserializationException(Messages.activationIdLengthError(SizeError("Activation id", id.length.B, 32.B)))
     }
-
-    behavior of "EntityPath"
-
-    it should "accept well formed paths" in {
-        val paths = Seq("/a", "//a", "//a//", "//a//b//c", "//a//b/c//", "a", "a/b", "a/b/", "a@b.c", "a@b.c/", "a@b.c/d", "_a/", "_ _", "a/b/c")
-        val expected = Seq("a", "a", "a", "a/b/c", "a/b/c", "a", "a/b", "a/b", "a@b.c", "a@b.c", "a@b.c/d", "_a", "_ _", "a/b/c")
-        val spaces = paths.zip(expected).foreach {
-            p => EntityPath(p._1).namespace shouldBe p._2
-        }
-
-        EntityPath.DEFAULT.addPath(EntityName("a")).toString shouldBe "_/a"
-
-        EntityPath.DEFAULT.addPath(EntityPath("a")).toString shouldBe "_/a"
-        EntityPath.DEFAULT.addPath(EntityPath("a/b")).toString shouldBe "_/a/b"
-
-        EntityPath.DEFAULT.resolveNamespace(EntityName("a")) shouldBe EntityPath("a")
-        EntityPath("a").resolveNamespace(EntityName("b")) shouldBe EntityPath("a")
-
-        EntityPath("a").defaultPackage shouldBe true
-        EntityPath("a/b").defaultPackage shouldBe false
-
-        EntityPath("a").root shouldBe EntityName("a")
-        EntityPath("a").last shouldBe EntityName("a")
-        EntityPath("a/b").root shouldBe EntityName("a")
-        EntityPath("a/b").last shouldBe EntityName("b")
-
-        EntityPath("a").relativePath shouldBe empty
-        EntityPath("a/b").relativePath shouldBe Some(EntityPath("b"))
-        EntityPath("a/b/c").relativePath shouldBe Some(EntityPath("b/c"))
-
-        EntityPath("a/b").toFullyQualifiedEntityName shouldBe FullyQualifiedEntityName(EntityPath("a"), EntityName("b"))
-    }
-
-    it should "reject malformed paths" in {
-        val paths = Seq(null, "", " ", "a/ ", "a/b/c ", " xxx", "xxx ", " xxx", "xxx/ ", "/", " /", "/ ", "//", "///", " / / / ", "a/b/ c", "a/ /b", " a/ b")
-        paths.foreach {
-            p => an[IllegalArgumentException] should be thrownBy EntityPath(p)
-        }
-
-        an[IllegalArgumentException] should be thrownBy EntityPath("a").toFullyQualifiedEntityName
-    }
-
-    behavior of "EntityName"
-
-    it should "accept well formed names" in {
-        val paths = Seq("a", "a b", "a@b.c", "_a", "_", "_ _", "a0", "a 0", "a.0", "a@@", "0", "0.0", "0.0.0", "0a", "0.a", "a" * EntityName.ENTITY_NAME_MAX_LENGTH)
-        paths.foreach { n =>
-            assert(EntityName(n).toString == n)
-        }
-    }
-
-    it should "reject malformed names" in {
-        val paths = Seq(null, "", " ", " xxx", "xxx ", "/", " /", "/ ", "0 ", "_ ", "a  ", "a \t", "a\n", "a" * (EntityName.ENTITY_NAME_MAX_LENGTH + 1))
-        paths.foreach {
-            p => an[IllegalArgumentException] should be thrownBy EntityName(p)
-        }
-    }
-
-    behavior of "FullyQualifiedEntityName"
-
-    it should "work with paths" in {
-        FullyQualifiedEntityName(EntityPath("a"), EntityName("b")).add(EntityName("c")) shouldBe
-            FullyQualifiedEntityName(EntityPath("a/b"), EntityName("c"))
-
-        FullyQualifiedEntityName(EntityPath("a"), EntityName("b")).fullPath shouldBe EntityPath("a/b")
-    }
-
-    it should "deserialize a fully qualified name without a version" in {
-        val names = Seq(
-            JsObject("path" -> "a".toJson, "name" -> "b".toJson),
-            JsObject("path" -> "a".toJson, "name" -> "b".toJson, "version" -> "0.0.1".toJson),
-            JsString("a/b"),
-            JsString("n/a/b"),
-            JsString("/a/b"),
-            JsString("/n/a/b"),
-            JsString("b")) //JsObject("namespace" -> "a".toJson, "name" -> "b".toJson))
-
-        FullyQualifiedEntityName.serdes.read(names(0)) shouldBe FullyQualifiedEntityName(EntityPath("a"), EntityName("b"))
-        FullyQualifiedEntityName.serdes.read(names(1)) shouldBe FullyQualifiedEntityName(EntityPath("a"), EntityName("b"), Some(SemVer()))
-        FullyQualifiedEntityName.serdes.read(names(2)) shouldBe FullyQualifiedEntityName(EntityPath("a"), EntityName("b"))
-        FullyQualifiedEntityName.serdes.read(names(3)) shouldBe FullyQualifiedEntityName(EntityPath("n/a"), EntityName("b"))
-        FullyQualifiedEntityName.serdes.read(names(4)) shouldBe FullyQualifiedEntityName(EntityPath("a"), EntityName("b"))
-        FullyQualifiedEntityName.serdes.read(names(5)) shouldBe FullyQualifiedEntityName(EntityPath("n/a"), EntityName("b"))
-        a[DeserializationException] should be thrownBy FullyQualifiedEntityName.serdes.read(names(6))
-
-        a[DeserializationException] should be thrownBy FullyQualifiedEntityName.serdesAsDocId.read(names(0))
-        a[DeserializationException] should be thrownBy FullyQualifiedEntityName.serdesAsDocId.read(names(1))
-        FullyQualifiedEntityName.serdesAsDocId.read(names(2)) shouldBe FullyQualifiedEntityName(EntityPath("a"), EntityName("b"))
-        FullyQualifiedEntityName.serdesAsDocId.read(names(3)) shouldBe FullyQualifiedEntityName(EntityPath("n/a"), EntityName("b"))
-        FullyQualifiedEntityName.serdesAsDocId.read(names(4)) shouldBe FullyQualifiedEntityName(EntityPath("a"), EntityName("b"))
-        FullyQualifiedEntityName.serdesAsDocId.read(names(5)) shouldBe FullyQualifiedEntityName(EntityPath("n/a"), EntityName("b"))
-        a[DeserializationException] should be thrownBy FullyQualifiedEntityName.serdesAsDocId.read(names(6))
-    }
-
-    behavior of "Binding"
-
-    it should "desiarilize legacy format" in {
-        val names = Seq(
-            JsObject("namespace" -> "a".toJson, "name" -> "b".toJson),
-            JsObject(),
-            JsObject("name" -> "b".toJson),
-            JsNull)
-
-        Binding.optionalBindingDeserializer.read(names(0)) shouldBe Some(Binding(EntityName("a"), EntityName("b")))
-        Binding.optionalBindingDeserializer.read(names(1)) shouldBe None
-        a[DeserializationException] should be thrownBy Binding.optionalBindingDeserializer.read(names(2))
-        a[DeserializationException] should be thrownBy Binding.optionalBindingDeserializer.read(names(3))
-    }
-
-    it should "serialize optional binding to empty object" in {
-        Binding.optionalBindingSerializer.write(None) shouldBe JsObject()
-    }
-
-    behavior of "WhiskPackagePut"
-
-    it should "deserialize empty request" in {
-        WhiskPackagePut.serdes.read(JsObject()) shouldBe WhiskPackagePut()
-        //WhiskPackagePut.serdes.read(JsObject("binding" -> JsNull)) shouldBe WhiskPackagePut()
-        WhiskPackagePut.serdes.read(JsObject("binding" -> JsObject())) shouldBe WhiskPackagePut()
-        //WhiskPackagePut.serdes.read(JsObject("binding" -> "a/b".toJson)) shouldBe WhiskPackagePut(binding = Some(Binding(EntityPath("a"), EntityName("b"))))
-        a[DeserializationException] should be thrownBy WhiskPackagePut.serdes.read(JsObject("binding" -> JsNull))
-    }
-
-    behavior of "WhiskPackage"
-
-    it should "not deserialize package without binding property" in {
-        val pkg = WhiskPackage(EntityPath("a"), EntityName("b"))
-        WhiskPackage.serdes.read(JsObject(pkg.toJson.fields + ("binding" -> JsObject()))) shouldBe pkg
-        a[DeserializationException] should be thrownBy WhiskPackage.serdes.read(JsObject(pkg.toJson.fields - "binding"))
-    }
-
-    it should "serialize package with empty binding property" in {
-        val pkg = WhiskPackage(EntityPath("a"), EntityName("b"))
-        WhiskPackage.serdes.write(pkg) shouldBe JsObject(
-            "namespace" -> "a".toJson,
-            "name" -> "b".toJson,
-            "binding" -> JsObject(),
-            "parameters" -> Parameters().toJson,
-            "version" -> SemVer().toJson,
-            "publish" -> JsBoolean(false),
-            "annotations" -> Parameters().toJson)
-    }
-
-    it should "serialize and deserialize package binding" in {
-        val pkg = WhiskPackage(EntityPath("a"), EntityName("b"), Some(Binding(EntityName("x"), EntityName("y"))))
-        val pkgAsJson = JsObject(
-            "namespace" -> "a".toJson,
-            "name" -> "b".toJson,
-            "binding" -> JsObject("namespace" -> "x".toJson, "name" -> "y".toJson),
-            "parameters" -> Parameters().toJson,
-            "version" -> SemVer().toJson,
-            "publish" -> JsBoolean(false),
-            "annotations" -> Parameters().toJson)
-        //val legacyPkgAsJson = JsObject(pkgAsJson.fields + ("binding" -> JsObject("namespace" -> "x".toJson, "name" -> "y".toJson)))
-        WhiskPackage.serdes.write(pkg) shouldBe pkgAsJson
-        WhiskPackage.serdes.read(pkgAsJson) shouldBe pkg
-        //WhiskPackage.serdes.read(legacyPkgAsJson) shouldBe pkg
-    }
-
-    behavior of "SemVer"
-
-    it should "parse semantic versions" in {
-        val semvers = Seq("0.0.1", "1", "1.2", "1.2.3.").map { SemVer(_) }
-        assert(semvers(0) == SemVer(0, 0, 1) && semvers(0).toString == "0.0.1")
-        assert(semvers(1) == SemVer(1, 0, 0) && semvers(1).toString == "1.0.0")
-        assert(semvers(2) == SemVer(1, 2, 0) && semvers(2).toString == "1.2.0")
-        assert(semvers(3) == SemVer(1, 2, 3) && semvers(3).toString == "1.2.3")
-
-    }
-
-    it should "permit leading zeros but strip them away" in {
-        val semvers = Seq("0.0.01", "01", "01.02", "01.02.003.").map { SemVer(_) }
-        assert(semvers(0) == SemVer(0, 0, 1))
-        assert(semvers(1) == SemVer(1, 0, 0))
-        assert(semvers(2) == SemVer(1, 2, 0))
-        assert(semvers(3) == SemVer(1, 2, 3))
-    }
-
-    it should "reject malformed semantic version" in {
-        val semvers = Seq("0", "0.0.0", "00.00.00", ".1", "-1", "0.-1.0", "0.0.-1", "xyz", "", null)
-        semvers.foreach { v =>
-            val thrown = intercept[IllegalArgumentException] {
-                SemVer(v)
-            }
-            assert(thrown.getMessage.contains("bad semantic version"))
-        }
-    }
-
-    it should "reject negative values" in {
-        an[IllegalArgumentException] should be thrownBy SemVer(-1, 0, 0)
-        an[IllegalArgumentException] should be thrownBy SemVer(0, -1, 0)
-        an[IllegalArgumentException] should be thrownBy SemVer(0, 0, -1)
-        an[IllegalArgumentException] should be thrownBy SemVer(0, 0, 0)
-    }
-
-    behavior of "Exec"
-
-    it should "initialize exec manifest" in {
-        val runtimes = ExecManifest.runtimesManifest
-        runtimes.resolveDefaultRuntime("nodejs:default").get.kind shouldBe "nodejs:6"
-        runtimes.resolveDefaultRuntime("swift").get.deprecated shouldBe Some(true)
-    }
-
-    it should "properly deserialize and reserialize JSON" in {
-        val b64Body = """ZnVuY3Rpb24gbWFpbihhcmdzKSB7IHJldHVybiBhcmdzOyB9Cg=="""
-
-        val json = Seq[JsObject](
-            JsObject("kind" -> "nodejs:6".toJson, "code" -> "js1".toJson, "binary" -> false.toJson),
-            JsObject("kind" -> "nodejs:6".toJson, "code" -> "js2".toJson, "binary" -> false.toJson, "foo" -> "bar".toJson),
-            JsObject("kind" -> "swift".toJson, "code" -> "swift1".toJson, "binary" -> false.toJson),
-            JsObject("kind" -> "swift:3".toJson, "code" -> b64Body.toJson, "binary" -> true.toJson),
-            JsObject("kind" -> "nodejs:6".toJson, "code" -> b64Body.toJson, "binary" -> true.toJson))
-
-        val execs = json.map { e => Exec.serdes.read(e) }
-
-        assert(execs(0) == jsDefault("js1") && json(0).compactPrint == jsDefault("js1").toString)
-        assert(execs(1) == jsDefault("js2") && json(1).compactPrint != jsDefault("js2").toString) // ignores unknown properties
-        assert(execs(2) == swift("swift1") && json(2).compactPrint == swift("swift1").toString)
-        assert(execs(3) == swift3(b64Body) && json(3).compactPrint == swift3(b64Body).toString)
-        assert(execs(4) == jsDefault(b64Body) && json(4).compactPrint == jsDefault(b64Body).toString)
-    }
-
-    it should "properly deserialize and reserialize JSON blackbox" in {
-        val b64 = Base64.getEncoder()
-        val contents = b64.encodeToString("tarball".getBytes)
-        val json = Seq[JsObject](
-            JsObject("kind" -> "blackbox".toJson, "image" -> "container1".toJson, "binary" -> false.toJson),
-            JsObject("kind" -> "blackbox".toJson, "image" -> "container1".toJson, "binary" -> true.toJson, "code" -> contents.toJson),
-            JsObject("kind" -> "blackbox".toJson, "image" -> "container1".toJson, "binary" -> true.toJson, "code" -> contents.toJson, "main" -> "naim".toJson))
-
-        val execs = json.map { e => Exec.serdes.read(e) }
-
-        execs(0) shouldBe bb("container1")
-        execs(1) shouldBe bb("container1", contents)
-        execs(2) shouldBe bb("container1", contents, Some("naim"))
-
-        json(0).compactPrint shouldBe bb("container1").toString
-        json(1).compactPrint shouldBe bb("container1", contents).toString
-        json(2).compactPrint shouldBe bb("container1", contents, Some("naim")).toString
-
-        execs(0) shouldBe Exec.serdes.read(JsObject("kind" -> "blackbox".toJson, "image" -> "container1".toJson, "binary" -> false.toJson, "code" -> " ".toJson))
-        execs(0) shouldBe Exec.serdes.read(JsObject("kind" -> "blackbox".toJson, "image" -> "container1".toJson, "binary" -> false.toJson, "code" -> "".toJson))
-    }
-
-    it should "exclude undefined code in whisk action initializer" in {
-        ExecutableWhiskAction(EntityPath("a"), EntityName("b"), bb("container1")).containerInitializer shouldBe {
-            JsObject("name" -> "b".toJson, "binary" -> false.toJson, "main" -> "main".toJson)
-        }
-        ExecutableWhiskAction(EntityPath("a"), EntityName("b"), bb("container1", "xyz")).containerInitializer shouldBe {
-            JsObject("name" -> "b".toJson, "binary" -> false.toJson, "main" -> "main".toJson, "code" -> "xyz".toJson)
-        }
-        ExecutableWhiskAction(EntityPath("a"), EntityName("b"), bb("container1", "", Some("naim"))).containerInitializer shouldBe {
-            JsObject("name" -> "b".toJson, "binary" -> false.toJson, "main" -> "naim".toJson)
-        }
-    }
-
-    it should "reject malformed JSON" in {
-        val b64 = Base64.getEncoder()
-        val contents = b64.encodeToString("tarball".getBytes)
-
-        val execs = Seq[JsValue](
-            null,
-            JsObject(),
-            JsNull,
-            JsObject("init" -> "zipfile".toJson),
-            JsObject("kind" -> "nodejs:6".toJson, "code" -> JsNumber(42)),
-            JsObject("kind" -> "nodejs:6".toJson, "init" -> "zipfile".toJson),
-            JsObject("kind" -> "turbopascal".toJson, "code" -> "BEGIN1".toJson),
-            JsObject("kind" -> "blackbox".toJson, "code" -> "js".toJson),
-            JsObject("kind" -> "swift".toJson, "swiftcode" -> "swift".toJson))
-
-        execs.foreach { e =>
-            withClue(if (e != null) e else "null") {
-                val thrown = intercept[Throwable] {
-                    Exec.serdes.read(e)
-                }
-                thrown match {
-                    case _: DeserializationException =>
-                    case _: IllegalArgumentException =>
-                    case t                           => assert(false, "Unexpected exception:" + t)
-                }
-            }
-        }
-    }
-
-    it should "reject null code/image arguments" in {
-        an[IllegalArgumentException] should be thrownBy Exec.serdes.read(null)
-        a[DeserializationException] should be thrownBy Exec.serdes.read("{}" parseJson)
-        a[DeserializationException] should be thrownBy Exec.serdes.read(JsString(""))
-    }
-
-    it should "serialize to json" in {
-        val execs = Seq(bb("container"), jsDefault("js"), jsDefault("js"), swift("swift")).map { _.toString }
-        assert(execs(0) == JsObject("kind" -> "blackbox".toJson, "image" -> "container".toJson, "binary" -> false.toJson).compactPrint)
-        assert(execs(1) == JsObject("kind" -> "nodejs:6".toJson, "code" -> "js".toJson, "binary" -> false.toJson).compactPrint)
-        assert(execs(2) == JsObject("kind" -> "nodejs:6".toJson, "code" -> "js".toJson, "binary" -> false.toJson).compactPrint)
-        assert(execs(3) == JsObject("kind" -> "swift".toJson, "code" -> "swift".toJson, "binary" -> false.toJson).compactPrint)
-    }
-
-    behavior of "Parameter"
-    it should "properly deserialize and reserialize JSON" in {
-        val json = Seq[JsValue](
-            JsArray(JsObject("key" -> "k".toJson, "value" -> "v".toJson)),
-            JsArray(JsObject("key" -> "k".toJson, "value" -> "v".toJson, "foo" -> "bar".toJson)),
-            JsArray(JsObject("key" -> "k".toJson, "value" -> 3.toJson)),
-            JsArray(JsObject("key" -> "k".toJson, "value" -> Vector(false, true).toJson)))
-        val params = json.map { p => Parameters.serdes.read(p) }
-        assert(params(0) == Parameters("k", "v"))
-        assert(params(1) == Parameters("k", "v"))
-        assert(params(0).toString == json(0).compactPrint)
-        assert(params(1).toString == json(0).compactPrint) // drops unknown prop "foo"
-        assert(params(1).toString != json(1).compactPrint) // drops unknown prop "foo"
-        assert(params(2).toString == json(2).compactPrint) // drops unknown prop "foo"
-        assert(params(3).toString == json(3).compactPrint) // drops unknown prop "foo"
-    }
-
-    it should "filter immutable parameters" in {
-        val params = Parameters("k", "v") ++ Parameters("ns", null: String) ++ Parameters("njs", JsNull)
-        params.definedParameters shouldBe Set("k")
-    }
-
-    it should "reject malformed JSON" in {
-        val params = Seq[JsValue](
-            null,
-            JsObject(),
-            JsObject("key" -> "k".toJson),
-            JsObject("value" -> "v".toJson),
-            JsObject("key" -> JsNull, "value" -> "v".toJson),
-            JsObject("key" -> "k".toJson, ("value" -> JsNull)),
-            JsObject("key" -> JsNull, "value" -> JsNull),
-            JsObject("KEY" -> "k".toJson, "VALUE" -> "v".toJson),
-            JsObject("key" -> "k".toJson, "value" -> 0.toJson))
-
-        params.foreach {
-            p => a[DeserializationException] should be thrownBy Parameters.serdes.read(p)
-        }
-    }
-
-    it should "reject undefined key" in {
-        a[DeserializationException] should be thrownBy Parameters.serdes.read(null: JsValue)
-        an[IllegalArgumentException] should be thrownBy Parameters(null, null: String)
-        an[IllegalArgumentException] should be thrownBy Parameters("", null: JsValue)
-        an[IllegalArgumentException] should be thrownBy Parameters(" ", null: String)
-        an[IllegalArgumentException] should be thrownBy Parameters(null, "")
-        an[IllegalArgumentException] should be thrownBy Parameters(null, " ")
-        an[IllegalArgumentException] should be thrownBy Parameters(null)
-
-    }
-
-    it should "serialize to json" in {
-        assert(Parameters("k", null: String).toString == JsArray(JsObject("key" -> "k".toJson, "value" -> JsNull)).compactPrint)
-        assert(Parameters("k", "").toString == JsArray(JsObject("key" -> "k".toJson, "value" -> "".toJson)).compactPrint)
-        assert(Parameters("k", " ").toString == JsArray(JsObject("key" -> "k".toJson, "value" -> "".toJson)).compactPrint)
-        assert(Parameters("k", "v").toString == JsArray(JsObject("key" -> "k".toJson, "value" -> "v".toJson)).compactPrint)
-    }
-
-    behavior of "ActionLimits"
-
-    it should "properly deserialize JSON" in {
-        val json = Seq[JsValue](
-            JsObject("timeout" -> TimeLimit.STD_DURATION.toMillis.toInt.toJson, "memory" -> MemoryLimit.STD_MEMORY.toMB.toInt.toJson, "logs" -> LogLimit.STD_LOGSIZE.toMB.toInt.toJson),
-            JsObject("timeout" -> TimeLimit.STD_DURATION.toMillis.toInt.toJson, "memory" -> MemoryLimit.STD_MEMORY.toMB.toInt.toJson, "logs" -> LogLimit.STD_LOGSIZE.toMB.toInt.toJson, "foo" -> "bar".toJson),
-            JsObject("timeout" -> TimeLimit.STD_DURATION.toMillis.toInt.toJson, "memory" -> MemoryLimit.STD_MEMORY.toMB.toInt.toJson))
-        val limits = json.map(ActionLimits.serdes.read)
-        assert(limits(0) == ActionLimits())
-        assert(limits(1) == ActionLimits())
-        assert(limits(2) == ActionLimits())
-        assert(limits(0).toJson == json(0))
-        assert(limits(1).toJson == json(0)) // drops unknown prop "foo"
-        assert(limits(1).toJson != json(1)) // drops unknown prop "foo"
-    }
-
-    it should "reject malformed JSON" in {
-        val limits = Seq[JsValue](
-            null,
-            JsObject(),
-            JsNull,
-            JsObject("timeout" -> TimeLimit.STD_DURATION.toMillis.toInt.toJson),
-            JsObject("memory" -> MemoryLimit.STD_MEMORY.toMB.toInt.toJson),
-            JsObject("logs" -> (LogLimit.STD_LOGSIZE.toMB.toInt + 1).toJson),
-            JsObject("TIMEOUT" -> TimeLimit.STD_DURATION.toMillis.toInt.toJson, "MEMORY" -> MemoryLimit.STD_MEMORY.toMB.toInt.toJson),
-            JsObject("timeout" -> (TimeLimit.STD_DURATION.toMillis.toDouble + .01).toJson, "memory" -> (MemoryLimit.STD_MEMORY.toMB.toDouble + .01).toJson),
-            JsObject("timeout" -> null, "memory" -> null),
-            JsObject("timeout" -> JsNull, "memory" -> JsNull),
-            JsObject("timeout" -> TimeLimit.STD_DURATION.toMillis.toString.toJson, "memory" -> MemoryLimit.STD_MEMORY.toMB.toInt.toString.toJson))
-
-        limits.foreach {
-            p => a[DeserializationException] should be thrownBy ActionLimits.serdes.read(p)
-        }
-    }
-
-    it should "pass the correct error message through" in {
-        val serdes = Seq(TimeLimit.serdes, MemoryLimit.serdes, LogLimit.serdes)
-
-        serdes foreach { s =>
-            withClue(s"serializer $s") {
-                if (s != LogLimit.serdes) {
-                    val lb = the[DeserializationException] thrownBy s.read(JsNumber(0))
-                    lb.getMessage should include("below allowed threshold")
-                } else {
-                    val lb = the[DeserializationException] thrownBy s.read(JsNumber(-1))
-                    lb.getMessage should include("a negative size of an object is not allowed")
-                }
-
-                val ub = the[DeserializationException] thrownBy s.read(JsNumber(Int.MaxValue))
-                ub.getMessage should include("exceeds allowed threshold")
-
-                val int = the[DeserializationException] thrownBy s.read(JsNumber(2.5))
-                int.getMessage should include("limit must be whole number")
-            }
-        }
-    }
-
-    it should "reject bad limit values" in {
-        an[IllegalArgumentException] should be thrownBy ActionLimits(TimeLimit(TimeLimit.MIN_DURATION - 1.millisecond), MemoryLimit(), LogLimit())
-        an[IllegalArgumentException] should be thrownBy ActionLimits(TimeLimit(), MemoryLimit(MemoryLimit.MIN_MEMORY - 1.B), LogLimit())
-        an[IllegalArgumentException] should be thrownBy ActionLimits(TimeLimit(), MemoryLimit(), LogLimit(LogLimit.MIN_LOGSIZE - 1.B))
-
-        an[IllegalArgumentException] should be thrownBy ActionLimits(TimeLimit(TimeLimit.MAX_DURATION + 1.millisecond), MemoryLimit(), LogLimit())
-        an[IllegalArgumentException] should be thrownBy ActionLimits(TimeLimit(), MemoryLimit(MemoryLimit.MAX_MEMORY + 1.B), LogLimit())
-        an[IllegalArgumentException] should be thrownBy ActionLimits(TimeLimit(), MemoryLimit(), LogLimit(LogLimit.MAX_LOGSIZE + 1.B))
-    }
-
-    it should "parse activation id as uuid" in {
-        val id = "213174381920559471141441e1111111"
-        val aid = ActivationId.unapply(id)
-        assert(aid.isDefined)
-        assert(aid.get.toString == id)
-    }
-
-    it should "parse activation id as uuid when made up of no numbers" in {
-        val id = "a" * 32
-        val aid = ActivationId.unapply(id)
-        assert(aid.isDefined)
-        assert(aid.get.toString == id)
-    }
-
-    it should "parse activation id as uuid when made up of no letters" in {
-        val id = "1" * 32
-        val aid = ActivationId.unapply(id)
-        assert(aid.isDefined)
-        assert(aid.get.toString == id)
-    }
-
-    it should "parse an activation id as uuid when it is a number" in {
-        val id = "1" * 32
-        val aid = Try { ActivationId.serdes.read(BigInt(id).toJson) }
-        assert(aid.isSuccess)
-        assert(aid.get.toString == id)
-    }
-
-    it should "not parse invalid activation id" in {
-        val id = "213174381920559471141441e111111z"
-        assert(ActivationId.unapply(id).isEmpty)
-        Try(ActivationId.serdes.read(JsString(id))) shouldBe Failure {
-            DeserializationException(Messages.activationIdIllegal)
-        }
-    }
-
-    it should "not parse activation id if longer than uuid" in {
-        val id = "213174381920559471141441e1111111abc"
-        assert(ActivationId.unapply(id).isEmpty)
-        Try(ActivationId.serdes.read(JsString(id))) shouldBe Failure {
-            DeserializationException(Messages.activationIdLengthError(SizeError("Activation id", id.length.B, 32.B)))
-        }
-    }
-
-    it should "not parse activation id if shorter than uuid" in {
-        val id = "213174381920559471141441e1"
-        ActivationId.unapply(id) shouldBe empty
-        Try(ActivationId.serdes.read(JsString(id))) shouldBe Failure {
-            DeserializationException(Messages.activationIdLengthError(SizeError("Activation id", id.length.B, 32.B)))
-        }
-    }
-
-    behavior of "Js Helpers"
-
-    it should "project paths from json object" in {
-        val js = JsObject("a" -> JsObject("b" -> JsObject("c" -> JsString("v"))), "b" -> JsString("v"))
-        JsHelpers.fieldPathExists(js) shouldBe true
-        JsHelpers.fieldPathExists(js, "a") shouldBe true
-        JsHelpers.fieldPathExists(js, "a", "b") shouldBe true
-        JsHelpers.fieldPathExists(js, "a", "b", "c") shouldBe true
-        JsHelpers.fieldPathExists(js, "a", "b", "c", "d") shouldBe false
-        JsHelpers.fieldPathExists(js, "b") shouldBe true
-        JsHelpers.fieldPathExists(js, "c") shouldBe false
-
-        JsHelpers.getFieldPath(js) shouldBe Some(js)
-        JsHelpers.getFieldPath(js, "x") shouldBe None
-        JsHelpers.getFieldPath(js, "b") shouldBe Some(JsString("v"))
-        JsHelpers.getFieldPath(js, "a") shouldBe Some(JsObject("b" -> JsObject("c" -> JsString("v"))))
-        JsHelpers.getFieldPath(js, "a", "b") shouldBe Some(JsObject("c" -> JsString("v")))
-        JsHelpers.getFieldPath(js, "a", "b", "c") shouldBe Some(JsString("v"))
-        JsHelpers.getFieldPath(js, "a", "b", "c", "d") shouldBe None
-        JsHelpers.getFieldPath(JsObject()) shouldBe Some(JsObject())
-    }
+  }
+
+  behavior of "Js Helpers"
+
+  it should "project paths from json object" in {
+    val js = JsObject("a" -> JsObject("b" -> JsObject("c" -> JsString("v"))), "b" -> JsString("v"))
+    JsHelpers.fieldPathExists(js) shouldBe true
+    JsHelpers.fieldPathExists(js, "a") shouldBe true
+    JsHelpers.fieldPathExists(js, "a", "b") shouldBe true
+    JsHelpers.fieldPathExists(js, "a", "b", "c") shouldBe true
+    JsHelpers.fieldPathExists(js, "a", "b", "c", "d") shouldBe false
+    JsHelpers.fieldPathExists(js, "b") shouldBe true
+    JsHelpers.fieldPathExists(js, "c") shouldBe false
+
+    JsHelpers.getFieldPath(js) shouldBe Some(js)
+    JsHelpers.getFieldPath(js, "x") shouldBe None
+    JsHelpers.getFieldPath(js, "b") shouldBe Some(JsString("v"))
+    JsHelpers.getFieldPath(js, "a") shouldBe Some(JsObject("b" -> JsObject("c" -> JsString("v"))))
+    JsHelpers.getFieldPath(js, "a", "b") shouldBe Some(JsObject("c" -> JsString("v")))
+    JsHelpers.getFieldPath(js, "a", "b", "c") shouldBe Some(JsString("v"))
+    JsHelpers.getFieldPath(js, "a", "b", "c", "d") shouldBe None
+    JsHelpers.getFieldPath(JsObject()) shouldBe Some(JsObject())
+  }
 }

--- a/tests/src/test/scala/whisk/core/entity/test/SizeTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/SizeTests.scala
@@ -29,119 +29,119 @@ import whisk.core.entity.ByteSize
 @RunWith(classOf[JUnitRunner])
 class SizeTests extends FlatSpec with Matchers {
 
-    behavior of "Size Entity"
+  behavior of "Size Entity"
 
-    // Comparing
-    it should "1 Byte smaller than 1 KB smaller than 1 MB" in {
-        val oneByte = 1 B
-        val oneKB = 1 KB
-        val oneMB = 1 MB
+  // Comparing
+  it should "1 Byte smaller than 1 KB smaller than 1 MB" in {
+    val oneByte = 1 B
+    val oneKB = 1 KB
+    val oneMB = 1 MB
 
-        oneByte < oneKB should be(true)
-        oneKB < oneMB should be(true)
+    oneByte < oneKB should be(true)
+    oneKB < oneMB should be(true)
+  }
+
+  it should "3 Bytes smaller than 2 KB smaller than 1 MB" in {
+    val myBytes = 3 B
+    val myKBs = 2 KB
+    val myMBs = 1 MB
+
+    myBytes < myKBs should be(true)
+    myKBs < myMBs should be(true)
+  }
+
+  it should "1 MB greater than 1 KB greater than 1 Byte" in {
+    val oneByte = 1 B
+    val oneKB = 1 KB
+    val oneMB = 1 MB
+
+    oneMB > oneKB should be(true)
+    oneKB > oneByte should be(true)
+  }
+
+  it should "1 MB == 1024 KB == 1048576 B" in {
+    val myBytes = 1048576 B
+    val myKBs = 1024 KB
+    val myMBs = 1 MB
+
+    myBytes equals (myKBs)
+    myKBs equals (myMBs)
+  }
+
+  // Addition
+  it should "1 Byte + 1 KB = 1025 Bytes" in {
+    1.B + 1.KB should be(1025 B)
+  }
+
+  it should "1 MB + 1 MB = 2 MB" in {
+    (1.MB + 1.MB).toBytes should be(2.MB.toBytes)
+  }
+
+  // Subtraction
+  it should "1 KB - 1B = 1023 Bytes" in {
+    1.KB - 1.B should be(1023 B)
+  }
+
+  it should "1 MB - 1 MB = 0 MB" in {
+    1.MB - 1.MB should be(0 B)
+  }
+
+  it should "throw an exception if subtraction leads to a negative size" in {
+    an[IllegalArgumentException] should be thrownBy {
+      0.B - 1.B
     }
+  }
 
-    it should "3 Bytes smaller than 2 KB smaller than 1 MB" in {
-        val myBytes = 3 B
-        val myKBs = 2 KB
-        val myMBs = 1 MB
+  // Conversions
+  it should "1024 B to KB = 1" in {
+    (1024 B).toKB should be(1)
+  }
 
-        myBytes < myKBs should be(true)
-        myKBs < myMBs should be(true)
-    }
+  it should "1048576 B to MB = 1" in {
+    (1048576 B).toMB should be(1)
+  }
 
-    it should "1 MB greater than 1 KB greater than 1 Byte" in {
-        val oneByte = 1 B
-        val oneKB = 1 KB
-        val oneMB = 1 MB
+  it should "1 KB to B = 1024" in {
+    (1 KB).toBytes should be(1024)
+  }
 
-        oneMB > oneKB should be(true)
-        oneKB > oneByte should be(true)
-    }
+  it should "1024 KB to MB = 1" in {
+    (1024 KB).toMB should be(1)
+  }
 
-    it should "1 MB == 1024 KB == 1048576 B" in {
-        val myBytes = 1048576 B
-        val myKBs = 1024 KB
-        val myMBs = 1 MB
+  it should "1 MB to B = 1048576" in {
+    (1 MB).toBytes should be(1048576)
+  }
 
-        myBytes equals (myKBs)
-        myKBs equals (myMBs)
-    }
+  it should "1 MB to KB = 1024" in {
+    (1 MB).toKB should be(1024)
+  }
 
-    // Addition
-    it should "1 Byte + 1 KB = 1025 Bytes" in {
-        1.B + 1.KB should be(1025 B)
-    }
+  // Create ObjectSize from String
+  it should "create ObjectSize from String 3B" in {
+    val fromString = ByteSize.fromString("3B")
+    fromString equals (3 B)
+  }
 
-    it should "1 MB + 1 MB = 2 MB" in {
-        (1.MB + 1.MB).toBytes should be(2.MB.toBytes)
-    }
+  it should "create ObjectSize from String 7K" in {
+    val fromString = ByteSize.fromString("7K")
+    fromString equals (7 KB)
+  }
 
-    // Subtraction
-    it should "1 KB - 1B = 1023 Bytes" in {
-        1.KB - 1.B should be(1023 B)
-    }
+  it should "create ObjectSize from String 120M" in {
+    val fromString = ByteSize.fromString("120M")
+    fromString equals (120 MB)
+  }
 
-    it should "1 MB - 1 MB = 0 MB" in {
-        1.MB - 1.MB should be(0 B)
-    }
+  it should "throw error on creating ObjectSize from String 120A" in {
+    the[IllegalArgumentException] thrownBy {
+      ByteSize.fromString("120A")
+    } should have message """Size Unit not supported. Only "B", "K" and "M" are supported."""
+  }
 
-    it should "throw an exception if subtraction leads to a negative size" in {
-        an[IllegalArgumentException] should be thrownBy {
-            0.B - 1.B
-        }
-    }
-
-    // Conversions
-    it should "1024 B to KB = 1" in {
-        (1024 B).toKB should be(1)
-    }
-
-    it should "1048576 B to MB = 1" in {
-        (1048576 B).toMB should be(1)
-    }
-
-    it should "1 KB to B = 1024" in {
-        (1 KB).toBytes should be(1024)
-    }
-
-    it should "1024 KB to MB = 1" in {
-        (1024 KB).toMB should be(1)
-    }
-
-    it should "1 MB to B = 1048576" in {
-        (1 MB).toBytes should be(1048576)
-    }
-
-    it should "1 MB to KB = 1024" in {
-        (1 MB).toKB should be(1024)
-    }
-
-    // Create ObjectSize from String
-    it should "create ObjectSize from String 3B" in {
-        val fromString = ByteSize.fromString("3B")
-        fromString equals (3 B)
-    }
-
-    it should "create ObjectSize from String 7K" in {
-        val fromString = ByteSize.fromString("7K")
-        fromString equals (7 KB)
-    }
-
-    it should "create ObjectSize from String 120M" in {
-        val fromString = ByteSize.fromString("120M")
-        fromString equals (120 MB)
-    }
-
-    it should "throw error on creating ObjectSize from String 120A" in {
-        the[IllegalArgumentException] thrownBy {
-            ByteSize.fromString("120A")
-        } should have message """Size Unit not supported. Only "B", "K" and "M" are supported."""
-    }
-
-    it should "throw error on creating ByteSize object with negative size" in {
-        the[IllegalArgumentException] thrownBy {
-            -130 MB
-        } should have message "requirement failed: a negative size of an object is not allowed."
-    }
+  it should "throw error on creating ByteSize object with negative size" in {
+    the[IllegalArgumentException] thrownBy {
+      -130 MB
+    } should have message "requirement failed: a negative size of an object is not allowed."
+  }
 }

--- a/tests/src/test/scala/whisk/core/entity/test/ViewTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ViewTests.scala
@@ -43,7 +43,8 @@ import whisk.core.entity._
 import whisk.core.entity.WhiskEntityQueries._
 
 @RunWith(classOf[JUnitRunner])
-class ViewTests extends FlatSpec
+class ViewTests
+    extends FlatSpec
     with BeforeAndAfter
     with BeforeAndAfterAll
     with Matchers
@@ -52,275 +53,423 @@ class ViewTests extends FlatSpec
     with WskActorSystem
     with StreamLogging {
 
-    def aname = MakeName.next("viewtests")
-    def afullname(namespace: EntityPath) = FullyQualifiedEntityName(namespace, aname)
+  def aname = MakeName.next("viewtests")
+  def afullname(namespace: EntityPath) = FullyQualifiedEntityName(namespace, aname)
 
-    object MakeName {
-        @volatile var counter = 1
-        def next(prefix: String = "test")(): EntityName = {
-            counter = counter + 1
-            EntityName(s"${prefix}_name$counter")
+  object MakeName {
+    @volatile var counter = 1
+    def next(prefix: String = "test")(): EntityName = {
+      counter = counter + 1
+      EntityName(s"${prefix}_name$counter")
+    }
+  }
+
+  val creds1 = WhiskAuthHelpers.newAuth(Subject("s12345"))
+  val namespace1 = EntityPath(creds1.subject.asString)
+
+  val creds2 = WhiskAuthHelpers.newAuth(Subject("t12345"))
+  val namespace2 = EntityPath(creds2.subject.asString)
+
+  val config = new WhiskConfig(WhiskEntityStore.requiredProperties ++ WhiskActivationStore.requiredProperties)
+  val entityStore = WhiskEntityStore.datastore(config)
+  val activationStore = WhiskActivationStore.datastore(config)
+
+  after {
+    cleanup()
+  }
+
+  override def afterAll() {
+    println("Shutting down store connections")
+    entityStore.shutdown()
+    activationStore.shutdown()
+    super.afterAll()
+  }
+
+  behavior of "Datastore View"
+
+  def getAllInNamespace[Au <: WhiskEntity](store: ArtifactStore[Au], ns: EntityPath)(
+    implicit entities: Seq[WhiskEntity]) = {
+    implicit val tid = transid()
+    val result =
+      Await.result(listAllInNamespace(store, ns, false, StaleParameter.No), dbOpTimeout).values.toList.flatten
+    val expected = entities filter { _.namespace.root.toPath == ns }
+    result.length should be(expected.length)
+    result should contain theSameElementsAs expected.map(_.summaryAsJson)
+  }
+
+  def getEntitiesInNamespace(ns: EntityPath)(implicit entities: Seq[WhiskEntity]) = {
+    implicit val tid = transid()
+    val map = Await.result(listEntitiesInNamespace(entityStore, ns, false), dbOpTimeout)
+    val result = map.values.toList flatMap { t =>
+      t
+    }
+    val expected = entities filter { !_.isInstanceOf[WhiskActivation] } filter { _.namespace.root.toPath == ns }
+    map.get(WhiskActivation.collectionName) should be(None)
+    result.length should be(expected.length)
+    expected forall { e =>
+      result contains e.summaryAsJson
+    } should be(true)
+  }
+
+  def getKindInNamespace[Au <: WhiskEntity](store: ArtifactStore[Au],
+                                            ns: EntityPath,
+                                            kind: String,
+                                            f: (WhiskEntity) => Boolean)(implicit entities: Seq[WhiskEntity]) = {
+    implicit val tid = transid()
+    val result =
+      Await.result(listCollectionInNamespace(store, kind, ns, 0, 0, stale = StaleParameter.No, convert = None) map {
+        _.left.get map { e =>
+          e
         }
+      }, dbOpTimeout)
+    val expected = entities filter { e =>
+      f(e) && e.namespace.root.toPath == ns
     }
+    result.length should be(expected.length)
+    expected forall { e =>
+      result contains e.summaryAsJson
+    } should be(true)
+  }
 
-    val creds1 = WhiskAuthHelpers.newAuth(Subject("s12345"))
-    val namespace1 = EntityPath(creds1.subject.asString)
-
-    val creds2 = WhiskAuthHelpers.newAuth(Subject("t12345"))
-    val namespace2 = EntityPath(creds2.subject.asString)
-
-    val config = new WhiskConfig(WhiskEntityStore.requiredProperties ++ WhiskActivationStore.requiredProperties)
-    val entityStore = WhiskEntityStore.datastore(config)
-    val activationStore = WhiskActivationStore.datastore(config)
-
-    after {
-        cleanup()
+  def getPublicPackages(implicit entities: Seq[WhiskEntity]) = {
+    implicit val tid = transid()
+    val result = Await.result(listCollectionInAnyNamespace(entityStore, "packages", 0, 0, true, convert = None) map {
+      _.left.get map { e =>
+        e
+      }
+    }, dbOpTimeout)
+    val expected = entities filter {
+      case (e: WhiskPackage) => e.publish && e.binding.isEmpty
+      case _                 => false
     }
+    result.length should be >= (expected.length)
+    expected forall { e =>
+      result contains e.summaryAsJson
+    } should be(true)
+  }
 
-    override def afterAll() {
-        println("Shutting down store connections")
-        entityStore.shutdown()
-        activationStore.shutdown()
-        super.afterAll()
+  def getKindInNamespaceWithDoc[T](ns: EntityPath,
+                                   kind: String,
+                                   f: (WhiskEntity) => Boolean,
+                                   convert: Option[JsObject => Try[T]])(implicit entities: Seq[WhiskEntity]) = {
+    implicit val tid = transid()
+    val result = Await.result(
+      listCollectionInNamespace(entityStore, kind, ns, 0, 0, stale = StaleParameter.No, convert = convert) map {
+        _.right.get
+      },
+      dbOpTimeout)
+    val expected = entities filter { e =>
+      f(e) && e.namespace.root.toPath == ns
     }
+    result.length should be(expected.length)
+    expected forall { e =>
+      result contains e
+    } should be(true)
+  }
 
-    behavior of "Datastore View"
-
-    def getAllInNamespace[Au <: WhiskEntity](store: ArtifactStore[Au], ns: EntityPath)(implicit entities: Seq[WhiskEntity]) = {
-        implicit val tid = transid()
-        val result = Await.result(listAllInNamespace(store, ns, false, StaleParameter.No), dbOpTimeout).values.toList.flatten
-        val expected = entities filter { _.namespace.root.toPath == ns }
-        result.length should be(expected.length)
-        result should contain theSameElementsAs expected.map(_.summaryAsJson)
-    }
-
-    def getEntitiesInNamespace(ns: EntityPath)(implicit entities: Seq[WhiskEntity]) = {
-        implicit val tid = transid()
-        val map = Await.result(listEntitiesInNamespace(entityStore, ns, false), dbOpTimeout)
-        val result = map.values.toList flatMap { t => t }
-        val expected = entities filter { !_.isInstanceOf[WhiskActivation] } filter { _.namespace.root.toPath == ns }
-        map.get(WhiskActivation.collectionName) should be(None)
-        result.length should be(expected.length)
-        expected forall { e => result contains e.summaryAsJson } should be(true)
-    }
-
-    def getKindInNamespace[Au <: WhiskEntity](store: ArtifactStore[Au], ns: EntityPath, kind: String, f: (WhiskEntity) => Boolean)(implicit entities: Seq[WhiskEntity]) = {
-        implicit val tid = transid()
-        val result = Await.result(listCollectionInNamespace(store, kind, ns, 0, 0, stale = StaleParameter.No, convert = None) map { _.left.get map { e => e } }, dbOpTimeout)
-        val expected = entities filter { e => f(e) && e.namespace.root.toPath == ns }
-        result.length should be(expected.length)
-        expected forall { e => result contains e.summaryAsJson } should be(true)
-    }
-
-    def getPublicPackages(implicit entities: Seq[WhiskEntity]) = {
-        implicit val tid = transid()
-        val result = Await.result(listCollectionInAnyNamespace(entityStore, "packages", 0, 0, true, convert = None) map { _.left.get map { e => e } }, dbOpTimeout)
-        val expected = entities filter { case (e: WhiskPackage) => e.publish && e.binding.isEmpty case _ => false }
-        result.length should be >= (expected.length)
-        expected forall { e => result contains e.summaryAsJson } should be(true)
-    }
-
-    def getKindInNamespaceWithDoc[T](ns: EntityPath, kind: String, f: (WhiskEntity) => Boolean, convert: Option[JsObject => Try[T]])(implicit entities: Seq[WhiskEntity]) = {
-        implicit val tid = transid()
-        val result = Await.result(listCollectionInNamespace(entityStore, kind, ns, 0, 0, stale = StaleParameter.No, convert = convert) map { _.right.get }, dbOpTimeout)
-        val expected = entities filter { e => f(e) && e.namespace.root.toPath == ns }
-        result.length should be(expected.length)
-        expected forall { e => result contains e } should be(true)
-    }
-
-    def getKindInNamespaceByName[Au <: WhiskEntity](store: ArtifactStore[Au], ns: EntityPath, kind: String, name: EntityName, f: (WhiskEntity) => Boolean)(implicit entities: Seq[WhiskEntity]) = {
-        implicit val tid = transid()
-        val result = Await.result(listCollectionByName(store, kind, ns, name, 0, 0, stale = StaleParameter.No, convert = None) map { _.left.get map { e => e } }, dbOpTimeout)
-        val expected = entities filter { e => f(e) && e.namespace.root.toPath == ns }
-        result.length should be(expected.length)
-        expected forall { e => result contains e.summaryAsJson } should be(true)
-    }
-
-    def getKindInPackage(ns: EntityPath, kind: String, f: (WhiskEntity) => Boolean)(implicit entities: Seq[WhiskEntity]) = {
-        implicit val tid = transid()
-        val result = Await.result(listCollectionInNamespace(entityStore, kind, ns, 0, 0, stale = StaleParameter.No, convert = None) map { _.left.get map { e => e } }, dbOpTimeout)
-        val expected = entities filter { e => f(e) && e.namespace == ns }
-        result.length should be(expected.length)
-        expected forall { e => result contains e.summaryAsJson } should be(true)
-    }
-
-    def getKindInNamespaceByNameSortedByDate[Au <: WhiskEntity](
-        store: ArtifactStore[Au], ns: EntityPath, kind: String, name: EntityName, skip: Int, count: Int, start: Option[Instant], end: Option[Instant], f: (WhiskEntity) => Boolean)(
-            implicit entities: Seq[WhiskEntity]) = {
-        implicit val tid = transid()
-        val result = Await.result(listCollectionByName(store, kind, ns, name, skip, count, start, end, StaleParameter.No, convert = None) map { _.left.get map { e => e } }, dbOpTimeout)
-        val expected = entities filter { e => f(e) && e.namespace.root.toPath == ns } sortBy { case (e: WhiskActivation) => e.start.toEpochMilli; case _ => 0 } map { _.summaryAsJson }
-        result.length should be(expected.length)
-        result should be(expected reverse)
-    }
-
-    it should "query whisk view by namespace, collection and entity name in whisk actions db" in {
-        implicit val tid = transid()
-        val exec = bb("image")
-        val pkgname1 = namespace1.addPath(aname)
-        val pkgname2 = namespace2.addPath(aname)
-        val actionName = aname
-        def now = Instant.now(Clock.systemUTC())
-
-        // creates 17 entities in each namespace as follows:
-        // - 2 actions in each namespace in the default namespace
-        // - 2 actions in the same package within a namespace
-        // - 1 action in two different packages in the same namespace
-        // - 1 action in package with prescribed name
-        // - 2 triggers in each namespace
-        // - 2 rules in each namespace
-        // - 2 packages in each namespace
-        // - 2 package bindings in each namespace
-        implicit val entities = Seq(
-            WhiskAction(namespace1, aname, exec),
-            WhiskAction(namespace1, aname, exec),
-            WhiskAction(namespace1.addPath(aname), aname, exec),
-            WhiskAction(namespace1.addPath(aname), aname, exec),
-            WhiskAction(pkgname1, aname, exec),
-            WhiskAction(pkgname1, aname, exec),
-            WhiskAction(pkgname1, actionName, exec),
-            WhiskTrigger(namespace1, aname),
-            WhiskTrigger(namespace1, aname),
-            WhiskRule(namespace1, aname, trigger = afullname(namespace1), action = afullname(namespace1)),
-            WhiskRule(namespace1, aname, trigger = afullname(namespace1), action = afullname(namespace1)),
-            WhiskPackage(namespace1, aname),
-            WhiskPackage(namespace1, aname),
-            WhiskPackage(namespace1, aname, Some(Binding(namespace2.root, aname))),
-            WhiskPackage(namespace1, aname, Some(Binding(namespace2.root, aname))),
-
-            WhiskAction(namespace2, aname, exec),
-            WhiskAction(namespace2, aname, exec),
-            WhiskAction(namespace2.addPath(aname), aname, exec),
-            WhiskAction(namespace2.addPath(aname), aname, exec),
-            WhiskAction(pkgname2, aname, exec),
-            WhiskAction(pkgname2, aname, exec),
-            WhiskTrigger(namespace2, aname),
-            WhiskTrigger(namespace2, aname),
-            WhiskRule(namespace2, aname, trigger = afullname(namespace2), action = afullname(namespace2)),
-            WhiskRule(namespace2, aname, trigger = afullname(namespace2), action = afullname(namespace2)),
-            WhiskPackage(namespace2, aname),
-            WhiskPackage(namespace2, aname),
-            WhiskPackage(namespace2, aname, Some(Binding(namespace1.root, aname))),
-            WhiskPackage(namespace2, aname, Some(Binding(namespace1.root, aname))))
-
-        entities foreach { put(entityStore, _) }
-        waitOnView(entityStore, namespace1, 15)
-        waitOnView(entityStore, namespace2, 14)
-
-        getAllInNamespace(entityStore, namespace1)
-        getKindInNamespace(entityStore, namespace1, "actions", { case (e: WhiskAction) => true case (_) => false })
-        getKindInNamespace(entityStore, namespace1, "triggers", { case (e: WhiskTrigger) => true case (_) => false })
-        getKindInNamespace(entityStore, namespace1, "rules", { case (e: WhiskRule) => true case (_) => false })
-        getKindInNamespace(entityStore, namespace1, "packages", { case (e: WhiskPackage) => true case (_) => false })
-        getKindInPackage(pkgname1, "actions", { case (e: WhiskAction) => true case (_) => false })
-        getKindInNamespaceByName(entityStore, pkgname1, "actions", actionName, { case (e: WhiskAction) => (e.name == actionName) case (_) => false })
-        getEntitiesInNamespace(namespace1)
-
-        getAllInNamespace(entityStore, namespace2)
-        getKindInNamespace(entityStore, namespace2, "actions", { case (e: WhiskAction) => true case (_) => false })
-        getKindInNamespace(entityStore, namespace2, "triggers", { case (e: WhiskTrigger) => true case (_) => false })
-        getKindInNamespace(entityStore, namespace2, "rules", { case (e: WhiskRule) => true case (_) => false })
-        getKindInNamespace(entityStore, namespace2, "packages", { case (e: WhiskPackage) => true case (_) => false })
-        getKindInPackage(pkgname2, "actions", { case (e: WhiskAction) => true case (_) => false })
-        getEntitiesInNamespace(namespace2)
-    }
-
-    it should "query whisk view by namespace, collection and entity name in whisk activations db" in {
-        implicit val tid = transid()
-        val actionName = aname
-        def now = Instant.now(Clock.systemUTC())
-
-        // creates 5 entities in each namespace as follows:
-        // - some activations in each namespace (some may have prescribed action name to query by name)
-        implicit val entities = Seq(
-            WhiskActivation(namespace1, aname, Subject(), ActivationId(), start = now, end = now),
-            WhiskActivation(namespace1, aname, Subject(), ActivationId(), start = now, end = now),
-
-            WhiskActivation(namespace2, aname, Subject(), ActivationId(), start = now, end = now),
-            WhiskActivation(namespace2, actionName, Subject(), ActivationId(), start = now, end = now),
-            WhiskActivation(namespace2, actionName, Subject(), ActivationId(), start = now, end = now))
-
-        entities foreach { put(activationStore, _) }
-        waitOnView(activationStore, namespace1, 2)
-        waitOnView(activationStore, namespace2, 3)
-
-        getAllInNamespace(activationStore, namespace1)
-        getKindInNamespace(activationStore, namespace1, "activations", { case (e: WhiskActivation) => true case (_) => false })
-
-        getAllInNamespace(activationStore, namespace2)
-        getKindInNamespace(activationStore, namespace2, "activations", { case (e: WhiskActivation) => true case (_) => false })
-        getKindInNamespaceByName(activationStore, namespace2, "activations", actionName, { case (e: WhiskActivation) => (e.name == actionName) case (_) => false })
-    }
-
-    it should "query whisk view for activations sorted by date" in {
-        implicit val tid = transid()
-        val actionName = aname
-        val now = Instant.now(Clock.systemUTC())
-        val others = Seq(
-            WhiskAction(namespace1, aname, jsDefault("??")),
-            WhiskAction(namespace1, aname, jsDefault("??")))
-        implicit val entities = Seq(
-            WhiskActivation(namespace1, actionName, Subject(), ActivationId(), start = now, end = now),
-            WhiskActivation(namespace1, actionName, Subject(), ActivationId(), start = now.plusSeconds(20), end = now.plusSeconds(20)),
-            WhiskActivation(namespace1, actionName, Subject(), ActivationId(), start = now.plusSeconds(10), end = now.plusSeconds(20)),
-            WhiskActivation(namespace1, actionName, Subject(), ActivationId(), start = now.plusSeconds(40), end = now.plusSeconds(20)),
-            WhiskActivation(namespace1, actionName, Subject(), ActivationId(), start = now.plusSeconds(30), end = now.plusSeconds(20)))
-
-        others foreach { put(entityStore, _) }
-        entities foreach { put(activationStore, _) }
-        if (config.dbActivations == config.dbWhisk) {
-            waitOnView(entityStore, namespace1, others.length + entities.length)
-        } else {
-            waitOnView(entityStore, namespace1, others.length)
-            waitOnView(activationStore, namespace1, entities.length)
+  def getKindInNamespaceByName[Au <: WhiskEntity](store: ArtifactStore[Au],
+                                                  ns: EntityPath,
+                                                  kind: String,
+                                                  name: EntityName,
+                                                  f: (WhiskEntity) => Boolean)(implicit entities: Seq[WhiskEntity]) = {
+    implicit val tid = transid()
+    val result =
+      Await.result(listCollectionByName(store, kind, ns, name, 0, 0, stale = StaleParameter.No, convert = None) map {
+        _.left.get map { e =>
+          e
         }
+      }, dbOpTimeout)
+    val expected = entities filter { e =>
+      f(e) && e.namespace.root.toPath == ns
+    }
+    result.length should be(expected.length)
+    expected forall { e =>
+      result contains e.summaryAsJson
+    } should be(true)
+  }
 
-        getKindInNamespaceByNameSortedByDate(activationStore, namespace1, "activations", actionName, 0, 5, None, None, {
-            case (e: WhiskActivation) => e.name == actionName
-            case (_)                  => false
-        })
+  def getKindInPackage(ns: EntityPath, kind: String, f: (WhiskEntity) => Boolean)(
+    implicit entities: Seq[WhiskEntity]) = {
+    implicit val tid = transid()
+    val result = Await.result(
+      listCollectionInNamespace(entityStore, kind, ns, 0, 0, stale = StaleParameter.No, convert = None) map {
+        _.left.get map { e =>
+          e
+        }
+      },
+      dbOpTimeout)
+    val expected = entities filter { e =>
+      f(e) && e.namespace == ns
+    }
+    result.length should be(expected.length)
+    expected forall { e =>
+      result contains e.summaryAsJson
+    } should be(true)
+  }
 
-        val since = entities(1).start
-        val upto = entities(4).start
-        getKindInNamespaceByNameSortedByDate(activationStore, namespace1, "activations", actionName, 0, 5, Some(since), Some(upto), {
-            case (e: WhiskActivation) => e.name == actionName && (e.start.equals(since) || e.start.equals(upto) || (e.start.isAfter(since) && e.start.isBefore(upto)))
-            case (_)                  => false
-        })
+  def getKindInNamespaceByNameSortedByDate[Au <: WhiskEntity](
+    store: ArtifactStore[Au],
+    ns: EntityPath,
+    kind: String,
+    name: EntityName,
+    skip: Int,
+    count: Int,
+    start: Option[Instant],
+    end: Option[Instant],
+    f: (WhiskEntity) => Boolean)(implicit entities: Seq[WhiskEntity]) = {
+    implicit val tid = transid()
+    val result = Await.result(
+      listCollectionByName(store, kind, ns, name, skip, count, start, end, StaleParameter.No, convert = None) map {
+        _.left.get map { e =>
+          e
+        }
+      },
+      dbOpTimeout)
+    val expected = entities filter { e =>
+      f(e) && e.namespace.root.toPath == ns
+    } sortBy { case (e: WhiskActivation) => e.start.toEpochMilli; case _ => 0 } map { _.summaryAsJson }
+    result.length should be(expected.length)
+    result should be(expected reverse)
+  }
+
+  it should "query whisk view by namespace, collection and entity name in whisk actions db" in {
+    implicit val tid = transid()
+    val exec = bb("image")
+    val pkgname1 = namespace1.addPath(aname)
+    val pkgname2 = namespace2.addPath(aname)
+    val actionName = aname
+    def now = Instant.now(Clock.systemUTC())
+
+    // creates 17 entities in each namespace as follows:
+    // - 2 actions in each namespace in the default namespace
+    // - 2 actions in the same package within a namespace
+    // - 1 action in two different packages in the same namespace
+    // - 1 action in package with prescribed name
+    // - 2 triggers in each namespace
+    // - 2 rules in each namespace
+    // - 2 packages in each namespace
+    // - 2 package bindings in each namespace
+    implicit val entities = Seq(
+      WhiskAction(namespace1, aname, exec),
+      WhiskAction(namespace1, aname, exec),
+      WhiskAction(namespace1.addPath(aname), aname, exec),
+      WhiskAction(namespace1.addPath(aname), aname, exec),
+      WhiskAction(pkgname1, aname, exec),
+      WhiskAction(pkgname1, aname, exec),
+      WhiskAction(pkgname1, actionName, exec),
+      WhiskTrigger(namespace1, aname),
+      WhiskTrigger(namespace1, aname),
+      WhiskRule(namespace1, aname, trigger = afullname(namespace1), action = afullname(namespace1)),
+      WhiskRule(namespace1, aname, trigger = afullname(namespace1), action = afullname(namespace1)),
+      WhiskPackage(namespace1, aname),
+      WhiskPackage(namespace1, aname),
+      WhiskPackage(namespace1, aname, Some(Binding(namespace2.root, aname))),
+      WhiskPackage(namespace1, aname, Some(Binding(namespace2.root, aname))),
+      WhiskAction(namespace2, aname, exec),
+      WhiskAction(namespace2, aname, exec),
+      WhiskAction(namespace2.addPath(aname), aname, exec),
+      WhiskAction(namespace2.addPath(aname), aname, exec),
+      WhiskAction(pkgname2, aname, exec),
+      WhiskAction(pkgname2, aname, exec),
+      WhiskTrigger(namespace2, aname),
+      WhiskTrigger(namespace2, aname),
+      WhiskRule(namespace2, aname, trigger = afullname(namespace2), action = afullname(namespace2)),
+      WhiskRule(namespace2, aname, trigger = afullname(namespace2), action = afullname(namespace2)),
+      WhiskPackage(namespace2, aname),
+      WhiskPackage(namespace2, aname),
+      WhiskPackage(namespace2, aname, Some(Binding(namespace1.root, aname))),
+      WhiskPackage(namespace2, aname, Some(Binding(namespace1.root, aname))))
+
+    entities foreach { put(entityStore, _) }
+    waitOnView(entityStore, namespace1, 15)
+    waitOnView(entityStore, namespace2, 14)
+
+    getAllInNamespace(entityStore, namespace1)
+    getKindInNamespace(entityStore, namespace1, "actions", {
+      case (e: WhiskAction) => true
+      case (_)              => false
+    })
+    getKindInNamespace(entityStore, namespace1, "triggers", {
+      case (e: WhiskTrigger) => true
+      case (_)               => false
+    })
+    getKindInNamespace(entityStore, namespace1, "rules", {
+      case (e: WhiskRule) => true
+      case (_)            => false
+    })
+    getKindInNamespace(entityStore, namespace1, "packages", {
+      case (e: WhiskPackage) => true
+      case (_)               => false
+    })
+    getKindInPackage(pkgname1, "actions", {
+      case (e: WhiskAction) => true
+      case (_)              => false
+    })
+    getKindInNamespaceByName(entityStore, pkgname1, "actions", actionName, {
+      case (e: WhiskAction) => (e.name == actionName)
+      case (_)              => false
+    })
+    getEntitiesInNamespace(namespace1)
+
+    getAllInNamespace(entityStore, namespace2)
+    getKindInNamespace(entityStore, namespace2, "actions", {
+      case (e: WhiskAction) => true
+      case (_)              => false
+    })
+    getKindInNamespace(entityStore, namespace2, "triggers", {
+      case (e: WhiskTrigger) => true
+      case (_)               => false
+    })
+    getKindInNamespace(entityStore, namespace2, "rules", {
+      case (e: WhiskRule) => true
+      case (_)            => false
+    })
+    getKindInNamespace(entityStore, namespace2, "packages", {
+      case (e: WhiskPackage) => true
+      case (_)               => false
+    })
+    getKindInPackage(pkgname2, "actions", {
+      case (e: WhiskAction) => true
+      case (_)              => false
+    })
+    getEntitiesInNamespace(namespace2)
+  }
+
+  it should "query whisk view by namespace, collection and entity name in whisk activations db" in {
+    implicit val tid = transid()
+    val actionName = aname
+    def now = Instant.now(Clock.systemUTC())
+
+    // creates 5 entities in each namespace as follows:
+    // - some activations in each namespace (some may have prescribed action name to query by name)
+    implicit val entities = Seq(
+      WhiskActivation(namespace1, aname, Subject(), ActivationId(), start = now, end = now),
+      WhiskActivation(namespace1, aname, Subject(), ActivationId(), start = now, end = now),
+      WhiskActivation(namespace2, aname, Subject(), ActivationId(), start = now, end = now),
+      WhiskActivation(namespace2, actionName, Subject(), ActivationId(), start = now, end = now),
+      WhiskActivation(namespace2, actionName, Subject(), ActivationId(), start = now, end = now))
+
+    entities foreach { put(activationStore, _) }
+    waitOnView(activationStore, namespace1, 2)
+    waitOnView(activationStore, namespace2, 3)
+
+    getAllInNamespace(activationStore, namespace1)
+    getKindInNamespace(activationStore, namespace1, "activations", {
+      case (e: WhiskActivation) => true
+      case (_)                  => false
+    })
+
+    getAllInNamespace(activationStore, namespace2)
+    getKindInNamespace(activationStore, namespace2, "activations", {
+      case (e: WhiskActivation) => true
+      case (_)                  => false
+    })
+    getKindInNamespaceByName(activationStore, namespace2, "activations", actionName, {
+      case (e: WhiskActivation) => (e.name == actionName)
+      case (_)                  => false
+    })
+  }
+
+  it should "query whisk view for activations sorted by date" in {
+    implicit val tid = transid()
+    val actionName = aname
+    val now = Instant.now(Clock.systemUTC())
+    val others = Seq(WhiskAction(namespace1, aname, jsDefault("??")), WhiskAction(namespace1, aname, jsDefault("??")))
+    implicit val entities = Seq(
+      WhiskActivation(namespace1, actionName, Subject(), ActivationId(), start = now, end = now),
+      WhiskActivation(
+        namespace1,
+        actionName,
+        Subject(),
+        ActivationId(),
+        start = now.plusSeconds(20),
+        end = now.plusSeconds(20)),
+      WhiskActivation(
+        namespace1,
+        actionName,
+        Subject(),
+        ActivationId(),
+        start = now.plusSeconds(10),
+        end = now.plusSeconds(20)),
+      WhiskActivation(
+        namespace1,
+        actionName,
+        Subject(),
+        ActivationId(),
+        start = now.plusSeconds(40),
+        end = now.plusSeconds(20)),
+      WhiskActivation(
+        namespace1,
+        actionName,
+        Subject(),
+        ActivationId(),
+        start = now.plusSeconds(30),
+        end = now.plusSeconds(20)))
+
+    others foreach { put(entityStore, _) }
+    entities foreach { put(activationStore, _) }
+    if (config.dbActivations == config.dbWhisk) {
+      waitOnView(entityStore, namespace1, others.length + entities.length)
+    } else {
+      waitOnView(entityStore, namespace1, others.length)
+      waitOnView(activationStore, namespace1, entities.length)
     }
 
-    it should "query whisk and retrieve full documents" in {
-        implicit val tid = transid()
-        val actionName = aname
-        val now = Instant.now(Clock.systemUTC())
-        implicit val entities = Seq(
-            WhiskAction(namespace1, aname, jsDefault("??")),
-            WhiskAction(namespace1, aname, jsDefault("??")))
+    getKindInNamespaceByNameSortedByDate(activationStore, namespace1, "activations", actionName, 0, 5, None, None, {
+      case (e: WhiskActivation) => e.name == actionName
+      case (_)                  => false
+    })
 
-        entities foreach { put(entityStore, _) }
-        waitOnView(entityStore, namespace1, entities.length)
-        getKindInNamespaceWithDoc[WhiskAction](namespace1, "actions", {
-            case (e: WhiskAction) => true case (_) => false
-        }, Some {
-            case (o: JsObject) => Try { WhiskAction.serdes.read(o) }
-        })
-    }
+    val since = entities(1).start
+    val upto = entities(4).start
+    getKindInNamespaceByNameSortedByDate(
+      activationStore,
+      namespace1,
+      "activations",
+      actionName,
+      0,
+      5,
+      Some(since),
+      Some(upto), {
+        case (e: WhiskActivation) =>
+          e.name == actionName && (e.start.equals(since) || e.start
+            .equals(upto) || (e.start.isAfter(since) && e.start.isBefore(upto)))
+        case (_) => false
+      })
+  }
 
-    it should "query whisk for public packages in all namespaces" in {
-        implicit val tid = transid()
-        implicit val entities = Seq(
-            WhiskPackage(namespace1, aname, publish = true),
-            WhiskPackage(namespace1, aname, publish = false),
-            WhiskPackage(namespace1, aname, Some(Binding(namespace2.root, aname)), publish = true),
-            WhiskPackage(namespace1, aname, Some(Binding(namespace2.root, aname))),
+  it should "query whisk and retrieve full documents" in {
+    implicit val tid = transid()
+    val actionName = aname
+    val now = Instant.now(Clock.systemUTC())
+    implicit val entities =
+      Seq(WhiskAction(namespace1, aname, jsDefault("??")), WhiskAction(namespace1, aname, jsDefault("??")))
 
-            WhiskPackage(namespace2, aname, publish = true),
-            WhiskPackage(namespace2, aname, publish = false),
-            WhiskPackage(namespace2, aname, Some(Binding(namespace1.root, aname)), publish = true),
-            WhiskPackage(namespace2, aname, Some(Binding(namespace1.root, aname))))
+    entities foreach { put(entityStore, _) }
+    waitOnView(entityStore, namespace1, entities.length)
+    getKindInNamespaceWithDoc[WhiskAction](namespace1, "actions", {
+      case (e: WhiskAction) => true
+      case (_)              => false
+    }, Some {
+      case (o: JsObject) => Try { WhiskAction.serdes.read(o) }
+    })
+  }
 
-        entities foreach { put(entityStore, _) }
-        waitOnView(entityStore, namespace1, entities.length / 2)
-        waitOnView(entityStore, namespace2, entities.length / 2)
-        getPublicPackages(entities)
-    }
+  it should "query whisk for public packages in all namespaces" in {
+    implicit val tid = transid()
+    implicit val entities = Seq(
+      WhiskPackage(namespace1, aname, publish = true),
+      WhiskPackage(namespace1, aname, publish = false),
+      WhiskPackage(namespace1, aname, Some(Binding(namespace2.root, aname)), publish = true),
+      WhiskPackage(namespace1, aname, Some(Binding(namespace2.root, aname))),
+      WhiskPackage(namespace2, aname, publish = true),
+      WhiskPackage(namespace2, aname, publish = false),
+      WhiskPackage(namespace2, aname, Some(Binding(namespace1.root, aname)), publish = true),
+      WhiskPackage(namespace2, aname, Some(Binding(namespace1.root, aname))))
+
+    entities foreach { put(entityStore, _) }
+    waitOnView(entityStore, namespace1, entities.length / 2)
+    waitOnView(entityStore, namespace2, entities.length / 2)
+    getPublicPackages(entities)
+  }
 }

--- a/tests/src/test/scala/whisk/core/limits/ActionLimitsTests.scala
+++ b/tests/src/test/scala/whisk/core/limits/ActionLimitsTests.scala
@@ -46,227 +46,224 @@ import whisk.http.Messages
 @RunWith(classOf[JUnitRunner])
 class ActionLimitsTests extends TestHelpers with WskTestHelpers {
 
-    implicit val wskprops = WskProps()
-    val wsk = new Wsk()
+  implicit val wskprops = WskProps()
+  val wsk = new Wsk()
 
-    val defaultDosAction = TestUtils.getTestActionFilename("timeout.js")
-    val allowedActionDuration = 10 seconds
+  val defaultDosAction = TestUtils.getTestActionFilename("timeout.js")
+  val allowedActionDuration = 10 seconds
 
-    val testActionsDir = WhiskProperties.getFileRelativeToWhiskHome("tests/dat/actions")
-    val actionCodeLimit = Exec.sizeLimit
+  val testActionsDir = WhiskProperties.getFileRelativeToWhiskHome("tests/dat/actions")
+  val actionCodeLimit = Exec.sizeLimit
 
-    val openFileAction = TestUtils.getTestActionFilename("openFiles.js")
-    val openFileLimit = 1024
-    val minExpectedOpenFiles = openFileLimit - 15 // allow for already opened files in container
+  val openFileAction = TestUtils.getTestActionFilename("openFiles.js")
+  val openFileLimit = 1024
+  val minExpectedOpenFiles = openFileLimit - 15 // allow for already opened files in container
 
-    behavior of "Action limits"
+  behavior of "Action limits"
 
-    /**
-     * Test a long running action that exceeds the maximum execution time allowed for action
-     * by setting the action limit explicitly and attempting to run the action for an additional second.
-     */
-    it should "error with a proper warning if the action exceeds its time limits" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "TestActionCausingTimeout"
-            assetHelper.withCleaner(wsk.action, name, confirmDelete = true) {
-                (action, _) => action.create(name, Some(defaultDosAction), timeout = Some(allowedActionDuration))
-            }
+  /**
+   * Test a long running action that exceeds the maximum execution time allowed for action
+   * by setting the action limit explicitly and attempting to run the action for an additional second.
+   */
+  it should "error with a proper warning if the action exceeds its time limits" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "TestActionCausingTimeout"
+      assetHelper.withCleaner(wsk.action, name, confirmDelete = true) { (action, _) =>
+        action.create(name, Some(defaultDosAction), timeout = Some(allowedActionDuration))
+      }
 
-            val run = wsk.action.invoke(name, Map("payload" -> allowedActionDuration.plus(1 second).toMillis.toJson))
-            withActivation(wsk.activation, run) {
-                _.response.result.get.fields("error") shouldBe {
-                    Messages.timedoutActivation(allowedActionDuration, false).toJson
-                }
-            }
-    }
-
-    /**
-     * Test an action that does not exceed the allowed execution timeout of an action.
-     */
-    it should "succeed on an action staying within its time limits" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "TestActionCausingNoTimeout"
-            assetHelper.withCleaner(wsk.action, name, confirmDelete = true) {
-                (action, _) => action.create(name, Some(defaultDosAction), timeout = Some(allowedActionDuration))
-            }
-
-            val run = wsk.action.invoke(name, Map("payload" -> allowedActionDuration.minus(1 second).toMillis.toJson))
-            withActivation(wsk.activation, run) {
-                _.response.result.get.toString should include(
-                    """[OK] message terminated successfully""")
-
-            }
-    }
-
-    it should "succeed but truncate logs, if log size exceeds its limit" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val bytesPerLine = 16
-            val allowedSize = 1 megabytes
-            val name = "TestActionCausingExceededLogs"
-            assetHelper.withCleaner(wsk.action, name, confirmDelete = true) {
-                val actionName = TestUtils.getTestActionFilename("dosLogs.js")
-                (action, _) => action.create(name, Some(actionName), logsize = Some(allowedSize))
-            }
-
-            // Add 10% to allowed size to exceed limit
-            val attemptedSize = (allowedSize.toBytes * 1.1).toLong.bytes
-
-            val run = wsk.action.invoke(name, Map("payload" -> attemptedSize.toBytes.toJson))
-            withActivation(wsk.activation, run, totalWait = 120 seconds) { response =>
-                val lines = response.logs.get
-                lines.last shouldBe Messages.truncateLogs(allowedSize)
-                (lines.length - 1) shouldBe (allowedSize.toBytes / bytesPerLine)
-                // dropping 39 characters (timestamp + stream name)
-                // then reform total string adding back newlines
-                val actual = lines.dropRight(1).map(_.drop(39)).mkString("", "\n", "\n").sizeInBytes.toBytes
-                actual shouldBe allowedSize.toBytes
-            }
-    }
-
-    Seq(true, false).foreach { blocking =>
-        it should s"succeed but truncate result, if result exceeds its limit (blocking: $blocking)" in withAssetCleaner(wskprops) {
-            (wp, assetHelper) =>
-                val name = "TestActionCausingExcessiveResult"
-                assetHelper.withCleaner(wsk.action, name) {
-                    val actionName = TestUtils.getTestActionFilename("sizedResult.js")
-                    (action, _) => action.create(name, Some(actionName), timeout = Some(15.seconds))
-                }
-
-                val allowedSize = ActivationEntityLimit.MAX_ACTIVATION_ENTITY_LIMIT.toBytes
-
-                def checkResponse(activation: ActivationResult) = {
-                    val response = activation.response
-                    response.success shouldBe false
-                    response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ContainerError)
-                    val msg = response.result.get.fields(ActivationResponse.ERROR_FIELD).convertTo[String]
-                    val expected = Messages.truncatedResponse((allowedSize + 10).B, allowedSize.B)
-                    withClue(s"is: ${msg.take(expected.length)}\nexpected: $expected") {
-                        msg.startsWith(expected) shouldBe true
-                    }
-                    msg.endsWith("a") shouldBe true
-                }
-
-                // this tests an active ack failure to post from invoker
-                val args = Map("size" -> (allowedSize + 1).toJson, "char" -> "a".toJson)
-                val code = if (blocking) TestUtils.APP_ERROR else TestUtils.SUCCESS_EXIT
-                val rr = wsk.action.invoke(name, args, blocking = blocking, expectedExitCode = code)
-                if (blocking) {
-                    checkResponse(wsk.parseJsonString(rr.stderr).convertTo[ActivationResult])
-                } else {
-                    withActivation(wsk.activation, rr, totalWait = 120 seconds) { checkResponse(_) }
-                }
+      val run = wsk.action.invoke(name, Map("payload" -> allowedActionDuration.plus(1 second).toMillis.toJson))
+      withActivation(wsk.activation, run) {
+        _.response.result.get.fields("error") shouldBe {
+          Messages.timedoutActivation(allowedActionDuration, false).toJson
         }
+      }
+  }
+
+  /**
+   * Test an action that does not exceed the allowed execution timeout of an action.
+   */
+  it should "succeed on an action staying within its time limits" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "TestActionCausingNoTimeout"
+    assetHelper.withCleaner(wsk.action, name, confirmDelete = true) { (action, _) =>
+      action.create(name, Some(defaultDosAction), timeout = Some(allowedActionDuration))
     }
 
-    it should "succeed with one log line" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "TestActionWithLogs"
-            assetHelper.withCleaner(wsk.action, name, confirmDelete = true) {
-                val actionName = TestUtils.getTestActionFilename("dosLogs.js")
-                (action, _) => action.create(name, Some(actionName))
-            }
+    val run = wsk.action.invoke(name, Map("payload" -> allowedActionDuration.minus(1 second).toMillis.toJson))
+    withActivation(wsk.activation, run) {
+      _.response.result.get.toString should include("""[OK] message terminated successfully""")
 
-            val run = wsk.action.invoke(name)
-            withActivation(wsk.activation, run) { response =>
-                val logs = response.logs.get
-                withClue(logs) { logs.size shouldBe 1 }
-                logs.head should include("123456789abcdef")
+    }
+  }
 
-                response.response.status shouldBe "success"
-                response.response.result shouldBe Some(JsObject(
-                    "msg" -> 1.toJson))
-            }
+  it should "succeed but truncate logs, if log size exceeds its limit" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val bytesPerLine = 16
+      val allowedSize = 1 megabytes
+      val name = "TestActionCausingExceededLogs"
+      assetHelper.withCleaner(wsk.action, name, confirmDelete = true) {
+        val actionName = TestUtils.getTestActionFilename("dosLogs.js")
+        (action, _) =>
+          action.create(name, Some(actionName), logsize = Some(allowedSize))
+      }
+
+      // Add 10% to allowed size to exceed limit
+      val attemptedSize = (allowedSize.toBytes * 1.1).toLong.bytes
+
+      val run = wsk.action.invoke(name, Map("payload" -> attemptedSize.toBytes.toJson))
+      withActivation(wsk.activation, run, totalWait = 120 seconds) { response =>
+        val lines = response.logs.get
+        lines.last shouldBe Messages.truncateLogs(allowedSize)
+        (lines.length - 1) shouldBe (allowedSize.toBytes / bytesPerLine)
+        // dropping 39 characters (timestamp + stream name)
+        // then reform total string adding back newlines
+        val actual = lines.dropRight(1).map(_.drop(39)).mkString("", "\n", "\n").sizeInBytes.toBytes
+        actual shouldBe allowedSize.toBytes
+      }
+  }
+
+  Seq(true, false).foreach { blocking =>
+    it should s"succeed but truncate result, if result exceeds its limit (blocking: $blocking)" in withAssetCleaner(
+      wskprops) { (wp, assetHelper) =>
+      val name = "TestActionCausingExcessiveResult"
+      assetHelper.withCleaner(wsk.action, name) {
+        val actionName = TestUtils.getTestActionFilename("sizedResult.js")
+        (action, _) =>
+          action.create(name, Some(actionName), timeout = Some(15.seconds))
+      }
+
+      val allowedSize = ActivationEntityLimit.MAX_ACTIVATION_ENTITY_LIMIT.toBytes
+
+      def checkResponse(activation: ActivationResult) = {
+        val response = activation.response
+        response.success shouldBe false
+        response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ContainerError)
+        val msg = response.result.get.fields(ActivationResponse.ERROR_FIELD).convertTo[String]
+        val expected = Messages.truncatedResponse((allowedSize + 10).B, allowedSize.B)
+        withClue(s"is: ${msg.take(expected.length)}\nexpected: $expected") {
+          msg.startsWith(expected) shouldBe true
+        }
+        msg.endsWith("a") shouldBe true
+      }
+
+      // this tests an active ack failure to post from invoker
+      val args = Map("size" -> (allowedSize + 1).toJson, "char" -> "a".toJson)
+      val code = if (blocking) TestUtils.APP_ERROR else TestUtils.SUCCESS_EXIT
+      val rr = wsk.action.invoke(name, args, blocking = blocking, expectedExitCode = code)
+      if (blocking) {
+        checkResponse(wsk.parseJsonString(rr.stderr).convertTo[ActivationResult])
+      } else {
+        withActivation(wsk.activation, rr, totalWait = 120 seconds) { checkResponse(_) }
+      }
+    }
+  }
+
+  it should "succeed with one log line" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "TestActionWithLogs"
+    assetHelper.withCleaner(wsk.action, name, confirmDelete = true) {
+      val actionName = TestUtils.getTestActionFilename("dosLogs.js")
+      (action, _) =>
+        action.create(name, Some(actionName))
     }
 
-    it should "fail on creating an action with exec which is too big" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "TestActionCausingExecTooBig"
+    val run = wsk.action.invoke(name)
+    withActivation(wsk.activation, run) { response =>
+      val logs = response.logs.get
+      withClue(logs) { logs.size shouldBe 1 }
+      logs.head should include("123456789abcdef")
 
-            val actionCode = new File(s"$testActionsDir${File.separator}$name.js")
-            actionCode.createNewFile()
-            val pw = new PrintWriter(actionCode)
-            pw.write("a" * (actionCodeLimit.toBytes + 1).toInt)
-            pw.close
+      response.response.status shouldBe "success"
+      response.response.result shouldBe Some(JsObject("msg" -> 1.toJson))
+    }
+  }
 
-            assetHelper.withCleaner(wsk.action, name, confirmDelete = false) {
-                (action, _) =>
-                    action.create(name, Some(actionCode.getAbsolutePath), expectedExitCode = TOO_LARGE)
-            }
+  it should "fail on creating an action with exec which is too big" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "TestActionCausingExecTooBig"
 
-            actionCode.delete
+    val actionCode = new File(s"$testActionsDir${File.separator}$name.js")
+    actionCode.createNewFile()
+    val pw = new PrintWriter(actionCode)
+    pw.write("a" * (actionCodeLimit.toBytes + 1).toInt)
+    pw.close
+
+    assetHelper.withCleaner(wsk.action, name, confirmDelete = false) { (action, _) =>
+      action.create(name, Some(actionCode.getAbsolutePath), expectedExitCode = TOO_LARGE)
     }
 
-    /**
-     * Test an action that does not exceed the allowed number of open files.
-     */
-    it should "successfully invoke an action when it is within nofile limit" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "TestFileLimitGood-" + System.currentTimeMillis()
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(openFileAction))
-            }
+    actionCode.delete
+  }
 
-            val run = wsk.action.invoke(name, Map("numFiles" -> minExpectedOpenFiles.toJson))
-            withActivation(wsk.activation, run) {
-                activation =>
-                    activation.response.success shouldBe true
-                    activation.response.result.get shouldBe {
-                        JsObject("filesToOpen" -> minExpectedOpenFiles.toJson, "filesOpen" -> minExpectedOpenFiles.toJson)
-                    }
-            }
+  /**
+   * Test an action that does not exceed the allowed number of open files.
+   */
+  it should "successfully invoke an action when it is within nofile limit" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "TestFileLimitGood-" + System.currentTimeMillis()
+      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+        action.create(name, Some(openFileAction))
+      }
+
+      val run = wsk.action.invoke(name, Map("numFiles" -> minExpectedOpenFiles.toJson))
+      withActivation(wsk.activation, run) { activation =>
+        activation.response.success shouldBe true
+        activation.response.result.get shouldBe {
+          JsObject("filesToOpen" -> minExpectedOpenFiles.toJson, "filesOpen" -> minExpectedOpenFiles.toJson)
+        }
+      }
+  }
+
+  /**
+   * Test an action that should fail to open way too many files.
+   */
+  it should "fail to invoke an action when it exceeds nofile limit" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "TestFileLimitBad-" + System.currentTimeMillis()
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, Some(openFileAction))
     }
 
-    /**
-     * Test an action that should fail to open way too many files.
-     */
-    it should "fail to invoke an action when it exceeds nofile limit" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "TestFileLimitBad-" + System.currentTimeMillis()
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(openFileAction))
-            }
+    val run = wsk.action.invoke(name, Map("numFiles" -> (openFileLimit + 1).toJson))
+    withActivation(wsk.activation, run) { activation =>
+      activation.response.success shouldBe false
 
-            val run = wsk.action.invoke(name, Map("numFiles" -> (openFileLimit + 1).toJson))
-            withActivation(wsk.activation, run) {
-                activation =>
-                    activation.response.success shouldBe false
+      val error = activation.response.result.get.fields("error").asJsObject
+      error.fields("filesToOpen") shouldBe (openFileLimit + 1).toJson
 
-                    val error = activation.response.result.get.fields("error").asJsObject
-                    error.fields("filesToOpen") shouldBe (openFileLimit + 1).toJson
+      error.fields("message") shouldBe {
+        JsObject(
+          "code" -> "EMFILE".toJson,
+          "errno" -> -24.toJson,
+          "path" -> "/dev/zero".toJson,
+          "syscall" -> "open".toJson)
+      }
 
-                    error.fields("message") shouldBe {
-                        JsObject(
-                            "code" -> "EMFILE".toJson,
-                            "errno" -> -24.toJson,
-                            "path" -> "/dev/zero".toJson,
-                            "syscall" -> "open".toJson)
-                    }
+      val JsNumber(n) = error.fields("filesOpen")
+      n.toInt should be >= minExpectedOpenFiles
 
-                    val JsNumber(n) = error.fields("filesOpen")
-                    n.toInt should be >= minExpectedOpenFiles
+      activation.logs
+        .getOrElse(List())
+        .filter {
+          _.contains("ERROR: opened files = ")
+        }
+        .length shouldBe 1
+    }
+  }
 
-                    activation.logs.getOrElse(List()).filter {
-                        _.contains("ERROR: opened files = ")
-                    }.length shouldBe 1
-            }
+  it should "be able to run memory intensive actions multiple times by running the GC in the action" in withAssetCleaner(
+    wskprops) { (wp, assetHelper) =>
+    val name = "TestNodeJsMemoryActionAbleToRunOften"
+    assetHelper.withCleaner(wsk.action, name, confirmDelete = true) {
+      val allowedMemory = 512 megabytes
+      val actionName = TestUtils.getTestActionFilename("memoryWithGC.js")
+      (action, _) =>
+        action.create(name, Some(actionName), memory = Some(allowedMemory))
     }
 
-    it should "be able to run memory intensive actions multiple times by running the GC in the action" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "TestNodeJsMemoryActionAbleToRunOften"
-            assetHelper.withCleaner(wsk.action, name, confirmDelete = true) {
-                val allowedMemory = 512 megabytes
-                val actionName = TestUtils.getTestActionFilename("memoryWithGC.js")
-                (action, _) => action.create(name, Some(actionName), memory = Some(allowedMemory))
-            }
-
-            for (a <- 1 to 10) {
-                val run = wsk.action.invoke(name, Map("payload" -> "128".toJson))
-                withActivation(wsk.activation, run) { response =>
-                    response.response.status shouldBe "success"
-                    response.response.result shouldBe Some(JsObject(
-                        "msg" -> "OK, buffer of size 128 MB has been filled.".toJson))
-                }
-            }
+    for (a <- 1 to 10) {
+      val run = wsk.action.invoke(name, Map("payload" -> "128".toJson))
+      withActivation(wsk.activation, run) { response =>
+        response.response.status shouldBe "success"
+        response.response.result shouldBe Some(JsObject("msg" -> "OK, buffer of size 128 MB has been filled.".toJson))
+      }
     }
+  }
 }

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/InvokerSupervisionTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/InvokerSupervisionTests.scala
@@ -75,7 +75,8 @@ import whisk.utils.retry
 import whisk.core.connector.test.TestConnector
 
 @RunWith(classOf[JUnitRunner])
-class InvokerSupervisionTests extends TestKit(ActorSystem("InvokerSupervision"))
+class InvokerSupervisionTests
+    extends TestKit(ActorSystem("InvokerSupervision"))
     with ImplicitSender
     with FlatSpecLike
     with Matchers
@@ -83,200 +84,212 @@ class InvokerSupervisionTests extends TestKit(ActorSystem("InvokerSupervision"))
     with MockFactory
     with StreamLogging {
 
-    val config = new WhiskConfig(ExecManifest.requiredProperties)
+  val config = new WhiskConfig(ExecManifest.requiredProperties)
 
-    ExecManifest.initialize(config)
+  ExecManifest.initialize(config)
 
-    override def afterAll {
-        TestKit.shutdownActorSystem(system)
+  override def afterAll {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  implicit val timeout = Timeout(5.seconds)
+
+  /** Imitates a StateTimeout in the FSM */
+  def timeout(actor: ActorRef) = actor ! FSM.StateTimeout
+
+  /** Queries all invokers for their state */
+  def allStates(pool: ActorRef) =
+    Await.result(pool.ask(GetStatus).mapTo[IndexedSeq[(InstanceId, InvokerState)]], timeout.duration)
+
+  /** Helper to generate a list of (InstanceId, InvokerState) */
+  def zipWithInstance(list: IndexedSeq[InvokerState]) = list.zipWithIndex.map {
+    case (state, index) => (InstanceId(index), state)
+  }
+
+  val pC = new TestConnector("pingFeedTtest", 4, false) {}
+
+  behavior of "InvokerPool"
+
+  it should "successfully create invokers in its pool on ping and keep track of statechanges" in {
+    val invoker5 = TestProbe()
+    val invoker2 = TestProbe()
+
+    val invoker5Instance = InstanceId(5)
+    val invoker2Instance = InstanceId(2)
+
+    val children = mutable.Queue(invoker5.ref, invoker2.ref)
+    val childFactory = (f: ActorRefFactory, instance: InstanceId) => children.dequeue()
+
+    val sendActivationToInvoker = stubFunction[ActivationMessage, InstanceId, Future[RecordMetadata]]
+    val supervisor = system.actorOf(InvokerPool.props(childFactory, sendActivationToInvoker, pC))
+
+    within(timeout.duration) {
+      // create first invoker
+      val ping0 = PingMessage(invoker5Instance)
+      supervisor ! ping0
+      invoker5.expectMsgType[SubscribeTransitionCallBack] // subscribe to the actor
+      invoker5.expectMsg(ping0)
+
+      invoker5.send(supervisor, CurrentState(invoker5.ref, Healthy))
+      allStates(supervisor) shouldBe zipWithInstance(IndexedSeq(Offline, Offline, Offline, Offline, Offline, Healthy))
+
+      // create second invoker
+      val ping1 = PingMessage(invoker2Instance)
+      supervisor ! ping1
+      invoker2.expectMsgType[SubscribeTransitionCallBack]
+      invoker2.expectMsg(ping1)
+
+      invoker2.send(supervisor, CurrentState(invoker2.ref, Healthy))
+      allStates(supervisor) shouldBe zipWithInstance(IndexedSeq(Offline, Offline, Healthy, Offline, Offline, Healthy))
+
+      // ping the first invoker again
+      supervisor ! ping0
+      invoker5.expectMsg(ping0)
+
+      allStates(supervisor) shouldBe zipWithInstance(IndexedSeq(Offline, Offline, Healthy, Offline, Offline, Healthy))
+
+      // one invoker goes offline
+      invoker2.send(supervisor, Transition(invoker2.ref, Healthy, Offline))
+      allStates(supervisor) shouldBe zipWithInstance(IndexedSeq(Offline, Offline, Offline, Offline, Offline, Healthy))
     }
+  }
 
-    implicit val timeout = Timeout(5.seconds)
+  it should "forward the ActivationResult to the appropriate invoker" in {
+    val invoker = TestProbe()
+    val invokerInstance = InstanceId(0)
+    val invokerName = s"invoker${invokerInstance.toInt}"
+    val childFactory = (f: ActorRefFactory, instance: InstanceId) => invoker.ref
+    val sendActivationToInvoker = stubFunction[ActivationMessage, InstanceId, Future[RecordMetadata]]
 
-    /** Imitates a StateTimeout in the FSM */
-    def timeout(actor: ActorRef) = actor ! FSM.StateTimeout
+    val supervisor = system.actorOf(InvokerPool.props(childFactory, sendActivationToInvoker, pC))
 
-    /** Queries all invokers for their state */
-    def allStates(pool: ActorRef) = Await.result(pool.ask(GetStatus).mapTo[IndexedSeq[(InstanceId, InvokerState)]], timeout.duration)
+    within(timeout.duration) {
+      // Create one invoker
+      val ping0 = PingMessage(invokerInstance)
+      supervisor ! ping0
+      invoker.expectMsgType[SubscribeTransitionCallBack] // subscribe to the actor
+      invoker.expectMsg(ping0)
+      invoker.send(supervisor, CurrentState(invoker.ref, Healthy))
+      allStates(supervisor) shouldBe zipWithInstance(IndexedSeq(Healthy))
 
-    /** Helper to generate a list of (InstanceId, InvokerState) */
-    def zipWithInstance(list: IndexedSeq[InvokerState]) = list.zipWithIndex.map { case (state, index) => (InstanceId(index), state) }
-
-    val pC = new TestConnector("pingFeedTtest", 4, false) {}
-
-    behavior of "InvokerPool"
-
-    it should "successfully create invokers in its pool on ping and keep track of statechanges" in {
-        val invoker5 = TestProbe()
-        val invoker2 = TestProbe()
-
-        val invoker5Instance = InstanceId(5)
-        val invoker2Instance = InstanceId(2)
-
-        val children = mutable.Queue(invoker5.ref, invoker2.ref)
-        val childFactory = (f: ActorRefFactory, instance: InstanceId) => children.dequeue()
-
-        val sendActivationToInvoker = stubFunction[ActivationMessage, InstanceId, Future[RecordMetadata]]
-        val supervisor = system.actorOf(InvokerPool.props(childFactory, sendActivationToInvoker, pC))
-
-        within(timeout.duration) {
-            // create first invoker
-            val ping0 = PingMessage(invoker5Instance)
-            supervisor ! ping0
-            invoker5.expectMsgType[SubscribeTransitionCallBack] // subscribe to the actor
-            invoker5.expectMsg(ping0)
-
-            invoker5.send(supervisor, CurrentState(invoker5.ref, Healthy))
-            allStates(supervisor) shouldBe zipWithInstance(IndexedSeq(Offline, Offline, Offline, Offline, Offline, Healthy))
-
-            // create second invoker
-            val ping1 = PingMessage(invoker2Instance)
-            supervisor ! ping1
-            invoker2.expectMsgType[SubscribeTransitionCallBack]
-            invoker2.expectMsg(ping1)
-
-            invoker2.send(supervisor, CurrentState(invoker2.ref, Healthy))
-            allStates(supervisor) shouldBe zipWithInstance(IndexedSeq(Offline, Offline, Healthy, Offline, Offline, Healthy))
-
-            // ping the first invoker again
-            supervisor ! ping0
-            invoker5.expectMsg(ping0)
-
-            allStates(supervisor) shouldBe zipWithInstance(IndexedSeq(Offline, Offline, Healthy, Offline, Offline, Healthy))
-
-            // one invoker goes offline
-            invoker2.send(supervisor, Transition(invoker2.ref, Healthy, Offline))
-            allStates(supervisor) shouldBe zipWithInstance(IndexedSeq(Offline, Offline, Offline, Offline, Offline, Healthy))
-        }
+      // Send message and expect receive in invoker
+      val msg = InvocationFinishedMessage(invokerInstance, true)
+      supervisor ! msg
+      invoker.expectMsg(msg)
     }
+  }
 
-    it should "forward the ActivationResult to the appropriate invoker" in {
-        val invoker = TestProbe()
-        val invokerInstance = InstanceId(0)
-        val invokerName = s"invoker${invokerInstance.toInt}"
-        val childFactory = (f: ActorRefFactory, instance: InstanceId) => invoker.ref
-        val sendActivationToInvoker = stubFunction[ActivationMessage, InstanceId, Future[RecordMetadata]]
+  it should "forward an ActivationMessage to the sendActivation-Method" in {
+    val invoker = TestProbe()
+    val invokerInstance = InstanceId(0)
+    val invokerName = s"invoker${invokerInstance.toInt}"
+    val childFactory = (f: ActorRefFactory, instance: InstanceId) => invoker.ref
 
-        val supervisor = system.actorOf(InvokerPool.props(childFactory, sendActivationToInvoker, pC))
+    val sendActivationToInvoker = stubFunction[ActivationMessage, InstanceId, Future[RecordMetadata]]
 
-        within(timeout.duration) {
-            // Create one invoker
-            val ping0 = PingMessage(invokerInstance)
-            supervisor ! ping0
-            invoker.expectMsgType[SubscribeTransitionCallBack] // subscribe to the actor
-            invoker.expectMsg(ping0)
-            invoker.send(supervisor, CurrentState(invoker.ref, Healthy))
-            allStates(supervisor) shouldBe zipWithInstance(IndexedSeq(Healthy))
+    val supervisor = system.actorOf(InvokerPool.props(childFactory, sendActivationToInvoker, pC))
 
-            // Send message and expect receive in invoker
-            val msg = InvocationFinishedMessage(invokerInstance, true)
-            supervisor ! msg
-            invoker.expectMsg(msg)
-        }
+    // Send ActivationMessage to InvokerPool
+    val activationMessage = ActivationMessage(
+      transid = TransactionId.invokerHealth,
+      action = FullyQualifiedEntityName(EntityPath("whisk.system/utils"), EntityName("date")),
+      revision = DocRevision.empty,
+      user = Identity(
+        Subject("unhealthyInvokerCheck"),
+        EntityName("unhealthyInvokerCheck"),
+        AuthKey(UUID(), Secret()),
+        Set[Privilege]()),
+      activationId = new ActivationIdGenerator {}.make(),
+      activationNamespace = EntityPath("guest"),
+      rootControllerIndex = InstanceId(0),
+      blocking = false,
+      content = None)
+    val msg = ActivationRequest(activationMessage, invokerInstance)
+
+    sendActivationToInvoker
+      .when(activationMessage, invokerInstance)
+      .returns(Future.successful(new RecordMetadata(new TopicPartition(invokerName, 0), 0L, 0L, 0L, 0L, 0, 0)))
+
+    supervisor ! msg
+
+    // Verify, that MessageProducer will receive a call to send the message
+    retry(
+      sendActivationToInvoker.verify(activationMessage, invokerInstance).once,
+      N = 3,
+      waitBeforeRetry = Some(500.milliseconds))
+  }
+
+  behavior of "InvokerActor"
+
+  // unHealthy -> offline
+  // offline -> unhealthy
+  it should "start unhealthy, go offline if the state times out and goes unhealthy on a successful ping again" in {
+    val pool = TestProbe()
+    val invoker = pool.system.actorOf(InvokerActor.props(InstanceId(0), InstanceId(0)))
+
+    within(timeout.duration) {
+      pool.send(invoker, SubscribeTransitionCallBack(pool.ref))
+      pool.expectMsg(CurrentState(invoker, UnHealthy))
+      timeout(invoker)
+      pool.expectMsg(Transition(invoker, UnHealthy, Offline))
+
+      invoker ! PingMessage(InstanceId(0))
+      pool.expectMsg(Transition(invoker, Offline, UnHealthy))
     }
+  }
 
-    it should "forward an ActivationMessage to the sendActivation-Method" in {
-        val invoker = TestProbe()
-        val invokerInstance = InstanceId(0)
-        val invokerName = s"invoker${invokerInstance.toInt}"
-        val childFactory = (f: ActorRefFactory, instance: InstanceId) => invoker.ref
+  // unhealthy -> healthy
+  it should "goto healthy again, if unhealthy and error buffer has enough successful invocations" in {
+    val pool = TestProbe()
+    val invoker = pool.system.actorOf(InvokerActor.props(InstanceId(0), InstanceId(0)))
 
-        val sendActivationToInvoker = stubFunction[ActivationMessage, InstanceId, Future[RecordMetadata]]
+    within(timeout.duration) {
+      pool.send(invoker, SubscribeTransitionCallBack(pool.ref))
+      pool.expectMsg(CurrentState(invoker, UnHealthy))
 
-        val supervisor = system.actorOf(InvokerPool.props(childFactory, sendActivationToInvoker, pC))
+      // Fill buffer with errors
+      (1 to InvokerActor.bufferSize).foreach { _ =>
+        invoker ! InvocationFinishedMessage(InstanceId(0), false)
+      }
 
-        // Send ActivationMessage to InvokerPool
-        val activationMessage = ActivationMessage(
-            transid = TransactionId.invokerHealth,
-            action = FullyQualifiedEntityName(EntityPath("whisk.system/utils"), EntityName("date")),
-            revision = DocRevision.empty,
-            user = Identity(Subject("unhealthyInvokerCheck"), EntityName("unhealthyInvokerCheck"), AuthKey(UUID(), Secret()), Set[Privilege]()),
-            activationId = new ActivationIdGenerator {}.make(),
-            activationNamespace = EntityPath("guest"),
-            rootControllerIndex = InstanceId(0),
-            blocking = false,
-            content = None)
-        val msg = ActivationRequest(activationMessage, invokerInstance)
-
-        sendActivationToInvoker.when(activationMessage, invokerInstance).returns(Future.successful(new RecordMetadata(new TopicPartition(invokerName, 0), 0L, 0L, 0L, 0L, 0, 0)))
-
-        supervisor ! msg
-
-        // Verify, that MessageProducer will receive a call to send the message
-        retry(sendActivationToInvoker.verify(activationMessage, invokerInstance).once, N = 3, waitBeforeRetry = Some(500.milliseconds))
+      // Fill buffer with successful invocations to become healthy again (one below errorTolerance)
+      (1 to InvokerActor.bufferSize - InvokerActor.bufferErrorTolerance).foreach { _ =>
+        invoker ! InvocationFinishedMessage(InstanceId(0), true)
+      }
+      pool.expectMsg(Transition(invoker, UnHealthy, Healthy))
     }
+  }
 
-    behavior of "InvokerActor"
+  // unhealthy -> offline
+  // offline -> unhealthy
+  it should "go offline when unhealthy, if the state times out and go unhealthy on a successful ping again" in {
+    val pool = TestProbe()
+    val invoker = pool.system.actorOf(InvokerActor.props(InstanceId(0), InstanceId(0)))
 
-    // unHealthy -> offline
-    // offline -> unhealthy
-    it should "start unhealthy, go offline if the state times out and goes unhealthy on a successful ping again" in {
-        val pool = TestProbe()
-        val invoker = pool.system.actorOf(InvokerActor.props(InstanceId(0), InstanceId(0)))
+    within(timeout.duration) {
+      pool.send(invoker, SubscribeTransitionCallBack(pool.ref))
+      pool.expectMsg(CurrentState(invoker, UnHealthy))
 
-        within(timeout.duration) {
-            pool.send(invoker, SubscribeTransitionCallBack(pool.ref))
-            pool.expectMsg(CurrentState(invoker, UnHealthy))
-            timeout(invoker)
-            pool.expectMsg(Transition(invoker, UnHealthy, Offline))
+      timeout(invoker)
+      pool.expectMsg(Transition(invoker, UnHealthy, Offline))
 
-            invoker ! PingMessage(InstanceId(0))
-            pool.expectMsg(Transition(invoker, Offline, UnHealthy))
-        }
+      invoker ! PingMessage(InstanceId(0))
+      pool.expectMsg(Transition(invoker, Offline, UnHealthy))
     }
+  }
 
-    // unhealthy -> healthy
-    it should "goto healthy again, if unhealthy and error buffer has enough successful invocations" in {
-        val pool = TestProbe()
-        val invoker = pool.system.actorOf(InvokerActor.props(InstanceId(0), InstanceId(0)))
+  it should "start timer to send testactions when unhealthy" in {
+    val invoker = TestFSMRef(new InvokerActor(InstanceId(0), InstanceId(0)))
+    invoker.stateName shouldBe UnHealthy
 
-        within(timeout.duration) {
-            pool.send(invoker, SubscribeTransitionCallBack(pool.ref))
-            pool.expectMsg(CurrentState(invoker, UnHealthy))
+    invoker.isTimerActive(InvokerActor.timerName) shouldBe true
 
-            // Fill buffer with errors
-            (1 to InvokerActor.bufferSize).foreach { _ =>
-                invoker ! InvocationFinishedMessage(InstanceId(0), false)
-            }
-
-            // Fill buffer with successful invocations to become healthy again (one below errorTolerance)
-            (1 to InvokerActor.bufferSize - InvokerActor.bufferErrorTolerance).foreach { _ =>
-                invoker ! InvocationFinishedMessage(InstanceId(0), true)
-            }
-            pool.expectMsg(Transition(invoker, UnHealthy, Healthy))
-        }
+    // Fill buffer with successful invocations to become healthy again (one below errorTolerance)
+    (1 to InvokerActor.bufferSize - InvokerActor.bufferErrorTolerance).foreach { _ =>
+      invoker ! InvocationFinishedMessage(InstanceId(0), true)
     }
+    invoker.stateName shouldBe Healthy
 
-    // unhealthy -> offline
-    // offline -> unhealthy
-    it should "go offline when unhealthy, if the state times out and go unhealthy on a successful ping again" in {
-        val pool = TestProbe()
-        val invoker = pool.system.actorOf(InvokerActor.props(InstanceId(0), InstanceId(0)))
-
-        within(timeout.duration) {
-            pool.send(invoker, SubscribeTransitionCallBack(pool.ref))
-            pool.expectMsg(CurrentState(invoker, UnHealthy))
-
-            timeout(invoker)
-            pool.expectMsg(Transition(invoker, UnHealthy, Offline))
-
-            invoker ! PingMessage(InstanceId(0))
-            pool.expectMsg(Transition(invoker, Offline, UnHealthy))
-        }
-    }
-
-    it should "start timer to send testactions when unhealthy" in {
-        val invoker = TestFSMRef(new InvokerActor(InstanceId(0), InstanceId(0)))
-        invoker.stateName shouldBe UnHealthy
-
-        invoker.isTimerActive(InvokerActor.timerName) shouldBe true
-
-        // Fill buffer with successful invocations to become healthy again (one below errorTolerance)
-        (1 to InvokerActor.bufferSize - InvokerActor.bufferErrorTolerance).foreach { _ =>
-            invoker ! InvocationFinishedMessage(InstanceId(0), true)
-        }
-        invoker.stateName shouldBe Healthy
-
-        invoker.isTimerActive(InvokerActor.timerName) shouldBe false
-    }
+    invoker.isTimerActive(InvokerActor.timerName) shouldBe false
+  }
 }

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/LoadBalancerDataTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/LoadBalancerDataTests.scala
@@ -17,163 +17,163 @@
 
 package whisk.core.loadBalancer.test
 
-import org.scalatest.{ FlatSpec, Matchers }
-import whisk.core.entity.{ ActivationId, UUID, WhiskActivation }
-import whisk.core.loadBalancer.{ ActivationEntry, LoadBalancerData }
+import org.scalatest.{FlatSpec, Matchers}
+import whisk.core.entity.{ActivationId, UUID, WhiskActivation}
+import whisk.core.loadBalancer.{ActivationEntry, LoadBalancerData}
 
-import scala.concurrent.{ Promise }
+import scala.concurrent.{Promise}
 import whisk.core.entity.InstanceId
 
 class LoadBalancerDataTests extends FlatSpec with Matchers {
 
-    val activationIdPromise = Promise[Either[ActivationId, WhiskActivation]]()
-    val firstEntry: ActivationEntry = ActivationEntry(ActivationId(), UUID(), InstanceId(0), activationIdPromise)
-    val secondEntry: ActivationEntry = ActivationEntry(ActivationId(), UUID(), InstanceId(1), activationIdPromise)
+  val activationIdPromise = Promise[Either[ActivationId, WhiskActivation]]()
+  val firstEntry: ActivationEntry = ActivationEntry(ActivationId(), UUID(), InstanceId(0), activationIdPromise)
+  val secondEntry: ActivationEntry = ActivationEntry(ActivationId(), UUID(), InstanceId(1), activationIdPromise)
 
-    behavior of "LoadBalancerData"
+  behavior of "LoadBalancerData"
 
-    it should "return the number of activations for a namespace" in {
+  it should "return the number of activations for a namespace" in {
 
-        val loadBalancerData = new LoadBalancerData()
-        loadBalancerData.putActivation(firstEntry.id, firstEntry)
+    val loadBalancerData = new LoadBalancerData()
+    loadBalancerData.putActivation(firstEntry.id, firstEntry)
 
-        loadBalancerData.activationCountOn(firstEntry.namespaceId) shouldBe 1
-        loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 1
-        loadBalancerData.activationById(firstEntry.id) shouldBe Some(firstEntry)
-    }
+    loadBalancerData.activationCountOn(firstEntry.namespaceId) shouldBe 1
+    loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 1
+    loadBalancerData.activationById(firstEntry.id) shouldBe Some(firstEntry)
+  }
 
-    it should "return the number of activations for each invoker" in {
+  it should "return the number of activations for each invoker" in {
 
-        val loadBalancerData = new LoadBalancerData()
-        loadBalancerData.putActivation(firstEntry.id, firstEntry)
-        loadBalancerData.putActivation(secondEntry.id, secondEntry)
+    val loadBalancerData = new LoadBalancerData()
+    loadBalancerData.putActivation(firstEntry.id, firstEntry)
+    loadBalancerData.putActivation(secondEntry.id, secondEntry)
 
-        loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 1
-        loadBalancerData.activationCountOn(secondEntry.invokerName) shouldBe 1
-        loadBalancerData.activationById(firstEntry.id) shouldBe Some(firstEntry)
-        loadBalancerData.activationById(secondEntry.id) shouldBe Some(secondEntry)
-    }
+    loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 1
+    loadBalancerData.activationCountOn(secondEntry.invokerName) shouldBe 1
+    loadBalancerData.activationById(firstEntry.id) shouldBe Some(firstEntry)
+    loadBalancerData.activationById(secondEntry.id) shouldBe Some(secondEntry)
+  }
 
-    it should "remove activations and reflect that accordingly" in {
+  it should "remove activations and reflect that accordingly" in {
 
-        val loadBalancerData = new LoadBalancerData()
-        loadBalancerData.putActivation(firstEntry.id, firstEntry)
-        loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 1
-        loadBalancerData.activationCountOn(firstEntry.namespaceId) shouldBe 1
+    val loadBalancerData = new LoadBalancerData()
+    loadBalancerData.putActivation(firstEntry.id, firstEntry)
+    loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 1
+    loadBalancerData.activationCountOn(firstEntry.namespaceId) shouldBe 1
 
-        loadBalancerData.removeActivation(firstEntry)
+    loadBalancerData.removeActivation(firstEntry)
 
-        loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 0
-        loadBalancerData.activationCountOn(firstEntry.namespaceId) shouldBe 0
-        loadBalancerData.activationById(firstEntry.id) shouldBe None
-    }
+    loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 0
+    loadBalancerData.activationCountOn(firstEntry.namespaceId) shouldBe 0
+    loadBalancerData.activationById(firstEntry.id) shouldBe None
+  }
 
-    it should "remove activations from all 3 maps by activation id" in {
+  it should "remove activations from all 3 maps by activation id" in {
 
-        val loadBalancerData = new LoadBalancerData()
-        loadBalancerData.putActivation(firstEntry.id, firstEntry)
-        loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 1
+    val loadBalancerData = new LoadBalancerData()
+    loadBalancerData.putActivation(firstEntry.id, firstEntry)
+    loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 1
 
-        loadBalancerData.removeActivation(firstEntry.id)
+    loadBalancerData.removeActivation(firstEntry.id)
 
-        loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 0
-    }
+    loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 0
+  }
 
-    it should "return None if the entry doesn't exist when we remove it" in {
-        val loadBalancerData = new LoadBalancerData()
-        loadBalancerData.removeActivation(firstEntry) shouldBe None
-    }
+  it should "return None if the entry doesn't exist when we remove it" in {
+    val loadBalancerData = new LoadBalancerData()
+    loadBalancerData.removeActivation(firstEntry) shouldBe None
+  }
 
-    it should "respond with different values accordingly" in {
+  it should "respond with different values accordingly" in {
 
-        val entry = ActivationEntry(ActivationId(), UUID(), InstanceId(1), activationIdPromise)
-        val entrySameInvokerAndNamespace = entry.copy(id = ActivationId())
-        val entrySameInvoker = entry.copy(id = ActivationId(), namespaceId = UUID())
+    val entry = ActivationEntry(ActivationId(), UUID(), InstanceId(1), activationIdPromise)
+    val entrySameInvokerAndNamespace = entry.copy(id = ActivationId())
+    val entrySameInvoker = entry.copy(id = ActivationId(), namespaceId = UUID())
 
-        val loadBalancerData = new LoadBalancerData()
-        loadBalancerData.putActivation(entry.id, entry)
-        loadBalancerData.activationCountOn(entry.namespaceId) shouldBe 1
-        loadBalancerData.activationCountOn(entry.invokerName) shouldBe 1
+    val loadBalancerData = new LoadBalancerData()
+    loadBalancerData.putActivation(entry.id, entry)
+    loadBalancerData.activationCountOn(entry.namespaceId) shouldBe 1
+    loadBalancerData.activationCountOn(entry.invokerName) shouldBe 1
 
-        loadBalancerData.putActivation(entrySameInvokerAndNamespace.id, entrySameInvokerAndNamespace)
-        loadBalancerData.activationCountOn(entry.namespaceId) shouldBe 2
-        loadBalancerData.activationCountOn(entry.invokerName) shouldBe 2
+    loadBalancerData.putActivation(entrySameInvokerAndNamespace.id, entrySameInvokerAndNamespace)
+    loadBalancerData.activationCountOn(entry.namespaceId) shouldBe 2
+    loadBalancerData.activationCountOn(entry.invokerName) shouldBe 2
 
-        loadBalancerData.putActivation(entrySameInvoker.id, entrySameInvoker)
-        loadBalancerData.activationCountOn(entry.namespaceId) shouldBe 2
-        loadBalancerData.activationCountOn(entry.invokerName) shouldBe 3
+    loadBalancerData.putActivation(entrySameInvoker.id, entrySameInvoker)
+    loadBalancerData.activationCountOn(entry.namespaceId) shouldBe 2
+    loadBalancerData.activationCountOn(entry.invokerName) shouldBe 3
 
-        loadBalancerData.removeActivation(entrySameInvokerAndNamespace)
-        loadBalancerData.activationCountOn(entry.namespaceId) shouldBe 1
-        loadBalancerData.activationCountOn(entry.invokerName) shouldBe 2
+    loadBalancerData.removeActivation(entrySameInvokerAndNamespace)
+    loadBalancerData.activationCountOn(entry.namespaceId) shouldBe 1
+    loadBalancerData.activationCountOn(entry.invokerName) shouldBe 2
 
-        // removing non existing entry doesn't mess up
-        loadBalancerData.removeActivation(entrySameInvokerAndNamespace)
-        loadBalancerData.activationCountOn(entry.namespaceId) shouldBe 1
-        loadBalancerData.activationCountOn(entry.invokerName) shouldBe 2
+    // removing non existing entry doesn't mess up
+    loadBalancerData.removeActivation(entrySameInvokerAndNamespace)
+    loadBalancerData.activationCountOn(entry.namespaceId) shouldBe 1
+    loadBalancerData.activationCountOn(entry.invokerName) shouldBe 2
 
-    }
+  }
 
-    it should "not add the same entry more then once" in {
+  it should "not add the same entry more then once" in {
 
-        val loadBalancerData = new LoadBalancerData()
+    val loadBalancerData = new LoadBalancerData()
 
-        loadBalancerData.putActivation(firstEntry.id, firstEntry)
-        loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 1
-        loadBalancerData.activationCountOn(firstEntry.namespaceId) shouldBe 1
+    loadBalancerData.putActivation(firstEntry.id, firstEntry)
+    loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 1
+    loadBalancerData.activationCountOn(firstEntry.namespaceId) shouldBe 1
 
-        loadBalancerData.putActivation(firstEntry.id, firstEntry)
-        loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 1
-        loadBalancerData.activationCountOn(firstEntry.namespaceId) shouldBe 1
-    }
+    loadBalancerData.putActivation(firstEntry.id, firstEntry)
+    loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 1
+    loadBalancerData.activationCountOn(firstEntry.namespaceId) shouldBe 1
+  }
 
-    it should "not evaluate the given block if an entry already exists" in {
+  it should "not evaluate the given block if an entry already exists" in {
 
-        val loadBalancerData = new LoadBalancerData()
-        var called = 0
+    val loadBalancerData = new LoadBalancerData()
+    var called = 0
 
-        val entry = loadBalancerData.putActivation(firstEntry.id, {
-            called += 1
-            firstEntry
-        })
+    val entry = loadBalancerData.putActivation(firstEntry.id, {
+      called += 1
+      firstEntry
+    })
 
-        called shouldBe 1
+    called shouldBe 1
 
-        // entry already exists, should not evaluate the block
-        val entryAfterSecond = loadBalancerData.putActivation(firstEntry.id, {
-            called += 1
-            firstEntry
-        })
+    // entry already exists, should not evaluate the block
+    val entryAfterSecond = loadBalancerData.putActivation(firstEntry.id, {
+      called += 1
+      firstEntry
+    })
 
-        called shouldBe 1
-        entry shouldBe entryAfterSecond
-    }
+    called shouldBe 1
+    entry shouldBe entryAfterSecond
+  }
 
-    it should "not evaluate the given block even if an entry is different (but has the same id)" in {
+  it should "not evaluate the given block even if an entry is different (but has the same id)" in {
 
-        val loadBalancerData = new LoadBalancerData()
-        var called = 0
-        val entrySameId = secondEntry.copy(id = firstEntry.id)
+    val loadBalancerData = new LoadBalancerData()
+    var called = 0
+    val entrySameId = secondEntry.copy(id = firstEntry.id)
 
-        val entry = loadBalancerData.putActivation(firstEntry.id, {
-            called += 1
-            firstEntry
-        })
+    val entry = loadBalancerData.putActivation(firstEntry.id, {
+      called += 1
+      firstEntry
+    })
 
-        called shouldBe 1
-        loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 1
-        loadBalancerData.activationCountOn(firstEntry.namespaceId) shouldBe 1
+    called shouldBe 1
+    loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 1
+    loadBalancerData.activationCountOn(firstEntry.namespaceId) shouldBe 1
 
-        // entry already exists, should not evaluate the block and change the state
-        val entryAfterSecond = loadBalancerData.putActivation(entrySameId.id, {
-            called += 1
-            entrySameId
-        })
+    // entry already exists, should not evaluate the block and change the state
+    val entryAfterSecond = loadBalancerData.putActivation(entrySameId.id, {
+      called += 1
+      entrySameId
+    })
 
-        called shouldBe 1
-        entry shouldBe entryAfterSecond
-        loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 1
-        loadBalancerData.activationCountOn(firstEntry.namespaceId) shouldBe 1
-    }
+    called shouldBe 1
+    entry shouldBe entryAfterSecond
+    loadBalancerData.activationCountOn(firstEntry.invokerName) shouldBe 1
+    loadBalancerData.activationCountOn(firstEntry.namespaceId) shouldBe 1
+  }
 
 }

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/LoadBalancerServiceObjectTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/LoadBalancerServiceObjectTests.scala
@@ -35,144 +35,127 @@ import whisk.core.entity.InstanceId
  */
 @RunWith(classOf[JUnitRunner])
 class LoadBalancerServiceObjectTests extends FlatSpec with Matchers {
-    behavior of "memoize"
+  behavior of "memoize"
 
-    it should "not recompute a value which was already given" in {
-        var calls = 0
-        val add1: Int => Int = LoadBalancerService.memoize {
-            case second =>
-                calls += 1
-                1 + second
-        }
-
-        add1(1) shouldBe 2
-        calls shouldBe 1
-        add1(1) shouldBe 2
-        calls shouldBe 1
-        add1(2) shouldBe 3
-        calls shouldBe 2
-        add1(1) shouldBe 2
-        calls shouldBe 2
+  it should "not recompute a value which was already given" in {
+    var calls = 0
+    val add1: Int => Int = LoadBalancerService.memoize {
+      case second =>
+        calls += 1
+        1 + second
     }
 
-    behavior of "pairwiseCoprimeNumbersUntil"
+    add1(1) shouldBe 2
+    calls shouldBe 1
+    add1(1) shouldBe 2
+    calls shouldBe 1
+    add1(2) shouldBe 3
+    calls shouldBe 2
+    add1(1) shouldBe 2
+    calls shouldBe 2
+  }
 
-    it should "return an empty set for malformed inputs" in {
-        LoadBalancerService.pairwiseCoprimeNumbersUntil(0) shouldBe Seq()
-        LoadBalancerService.pairwiseCoprimeNumbersUntil(-1) shouldBe Seq()
-    }
+  behavior of "pairwiseCoprimeNumbersUntil"
 
-    it should "return all coprime numbers until the number given" in {
-        LoadBalancerService.pairwiseCoprimeNumbersUntil(1) shouldBe Seq(1)
-        LoadBalancerService.pairwiseCoprimeNumbersUntil(2) shouldBe Seq(1)
-        LoadBalancerService.pairwiseCoprimeNumbersUntil(3) shouldBe Seq(1, 2)
-        LoadBalancerService.pairwiseCoprimeNumbersUntil(4) shouldBe Seq(1, 3)
-        LoadBalancerService.pairwiseCoprimeNumbersUntil(5) shouldBe Seq(1, 2, 3)
-        LoadBalancerService.pairwiseCoprimeNumbersUntil(9) shouldBe Seq(1, 2, 5, 7)
-        LoadBalancerService.pairwiseCoprimeNumbersUntil(10) shouldBe Seq(1, 3, 7)
-    }
+  it should "return an empty set for malformed inputs" in {
+    LoadBalancerService.pairwiseCoprimeNumbersUntil(0) shouldBe Seq()
+    LoadBalancerService.pairwiseCoprimeNumbersUntil(-1) shouldBe Seq()
+  }
 
-    behavior of "chooseInvoker"
+  it should "return all coprime numbers until the number given" in {
+    LoadBalancerService.pairwiseCoprimeNumbersUntil(1) shouldBe Seq(1)
+    LoadBalancerService.pairwiseCoprimeNumbersUntil(2) shouldBe Seq(1)
+    LoadBalancerService.pairwiseCoprimeNumbersUntil(3) shouldBe Seq(1, 2)
+    LoadBalancerService.pairwiseCoprimeNumbersUntil(4) shouldBe Seq(1, 3)
+    LoadBalancerService.pairwiseCoprimeNumbersUntil(5) shouldBe Seq(1, 2, 3)
+    LoadBalancerService.pairwiseCoprimeNumbersUntil(9) shouldBe Seq(1, 2, 5, 7)
+    LoadBalancerService.pairwiseCoprimeNumbersUntil(10) shouldBe Seq(1, 3, 7)
+  }
 
-    def invokers(n: Int) = (0 until n).map(i => (InstanceId(i), Healthy, 0))
-    def hashInto[A](list: Seq[A], hash: Int) = list(hash % list.size)
+  behavior of "chooseInvoker"
 
-    it should "return None on an empty invokers list" in {
-        LoadBalancerService.schedule(IndexedSeq(), 0, 1) shouldBe None
-    }
+  def invokers(n: Int) = (0 until n).map(i => (InstanceId(i), Healthy, 0))
+  def hashInto[A](list: Seq[A], hash: Int) = list(hash % list.size)
 
-    it should "return None on a list of offline/unhealthy invokers" in {
-        val invs = IndexedSeq(
-            (InstanceId(0), Offline, 0),
-            (InstanceId(1), UnHealthy, 0))
+  it should "return None on an empty invokers list" in {
+    LoadBalancerService.schedule(IndexedSeq(), 0, 1) shouldBe None
+  }
 
-        LoadBalancerService.schedule(invs, 0, 1) shouldBe None
-    }
+  it should "return None on a list of offline/unhealthy invokers" in {
+    val invs = IndexedSeq((InstanceId(0), Offline, 0), (InstanceId(1), UnHealthy, 0))
 
-    it should "schedule to the home invoker" in {
-        val invs = invokers(10)
-        val hash = 2
+    LoadBalancerService.schedule(invs, 0, 1) shouldBe None
+  }
 
-        LoadBalancerService.schedule(invs, 1, hash) shouldBe Some(InstanceId(hash % invs.size))
-    }
+  it should "schedule to the home invoker" in {
+    val invs = invokers(10)
+    val hash = 2
 
-    it should "take the only online invoker" in {
-        LoadBalancerService.schedule(IndexedSeq(
-            (InstanceId(0), Offline, 0),
-            (InstanceId(1), UnHealthy, 0),
-            (InstanceId(2), Healthy, 0)), 0, 1) shouldBe Some(InstanceId(2))
-    }
+    LoadBalancerService.schedule(invs, 1, hash) shouldBe Some(InstanceId(hash % invs.size))
+  }
 
-    it should "skip an offline/unhealthy invoker, even if its underloaded" in {
-        val hash = 0
-        val invs = IndexedSeq(
-            (InstanceId(0), Healthy, 10),
-            (InstanceId(1), UnHealthy, 0),
-            (InstanceId(2), Healthy, 0))
+  it should "take the only online invoker" in {
+    LoadBalancerService.schedule(
+      IndexedSeq((InstanceId(0), Offline, 0), (InstanceId(1), UnHealthy, 0), (InstanceId(2), Healthy, 0)),
+      0,
+      1) shouldBe Some(InstanceId(2))
+  }
 
-        LoadBalancerService.schedule(invs, 10, hash) shouldBe Some(InstanceId(2))
-    }
+  it should "skip an offline/unhealthy invoker, even if its underloaded" in {
+    val hash = 0
+    val invs = IndexedSeq((InstanceId(0), Healthy, 10), (InstanceId(1), UnHealthy, 0), (InstanceId(2), Healthy, 0))
 
-    it should "jump to the next invoker determined by a hashed stepsize if the home invoker is overloaded" in {
-        val invokerCount = 10
-        val hash = 2
-        val targetInvoker = hash % invokerCount
+    LoadBalancerService.schedule(invs, 10, hash) shouldBe Some(InstanceId(2))
+  }
 
-        val invs = invokers(invokerCount).updated(targetInvoker, (InstanceId(targetInvoker), Healthy, 1))
-        val step = hashInto(LoadBalancerService.pairwiseCoprimeNumbersUntil(invokerCount), hash)
+  it should "jump to the next invoker determined by a hashed stepsize if the home invoker is overloaded" in {
+    val invokerCount = 10
+    val hash = 2
+    val targetInvoker = hash % invokerCount
 
-        LoadBalancerService.schedule(invs, 1, hash) shouldBe Some(InstanceId((hash + step) % invs.size))
-    }
+    val invs = invokers(invokerCount).updated(targetInvoker, (InstanceId(targetInvoker), Healthy, 1))
+    val step = hashInto(LoadBalancerService.pairwiseCoprimeNumbersUntil(invokerCount), hash)
 
-    it should "wrap the search at the end of the invoker list" in {
-        val invokerCount = 3
-        val invs = IndexedSeq(
-            (InstanceId(0), Healthy, 1),
-            (InstanceId(1), Healthy, 1),
-            (InstanceId(2), Healthy, 0))
-        val hash = 1
+    LoadBalancerService.schedule(invs, 1, hash) shouldBe Some(InstanceId((hash + step) % invs.size))
+  }
 
-        val targetInvoker = hashInto(invs, hash) // will be invoker1
-        val step = hashInto(LoadBalancerService.pairwiseCoprimeNumbersUntil(invokerCount), hash) // will be 2
-        step shouldBe 2
+  it should "wrap the search at the end of the invoker list" in {
+    val invokerCount = 3
+    val invs = IndexedSeq((InstanceId(0), Healthy, 1), (InstanceId(1), Healthy, 1), (InstanceId(2), Healthy, 0))
+    val hash = 1
 
-        // invoker1 is overloaded so it will step (2 steps) to the next one --> 1 2 0 --> invoker0 is next target
-        // invoker0 is overloaded so it will step to the next one --> 0 1 2 --> invoker2 is next target and underloaded
-        LoadBalancerService.schedule(invs, 1, hash) shouldBe Some(InstanceId((hash + step + step) % invs.size))
-    }
+    val targetInvoker = hashInto(invs, hash) // will be invoker1
+    val step = hashInto(LoadBalancerService.pairwiseCoprimeNumbersUntil(invokerCount), hash) // will be 2
+    step shouldBe 2
 
-    it should "multiply its threshold in 3 iterations to find an invoker with a good warm-chance" in {
-        val invs = IndexedSeq(
-            (InstanceId(0), Healthy, 33),
-            (InstanceId(1), Healthy, 36),
-            (InstanceId(2), Healthy, 33))
-        val hash = 0 // home is 0, stepsize is 1
+    // invoker1 is overloaded so it will step (2 steps) to the next one --> 1 2 0 --> invoker0 is next target
+    // invoker0 is overloaded so it will step to the next one --> 0 1 2 --> invoker2 is next target and underloaded
+    LoadBalancerService.schedule(invs, 1, hash) shouldBe Some(InstanceId((hash + step + step) % invs.size))
+  }
 
-        // even though invoker1 is not the home invoker in this case, it gets chosen over
-        // the others because it's the first one encountered by the iteration mechanism to be below
-        // the threshold of 3 * 16 invocations
-        LoadBalancerService.schedule(invs, 16, hash) shouldBe Some(InstanceId(0))
-    }
+  it should "multiply its threshold in 3 iterations to find an invoker with a good warm-chance" in {
+    val invs = IndexedSeq((InstanceId(0), Healthy, 33), (InstanceId(1), Healthy, 36), (InstanceId(2), Healthy, 33))
+    val hash = 0 // home is 0, stepsize is 1
 
-    it should "choose the home invoker if all invokers are overloaded even above the muliplied threshold" in {
-        val invs = IndexedSeq(
-            (InstanceId(0), Healthy, 51),
-            (InstanceId(1), Healthy, 50),
-            (InstanceId(2), Healthy, 49))
-        val hash = 0 // home is 0, stepsize is 1
+    // even though invoker1 is not the home invoker in this case, it gets chosen over
+    // the others because it's the first one encountered by the iteration mechanism to be below
+    // the threshold of 3 * 16 invocations
+    LoadBalancerService.schedule(invs, 16, hash) shouldBe Some(InstanceId(0))
+  }
 
-        LoadBalancerService.schedule(invs, 16, hash) shouldBe Some(InstanceId(0))
-    }
+  it should "choose the home invoker if all invokers are overloaded even above the muliplied threshold" in {
+    val invs = IndexedSeq((InstanceId(0), Healthy, 51), (InstanceId(1), Healthy, 50), (InstanceId(2), Healthy, 49))
+    val hash = 0 // home is 0, stepsize is 1
 
-    it should "transparently work with partitioned sets of invokers" in {
-        val invs = IndexedSeq(
-            (InstanceId(3), Healthy, 0),
-            (InstanceId(4), Healthy, 0),
-            (InstanceId(5), Healthy, 0))
+    LoadBalancerService.schedule(invs, 16, hash) shouldBe Some(InstanceId(0))
+  }
 
-        LoadBalancerService.schedule(invs, 1, 0) shouldBe Some(InstanceId(3))
-        LoadBalancerService.schedule(invs, 1, 1) shouldBe Some(InstanceId(4))
-        LoadBalancerService.schedule(invs, 1, 2) shouldBe Some(InstanceId(5))
-        LoadBalancerService.schedule(invs, 1, 3) shouldBe Some(InstanceId(3))
-    }
+  it should "transparently work with partitioned sets of invokers" in {
+    val invs = IndexedSeq((InstanceId(3), Healthy, 0), (InstanceId(4), Healthy, 0), (InstanceId(5), Healthy, 0))
+
+    LoadBalancerService.schedule(invs, 1, 0) shouldBe Some(InstanceId(3))
+    LoadBalancerService.schedule(invs, 1, 1) shouldBe Some(InstanceId(4))
+    LoadBalancerService.schedule(invs, 1, 2) shouldBe Some(InstanceId(5))
+    LoadBalancerService.schedule(invs, 1, 3) shouldBe Some(InstanceId(3))
+  }
 }

--- a/tests/src/test/scala/whisk/spi/SpiTests.scala
+++ b/tests/src/test/scala/whisk/spi/SpiTests.scala
@@ -28,24 +28,24 @@ import org.scalatest.junit.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class SpiTests extends FlatSpec with Matchers with WskActorSystem with StreamLogging {
 
-    behavior of "SpiProvider"
+  behavior of "SpiProvider"
 
-    it should "load an Spi from SpiLoader via typesafe config" in {
-        val simpleSpi = SpiLoader.get[SimpleSpi]
-        simpleSpi shouldBe a[SimpleSpi]
-    }
+  it should "load an Spi from SpiLoader via typesafe config" in {
+    val simpleSpi = SpiLoader.get[SimpleSpi]
+    simpleSpi shouldBe a[SimpleSpi]
+  }
 
-    it should "throw an exception if the impl defined in application.conf is missing" in {
-        a[ClassNotFoundException] should be thrownBy SpiLoader.get[MissingSpi]
-    }
+  it should "throw an exception if the impl defined in application.conf is missing" in {
+    a[ClassNotFoundException] should be thrownBy SpiLoader.get[MissingSpi]
+  }
 
-    it should "throw an exception if the module is missing" in {
-        a[ClassNotFoundException] should be thrownBy SpiLoader.get[MissingModule]
-    }
+  it should "throw an exception if the module is missing" in {
+    a[ClassNotFoundException] should be thrownBy SpiLoader.get[MissingModule]
+  }
 
-    it should "throw an exception if the config key is missing" in {
-        a[ConfigException] should be thrownBy SpiLoader.get[MissingKey]
-    }
+  it should "throw an exception if the config key is missing" in {
+    a[ConfigException] should be thrownBy SpiLoader.get[MissingKey]
+  }
 }
 
 trait SimpleSpi extends Spi

--- a/tests/src/test/scala/whisk/test/http/RESTProxy.scala
+++ b/tests/src/test/scala/whisk/test/http/RESTProxy.scala
@@ -34,109 +34,110 @@ import akka.pattern.pipe
 import akka.util.Timeout
 
 object RESTProxy {
-    // Orders the proxy to immediately unbind and rebind after the duration has passed.
-    case class UnbindFor(duration: FiniteDuration)
+  // Orders the proxy to immediately unbind and rebind after the duration has passed.
+  case class UnbindFor(duration: FiniteDuration)
 }
 
 /**
  * A simple REST proxy that can receive commands to change its behavior (e.g.
  * simulate failures of the proxied service). Not for use in production.
  */
-class RESTProxy(val host: String, val port: Int)(val serviceAuthority: Uri.Authority, val useHTTPS: Boolean) extends Actor with ActorLogging {
-    private implicit val actorSystem = context.system
-    private implicit val executionContex = actorSystem.dispatcher
+class RESTProxy(val host: String, val port: Int)(val serviceAuthority: Uri.Authority, val useHTTPS: Boolean)
+    extends Actor
+    with ActorLogging {
+  private implicit val actorSystem = context.system
+  private implicit val executionContex = actorSystem.dispatcher
 
-    private val destHost = serviceAuthority.host.address
-    private val destPort = serviceAuthority.port
+  private val destHost = serviceAuthority.host.address
+  private val destPort = serviceAuthority.port
 
-    // These change as connections come and go
-    private var materializer: Option[ActorMaterializer] = None
-    private var binding: Option[Http.ServerBinding] = None
+  // These change as connections come and go
+  private var materializer: Option[ActorMaterializer] = None
+  private var binding: Option[Http.ServerBinding] = None
 
-    // Public messages
-    import RESTProxy._
+  // Public messages
+  import RESTProxy._
 
-    // Internal messages
-    private case object DoBind
-    private case object DoUnbind
-    private case class Request(request: HttpRequest)
+  // Internal messages
+  private case object DoBind
+  private case object DoUnbind
+  private case class Request(request: HttpRequest)
 
-    // Route requests through messages to this actor, to serialize w.r.t events such as unbinding
-    private def mkRequestFlow(materializer: Materializer) : Flow[HttpRequest,HttpResponse,_] = {
-        implicit val m = materializer
+  // Route requests through messages to this actor, to serialize w.r.t events such as unbinding
+  private def mkRequestFlow(materializer: Materializer): Flow[HttpRequest, HttpResponse, _] = {
+    implicit val m = materializer
 
-        Flow.apply[HttpRequest].mapAsync(4) { request =>
-            ask(self, Request(request))(timeout = Timeout(1.minute)).mapTo[HttpResponse]
+    Flow.apply[HttpRequest].mapAsync(4) { request =>
+      ask(self, Request(request))(timeout = Timeout(1.minute)).mapTo[HttpResponse]
+    }
+  }
+
+  private def bind(checkState: Boolean = true): Unit = {
+    assert(!checkState || binding.isEmpty, "Proxy is already bound")
+
+    if (binding.isEmpty) {
+      assert(materializer.isEmpty)
+      implicit val m = ActorMaterializer()
+      materializer = Some(m)
+      log.debug(s"[RESTProxy] Binding to '$host:$port'.")
+      val b = Await.result(Http().bindAndHandle(mkRequestFlow(m), host, port), 5.seconds)
+      binding = Some(b)
+    }
+  }
+
+  private def unbind(checkState: Boolean = true): Unit = {
+    assert(!checkState || binding.isDefined, "Proxy is not bound")
+
+    binding.foreach { b =>
+      log.debug(s"[RESTProxy] Unbinding from '${b.localAddress}'")
+      Await.result(b.unbind(), 5.seconds)
+      binding = None
+      assert(materializer.isDefined)
+      materializer.foreach { m =>
+        materializer = None
+        m.shutdown()
+      }
+    }
+  }
+
+  override def preStart() = bind()
+
+  override def postStop() = unbind(checkState = false)
+
+  override def receive = {
+    case UnbindFor(d) =>
+      self ! DoUnbind
+      actorSystem.scheduler.scheduleOnce(d, self, DoBind)
+
+    case DoUnbind =>
+      unbind(checkState = false)
+
+    case DoBind =>
+      bind(checkState = false)
+
+    case Request(request) =>
+      // If the actor isn't bound to the port / has no materializer,
+      // the request is simply dropped.
+      materializer.map { implicit m =>
+        log.debug(s"[RESTProxy] Proxying '${request.uri}' to '${serviceAuthority}'")
+
+        val flow = if (useHTTPS) {
+          Http().outgoingConnectionHttps(destHost, destPort)
+        } else {
+          Http().outgoingConnection(destHost, destPort)
         }
-    }
 
-    private def bind(checkState: Boolean = true) : Unit = {
-        assert(!checkState || binding.isEmpty, "Proxy is already bound")
+        // akka-http doesn't like us to set those headers ourselves.
+        val upstreamRequest = request.copy(headers = request.headers.filter(_ match {
+          case `Timeout-Access`(_) => false
+          case _                   => true
+        }))
 
-        if(binding.isEmpty) {
-            assert(materializer.isEmpty)
-            implicit val m = ActorMaterializer()
-            materializer = Some(m)
-            log.debug(s"[RESTProxy] Binding to '$host:$port'.")
-            val b = Await.result(Http().bindAndHandle(mkRequestFlow(m), host, port), 5.seconds)
-            binding = Some(b)
-        }
-    }
-
-    private def unbind(checkState: Boolean = true) : Unit = {
-        assert(!checkState || binding.isDefined, "Proxy is not bound")
-
-        binding.foreach { b =>
-            log.debug(s"[RESTProxy] Unbinding from '${b.localAddress}'")
-            Await.result(b.unbind(), 5.seconds)
-            binding = None
-            assert(materializer.isDefined)
-            materializer.foreach { m =>
-                materializer = None
-                m.shutdown()
-            }
-        }
-    }
-
-    override def preStart() = bind()
-
-    override def postStop() = unbind(checkState = false)
-
-    override def receive = {
-        case UnbindFor(d) =>
-            self ! DoUnbind
-            actorSystem.scheduler.scheduleOnce(d, self, DoBind)
-
-        case DoUnbind =>
-            unbind(checkState = false)
-
-        case DoBind =>
-            bind(checkState = false)
-
-        case Request(request) =>
-            // If the actor isn't bound to the port / has no materializer,
-            // the request is simply dropped.
-            materializer.map { implicit m =>
-                log.debug(s"[RESTProxy] Proxying '${request.uri}' to '${serviceAuthority}'")
-
-                val flow = if(useHTTPS) {
-                    Http().outgoingConnectionHttps(destHost, destPort)
-                } else {
-                    Http().outgoingConnection(destHost, destPort)
-                }
-
-                // akka-http doesn't like us to set those headers ourselves.
-                val upstreamRequest = request.copy(
-                    headers = request.headers.filter(_ match {
-                        case `Timeout-Access`(_) => false
-                        case _ => true
-                    })
-                )
-
-                Source.single(upstreamRequest)
-                    .via(flow)
-                    .runWith(Sink.head)
-                    .pipeTo(sender)
-            }
-    }
+        Source
+          .single(upstreamRequest)
+          .via(flow)
+          .runWith(Sink.head)
+          .pipeTo(sender)
+      }
+  }
 }

--- a/tests/src/test/scala/whisk/utils/test/ExecutionContextFactoryTests.scala
+++ b/tests/src/test/scala/whisk/utils/test/ExecutionContextFactoryTests.scala
@@ -32,14 +32,14 @@ import whisk.utils.ExecutionContextFactory.FutureExtensions
 @RunWith(classOf[JUnitRunner])
 class ExecutionContextFactoryTests extends FlatSpec with Matchers with WskActorSystem {
 
-    behavior of "future extensions"
+  behavior of "future extensions"
 
-    it should "take first to complete" in {
-        val f1 = Future.successful({}).withTimeout(500.millis, new Throwable("error"))
-        Await.result(f1, 1.second) shouldBe ({})
+  it should "take first to complete" in {
+    val f1 = Future.successful({}).withTimeout(500.millis, new Throwable("error"))
+    Await.result(f1, 1.second) shouldBe ({})
 
-        val failure = new Throwable("error")
-        val f2 = Future { Thread.sleep(1.second.toMillis) }.withTimeout(500.millis, failure)
-        a[Throwable] shouldBe thrownBy { Await.result(f2, 1.seconds) }
-    }
+    val failure = new Throwable("error")
+    val f2 = Future { Thread.sleep(1.second.toMillis) }.withTimeout(500.millis, failure)
+    a[Throwable] shouldBe thrownBy { Await.result(f2, 1.seconds) }
+  }
 }

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -14,6 +14,10 @@ git clone https://github.com/apache/incubator-openwhisk-utilities.git
 # run the scancode util. against project source code starting at its root
 incubator-openwhisk-utilities/scancode/scanCode.py $ROOTDIR --config $ROOTDIR/tools/build/scanCode.cfg
 
+# run scalafmt checks
+cd $ROOTDIR
+TERM=dumb ./gradlew checkScalafmtAll
+
 cd $ROOTDIR/ansible
 
 ANSIBLE_CMD="ansible-playbook -i environments/local -e docker_image_prefix=testing"


### PR DESCRIPTION
Formats all .scala files according to `scalafmt`'s (opinionated) style. Travis checks for correcly formatted code.

Let's discuss which style we want to adapt and enforce and then forget about misformatted code forever!