### PR TITLE
Treat a timed out active ack as failed activation in invokerhealth protocol

### DIFF
--- a/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
@@ -285,8 +285,9 @@ class InvokerActor(invokerInstance: InstanceId, controllerInstance: InstanceId) 
 
     // If the action is successful it seems like the Invoker is Healthy again. So we execute immediately
     // a new test action to remove the errors out of the RingBuffer as fast as possible.
-    // The actions that arrice while the invoker is unhealthy are most likely health actions.
-    // But it could be real actions as well, if they were already in the queue/in progress while the invoker turned unhealthy.
+    // The actions that arrive while the invoker is unhealthy are most likely health actions.
+    // It is possible they are normal user actions as well. This can happen if such actions were in the
+    // invoker queue or in progress while the invoker's status flipped to Unhealthy.
     if (wasActivationSuccessful && stateName == UnHealthy) {
       invokeTestAction()
     }

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
@@ -283,9 +283,10 @@ class InvokerActor(invokerInstance: InstanceId, controllerInstance: InstanceId) 
   private def handleCompletionMessage(wasActivationSuccessful: Boolean, buffer: RingBuffer[Boolean]) = {
     buffer.add(wasActivationSuccessful)
 
-    // If the current state is UnHealthy, then the active ack is the result of a test action.
-    // If this is successful it seems like the Invoker is Healthy again. So we execute immediately
+    // If the action is successful it seems like the Invoker is Healthy again. So we execute immediately
     // a new test action to remove the errors out of the RingBuffer as fast as possible.
+    // The actions that arrice while the invoker is unhealthy are most likely health actions.
+    // But it could be real actions as well, if they were already in the queue/in progress while the invoker turned unhealthy.
     if (wasActivationSuccessful && stateName == UnHealthy) {
       invokeTestAction()
     }

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -129,7 +129,7 @@ class LoadBalancerService(config: WhiskConfig, instance: InstanceId, entityStore
                                 invoker: InstanceId): Unit = {
     val aid = response.fold(l => l, r => r.activationId)
 
-    // treat left as success (as it is the result a the message exceeding the bus limit)
+    // treat left as success (as it is the result of a message exceeding the bus limit)
     val isSuccess = response.fold(l => true, r => !r.response.isWhiskError)
 
     loadBalancerData.removeActivation(aid) match {


### PR DESCRIPTION
The Loadbalancer has a buffer of, if the last activations of an invoker has been successful.
This PR treats an activation as unsuccessful, if the active ack times out.
This will take the invoker unhealthy, if it does not respond with active acks anymore.

PG4#714 is running