### PR TITLE
Wait for view in AuthenticateTests.

### DIFF
--- a/tests/src/test/scala/whisk/core/controller/test/AuthenticateTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/AuthenticateTests.scala
@@ -57,6 +57,7 @@ class AuthenticateTests extends ControllerTestCommon with Authenticate {
         // Try to login with each specific namespace
         namespaces.foreach { ns =>
             println(s"Trying to login to $ns")
+            waitOnView(authStore, ns.authkey, 1) // wait for the view to be updated
             val pass = BasicHttpCredentials(ns.authkey.uuid.asString, ns.authkey.key.asString)
             val user = Await.result(validateCredentials(Some(pass)), dbOpTimeout)
             user.get shouldBe Identity(subject, ns.name, ns.authkey, Privilege.ALL)


### PR DESCRIPTION
This test can be subject to a race condition, where the checks are run before the database has updated its views.