### PR TITLE
Simplify Spi implementations.

### DIFF
--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaMessagingProvider.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaMessagingProvider.scala
@@ -24,20 +24,14 @@ import whisk.core.WhiskConfig
 import whisk.core.connector.MessageConsumer
 import whisk.core.connector.MessageProducer
 import whisk.core.connector.MessagingProvider
-import whisk.spi.Dependencies
-import whisk.spi.SingletonSpiFactory
 
 /**
  * A Kafka based implementation of MessagingProvider
  */
-class KafkaMessagingProvider() extends MessagingProvider {
+object KafkaMessagingProvider extends MessagingProvider {
     def getConsumer(config: WhiskConfig, groupId: String, topic: String, maxPeek: Int, maxPollInterval: FiniteDuration)(implicit logging: Logging): MessageConsumer =
         new KafkaConsumerConnector(config.kafkaHost, groupId, topic, maxPeek, maxPollInterval = maxPollInterval)
 
     def getProducer(config: WhiskConfig, ec: ExecutionContext)(implicit logging: Logging): MessageProducer =
         new KafkaProducerConnector(config.kafkaHost, ec)
-}
-
-object KafkaMessagingProvider extends SingletonSpiFactory[MessagingProvider] {
-    override def apply(dependencies: Dependencies): MessagingProvider = new KafkaMessagingProvider
 }

--- a/common/scala/src/main/scala/whisk/core/database/CouchDbStoreProvider.scala
+++ b/common/scala/src/main/scala/whisk/core/database/CouchDbStoreProvider.scala
@@ -21,13 +21,9 @@ import akka.actor.ActorSystem
 import spray.json.RootJsonFormat
 import whisk.common.Logging
 import whisk.core.WhiskConfig
-import whisk.spi.Dependencies
-import whisk.spi.SpiFactory
 
-/**
- * A CouchDB implementation of ArtifactStoreProvider
- */
-class CouchDbStoreProvider extends ArtifactStoreProvider {
+object CouchDbStoreProvider extends ArtifactStoreProvider {
+
     def makeStore[D <: DocumentSerializer](config: WhiskConfig, name: WhiskConfig => String)(
         implicit jsonFormat: RootJsonFormat[D],
         actorSystem: ActorSystem,
@@ -38,8 +34,4 @@ class CouchDbStoreProvider extends ArtifactStoreProvider {
 
         new CouchDbRestStore[D](config.dbProtocol, config.dbHost, config.dbPort.toInt, config.dbUsername, config.dbPassword, name(config))
     }
-}
-
-object CouchDbStoreProvider extends SpiFactory[ArtifactStoreProvider] {
-    override def apply(deps: Dependencies): ArtifactStoreProvider = new CouchDbStoreProvider
 }

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
@@ -98,7 +98,7 @@ object WhiskAuthStore {
             dbAuths -> null)
 
     def datastore(config: WhiskConfig)(implicit system: ActorSystem, logging: Logging) =
-        SpiLoader.get[ArtifactStoreProvider]().makeStore[WhiskAuth](config, _.dbAuths)
+        SpiLoader.get[ArtifactStoreProvider].makeStore[WhiskAuth](config, _.dbAuths)
 }
 
 object WhiskEntityStore {
@@ -112,7 +112,7 @@ object WhiskEntityStore {
             dbWhisk -> null)
 
     def datastore(config: WhiskConfig)(implicit system: ActorSystem, logging: Logging) =
-        SpiLoader.get[ArtifactStoreProvider]().makeStore[WhiskEntity](config, _.dbWhisk)(WhiskEntityJsonFormat, system, logging)
+        SpiLoader.get[ArtifactStoreProvider].makeStore[WhiskEntity](config, _.dbWhisk)(WhiskEntityJsonFormat, system, logging)
 
 }
 
@@ -127,7 +127,7 @@ object WhiskActivationStore {
             dbActivations -> null)
 
     def datastore(config: WhiskConfig)(implicit system: ActorSystem, logging: Logging) =
-        SpiLoader.get[ArtifactStoreProvider]().makeStore[WhiskActivation](config, _.dbActivations)
+        SpiLoader.get[ArtifactStoreProvider].makeStore[WhiskActivation](config, _.dbActivations)
 }
 
 /**

--- a/common/scala/src/main/scala/whisk/spi/SpiLoader.scala
+++ b/common/scala/src/main/scala/whisk/spi/SpiLoader.scala
@@ -18,49 +18,13 @@
 package whisk.spi
 
 import com.typesafe.config.ConfigFactory
-import java.util.concurrent.atomic.AtomicReference
 
 /** Marker trait to mark an Spi */
 trait Spi
 
-/** Trait to be extended by factory objects creating Spi implementations */
-trait SpiFactory[T <: Spi] {
-    def apply(dependencies: Dependencies): T
-
-    /**
-     * Proxy method only called by the SpiLoader so the apply method
-     * is overridable even with custom logic implemented.
-     *
-     * @param dependencies Dependencies to pass to the Spi
-     */
-    def buildInstance(dependencies: Dependencies): T = apply(dependencies)
-}
-
-/**
- * SpiFactory which is guaranteed to always return the same reference for
- * the same type of Spi.
- */
-trait SingletonSpiFactory[T <: Spi] extends SpiFactory[T] {
-    private val ref = new AtomicReference[T]()
-
-    override def buildInstance(dependencies: Dependencies): T = {
-        val oldValue = ref.get()
-        if (oldValue != null.asInstanceOf[T]) {
-            oldValue
-        } else {
-            val newValue = apply(dependencies)
-            if (ref.compareAndSet(null.asInstanceOf[T], newValue)) {
-                newValue
-            } else {
-                ref.get()
-            }
-        }
-    }
-}
-
 trait SpiClassResolver {
     /** Resolves the implementation for a given type */
-    def getClassNameForType[T](implicit man: Manifest[T]): String
+    def getClassNameForType[T : Manifest]: String
 }
 
 object SpiLoader {
@@ -70,9 +34,9 @@ object SpiLoader {
      * The ClassName to load is resolved via the SpiClassResolver in scode, which defaults to
      * a TypesafeConfig based resolver.
      */
-    def get[A <: Spi](deps: Dependencies = Dependencies())(implicit resolver: SpiClassResolver = TypesafeConfigClassResolver, man: Manifest[A]): A = {
+    def get[A <: Spi : Manifest](implicit resolver: SpiClassResolver = TypesafeConfigClassResolver): A = {
         val clazz = Class.forName(resolver.getClassNameForType[A] + "$")
-        clazz.getField("MODULE$").get(clazz).asInstanceOf[SpiFactory[A]].buildInstance(deps)
+        clazz.getField("MODULE$").get(clazz).asInstanceOf[A]
     }
 }
 
@@ -80,21 +44,5 @@ object SpiLoader {
 object TypesafeConfigClassResolver extends SpiClassResolver {
     private val config = ConfigFactory.load()
 
-    override def getClassNameForType[T](implicit man: Manifest[T]): String = config.getString("whisk.spi." + man.runtimeClass.getSimpleName)
-}
-
-/**
- * Object containing arbitrary objects acting as dependencies.
- *
- * This is solely a helper type to cross the border between possibly heterogeneous Spi
- * interfaces and the production code.
- */
-case class Dependencies(private val deps: Any*) {
-    require(deps.map(_.getClass).distinct.size == deps.size, "A type can only occur once as a dependency")
-
-    def get[T](implicit man: Manifest[T]): T =
-        deps.find(d => man.runtimeClass.isAssignableFrom(d.getClass)) match {
-            case Some(d: T) => d
-            case _          => throw new IllegalArgumentException(s"missing dependency of type ${man.runtimeClass.getName}")
-        }
+    override def getClassNameForType[T : Manifest]: String = config.getString("whisk.spi." + manifest[T].runtimeClass.getSimpleName)
 }

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -172,8 +172,8 @@ class LoadBalancerService(
     }
 
     /** Gets a producer which can publish messages to the kafka bus. */
-    private val messasgingProvider = SpiLoader.get[MessagingProvider]()
-    private val messageProducer = messasgingProvider.getProducer(config, executionContext)
+    private val messagingProvider = SpiLoader.get[MessagingProvider]
+    private val messageProducer = messagingProvider.getProducer(config, executionContext)
 
     private def sendActivationToInvoker(producer: MessageProducer, msg: ActivationMessage, invoker: InstanceId): Future[RecordMetadata] = {
         implicit val transid = msg.transid
@@ -198,7 +198,7 @@ class LoadBalancerService(
         }
 
         val maxPingsPerPoll = 128
-        val pingConsumer = messasgingProvider.getConsumer(config, s"health${instance.toInt}", "health", maxPeek = maxPingsPerPoll)
+        val pingConsumer = messagingProvider.getConsumer(config, s"health${instance.toInt}", "health", maxPeek = maxPingsPerPoll)
         val invokerFactory = (f: ActorRefFactory, invokerInstance: InstanceId) => f.actorOf(InvokerActor.props(invokerInstance, instance))
 
         actorSystem.actorOf(InvokerPool.props(
@@ -212,7 +212,7 @@ class LoadBalancerService(
      */
     val maxActiveAcksPerPoll = 128
     val activeAckPollDuration = 1.second
-    private val activeAckConsumer = messasgingProvider.getConsumer(config, "completions", s"completed${instance.toInt}", maxPeek = maxActiveAcksPerPoll)
+    private val activeAckConsumer = messagingProvider.getConsumer(config, "completions", s"completed${instance.toInt}", maxPeek = maxActiveAcksPerPoll)
     val activationFeed = actorSystem.actorOf(Props {
         new MessageFeed("activeack", logging,
             activeAckConsumer, maxActiveAcksPerPoll, activeAckPollDuration, processActiveAck)

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -87,7 +87,7 @@ object Invoker {
             abort()
         }
 
-        val msgProvider = SpiLoader.get[MessagingProvider]()
+        val msgProvider = SpiLoader.get[MessagingProvider]
         val producer = msgProvider.getProducer(config, ec)
         val invoker = new InvokerReactive(config, invokerInstance, producer)
 

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
@@ -67,7 +67,7 @@ class InvokerReactive(config: WhiskConfig, instance: InstanceId, producer: Messa
     /** Initialize message consumers */
     val topic = s"invoker${instance.toInt}"
     val maximumContainers = config.invokerNumCore.toInt * config.invokerCoreShare.toInt
-    val msgProvider = SpiLoader.get[MessagingProvider]()
+    val msgProvider = SpiLoader.get[MessagingProvider]
     val consumer = msgProvider.getConsumer(config, "invokers", topic, maximumContainers, maxPollInterval = TimeLimit.MAX_DURATION + 1.minute)
 
     val activationFeed = actorSystem.actorOf(Props {

--- a/docs/spi.md
+++ b/docs/spi.md
@@ -12,66 +12,53 @@ class TheImpl extends ThisIsPluggable { ... }
 class TheOtherImpl extends ThisIsPluggable { ... }
 ```
 
-Runtime resolution of an Spi trait to a specific impl is provided by:
-* SpiLoader - a utility for loading the impl of a specific Spi, using a resolver to determine the impls factory classname, and reflection to load the factory object
-* SpiFactory - a way to define a factory for each impl, all of which are loaded via reflection
-* application.conf - each SpiFactory is resolved to a classname based on the config key provided to SpiLoader
+Runtime resolution of an Spi trait to a specific implementation is provided by:
+* `SpiLoader` - a utility for loading the implementation of a specific Spi, using a resolver to determine the implentations factory classname, and reflection to load the factory object.
+* `application.conf` - each `Spi` is resolved to a classname based on the config key provided to `SpiLoader`.
 
-A single SpiFactory per unique Spi is usable at runtime, since the key will have a single string value. 
+Only a single implementation per Spi is usable at runtime, since the key will have a single string value.
 
 # Example
 
 The process to create and use an SPI is as follows:
 
-## Define the Spi and impl(s)
+## Define the Spi and implementations
 
-* create your Spi trait `YourSpi` as an class that is an extension of `whisk.spi.Spi`
-* create you SpiFactory impl `YourSpiFactory` as an object that is an extension of `whisk.spi.SpiFactory` (or `whisk.spi.SingletonSpiFactory`)
-* create your impls as classes that extend `YourSpi`
-
-## Define the SpiFactory to load the impl
-
-```scala
-class YourImplFactory extends SpiFactory[YourSpi]{
-  def apply(dependencies: Dependencies): { ...construct the impl...}
-}
-```
-for singleton behavior you can use
-```scala
-class YourImplFactory extends SingletonSpiFactory[YourSpi]{
-  def apply(dependencies: Dependencies): { ...construct the impl...}
-}
-```
+* Create your Spi trait `YourSpi` as a trait that is an extension of `whisk.spi.Spi`.
+* Create your factory object which extends `YourSpi` and provides the relevant functionality.
+* Create your functionality classes with whatever name you like. The factory object is supposed to build and return those instances.
 
 ## Invoke SpiLoader.get to acquire an instance of the SPI
 
-SpiLoader uses a TypesafeConfig key to use for resolving which impl should be loaded. 
+SpiLoader uses a TypesafeConfig key to use for resolving which implementation should be loaded.
 
-The config key used to find the impl classname is `whisk.spi.<SpiInterface>` 
+The config key used to find the implementations classname is `whisk.spi.<SpiInterface>`.
 
-For example, the SPI interface `whisk.core.database.ArtifactStoreProvider` would load a specific impl indicated by the  `whisk.spi.ArtifactStoreProvider` config key.
+For example, the SPI interface `whisk.core.database.ArtifactStoreProvider` would load a specific implementation indicated by the  `whisk.spi.ArtifactStoreProvider` config key.
 
 (so you cannot use multiple SPI interfaces with the same class name in different packages)
  
 
-Invoke the loader using `SpiLoader.get[<the SPI interface>]()(<implicit resolver>)`
+Invoke the loader using `SpiLoader.get[<the SPI interface>](<implicit resolver>)`
 
 ```scala
-val messagingProvider = SpiLoader.get[MessagingProvider]()
+val messagingProvider = SpiLoader.get[MessagingProvider]
 ```
 
 ## Defaults
 
-Default impls resolution is dependent on the config values in order of priority from:
-1. application.conf
-2. reference.conf
+Default implementation resolution is dependent on the config values in order of priority from:
+
+1. `application.conf`
+2. `reference.conf`
 
 So use `reference.conf` to specify defaults.
 
 # Runtime
 
-Since SPI impls are loaded from the classpath, and a specific impl is used only if explicitly configured it is possible to optimize the classpath based on your preference of:
-* include only default impls, and only use default impls
-* include all impls, and only use the specified impls
-* include some combination of defaults and alternate impls, and use the specified impls for the alternates, and default impls for the rest
+Since SPI implementations are loaded from the classpath, and a specific implementation is used only if explicitly configured it is possible to optimize the classpath based on your preference of:
+
+* Include only default implementations, and only use default implementations.
+* Include all implementations, and only use the specified implementations.
+* Include some combination of defaults and alternative implementations, and use the specified implementations for the alternatives, and default implementations for the rest.
 

--- a/tests/src/test/resources/application.conf
+++ b/tests/src/test/resources/application.conf
@@ -1,7 +1,5 @@
 
 whisk.spi {
-  DependentSpi = whisk.spi.DepSpiImpl
-  TestSpi = whisk.spi.TestSpiImpl
   SimpleSpi = whisk.spi.SimpleSpiImpl
   MissingSpi = whisk.spi.MissingImpl
   MissingModule = missing.module

--- a/tests/src/test/scala/whisk/core/controller/test/ActivationsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActivationsApiTests.scala
@@ -354,7 +354,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
 
     it should "report proper error when record is corrupted on get" in {
 
-        val activationStore = SpiLoader.get[ArtifactStoreProvider]().makeStore[WhiskEntity](whiskConfig, _.dbActivations)(WhiskEntityJsonFormat, system, logging)
+        val activationStore = SpiLoader.get[ArtifactStoreProvider].makeStore[WhiskEntity](whiskConfig, _.dbActivations)(WhiskEntityJsonFormat, system, logging)
         implicit val tid = transid()
         val entity = BadEntity(namespace, EntityName(ActivationId().toString))
         put(activationStore, entity)

--- a/tests/src/test/scala/whisk/spi/SpiTests.scala
+++ b/tests/src/test/scala/whisk/spi/SpiTests.scala
@@ -24,7 +24,6 @@ import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import org.scalatest.junit.JUnitRunner
-import whisk.core.WhiskConfig
 
 @RunWith(classOf[JUnitRunner])
 class SpiTests extends FlatSpec with Matchers with WskActorSystem with StreamLogging {
@@ -32,145 +31,26 @@ class SpiTests extends FlatSpec with Matchers with WskActorSystem with StreamLog
     behavior of "SpiProvider"
 
     it should "load an Spi from SpiLoader via typesafe config" in {
-        val simpleSpi = SpiLoader.get[SimpleSpi]()
+        val simpleSpi = SpiLoader.get[SimpleSpi]
         simpleSpi shouldBe a[SimpleSpi]
     }
 
     it should "throw an exception if the impl defined in application.conf is missing" in {
-        a[ClassNotFoundException] should be thrownBy SpiLoader.get[MissingSpi]() // MissingSpi(actorSystem)
+        a[ClassNotFoundException] should be thrownBy SpiLoader.get[MissingSpi]
     }
 
     it should "throw an exception if the module is missing" in {
-        a[ClassNotFoundException] should be thrownBy SpiLoader.get[MissingModule]() // MissingModule(actorSystem)
+        a[ClassNotFoundException] should be thrownBy SpiLoader.get[MissingModule]
     }
 
     it should "throw an exception if the config key is missing" in {
-        a[ConfigException] should be thrownBy SpiLoader.get[MissingKey]() // MissingModule(actorSystem)
-    }
-
-    it should "load an Spi with injected WhiskConfig" in {
-        val whiskConfig = new WhiskConfig(Map())
-        val deps = Dependencies("some name", whiskConfig)
-        val dependentSpi = SpiLoader.get[DependentSpi](deps)
-        dependentSpi.config shouldBe whiskConfig
-    }
-
-    it should "load an Spi with injected Spi" in {
-        val whiskConfig = new WhiskConfig(Map())
-        val deps = Dependencies("some name", whiskConfig)
-        val dependentSpi = SpiLoader.get[DependentSpi](deps)
-
-        val deps2 = Dependencies("dep2", dependentSpi)
-        val testSpi = SpiLoader.get[TestSpi](deps2)
-
-        testSpi.dep shouldBe dependentSpi
-    }
-
-    it should "not allow duplicate-type dependencies" in {
-        a[IllegalArgumentException] should be thrownBy Dependencies("some string", "some other string")
-    }
-
-    it should "load SPI impls as singletons via SingletonSpiFactory" in {
-        val instance1 = SpiLoader.get[DependentSpi]()
-        val instance2 = SpiLoader.get[DependentSpi]()
-        val instance3 = SpiLoader.get[DependentSpi]()
-
-        instance1 shouldBe instance2
-        instance2 shouldBe instance3
-    }
-
-    it should "load SPI impls as singletons via lazy val init" in {
-        val instance1 = SpiLoader.get[SimpleSpi]()
-        val instance2 = SpiLoader.get[SimpleSpi]()
-        val instance3 = SpiLoader.get[SimpleSpi]()
-
-        instance1 shouldBe instance2
-        instance2 shouldBe instance3
+        a[ConfigException] should be thrownBy SpiLoader.get[MissingKey]
     }
 }
 
-trait TestSpi extends Spi {
-    val name: String
-    val dep: DependentSpi
-}
+trait SimpleSpi extends Spi
+object SimpleSpiImpl extends SimpleSpi
 
-trait DependentSpi extends Spi {
-    val name: String
-    val config: WhiskConfig
-}
-
-trait TestSpiFactory extends Spi {
-    def getTestSpi(name: String, dep: DependentSpi): TestSpi
-}
-
-trait DependentSpiFactory extends Spi {
-    def getDependentSpi(name: String, config: WhiskConfig): DependentSpi
-}
-
-abstract class Key(key: String) {
-
-}
-
-trait SimpleSpi extends Spi {
-    val name: String
-}
-
-trait MissingSpi extends Spi {
-    val name: String
-}
-
-trait MissingModule extends Spi {
-    val name: String
-}
+trait MissingSpi extends Spi
+trait MissingModule extends Spi
 trait MissingKey extends Spi
-
-//SPI impls
-//a singleton enforced by SingletonSpiFactory
-class DepSpiImpl(val name: String, val config: WhiskConfig) extends DependentSpi
-object DepSpiImpl extends SingletonSpiFactory[DependentSpi] {
-    override def apply(deps: Dependencies): DependentSpi = {
-        new DepSpiImpl(deps.get[String], deps.get[WhiskConfig])
-    }
-}
-
-class TestSpiImpl(val name: String, val dep: DependentSpi) extends TestSpi
-//an alternative to extending SingletonSpiFactory is using lazy val:
-object TestSpiImpl extends SpiFactory[TestSpi] {
-    var name: String = null
-    var conf: DependentSpi = null
-    lazy val instance = new TestSpiImpl(name, conf)
-    override def apply(dependencies: Dependencies): TestSpi = {
-        name = dependencies.get[String]
-        conf = dependencies.get[DependentSpi]
-        instance
-    }
-
-}
-
-class TestSpiFactoryImpl extends TestSpiFactory {
-    def getTestSpi(name: String, dep: DependentSpi) = new TestSpiImpl(name, dep)
-}
-
-object TestSpiFactoryImpl extends SpiFactory[TestSpiFactory] {
-    override def apply(deps: Dependencies): TestSpiFactory = new TestSpiFactoryImpl()
-}
-
-class DependentSpiFactoryImpl extends DependentSpiFactory {
-    override def getDependentSpi(name: String, config: WhiskConfig): DependentSpi = new DepSpiImpl(name, config)
-}
-
-object DependentSpiFactoryImpl extends SpiFactory[DependentSpiFactory] {
-    override def apply(deps: Dependencies): DependentSpiFactory = new DependentSpiFactoryImpl()
-}
-
-class SimpleSpiImpl(val name: String) extends SimpleSpi
-
-object SimpleSpiImpl extends SingletonSpiFactory[SimpleSpi] {
-    override def apply(dependencies: Dependencies): SimpleSpi = new SimpleSpiImpl("some val ")
-}
-
-class MissingSpiImpl(val name: String) extends MissingSpi
-
-object MissingSpiImpl extends SpiFactory[MissingSpi] {
-    override def apply(deps: Dependencies): MissingSpi = new MissingSpiImpl("some val ")
-}


### PR DESCRIPTION
Using `object`s instead of a hollow class as the "factory" for an Spi makes them being singleton by default, which reduces boilerplate to implement an Spi.

The `Dependencies` object is not used anywhere and there might be better alternatives which we can decide on once the need of them comes up. For now, the Spi's interfaces are relatively tightly coupled to their current default implementations anyway.