### PR TITLE
Fix Ansible playbook problems with missing variable interpolation

### DIFF
--- a/ansible/roles/cli/tasks/clean.yml
+++ b/ansible/roles/cli/tasks/clean.yml
@@ -4,4 +4,4 @@
   file:
     path: "{{ cli.nginxdir }}"
     state: absent
-  become: cli.dir.become
+  become: "{{ cli.dir.become }}"

--- a/ansible/roles/cli/tasks/deploy.yml
+++ b/ansible/roles/cli/tasks/deploy.yml
@@ -5,7 +5,7 @@
   file:
     path: "{{ cli.nginxdir  }}"
     state: directory
-  become: cli.dir.become
+  become: "{{ cli.dir.become }}"
 
 - set_fact:
     cli_installation_mode="{{ openwhisk_cli.installation_mode }}"

--- a/ansible/roles/controller/tasks/clean.yml
+++ b/ansible/roles/controller/tasks/clean.yml
@@ -12,4 +12,4 @@
   file:
     path: "{{ whisk_logs_dir }}/controller{{ groups['controllers'].index(inventory_hostname) }}"
     state: absent
-  become: logs.dir.become
+  become: "{{ logs.dir.become }}"

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -14,7 +14,7 @@
     path: "{{ whisk_logs_dir }}/controller{{ groups['controllers'].index(inventory_hostname) }}"
     state: directory
     mode: 0777
-  become: logs.dir.become
+  become: "{{ logs.dir.become }}"
 
 - name: (re)start controller
   docker_container:

--- a/ansible/roles/invoker/tasks/clean.yml
+++ b/ansible/roles/invoker/tasks/clean.yml
@@ -21,7 +21,7 @@
         echo "Handled $TOTAL remaining actions."
   register: runc_output
   ignore_errors: True
-  become: invoker.docker.become
+  become: "{{ invoker.docker.become }}"
 
 - debug: msg="{{ runc_output.stdout }}"
 
@@ -37,4 +37,4 @@
   file:
     path: "{{ whisk_logs_dir }}/invoker{{ groups['invokers'].index(inventory_hostname) }}"
     state: absent
-  become: logs.dir.become
+  become: "{{ logs.dir.become }}"

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -35,7 +35,7 @@
     path: "{{ whisk_logs_dir }}/invoker{{ groups['invokers'].index(inventory_hostname) }}"
     state: directory
     mode: 0777
-  become: logs.dir.become
+  become: "{{ logs.dir.become }}"
 
 - name: define options when deploying invoker on Ubuntu
   set_fact:

--- a/ansible/roles/nginx/tasks/clean.yml
+++ b/ansible/roles/nginx/tasks/clean.yml
@@ -12,10 +12,10 @@
   file:
     path: "{{ nginx.confdir }}"
     state: absent
-  become: nginx.dir.become
+  become: "{{ nginx.dir.become }}"
 
 - name: remove nginx log directory
   file:
     path: "{{ whisk_logs_dir }}/nginx"
     state: absent
-  become: logs.dir.become
+  become: "{{ logs.dir.become }}"

--- a/ansible/roles/nginx/tasks/deploy.yml
+++ b/ansible/roles/nginx/tasks/deploy.yml
@@ -5,7 +5,7 @@
   file:
     path: "{{ nginx.confdir }}"
     state: directory
-  become: nginx.dir.become
+  become: "{{ nginx.dir.become }}"
 
 - name: copy template from local to remote in nginx config directory
   template:
@@ -32,7 +32,7 @@
     path: "{{ whisk_logs_dir }}/nginx"
     state: directory
     mode: 0777
-  become: logs.dir.become
+  become: "{{ logs.dir.become }}"
 
 - name: "pull the nginx:{{ nginx.version }} image"
   shell: "docker pull nginx:{{ nginx.version }}"

--- a/ansible/roles/sdk/tasks/clean.yml
+++ b/ansible/roles/sdk/tasks/clean.yml
@@ -5,4 +5,4 @@
   file:
     path: "{{ nginx.confdir }}/blackbox-0.1.0.tar.gz"
     state: absent
-  become: sdk.dir.become
+  become: "{{ sdk.dir.become }}"

--- a/ansible/roles/sdk/tasks/deploy.yml
+++ b/ansible/roles/sdk/tasks/deploy.yml
@@ -5,7 +5,7 @@
   file:
     path: "{{ nginx.confdir }}"
     state: directory
-  become: sdk.dir.become
+  become: "{{ sdk.dir.become }}"
 
 # Blackbox
 


### PR DESCRIPTION
Surround variables introduced with PR #2669 with double curly braces to force interpolation.
We observed Ansible playbook runs where `become` was not active because variables
were not interpolated such that the value was `false`.