### PR TITLE
Reduce memory consumption for invocations of cached actions

### DIFF
--- a/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
@@ -36,6 +36,7 @@ import whisk.core.entity.DocInfo
 import whisk.core.entity.DocRevision
 import whisk.core.entity.WhiskDocument
 import whisk.http.Messages
+import whisk.core.entity.DocumentReader
 
 /**
  * Basic client to put and delete artifacts in a data store.
@@ -58,7 +59,8 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
   implicit system: ActorSystem,
   val logging: Logging,
   jsonFormat: RootJsonFormat[DocumentAbstraction],
-  materializer: ActorMaterializer)
+  materializer: ActorMaterializer,
+  docReader: DocumentReader)
     extends ArtifactStore[DocumentAbstraction]
     with DefaultJsonProtocol {
 
@@ -223,7 +225,13 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
       e match {
         case Right(response) =>
           transid.finished(this, start, s"[GET] '$dbName' completed: found document '$doc'")
-          val asFormat = jsonFormat.read(response)
+
+          val asFormat = try {
+            docReader.read(ma, response)
+          } catch {
+            case e: Exception => jsonFormat.read(response)
+          }
+
           if (asFormat.getClass != ma.runtimeClass) {
             throw DocumentTypeMismatchException(
               s"document type ${asFormat.getClass} did not match expected type ${ma.runtimeClass}.")

--- a/common/scala/src/main/scala/whisk/core/database/CouchDbStoreProvider.scala
+++ b/common/scala/src/main/scala/whisk/core/database/CouchDbStoreProvider.scala
@@ -22,11 +22,13 @@ import akka.stream.ActorMaterializer
 import spray.json.RootJsonFormat
 import whisk.common.Logging
 import whisk.core.WhiskConfig
+import whisk.core.entity.DocumentReader
 
 object CouchDbStoreProvider extends ArtifactStoreProvider {
 
   def makeStore[D <: DocumentSerializer](config: WhiskConfig, name: WhiskConfig => String, useBatching: Boolean)(
     implicit jsonFormat: RootJsonFormat[D],
+    docReader: DocumentReader,
     actorSystem: ActorSystem,
     logging: Logging,
     materializer: ActorMaterializer): ArtifactStore[D] = {

--- a/common/scala/src/main/scala/whisk/core/database/RemoteCacheInvalidation.scala
+++ b/common/scala/src/main/scala/whisk/core/database/RemoteCacheInvalidation.scala
@@ -36,6 +36,7 @@ import whisk.core.connector.MessagingProvider
 import whisk.core.entity.CacheKey
 import whisk.core.entity.InstanceId
 import whisk.core.entity.WhiskAction
+import whisk.core.entity.WhiskActionMetaData
 import whisk.core.entity.WhiskPackage
 import whisk.core.entity.WhiskRule
 import whisk.core.entity.WhiskTrigger
@@ -76,12 +77,16 @@ class RemoteCacheInvalidation(config: WhiskConfig, component: String, instance: 
       removeFromLocalCache)
   })
 
+  def invalidateWhiskActionMetaData(key: CacheKey) =
+    WhiskActionMetaData.removeId(key)
+
   private def removeFromLocalCache(bytes: Array[Byte]): Future[Unit] = Future {
     val raw = new String(bytes, StandardCharsets.UTF_8)
 
     CacheInvalidationMessage.parse(raw) match {
       case Success(msg: CacheInvalidationMessage) => {
         if (msg.instanceId != instanceId) {
+          WhiskActionMetaData.removeId(msg.key)
           WhiskAction.removeId(msg.key)
           WhiskPackage.removeId(msg.key)
           WhiskRule.removeId(msg.key)

--- a/common/scala/src/main/scala/whisk/core/entity/DocumentReader.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/DocumentReader.scala
@@ -15,26 +15,10 @@
  * limitations under the License.
  */
 
-package whisk.core.database
+package whisk.core.entity
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
-import spray.json.RootJsonFormat
-import whisk.common.Logging
-import whisk.core.WhiskConfig
-import whisk.spi.Spi
-import whisk.core.entity.DocumentReader
+import spray.json._
 
