### PR TITLE
do not use InstanceId.int within TransactionCounter

### DIFF
--- a/common/scala/src/main/scala/whisk/common/TransactionId.scala
+++ b/common/scala/src/main/scala/whisk/common/TransactionId.scala
@@ -31,7 +31,6 @@ import spray.json.JsArray
 import spray.json.JsNumber
 import spray.json.JsValue
 import spray.json.RootJsonFormat
-import whisk.core.entity.InstanceId
 
 /**
  * A transaction id for tracking operations in the system that are specific to a request.
@@ -196,9 +195,9 @@ object TransactionId {
  */
 trait TransactionCounter {
   val numberOfInstances: Int
-  val instance: InstanceId
+  val instanceOrdinal: Int
 
-  private lazy val cnt = new AtomicInteger(numberOfInstances + instance.toInt)
+  private lazy val cnt = new AtomicInteger(numberOfInstances + instanceOrdinal)
 
   def transid(): TransactionId = {
     TransactionId(cnt.addAndGet(numberOfInstances))

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -68,7 +68,7 @@ import whisk.http.BasicRasService
  * @param verbosity logging verbosity
  * @param executionContext Scala runtime support for concurrent operations
  */
-class Controller(override val instance: InstanceId,
+class Controller(val instance: InstanceId,
                  runtimes: Runtimes,
                  implicit val whiskConfig: WhiskConfig,
                  implicit val actorSystem: ActorSystem,
@@ -77,6 +77,7 @@ class Controller(override val instance: InstanceId,
     extends BasicRasService {
 
   override val numberOfInstances = whiskConfig.controllerInstances.toInt
+  override val instanceOrdinal = instance.toInt
 
   TransactionId.controller.mark(
     this,

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -96,8 +96,6 @@ object Invoker {
     })
 
     val port = config.servicePort.toInt
-    BasicHttpService.startService(new InvokerServer(invokerInstance, invokerInstance.toInt).route, port)(
-      actorSystem,
-      ActorMaterializer.create(actorSystem))
+    BasicHttpService.startService(new InvokerServer().route, port)(actorSystem, ActorMaterializer.create(actorSystem))
   }
 }

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerServer.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerServer.scala
@@ -17,12 +17,14 @@
 
 package whisk.core.invoker
 
-import whisk.core.entity.InstanceId
-
 import whisk.http.BasicRasService
 
 /**
  * Implements web server to handle certain REST API calls.
  * Currently provides a health ping route, only.
  */
-class InvokerServer(override val instance: InstanceId, override val numberOfInstances: Int) extends BasicRasService {}
+class InvokerServer() extends BasicRasService {
+
+  override val numberOfInstances = 1
+  override val instanceOrdinal = 1
+}

--- a/tests/src/test/scala/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ControllerTestCommon.scala
@@ -61,9 +61,10 @@ protected trait ControllerTestCommon
     with WhiskServices
     with StreamLogging {
 
-  override val instance = InstanceId(0)
+  override val instanceOrdinal = 0
+  override val instance = InstanceId(instanceOrdinal)
   override val numberOfInstances = 1
-  val activeAckTopicIndex = InstanceId(0)
+  val activeAckTopicIndex = InstanceId(instanceOrdinal)
 
   implicit val routeTestTimeout = RouteTestTimeout(90 seconds)
 

--- a/tests/src/test/scala/whisk/core/database/test/DbUtils.scala
+++ b/tests/src/test/scala/whisk/core/database/test/DbUtils.scala
@@ -59,7 +59,8 @@ import whisk.core.entity.types.EntityStore
 trait DbUtils extends TransactionCounter {
   implicit val dbOpTimeout = 15 seconds
   override val numberOfInstances = 1
-  override val instance = InstanceId(0)
+  override val instanceOrdinal = 0
+  val instance = InstanceId(instanceOrdinal)
   val docsToDelete = ListBuffer[(ArtifactStore[_], DocInfo)]()
   case class RetryOp() extends Throwable
 


### PR DESCRIPTION
abstract away the assumption that InstanceId must be
an integer in the range 0..numInstances-1 in TransactionCounter.
Small step in preparation for adding invoker elasticity.