### PR TITLE
Add scala fmt to redo.

### DIFF
--- a/tools/build/redo
+++ b/tools/build/redo
@@ -207,6 +207,12 @@ Components = [
                   yaml = False,
                   steps = 'setup, prereq, couchdb, initdb, wipedb, deploy, catalog'),
 
+    makeComponent('fmt',
+                  'apply source code formats',
+                  gradle = True,
+                  yaml = False,
+                  tasks = 'scalafmtAll'),
+
     makeComponent('setup',
                   'system setup'),
 


### PR DESCRIPTION
Add shorthand for applying scala format.

```
> redo -n fmt
apply source code formats
/Users/rabbah/projects/openwhisk/tools/build/../..//gradlew scalafmtAll  --parallel -PdockerHost=192.168.99.100:4243
```