-/**
- * An Spi for providing ArtifactStore implementations
- */
-trait ArtifactStoreProvider extends Spi {
-  def makeStore[D <: DocumentSerializer](config: WhiskConfig,
-                                         name: WhiskConfig => String,
-                                         useBatching: Boolean = false)(
-    implicit jsonFormat: RootJsonFormat[D],
-    docReader: DocumentReader,
-    actorSystem: ActorSystem,
-    logging: Logging,
-    materializer: ActorMaterializer): ArtifactStore[D]
+protected[core] abstract class DocumentReader {
+  def read[A](ma: Manifest[A], value: JsValue): WhiskDocument
 }

--- a/common/scala/src/main/scala/whisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Exec.scala
@@ -45,13 +45,17 @@ import whisk.core.entity.size.SizeString
  *   main  : name of the entry point function, when using a non-default value (for Java, the name of the main class)" }
  */
 sealed abstract class Exec extends ByteSizeable {
-  override def toString = Exec.serdes.write(this).compactPrint
+  override def toString: String = Exec.serdes.write(this).compactPrint
 
   /** A type descriptor. */
   val kind: String
 
   /** When true exec may not be executed or updated. */
   val deprecated: Boolean
+}
+
+sealed abstract class ExecMetaDataBase extends Exec {
+  override def toString: String = ExecMetaDataBase.serdes.write(this).compactPrint
 }
 
 /**
@@ -89,6 +93,14 @@ sealed abstract class CodeExec[+T <% SizeConversion] extends Exec {
   override def size = code.sizeInBytes + entryPoint.map(_.sizeInBytes).getOrElse(0.B)
 }
 
+sealed abstract class ExecMetaData extends ExecMetaDataBase {
+
+  /** Indicates if a container image is required from the registry to execute the action. */
+  val pull: Boolean
+
+  override def size = 0.B
+}
+
 protected[core] case class CodeExecAsString(manifest: RuntimeManifest,
                                             override val code: String,
                                             override val entryPoint: Option[String])
@@ -100,6 +112,12 @@ protected[core] case class CodeExecAsString(manifest: RuntimeManifest,
   override val pull = false
   override lazy val binary = Exec.isBinaryCode(code)
   override def codeAsJson = JsString(code)
+}
+
+protected[core] case class CodeExecMetaDataAsString(manifest: RuntimeManifest) extends ExecMetaData {
+  override val kind = manifest.kind
+  override val deprecated = manifest.deprecated.getOrElse(false)
+  override val pull = false
 }
 
 protected[core] case class CodeExecAsAttachment(manifest: RuntimeManifest,
@@ -126,6 +144,12 @@ protected[core] case class CodeExecAsAttachment(manifest: RuntimeManifest,
   }
 }
 
