### PR TITLE
Report 404 when no paths match.

### DIFF
--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -126,7 +126,7 @@ object Messages {
     s"Logs were truncated because the total bytes size exceeds the limit of ${limit.toBytes} bytes."
   }
 
-  /** Error for meta api. */
+  /** Error for web actions. */
   val propertyNotFound = "Response does not include requested property."
   def invalidMedia(m: MediaType) = s"Response is not valid '${m.value}'."
   def contentTypeExtensionNotSupported(extensions: Set[String]) = {

--- a/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
@@ -43,6 +43,7 @@ import whisk.core.entity.ActivationId.ActivationIdGenerator
 import whisk.core.entity.WhiskAuthStore
 import whisk.core.entity.types._
 import whisk.core.loadBalancer.LoadBalancerService
+import whisk.http.Messages
 
 /**
  * Abstract class which provides basic Directives which are used to construct route structures
@@ -195,7 +196,7 @@ class RestAPIVersion(config: WhiskConfig, apiPath: String, apiVersion: String)(
           }
         }
       }
-    }
+    } ~ complete(NotFound, Messages.resourceDoesNotExist)
 
   }
 

--- a/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
@@ -268,6 +268,26 @@ class WskWebActionsTests extends TestHelpers with WskTestHelpers with RestUtil w
       response.body.asByteArray shouldBe Base64.getDecoder().decode(png)
   }
 
+  it should "not report authorization required when an url does not match any paths" in {
+    val host = getServiceURL()
+    val url = host + s"$testRoutePath//namespace/default/action"
+
+    val response = RestAssured.given().config(sslconfig).get(url)
+    response.statusCode shouldBe 404
+    response.body.asString shouldBe whisk.http.Messages.resourceDoesNotExist
+
+    val authorizedResponse = RestAssured
+      .given()
+      .config(sslconfig)
+      .auth()
+      .preemptive()
+      .basic(wskprops.authKey.split(":")(0), wskprops.authKey.split(":")(1))
+      .get(url)
+
+    authorizedResponse.statusCode shouldBe 404
+    response.body.asString shouldBe whisk.http.Messages.resourceDoesNotExist
+  }
+
   private val subdomainRegex = Seq.fill(WhiskProperties.getPartsInVanitySubdomain)("[a-zA-Z0-9]+").mkString("-")
 
   private val (vanitySubdomain, vanityNamespace, makeTestSubject) = {


### PR DESCRIPTION
Instead of reporting 401 which is misleading and confusing, report 404 not found for a bad path.