### PR TITLE
Apply prereqs serially to prevent installation conflicts.

### DIFF
--- a/ansible/prereq.yml
+++ b/ansible/prereq.yml
@@ -3,5 +3,6 @@
 # It will install all necessary packages to run Openwhisk playbooks.  
 
 - hosts: all:!ansible
+  serial: 1
   roles:
   - prereq


### PR DESCRIPTION
Using the same host for different "machines" seems to cause trouble when trying to concurrently install packages.