### PR TITLE
Use latest version of Akka HTTP

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     compile 'com.typesafe.akka:akka-actor_2.11:2.4.16'
     compile 'com.typesafe.akka:akka-slf4j_2.11:2.4.16'
     compile 'com.typesafe.akka:akka-http-core_2.11:10.0.10'
-    compile 'com.typesafe.akka:akka-http-spray-json_2.11:10.0.2'
+    compile 'com.typesafe.akka:akka-http-spray-json_2.11:10.0.10'
 
     compile 'log4j:log4j:1.2.16'
     compile 'commons-codec:commons-codec:1.9'

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
     compile 'com.typesafe.akka:akka-actor_2.11:2.4.16'
     compile 'com.typesafe.akka:akka-slf4j_2.11:2.4.16'
-    compile 'com.typesafe.akka:akka-http-core_2.11:10.0.9'
+    compile 'com.typesafe.akka:akka-http-core_2.11:10.0.10'
     compile 'com.typesafe.akka:akka-http-spray-json_2.11:10.0.2'
 
     compile 'log4j:log4j:1.2.16'

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     compile 'com.google.code.gson:gson:2.3.1'
     compile 'org.scalamock:scalamock-scalatest-support_2.11:3.4.2'
     compile 'com.typesafe.akka:akka-testkit_2.11:2.4.16'
-    compile 'com.typesafe.akka:akka-http-testkit_2.11:10.0.9'
+    compile 'com.typesafe.akka:akka-http-testkit_2.11:10.0.10'
     compile 'com.github.java-json-tools:json-schema-validator:2.2.8';
 
     compile project(':common:scala')


### PR DESCRIPTION
A new version of akka-http was released August 31st. For more information regarding the new release see http://akka.io/blog/news/2017/08/31/akka-http-10.0.10-released.

PG4 785 🔵 