### PR TITLE
Remove deployment code to remove controllers without indexes

### DIFF
--- a/ansible/roles/controller/tasks/clean.yml
+++ b/ansible/roles/controller/tasks/clean.yml
@@ -13,17 +13,3 @@
     path: "{{ whisk_logs_dir }}/controller{{ groups['controllers'].index(inventory_hostname) }}"
     state: absent
   become: true
-
-# Remove controller without prefix
-- name: remove controller
-  docker_container:
-    name: controller
-    image: "{{ docker_registry }}{{ docker.image.prefix }}/controller:{{ docker.image.tag }}"
-    state: absent
-  ignore_errors: True
-
-- name: remove controller log directory
-  file:
-    path: "{{ whisk_logs_dir }}/controller"
-    state: absent
-  become: true


### PR DESCRIPTION
In June, we've added the ability to deploy hot-standby controllers (https://github.com/apache/incubator-openwhisk/commit/fdbf073a386c33aed1b06ed93eaea39ee4382c7b).
With this commit, the containername of the controllers has been changed from `controller` to `controller0`, `controller1`, ...
To not break the update of existing deployments we left the cleanup of containers called `controller` in the cleanup script of the controller.
Since the change of renaming the containers is long time ago, we can remove this old code now.