### PR TITLE
first stage of support for dynamic invoker id assignment

### DIFF
--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -119,6 +119,8 @@
         -e PORT='8080'
         -e KAFKA_HOST='{{ groups['kafka']|first }}'
         -e KAFKA_HOST_PORT='{{ kafka.port }}'
+        -e REDIS_HOST='{{ groups['redis'] | first }}'
+        -e REDIS_HOST_PORT='{{ redis.port }}'
         -e DB_PROTOCOL='{{ db_protocol }}'
         -e DB_PROVIDER='{{ db_provider }}'
         -e DB_HOST='{{ db_host }}'
@@ -140,6 +142,7 @@
         -e INVOKER_NUMCORE='{{ invoker.numcore }}'
         -e INVOKER_CORESHARE='{{ invoker.coreshare }}'
         -e INVOKER_USE_RUNC='{{ invoker.useRunc }}'
+        -e INVOKER_NAME='{{ groups['invokers'].index(inventory_hostname) }}'
         -e WHISK_LOGS_DIR='{{ whisk_logs_dir }}'
         -v /sys/fs/cgroup:/sys/fs/cgroup
         -v /run/runc:/run/runc

--- a/ansible/templates/whisk.properties.j2
+++ b/ansible/templates/whisk.properties.j2
@@ -43,6 +43,7 @@ limits.actions.sequence.maxLength={{ limits.sequenceMaxLength }}
 
 edge.host={{ groups["edge"]|first }}
 kafka.host={{ groups["kafka"]|first }}
+redis.host={{ groups["redis"]|first }}
 router.host={{ groups["edge"]|first }}
 zookeeper.host={{ groups["kafka"]|first }}
 invoker.hosts={{ groups["invokers"] | map('extract', hostvars, 'ansible_host') | list | join(",") }}
@@ -51,6 +52,7 @@ edge.host.apiport=443
 zookeeper.host.port={{ zookeeper.port }}
 kafka.host.port={{ kafka.port }}
 kafkaras.host.port={{ kafka.ras.port }}
+redis.host.port={{ redis.port }}
 invoker.hosts.baseport={{ invoker.port }}
 
 controller.hosts={{ groups["controllers"] | map('extract', hostvars, 'ansible_host') | list | join(",") }}

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     compile 'ch.qos.logback:logback-classic:1.2.3'
     compile 'org.slf4j:jcl-over-slf4j:1.7.25'
     compile 'org.slf4j:log4j-over-slf4j:1.7.25'
