### PR TITLE
Add judge condition for invoker deployment

### DIFF
--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -59,6 +59,10 @@
   with_items: "{{ invokerInfo.json }}"
   when: not invoker.allowMultipleInstances and item.Names[0] != "/invoker{{ groups['invokers'].index(inventory_hostname) }}"
 
+- name: get invoker container Names list
+  set_fact:
+    nameList: "{{ invokerInfo.json | map(attribute='Names') | list }}"
+
 - name: start invoker using docker cli
   shell: >
         docker run -d
@@ -104,6 +108,7 @@
         -p {{ invoker.port + groups['invokers'].index(inventory_hostname) }}:8080
         {{ docker_registry }}{{ docker.image.prefix }}/invoker:{{ docker.image.tag }}
         /bin/sh -c "exec /invoker/bin/invoker {{ groups['invokers'].index(inventory_hostname) }} >> /logs/invoker{{ groups['invokers'].index(inventory_hostname) }}_logs.log 2>&1"
+  when: "['/invoker{{ groups['invokers'].index(inventory_hostname) }}'] not in nameList"
 
 # todo: re-enable docker_container module once https://github.com/ansible/ansible-modules-core/issues/5054 is resolved
 


### PR DESCRIPTION
If invokers have been deployed success.
Then, it will report error when execute `ansible-playbook -i environments/<env> invoker.yml ` again.
because the invoker0 or invoker1 alreay exist, so below errors will appear.
```
TASK [invoker : start invoker using docker cli] *********************************************************************************************
...
...
You have to remove (or rename) that container to be able to reuse that name..\nSee 'docker run --help'.", "stderr_lines": ["docker: Error response from daemon: Conflict. The name \"/invoker0\" is already in use by container 1de4dc7d6ca3234d1b6590061e637c48367f9076766f767ef9271d1848e08620. You have to remove (or rename) that container to be able to reuse that name..", "See 'docker run --help'."], "stdout": "", "stdout_lines": []}
[FAILED]
```

So it is necessary to add the `judge condition` that whether the invoker has been deployed,
if already deployed, there has no need to deploy again.