### PR TITLE
Decorate throttled error response with count/limit.

### DIFF
--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -59,10 +59,12 @@ object Messages {
   val resourceDoesNotExist = "The requested resource does not exist."
 
   /** Standard message for too many activation requests within a rolling time window. */
-  val tooManyRequests = "Too many requests in a given amount of time for namespace."
+  def tooManyRequests(count: Int, allowed: Int) =
+    s"Too many requests in the last minute (count: $count, allowed: $allowed)."
 
   /** Standard message for too many concurrent activation requests within a time window. */
-  val tooManyConcurrentRequests = "Too many concurrent requests in flight for namespace."
+  def tooManyConcurrentRequests(count: Int, allowed: Int) =
+    s"Too many concurrent requests in flight (count: $count, allowed: $allowed)."
 
   /** System overload message. */
   val systemOverloaded = "System is overloaded, try again later."

--- a/tests/src/test/scala/whisk/core/controller/test/RateThrottleTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/RateThrottleTests.scala
@@ -44,24 +44,24 @@ class RateThrottleTests extends FlatSpec with Matchers with StreamLogging {
   behavior of "Rate Throttle"
 
   it should "throttle when rate exceeds allowed threshold" in {
-    new RateThrottler("test", 0, _.limits.invocationsPerMinute).check(subject) shouldBe false
+    new RateThrottler("test", 0, _.limits.invocationsPerMinute).check(subject).ok shouldBe false
     val rt = new RateThrottler("test", 1, _.limits.invocationsPerMinute)
-    rt.check(subject) shouldBe true
-    rt.check(subject) shouldBe false
-    rt.check(subject) shouldBe false
+    rt.check(subject).ok shouldBe true
+    rt.check(subject).ok shouldBe false
+    rt.check(subject).ok shouldBe false
     Thread.sleep(1.minute.toMillis)
-    rt.check(subject) shouldBe true
+    rt.check(subject).ok shouldBe true
   }
 
   it should "check against an alternative limit if passed in" in {
     val withLimits = subject.copy(limits = UserLimits(invocationsPerMinute = Some(5)))
     val rt = new RateThrottler("test", 1, _.limits.invocationsPerMinute)
-    rt.check(withLimits) shouldBe true // 1
-    rt.check(withLimits) shouldBe true // 2
-    rt.check(withLimits) shouldBe true // 3
-    rt.check(withLimits) shouldBe true // 4
-    rt.check(withLimits) shouldBe true // 5
-    rt.check(withLimits) shouldBe false
+    rt.check(withLimits).ok shouldBe true // 1
+    rt.check(withLimits).ok shouldBe true // 2
+    rt.check(withLimits).ok shouldBe true // 3
+    rt.check(withLimits).ok shouldBe true // 4
+    rt.check(withLimits).ok shouldBe true // 5
+    rt.check(withLimits).ok shouldBe false
   }
 
 }

--- a/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
@@ -1159,7 +1159,7 @@ trait WebActionsApiTests extends ControllerTestCommon with BeforeAndAfterEach wi
           failThrottleForSubject = Some(systemId)
           m(s"$testRoutePath/$path") ~> Route.seal(routes(creds)) ~> check {
             status should be(TooManyRequests)
-            confirmErrorWithTid(responseAs[JsObject], Some(Messages.tooManyRequests))
+            confirmErrorWithTid(responseAs[JsObject], Some(Messages.tooManyRequests(2, 1)))
           }
           failThrottleForSubject = None
         }
@@ -1353,7 +1353,7 @@ trait WebActionsApiTests extends ControllerTestCommon with BeforeAndAfterEach wi
 
       failThrottleForSubject match {
         case Some(subject) if subject == user.subject =>
-          Future.failed(RejectRequest(TooManyRequests, Messages.tooManyRequests))
+          Future.failed(RejectRequest(TooManyRequests, Messages.tooManyRequests(2, 1)))
         case _ => Future.successful({})
       }
     }


### PR DESCRIPTION
Fixes #1385.

Reports error messages as:
`Too many requests in the last minute (count: 120, allowed: 60). (code ...)`
`Too many concurrent requests in flight (count: 30, allowed: 30). (code ...)`


PG2/2032 🔵 