+protected[core] case class CodeExecMetaDataAsAttachment(manifest: RuntimeManifest) extends ExecMetaData {
+  override val kind = manifest.kind
+  override val deprecated = manifest.deprecated.getOrElse(false)
+  override val pull = false
+}
+
 /**
  * @param image the image name
  * @param code an optional script or zip archive (as base64 encoded) string
@@ -144,8 +168,20 @@ protected[core] case class BlackBoxExec(override val image: ImageName,
   override def size = super.size + image.publicImageName.sizeInBytes
 }
 
+protected[core] case class BlackBoxExecMetaData(val native: Boolean) extends ExecMetaData {
+  override val kind = ExecMetaDataBase.BLACKBOX
+  override val deprecated = false
+  override val pull = !native
+}
+
 protected[core] case class SequenceExec(components: Vector[FullyQualifiedEntityName]) extends Exec {
   override val kind = Exec.SEQUENCE
+  override val deprecated = false
+  override def size = components.map(_.size).reduceOption(_ + _).getOrElse(0.B)
+}
+
+protected[core] case class SequenceExecMetaData(components: Vector[FullyQualifiedEntityName]) extends ExecMetaDataBase {
+  override val kind = ExecMetaDataBase.SEQUENCE
   override val deprecated = false
   override def size = components.map(_.size).reduceOption(_ + _).getOrElse(0.B)
 }
@@ -187,6 +223,7 @@ protected[core] object Exec extends ArgNormalizer[Exec] with DefaultJsonProtocol
         val code = b.code.filter(_.trim.nonEmpty).map("code" -> JsString(_))
         val main = b.entryPoint.map("main" -> JsString(_))
         JsObject(base ++ code ++ main)
+      case _ => JsObject()
     }
 
     override def read(v: JsValue) = {
@@ -276,5 +313,121 @@ protected[core] object Exec extends ArgNormalizer[Exec] with DefaultJsonProtocol
       val t = code.trim
       (t.length > 0) && (t.length % 4 == 0) && isBase64Pattern.matcher(t).matches()
     } else false
+  }
+}
+
+protected[core] object ExecMetaDataBase extends ArgNormalizer[ExecMetaDataBase] with DefaultJsonProtocol {
+
+  val sizeLimit = 48 MB
+
+  // The possible values of the JSON 'kind' field for certain runtimes:
+  // - Sequence because it is an intrinsic
+  // - Black Box because it is a type marker
+  protected[core] val SEQUENCE = "sequence"
+  protected[core] val BLACKBOX = "blackbox"
+
+  private def execManifests = ExecManifest.runtimesManifest
+
+  override protected[core] implicit lazy val serdes = new RootJsonFormat[ExecMetaDataBase] {
+    private def attFmt[T: JsonFormat] = Attachments.serdes[T]
+    private lazy val runtimes: Set[String] = execManifests.knownContainerRuntimes ++ Set(SEQUENCE, BLACKBOX)
+
+    override def write(e: ExecMetaDataBase) = e match {
+      case c: CodeExecMetaDataAsString =>
+        val base = Map("kind" -> JsString(c.kind))
+        JsObject(base)
+
+      case a: CodeExecMetaDataAsAttachment =>
+        val base =
+          Map("kind" -> JsString(a.kind))
+        JsObject(base)
+
+      case s @ SequenceExecMetaData(comp) =>
+        JsObject("kind" -> JsString(s.kind), "components" -> comp.map(_.qualifiedNameWithLeadingSlash).toJson)
+
+      case b: BlackBoxExecMetaData =>
+        val base =
+          Map("kind" -> JsString(b.kind))
+        JsObject(base)
+    }
+
+    override def read(v: JsValue) = {
+      require(v != null)
+
+      val obj = v.asJsObject
+
+      val kind = obj.fields.get("kind") match {
+        case Some(JsString(k)) => k.trim.toLowerCase
+        case _                 => throw new DeserializationException("'kind' must be a string defined in 'exec'")
+      }
+
+      lazy val optMainField: Option[String] = obj.fields.get("main") match {
+        case Some(JsString(m)) => Some(m)
+        case Some(_) =>
+          throw new DeserializationException(s"if defined, 'main' be a string in 'exec' for '$kind' actions")
+        case None => None
+      }
+
+      kind match {
+        case ExecMetaDataBase.SEQUENCE =>
+          val comp: Vector[FullyQualifiedEntityName] = obj.fields.get("components") match {
+            case Some(JsArray(components)) => components map (FullyQualifiedEntityName.serdes.read(_))
+            case Some(_)                   => throw new DeserializationException(s"'components' must be an array")
+            case None                      => throw new DeserializationException(s"'components' must be defined for sequence kind")
+          }
+          SequenceExecMetaData(comp)
+
+        case ExecMetaDataBase.BLACKBOX =>
+          val image: ImageName = obj.fields.get("image") match {
+            case Some(JsString(i)) => ImageName.fromString(i).get // throws deserialization exception on failure
+            case _ =>
+              throw new DeserializationException(
+                s"'image' must be a string defined in 'exec' for '${Exec.BLACKBOX}' actions")
+          }
+          val code: Option[String] = obj.fields.get("code") match {
+            case Some(JsString(i)) => if (i.trim.nonEmpty) Some(i) else None
+            case Some(_) =>
+              throw new DeserializationException(
+                s"if defined, 'code' must a string defined in 'exec' for '${Exec.BLACKBOX}' actions")
+            case None => None
+          }
+          val native = execManifests.blackboxImages.contains(image)
+          BlackBoxExecMetaData(native)
+
+        case _ =>
+          // map "default" virtual runtime versions to the currently blessed actual runtime version
+          val manifest = execManifests.resolveDefaultRuntime(kind) match {
+            case Some(k) => k
+            case None    => throw new DeserializationException(s"kind '$kind' not in $runtimes")
+          }
+
+          manifest.attached
+            .map { a =>
+              val jar: Attachment[String] = {
+                // java actions once stored the attachment in "jar" instead of "code"
+                obj.fields.get("code").orElse(obj.fields.get("jar"))
+              } map {
+                attFmt[String].read(_)
+              } getOrElse {
+                throw new DeserializationException(
+                  s"'code' must be a valid base64 string in 'exec' for '$kind' actions")
+              }
+              val main = optMainField.orElse {
+                if (manifest.requireMain.exists(identity)) {
+                  throw new DeserializationException(s"'main' must be a string defined in 'exec' for '$kind' actions")
+                } else None
+              }
+              CodeExecMetaDataAsAttachment(manifest)
+            }
+            .getOrElse {
+              val code: String = obj.fields.get("code") match {
+                case Some(JsString(c)) => c
+                case _ =>
+                  throw new DeserializationException(s"'code' must be a string defined in 'exec' for '$kind' actions")
+              }
+              CodeExecMetaDataAsString(manifest)
+            }
+      }
+    }
   }
 }

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskEntity.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskEntity.scala
@@ -106,6 +106,20 @@ object WhiskEntity {
   }
 }
 
+object WhiskDocumentReader extends DocumentReader {
+  override def read[A](ma: Manifest[A], value: JsValue) = {
+    ma.runtimeClass match {
+      case x if x == classOf[WhiskAction]         => WhiskAction.serdes.read(value)
+      case x if x == classOf[WhiskActionMetaData] => WhiskActionMetaData.serdes.read(value)
+      case x if x == classOf[WhiskPackage]        => WhiskPackage.serdes.read(value)
+      case x if x == classOf[WhiskActivation]     => WhiskActivation.serdes.read(value)
+      case x if x == classOf[WhiskTrigger]        => WhiskTrigger.serdes.read(value)
+      case x if x == classOf[WhiskRule]           => WhiskRule.serdes.read(value)
+      case _                                      => throw DocumentUnreadable(Messages.corruptedEntity)
+    }
+  }
+}
+
 /**
  * Dispatches to appropriate serdes. This object is not itself implicit so as to
  * avoid multiple implicit alternatives when working with one of the subtypes.

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
@@ -88,6 +88,8 @@ protected[core] trait WhiskDocument extends DocumentSerializer with DocumentRevi
 }
 
 object WhiskAuthStore {
+  implicit val docReader = WhiskDocumentReader
+
   def requiredProperties =
     Map(
       dbProvider -> null,
@@ -116,11 +118,16 @@ object WhiskEntityStore {
   def datastore(config: WhiskConfig)(implicit system: ActorSystem, logging: Logging, materializer: ActorMaterializer) =
     SpiLoader
       .get[ArtifactStoreProvider]
-      .makeStore[WhiskEntity](config, _.dbWhisk)(WhiskEntityJsonFormat, system, logging, materializer)
-
+      .makeStore[WhiskEntity](config, _.dbWhisk)(
+        WhiskEntityJsonFormat,
+        WhiskDocumentReader,
+        system,
+        logging,
+        materializer)
 }
 
 object WhiskActivationStore {
+  implicit val docReader = WhiskDocumentReader
   def requiredProperties =
     Map(
       dbProvider -> null,

--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -35,6 +35,7 @@ import whisk.common.TransactionId
 import whisk.core.entity.SizeError
 import whisk.core.entity.ByteSize
 import whisk.core.entity.Exec
+import whisk.core.entity.ExecMetaDataBase
 import whisk.core.entity.ActivationId
 
 object Messages {
@@ -53,6 +54,12 @@ object Messages {
    * Standard message for reporting deprecated runtimes.
    */
   def runtimeDeprecated(e: Exec) =