+    compile 'net.debasishg:redisclient_2.11:3.4'
     compile 'commons-codec:commons-codec:1.9'
     compile 'commons-io:commons-io:2.4'
     compile 'commons-collections:commons-collections:3.2.2'

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -65,6 +65,7 @@ class WhiskConfig(requiredProperties: Map[String, String],
   val invokerNumCore = this(WhiskConfig.invokerNumCore)
   val invokerCoreShare = this(WhiskConfig.invokerCoreShare)
   val invokerUseRunc = this.getAsBoolean(WhiskConfig.invokerUseRunc, true)
+  val invokerName = this(WhiskConfig.invokerName)
 
   val wskApiHost = this(WhiskConfig.wskApiProtocol) + "://" + this(WhiskConfig.wskApiHostname) + ":" + this(
     WhiskConfig.wskApiPort)
@@ -74,6 +75,8 @@ class WhiskConfig(requiredProperties: Map[String, String],
 
   val edgeHost = this(WhiskConfig.edgeHostName) + ":" + this(WhiskConfig.edgeHostApiPort)
   val kafkaHost = this(WhiskConfig.kafkaHostName) + ":" + this(WhiskConfig.kafkaHostPort)
+  val redisHostName = this(WhiskConfig.redisHostName)
+  val redisHostPort = this(WhiskConfig.redisHostPort)
 
   val edgeHostName = this(WhiskConfig.edgeHostName)
 
@@ -190,6 +193,7 @@ object WhiskConfig {
   val invokerNumCore = "invoker.numcore"
   val invokerCoreShare = "invoker.coreshare"
   val invokerUseRunc = "invoker.use.runc"
+  val invokerName = "invoker.name"
 
   val wskApiProtocol = "whisk.api.host.proto"
   val wskApiPort = "whisk.api.host.port"
@@ -205,9 +209,11 @@ object WhiskConfig {
 
   val kafkaHostName = "kafka.host"
   private val zookeeperHostName = "zookeeper.host"
+  val redisHostName = "redis.host"
 
   private val edgeHostApiPort = "edge.host.apiport"
   val kafkaHostPort = "kafka.host.port"
+  val redisHostPort = "redis.host.port"
   private val zookeeperHostPort = "zookeeper.host.port"
 
   val invokerHostsList = "invoker.hosts"
@@ -215,6 +221,7 @@ object WhiskConfig {
   val edgeHost = Map(edgeHostName -> null, edgeHostApiPort -> null)
   val invokerHosts = Map(invokerHostsList -> null)
   val kafkaHost = Map(kafkaHostName -> null, kafkaHostPort -> null)
+  val redisHost = Map(redisHostName -> null, redisHostPort -> null)
 
   val runtimesManifest = "runtimes.manifest"
 

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -21,6 +21,8 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Failure
 
+import com.redis.RedisClient
+
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import whisk.common.AkkaLogging
@@ -48,6 +50,7 @@ object Invoker {
       WhiskEntityStore.requiredProperties ++
       WhiskActivationStore.requiredProperties ++
       kafkaHost ++
+      redisHost ++
       wskApiHost ++ Map(
       dockerImageTag -> "latest",
       invokerNumCore -> "4",
@@ -55,12 +58,10 @@ object Invoker {
       invokerContainerPolicy -> "",
       invokerContainerDns -> "",
       invokerContainerNetwork -> null,
-      invokerUseRunc -> "true")
+      invokerUseRunc -> "true") ++
+      Map(invokerName -> null)
 
   def main(args: Array[String]): Unit = {
-    require(args.length == 1, "invoker instance required")
-    val invokerInstance = InstanceId(args(0).toInt)
-
     implicit val ec = ExecutionContextFactory.makeCachedThreadPoolExecutionContext()
     implicit val actorSystem: ActorSystem =
       ActorSystem(name = "invoker-actor-system", defaultExecutionContext = Some(ec))
@@ -86,6 +87,41 @@ object Invoker {
       abort()
     }
 
+    val proposedInvokerId: Option[Int] = args.headOption.map(_.toInt)
+    val assignedInvokerId = proposedInvokerId
+      .map { id =>
+        logger.info(this, s"invokerReg: using proposedInvokerId ${id}")
+        id
+      }
+      .getOrElse {
+        val invokerName = config.invokerName
+        val redisClient = new RedisClient(config.redisHostName, config.redisHostPort.toInt)
+        val assignedId = redisClient
+          .hget("controller:registar:idAssignments", invokerName)
+          .map { oldId =>
+            logger.info(this, s"invokerReg: invoker ${invokerName} was assigned its previous invokerId ${oldId}")
+            oldId.toInt
+          }
+          .getOrElse {
+            // If key not present, incr initializes to 0 before applying increment.
+            // Convert from 1-based to 0-based invokerIds by subtracting 1 from incr's result
+            val newId = redisClient
+              .incr("controller:registrar:nextInvokerId")
+              .map { id =>
+                id.toInt - 1
+              }
+              .getOrElse {
+                logger.error(this, "Failed to increment invokerId")
+                abort()
+              }
+            redisClient.hset("controller:registar:idAssignments", invokerName, newId)
+            logger.info(this, s"invokerReg: invoker ${invokerName} was assigned invokerId ${newId}")
+            newId
+          }
+        redisClient.quit
+        assignedId
+      }
+    val invokerInstance = InstanceId(assignedInvokerId);
     val msgProvider = SpiLoader.get[MessagingProvider]
     val producer = msgProvider.getProducer(config, ec)
     val invoker = new InvokerReactive(config, invokerInstance, producer)


### PR DESCRIPTION
A prototype of one possible approach for dynamic invoker registration.
The invoker's instanceId is not provided on the command line on
startup.  Instead, the invoker dynamically requests an id from
the controller during its startup via the message bus (kafka).
Once it receives an id, invoker startup continues unchanged.

On the plus side, this protocol maintains the property that invokers
are densely assigned ids starting from 0.  On the minus side, it takes
an extra round of messages thus mildly delaying system startup.

An alternative approach would be to use randomly generated UUIDs as
the invoker's id and adapt the load balancer algorithm accordingly.
Using UUIDs as invoker ids might make some aspects of operations
slightly more annoying as well, as the invokers would not have
stable (or short/easy to recognize) names.  This is a larger change,
but I think it is possible to implement without too much trouble.