### PR TITLE
Increase CouchDB to version 2.0

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -197,7 +197,7 @@ linux:
   version: 4.4.0-31
 
 couchdb:
-  version: 1.6
+  version: 2.0
 
 docker:
   # The user to install docker for. Defaults to the ansible user if not set. This will be the user who is able to run

--- a/ansible/roles/couchdb/tasks/clean.yml
+++ b/ansible/roles/couchdb/tasks/clean.yml
@@ -4,6 +4,6 @@
 - name: remove CouchDB
   docker_container:
     name: couchdb
-    image: couchdb
+    image: klaemo/couchdb
     state: absent
   ignore_errors: True

--- a/ansible/roles/couchdb/tasks/deploy.yml
+++ b/ansible/roles/couchdb/tasks/deploy.yml
@@ -1,6 +1,10 @@
 ---
 # This role will run a CouchDB server on the db group
 
+- name: "Set node name to couchdb{{ groups['db'].index(inventory_hostname) }}"
+  set_fact:
+    nodeName: "couchdb{{ groups['db'].index(inventory_hostname) }}"
+
 - name: check if db credentials are valid for CouchDB
   fail: msg="The db provider in your {{ inventory_dir }}/group_vars/all is {{ db_provider }}, it has to be CouchDB, pls double check"
   when: db_provider != "CouchDB"
@@ -17,21 +21,25 @@
     volume_dir: "{{ instance.volume.fsmount | default( '/mnt/' + group_names|first, true ) }}:/usr/local/var/lib/couchdb"
   when: (block_device is defined) and (block_device in disk_status.stdout)
 
-- name: "pull the couchdb:{{ couchdb.version }} image"
-  shell: "docker pull couchdb:{{ couchdb.version }}"
+- name: "pull the klaemo/couchdb:{{ couchdb.version }} image"
+  shell: "docker pull klaemo/couchdb:{{ couchdb.version }}"
   retries: "{{ docker.pull.retries }}"
   delay: "{{ docker.pull.delay }}"
 
 - name: (re)start CouchDB
   docker_container:
     name: couchdb
-    image: couchdb:{{ couchdb.version }}
+    image: klaemo/couchdb:{{ couchdb.version }}
     state: started
     recreate: true
     restart_policy: "{{ docker.restart.policy }}"
     volumes: "{{volume_dir | default([])}}"
     ports:
       - "{{ db_port }}:5984"
+    env:
+      COUCHDB_USER: "{{ db_username }}"
+      COUCHDB_PASSWORD: "{{ db_password }}"
+      NODENAME: "{{ nodeName }}"
 
 - name: wait until the CouchDB in this host is up and running
   wait_for:
@@ -40,18 +48,9 @@
     port: "{{ db_port }}"
     timeout: 60
 
-- name: create admin user
-  uri:
-    url: "{{ db_protocol }}://{{ ansible_host }}:{{ db_port }}/_config/admins/{{ db_username }}"
-    method: PUT
-    body: >
-        "{{ db_password }}"
-    body_format: json
-    status_code: 200
-
 - name: disable reduce limit on views
   uri:
-    url: "{{ db_protocol }}://{{ ansible_host }}:{{ db_port }}/_config/query_server_config/reduce_limit"
+    url: "{{ db_protocol }}://{{ ansible_host }}:{{ db_port }}/_node/couchdb@{{ nodeName }}/_config/query_server_config/reduce_limit"
     method: PUT
     body: >
         "false"

--- a/tests/src/test/scala/whisk/core/database/test/ReplicatorTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/ReplicatorTests.scala
@@ -52,6 +52,7 @@ class ReplicatorTests
 
   val replicatorClient =
     new ExtendedCouchDbRestClient(dbProtocol, dbHost, dbPort.toInt, dbUsername, dbPassword, "_replicator")
+  replicatorClient.createDb().futureValue
 
   val replicator = WhiskProperties.getFileRelativeToWhiskHome("tools/db/replicateDbs.py").getAbsolutePath
   val designDocPath =


### PR DESCRIPTION
If the cache is disabled in the controller, the following tests are failing:
- Wsk actions should create, and get an action to verify parameter and annotation parsing
- Wsk packages should create, and get a package to verify parameter and annotation parsing
- Wsk triggers should create, and get a trigger to verify parameter and annotation parsing

The reason is, that the number `12345678912.123456789012` is rounded to `12345678912.123457` in the controller.
On writing `12345678912.123457` into CouchDB, the value `12345678912.123456955` is saved.
On getting the document again from CouchDB, the controller returns `12345678912.123456955`. That's why the test is failing.
The cache in the controller has hidden this issue until now.
Increasing to version 2.0 fixes this issue.