+    s"The '${e.kind}' runtime is no longer supported. You may read and delete but not update or invoke this action."
+
+  /**
+   * Standard message for reporting deprecated runtimes.
+   */
+  def runtimeDeprecated(e: ExecMetaDataBase) =
     s"The '${e.kind}' runtime is no longer supported. You may read and delete but not update or invoke this action."
 
   /** Standard message for resource not found. */

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -110,7 +110,10 @@ class Controller(val instance: InstanceId,
   private implicit val activationStore = WhiskActivationStore.datastore(whiskConfig)
   private implicit val cacheChangeNotification = Some(new CacheChangeNotification {
     val remoteCacheInvalidaton = new RemoteCacheInvalidation(whiskConfig, "controller", instance)
-    override def apply(k: CacheKey) = remoteCacheInvalidaton.notifyOtherInstancesAboutInvalidation(k)
+    override def apply(k: CacheKey) = {
+      remoteCacheInvalidaton.invalidateWhiskActionMetaData(k)
+      remoteCacheInvalidaton.notifyOtherInstancesAboutInvalidation(k)
+    }
   })
 
   // initialize backend services

--- a/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
@@ -449,8 +449,8 @@ trait WhiskWebActionsApi extends Directives with ValidateRequestSize with PostAc
    * This method is factored out to allow mock testing.
    */
   protected def getAction(actionName: FullyQualifiedEntityName)(
-    implicit transid: TransactionId): Future[WhiskAction] = {
-    WhiskAction.get(entityStore, actionName.toDocId)
+    implicit transid: TransactionId): Future[WhiskActionMetaData] = {
+    WhiskActionMetaData.get(entityStore, actionName.toDocId)
   }
 
   /**
@@ -549,7 +549,7 @@ trait WhiskWebActionsApi extends Directives with ValidateRequestSize with PostAc
   }
 
   private def extractEntityAndProcessRequest(actionOwnerIdentity: Identity,
-                                             action: WhiskAction,
+                                             action: WhiskActionMetaData,
                                              extension: MediaExtension,
                                              onBehalfOf: Option[Identity],
                                              context: Context,
@@ -597,7 +597,7 @@ trait WhiskWebActionsApi extends Directives with ValidateRequestSize with PostAc
   }
 
   private def processRequest(actionOwnerIdentity: Identity,
-                             action: WhiskAction,
+                             action: WhiskActionMetaData,
                              responseType: MediaExtension,
                              onBehalfOf: Option[Identity],
                              context: Context,
@@ -694,7 +694,7 @@ trait WhiskWebActionsApi extends Directives with ValidateRequestSize with PostAc
    * @return future action document or NotFound rejection
    */
   private def actionLookup(actionName: FullyQualifiedEntityName)(
-    implicit transid: TransactionId): Future[WhiskAction] = {
+    implicit transid: TransactionId): Future[WhiskActionMetaData] = {
     getAction(actionName) recoverWith {
       case _: ArtifactStoreException | DeserializationException(_, _, _) =>
         Future.failed(RejectRequest(NotFound))
@@ -717,8 +717,8 @@ trait WhiskWebActionsApi extends Directives with ValidateRequestSize with PostAc
   /**
    * Checks if an action is exported (i.e., carries the required annotation).
    */
-  private def confirmExportedAction(actionLookup: Future[WhiskAction], authenticated: Boolean)(
-    implicit transid: TransactionId): Future[WhiskAction] = {
+  private def confirmExportedAction(actionLookup: Future[WhiskActionMetaData], authenticated: Boolean)(
+    implicit transid: TransactionId): Future[WhiskActionMetaData] = {
     actionLookup flatMap { action =>
       val requiresAuthenticatedUser = action.annotations.asBool("require-whisk-auth").exists(identity)
       val isExported = action.annotations.asBool("web-export").exists(identity)

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PostActionActivation.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PostActionActivation.scala
@@ -46,14 +46,14 @@ protected[core] trait PostActionActivation extends PrimitiveActions with Sequenc
    */
   protected[controller] def invokeAction(
     user: Identity,
-    action: WhiskAction,
+    action: WhiskActionMetaData,
     payload: Option[JsObject],
     waitForResponse: Option[FiniteDuration],
     cause: Option[ActivationId])(implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
     action.toExecutableWhiskAction match {
       // this is a topmost sequence
       case None =>
-        val SequenceExec(components) = action.exec
+        val SequenceExecMetaData(components) = action.exec
         invokeSequence(user, action, components, payload, waitForResponse, cause, topmost = true, 0).map(r => r._1)
       // a non-deprecated ExecutableWhiskAction
       case Some(executable) if !executable.exec.deprecated =>

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
@@ -92,7 +92,7 @@ protected[actions] trait PrimitiveActions {
    */
   protected[actions] def invokeSingleAction(
     user: Identity,
-    action: ExecutableWhiskAction,
+    action: ExecutableWhiskActionMetaData,
     payload: Option[JsObject],
     waitForResponse: Option[FiniteDuration],
     cause: Option[ActivationId])(implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -325,6 +325,10 @@ trait ReferencedEntities {
         e.components.map { c =>
           Resource(c.path, Collection(Collection.ACTIONS), Some(c.name.asString))
         }.toSet
+      case e: SequenceExecMetaData =>
+        e.components.map { c =>
+          Resource(c.path, Collection(Collection.ACTIONS), Some(c.name.asString))
+        }.toSet
       case _ => Set()
     }
   }

--- a/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
@@ -812,6 +812,19 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     }
   }
 
+  it should "ensure WhiskActionMetadata is used to invoke an action" in {
+    implicit val tid = transid()
+    val action = WhiskAction(namespace, aname(), jsDefault("??"))
+    put(entityStore, action)
+    Post(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(Accepted)
+      val response = responseAs[JsObject]
+      response.fields("activationId") should not be None
+    }
+    stream.toString should include(s"[WhiskActionMetaData] [GET] serving from datastore: ${CacheKey(action)}")
+    stream.reset()
+  }
+
   it should "report proper error when record is corrupted on delete" in {
     implicit val tid = transid()
     val entity = BadEntity(namespace, aname())

--- a/tests/src/test/scala/whisk/core/controller/test/ActivationsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActivationsApiTests.scala
@@ -448,7 +448,12 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     implicit val materializer = ActorMaterializer()
     val activationStore = SpiLoader
       .get[ArtifactStoreProvider]
-      .makeStore[WhiskEntity](whiskConfig, _.dbActivations)(WhiskEntityJsonFormat, system, logging, materializer)
+      .makeStore[WhiskEntity](whiskConfig, _.dbActivations)(
+        WhiskEntityJsonFormat,
+        WhiskDocumentReader,
+        system,
+        logging,
+        materializer)
     implicit val tid = transid()
     val entity = BadEntity(namespace, EntityName(ActivationId().toString))
     put(activationStore, entity)

--- a/tests/src/test/scala/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ControllerTestCommon.scala
@@ -184,7 +184,7 @@ class DegenerateLoadBalancerService(config: WhiskConfig)(implicit ec: ExecutionC
   override def totalActiveActivations = Future.successful(0)
   override def activeActivationsFor(namespace: UUID) = Future.successful(0)
 
-  override def publish(action: ExecutableWhiskAction, msg: ActivationMessage)(
+  override def publish(action: ExecutableWhiskActionMetaData, msg: ActivationMessage)(
     implicit transid: TransactionId): Future[Future[Either[ActivationId, WhiskActivation]]] =
     Future.successful {
       whiskActivationStub map {

--- a/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
@@ -185,12 +185,12 @@ trait WebActionsApiBaseTests extends ControllerTestCommon with BeforeAndAfterEac
   override protected def getAction(actionName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
     if (!failActionLookup) {
       def theAction = {
-        val annotations = Parameters(WhiskAction.finalParamsAnnotationName, JsBoolean(true))
+        val annotations = Parameters(WhiskActionMetaData.finalParamsAnnotationName, JsBoolean(true))
 
-        WhiskAction(
+        WhiskActionMetaData(
           actionName.path,
           actionName.name,
-          jsDefault("??"),
+          jsDefaultMetaData("??"),
           defaultActionParameters,
           annotations = {
             if (actionName.name.asString.startsWith("export_")) {
@@ -242,7 +242,7 @@ trait WebActionsApiBaseTests extends ControllerTestCommon with BeforeAndAfterEac
 
   override protected[controller] def invokeAction(
     user: Identity,
-    action: WhiskAction,
+    action: WhiskActionMetaData,
     payload: Option[JsObject],
     waitForResponse: Option[FiniteDuration],
     cause: Option[ActivationId])(implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {

--- a/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
@@ -56,6 +56,15 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
     js6(code, main)
   }
 
+  protected def js6MetaData(code: String, main: Option[String] = None) = {
+    CodeExecMetaDataAsString(
+      RuntimeManifest(NODEJS6, imagename(NODEJS6), default = Some(true), deprecated = Some(false)))
+  }
+
+  protected def jsDefaultMetaData(code: String, main: Option[String] = None) = {
+    js6MetaData(code, main)
+  }
+
   protected def swift(code: String, main: Option[String] = None) = {
     CodeExecAsString(RuntimeManifest(SWIFT, imagename(SWIFT), deprecated = Some(true)), trim(code), main.map(_.trim))
   }


### PR DESCRIPTION
Creates new datatype called WhiskActionMetadata that drops code property from its Exec data type for action invocations. This prevents action code from being loaded into memory.