### PR TITLE
Remove redundant view which predates db split into activations and assets.

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
@@ -48,7 +48,7 @@ import whisk.core.database.StaleParameter
  * @param logs the activation logs
  * @param version the semantic version (usually matches the activated entity)
  * @param publish true to share the activation or false otherwise
- * @param annotation the set of annotations to attribute to the activation
+ * @param annotations the set of annotations to attribute to the activation
  * @param duration of the activation in milliseconds
  * @throws IllegalArgumentException if any required argument is undefined
  */

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
@@ -75,6 +75,7 @@ case class WhiskActivation(namespace: EntityPath,
 
   def toJson = WhiskActivation.serdes.write(this).asJsObject
 
+  /** This the activation summary as computed by the database view. Strictly used for testing. */
   override def summaryAsJson = {
     val JsObject(fields) = super.summaryAsJson
     JsObject(fields + ("activationId" -> activationId.toJson))

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
@@ -179,12 +179,12 @@ object WhiskEntityQueries {
 
   /**
    * Queries the datastore for all entities in a namespace, and converts the list of entities
-   * to a map that collects the entities by their type. This method applies to both the main
-   * asset database and the activation records because they both have an "all" view.
+   * to a map that collects the entities by their type. This method applies to only to the main
+   * asset database, not the activations records because it does not offer the required view.
    */
   def listAllInNamespace[A <: WhiskEntity](
     db: ArtifactStore[A],
-    namespace: EntityPath,
+    namespace: EntityName,
     includeDocs: Boolean,
     stale: StaleParameter = StaleParameter.No)(implicit transid: TransactionId): Future[Map[String, List[JsObject]]] = {
     implicit val ec = db.executionContext

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
@@ -170,21 +170,17 @@ object WhiskEntityQueries {
   val TOP = "\ufff0"
   val WHISKVIEW = "whisks"
   val ALL = "all"
-  val ENTITIES = "entities"
 
   /**
    * Determines the view name for the collection. There are two cases: a view
    * that is namespace specific, or namespace agnostic..
    */
-  def viewname(collection: String, allNamespaces: Boolean = false): String = {
-    if (!allNamespaces) {
-      s"$WHISKVIEW/$collection"
-    } else s"$WHISKVIEW/$collection-all"
-  }
+  def viewname(collection: String): String = s"$WHISKVIEW/$collection"
 
   /**
    * Queries the datastore for all entities in a namespace, and converts the list of entities
-   * to a map that collects the entities by their type.
+   * to a map that collects the entities by their type. This method applies to both the main
+   * asset database and the activation records because they both have an "all" view.
    */
   def listAllInNamespace[A <: WhiskEntity](
     db: ArtifactStore[A],
@@ -192,8 +188,8 @@ object WhiskEntityQueries {
     includeDocs: Boolean,
     stale: StaleParameter = StaleParameter.No)(implicit transid: TransactionId): Future[Map[String, List[JsObject]]] = {
     implicit val ec = db.executionContext
-    val startKey = List(namespace.toString)
-    val endKey = List(namespace.toString, TOP)
+    val startKey = List(namespace.asString)
+    val endKey = List(namespace.asString, TOP)
     db.query(viewname(ALL), startKey, endKey, 0, 0, includeDocs, descending = true, reduce = false, stale = stale) map {
       _ map { row =>
         val value = row.fields("value").asJsObject
@@ -202,75 +198,36 @@ object WhiskEntityQueries {
       } groupBy { _._1 } mapValues { _.map(_._2) }
     }
   }
+}
+
+trait WhiskEntityQueries[T] {
+  val collectionName: String
+  val serdes: RootJsonFormat[T]
+  import WhiskEntityQueries._
 
   /**
-   * Queries the datastore for all entities without activations in a namespace, and converts the list of entities
-   * to a map that collects the entities by their type.
+   * Queries the datastore for records from a specific collection (i.e., type) matching
+   * the given path (which should be one namespace, or namespace + package name).
+   *
+   * @return list of records as JSON object if docs parameter is false, as Left
+   *         and a list of the records as their type T if including the full record, as Right
    */
-  def listEntitiesInNamespace[A <: WhiskEntity](
-    db: ArtifactStore[A],
-    namespace: EntityPath,
-    includeDocs: Boolean,
-    stale: StaleParameter = StaleParameter.No)(implicit transid: TransactionId): Future[Map[String, List[JsObject]]] = {
-    implicit val ec = db.executionContext
-    val startKey = List(namespace.toString)
-    val endKey = List(namespace.toString, TOP)
-    db.query(viewname(ENTITIES), startKey, endKey, 0, 0, includeDocs, descending = true, reduce = false, stale = stale) map {
-      _ map { row =>
-        val value = row.fields("value").asJsObject
-        val JsString(collection) = value.fields("collection")
-        (collection, JsObject(value.fields.filterNot { _._1 == "collection" }))
-      } groupBy { _._1 } mapValues { _.map(_._2) }
-    }
+  def listCollectionInNamespace[A <: WhiskEntity](db: ArtifactStore[A],
+                                                  path: EntityPath, // could be a namesapce or namespace + package name
+                                                  skip: Int,
+                                                  limit: Int,
+                                                  includeDocs: Boolean = false,
+                                                  since: Option[Instant] = None,
+                                                  upto: Option[Instant] = None,
+                                                  stale: StaleParameter = StaleParameter.No)(
+    implicit transid: TransactionId): Future[Either[List[JsObject], List[T]]] = {
+    val convert = if (includeDocs) Some((o: JsObject) => Try { serdes.read(o) }) else None
+    val startKey = List(path.asString, since map { _.toEpochMilli } getOrElse 0)
+    val endKey = List(path.asString, upto map { _.toEpochMilli } getOrElse TOP, TOP)
+    query(db, viewname(collectionName), startKey, endKey, skip, limit, reduce = false, stale, convert)
   }
 
-  def listCollectionInAnyNamespace[A <: WhiskEntity, T](
-    db: ArtifactStore[A],
-    collection: String,
-    skip: Int,
-    limit: Int,
-    reduce: Boolean,
-    since: Option[Instant] = None,
-    upto: Option[Instant] = None,
-    stale: StaleParameter = StaleParameter.No,
-    convert: Option[JsObject => Try[T]])(implicit transid: TransactionId): Future[Either[List[JsObject], List[T]]] = {
-    val startKey = List(since map { _.toEpochMilli } getOrElse 0)
-    val endKey = List(upto map { _.toEpochMilli } getOrElse TOP, TOP)
-    query(db, viewname(collection, true), startKey, endKey, skip, limit, reduce, stale, convert)
-  }
-
-  def listCollectionInNamespace[A <: WhiskEntity, T](
-    db: ArtifactStore[A],
-    collection: String,
-    namespace: EntityPath,
-    skip: Int,
-    limit: Int,
-    since: Option[Instant] = None,
-    upto: Option[Instant] = None,
-    stale: StaleParameter = StaleParameter.No,
-    convert: Option[JsObject => Try[T]])(implicit transid: TransactionId): Future[Either[List[JsObject], List[T]]] = {
-    val startKey = List(namespace.toString, since map { _.toEpochMilli } getOrElse 0)
-    val endKey = List(namespace.toString, upto map { _.toEpochMilli } getOrElse TOP, TOP)
-    query(db, viewname(collection), startKey, endKey, skip, limit, reduce = false, stale, convert)
-  }
-
-  def listCollectionByName[A <: WhiskEntity, T](
-    db: ArtifactStore[A],
-    collection: String,
-    namespace: EntityPath,
-    name: EntityName,
-    skip: Int,
-    limit: Int,
-    since: Option[Instant] = None,
-    upto: Option[Instant] = None,
-    stale: StaleParameter = StaleParameter.No,
-    convert: Option[JsObject => Try[T]])(implicit transid: TransactionId): Future[Either[List[JsObject], List[T]]] = {
-    val startKey = List(namespace.addPath(name).toString, since map { _.toEpochMilli } getOrElse 0)
-    val endKey = List(namespace.addPath(name).toString, upto map { _.toEpochMilli } getOrElse TOP, TOP)
-    query(db, viewname(collection), startKey, endKey, skip, limit, reduce = false, stale, convert)
-  }
-
-  private def query[A <: WhiskEntity, T](
+  protected[entity] def query[A <: WhiskEntity](
     db: ArtifactStore[A],
     view: String,
     startKey: List[Any],
@@ -301,78 +258,5 @@ object WhiskEntityQueries {
     if (!reduce) {
       row.fields("value").asJsObject
     } else row
-  }
-}
-
-trait WhiskEntityQueries[T] {
-  val collectionName: String
-  val serdes: RootJsonFormat[T]
-
-  def listCollectionInAnyNamespace[A <: WhiskEntity, T](
-    db: ArtifactStore[A],
-    skip: Int,
-    limit: Int,
-    docs: Boolean = false,
-    reduce: Boolean = false,
-    since: Option[Instant] = None,
-    upto: Option[Instant] = None,
-    stale: StaleParameter = StaleParameter.No)(implicit transid: TransactionId) = {
-    val convert = if (docs) Some((o: JsObject) => Try { serdes.read(o) }) else None
-    WhiskEntityQueries.listCollectionInAnyNamespace(
-      db,
-      collectionName,
-      skip,
-      limit,
-      reduce,
-      since,
-      upto,
-      stale,
-      convert)
-  }
-
-  def listCollectionInNamespace[A <: WhiskEntity, T](
-    db: ArtifactStore[A],
-    namespace: EntityPath,
-    skip: Int,
-    limit: Int,
-    docs: Boolean = false,
-    since: Option[Instant] = None,
-    upto: Option[Instant] = None,
-    stale: StaleParameter = StaleParameter.No)(implicit transid: TransactionId) = {
-    val convert = if (docs) Some((o: JsObject) => Try { serdes.read(o) }) else None
-    WhiskEntityQueries.listCollectionInNamespace(
-      db,
-      collectionName,
-      namespace,
-      skip,
-      limit,
-      since,
-      upto,
-      stale,
-      convert)
-  }
-
-  def listCollectionByName[A <: WhiskEntity, T](
-    db: ArtifactStore[A],
-    namespace: EntityPath,
-    name: EntityName,
-    skip: Int,
-    limit: Int,
-    docs: Boolean = false,
-    since: Option[Instant] = None,
-    upto: Option[Instant] = None,
-    stale: StaleParameter = StaleParameter.No)(implicit transid: TransactionId) = {
-    val convert = if (docs) Some((o: JsObject) => Try { serdes.read(o) }) else None
-    WhiskEntityQueries.listCollectionByName(
-      db,
-      collectionName,
-      namespace,
-      name,
-      skip,
-      limit,
-      since,
-      upto,
-      stale,
-      convert)
   }
 }

--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -322,9 +322,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
     parameter('skip ? 0, 'limit ? collection.listLimit, 'count ? false) { (skip, limit, count) =>
       listEntities {
         WhiskAction.listCollectionInNamespace(entityStore, namespace, skip, limit, docs) map { list =>
-          val actions = if (docs) {
-            list.right.get map { WhiskAction.serdes.write(_) }
-          } else list.left.get
+          val actions = list.fold((js) => js, (as) => as.map(WhiskAction.serdes.write(_)))
           FilterEntityList.filter(actions, excludePrivate)
         }
       }

--- a/core/controller/src/main/scala/whisk/core/controller/Activations.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Activations.scala
@@ -130,7 +130,7 @@ trait WhiskActivationsApi extends Directives with AuthenticatedRouteProvider wit
       if (cappedLimit <= WhiskActivationsApi.maxActivationLimit) {
         val activations = name match {
           case Some(action) =>
-            WhiskActivation.listCollectionByName(
+            WhiskActivation.listActivationsMatchingName(
               activationStore,
               namespace,
               action,
@@ -153,11 +153,7 @@ trait WhiskActivationsApi extends Directives with AuthenticatedRouteProvider wit
         }
 
         listEntities {
-          activations map { l =>
-            if (docs) l.right.get map {
-              _.toExtendedJson
-            } else l.left.get
-          }
+          activations map (_.fold((js) => js, (wa) => wa.map(_.toExtendedJson)))
         }
       } else {
         terminate(BadRequest, Messages.maxActivationLimitExceeded(limit, WhiskActivationsApi.maxActivationLimit))

--- a/core/controller/src/main/scala/whisk/core/controller/ApiUtils.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/ApiUtils.scala
@@ -91,9 +91,9 @@ protected[controller] object FilterEntityList {
     if (excludePrivate) {
       resources filter {
         case obj: JsObject =>
-          obj.getFields(sharedFieldName) match {
-            case Seq(JsBoolean(true)) => true && additionalFilter(obj) // a shared entity
-            case _                    => false
+          obj.fields.get(sharedFieldName) match {
+            case Some(JsBoolean(true)) => additionalFilter(obj) // a shared entity
+            case _                     => false
           }
         case _ => false // only expecting JsObject instances
       }

--- a/core/controller/src/main/scala/whisk/core/controller/Namespaces.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Namespaces.scala
@@ -37,8 +37,7 @@ import whisk.core.entitlement.Resource
 import whisk.core.entity.EntityPath
 import whisk.core.entity.Identity
 import whisk.core.entity.WhiskAction
-import whisk.core.entity.WhiskActivation
-import whisk.core.entity.WhiskEntityQueries.listEntitiesInNamespace
+import whisk.core.entity.WhiskEntityQueries.listAllInNamespace
 import whisk.core.entity.WhiskPackage
 import whisk.core.entity.WhiskRule
 import whisk.core.entity.WhiskTrigger
@@ -105,9 +104,9 @@ trait WhiskNamespacesApi
    */
   private def getAllInNamespace(namespace: EntityPath)(
     implicit transid: TransactionId): RequestContext => Future[RouteResult] = {
-    onComplete(listEntitiesInNamespace(entityStore, namespace, false)) {
+    onComplete(listAllInNamespace(entityStore, namespace, false)) {
       case Success(entities) => {
-        complete(OK, Namespaces.emptyNamespace ++ entities - WhiskActivation.collectionName)
+        complete(OK, Namespaces.emptyNamespace ++ entities)
       }
       case Failure(t) =>
         logging.error(this, s"[GET] namespaces failed: ${t.getMessage}")

--- a/core/controller/src/main/scala/whisk/core/controller/Namespaces.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Namespaces.scala
@@ -104,7 +104,7 @@ trait WhiskNamespacesApi
    */
   private def getAllInNamespace(namespace: EntityPath)(
     implicit transid: TransactionId): RequestContext => Future[RouteResult] = {
-    onComplete(listAllInNamespace(entityStore, namespace, false)) {
+    onComplete(listAllInNamespace(entityStore, namespace.root, false)) {
       case Success(entities) => {
         complete(OK, Namespaces.emptyNamespace ++ entities)
       }

--- a/core/controller/src/main/scala/whisk/core/controller/Packages.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Packages.scala
@@ -20,7 +20,6 @@ package whisk.core.controller
 import scala.concurrent.Future
 import scala.util.Failure
 import scala.util.Success
-import scala.util.Try
 
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
@@ -176,40 +175,23 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
     // Actions API for more.
     val docs = false
 
-    // disable listing all public (shared) packages in all namespaces until
-    // there exists a process in place to curate and rank these packages
-    val publicPackagesInAnyNamespace = false
     parameter('skip ? 0, 'limit ? collection.listLimit, 'count ? false) { (skip, limit, count) =>
-      if (publicPackagesInAnyNamespace && docs) {
-        terminate(BadRequest, "Parameters 'public' and 'docs' may not both be true at the same time")
-      } else
-        listEntities {
-          if (!publicPackagesInAnyNamespace) {
-            WhiskPackage.listCollectionInNamespace(entityStore, namespace, skip, limit, docs) map { list =>
-              // any subject is entitled to list packages in any namespace
-              // however, they shall only observe public packages if the packages
-              // are not in one of the namespaces the subject is entitled to
-              val packages = if (docs) {
-                list.right.get map { WhiskPackage.serdes.write(_) }
-              } else list.left.get
-              FilterEntityList.filter(packages, excludePrivate, additionalFilter = { // additionally exclude bindings
-                case pkg: JsObject =>
-                  Try {
-                    pkg.fields(WhiskPackage.bindingFieldName) == JsBoolean(false)
-                  } getOrElse false
-              })
+      listEntities {
+        WhiskPackage.listCollectionInNamespace(entityStore, namespace, skip, limit, docs) map { list =>
+          // any subject is entitled to list packages in any namespace
+          // however, they shall only observe public packages if the packages
+          // are not in one of the namespaces the subject is entitled to
+          val packages = list.fold((js) => js, (ps) => ps.map(WhiskPackage.serdes.write(_)))
+
+          FilterEntityList.filter(packages, excludePrivate, additionalFilter = {
+            // additionally exclude bindings
+            _.fields.get(WhiskPackage.bindingFieldName) match {
+              case Some(JsBoolean(isbinding)) => !isbinding
+              case _                          => false // exclude anything that does not conform
             }
-          } else {
-            WhiskPackage.listCollectionInAnyNamespace(
-              entityStore,
-              skip,
-              limit,
-              docs = false,
-              reduce = publicPackagesInAnyNamespace) map {
-              _.left.get
-            }
-          }
+          })
         }
+      }
     }
   }
 

--- a/core/controller/src/main/scala/whisk/core/controller/Rules.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Rules.scala
@@ -248,9 +248,7 @@ trait WhiskRulesApi extends WhiskCollectionAPI with ReferencedEntities {
     parameter('skip ? 0, 'limit ? collection.listLimit, 'count ? false) { (skip, limit, count) =>
       listEntities {
         WhiskRule.listCollectionInNamespace(entityStore, namespace, skip, limit, docs) map { list =>
-          val rules = if (docs) {
-            list.right.get map { WhiskRule.serdes.write(_) }
-          } else list.left.get
+          val rules = list.fold((js) => js, (rls) => rls.map(WhiskRule.serdes.write(_)))
           FilterEntityList.filter(rules, excludePrivate)
         }
       }

--- a/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
@@ -267,9 +267,7 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
     parameter('skip ? 0, 'limit ? collection.listLimit, 'count ? false) { (skip, limit, count) =>
       listEntities {
         WhiskTrigger.listCollectionInNamespace(entityStore, namespace, skip, limit, docs) map { list =>
-          val triggers = if (docs) {
-            list.right.get map { WhiskTrigger.serdes.write(_) }
-          } else list.left.get
+          val triggers = list.fold((js) => js, (ts) => ts.map(WhiskTrigger.serdes.write(_)))
           FilterEntityList.filter(triggers, excludePrivate)
         }
       }

--- a/tests/src/test/scala/whisk/core/controller/test/ActivationsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActivationsApiTests.scala
@@ -58,7 +58,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
   val creds = WhiskAuthHelpers.newIdentity()
   val namespace = EntityPath(creds.subject.asString)
   val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
-  def aname = MakeName.next("activations_tests")
+  def aname() = MakeName.next("activations_tests")
 
   //// GET /activations
   it should "get summary activation by namespace" in {
@@ -68,14 +68,14 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     (1 to 2).map { i =>
       WhiskActivation(
         EntityPath(creds1.subject.asString),
-        aname,
+        aname(),
         creds1.subject,
         ActivationId(),
         start = Instant.now,
         end = Instant.now)
     } foreach { put(entityStore, _) }
 
-    val actionName = aname
+    val actionName = aname()
     val activations = (1 to 2).map { i =>
       WhiskActivation(namespace, actionName, creds.subject, ActivationId(), start = Instant.now, end = Instant.now)
     }.toList
@@ -133,14 +133,14 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     (1 to 2).map { i =>
       WhiskActivation(
         EntityPath(creds1.subject.asString),
-        aname,
+        aname(),
         creds1.subject,
         ActivationId(),
         start = Instant.now,
         end = Instant.now)
     } foreach { put(entityStore, _) }
 
-    val actionName = aname
+    val actionName = aname()
     val activations = (1 to 2).map { i =>
       WhiskActivation(
         namespace,
@@ -174,14 +174,14 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     (1 to 2).map { i =>
       WhiskActivation(
         EntityPath(creds1.subject.asString),
-        aname,
+        aname(),
         creds1.subject,
         ActivationId(),
         start = Instant.now,
         end = Instant.now)
     } foreach { put(activationStore, _) }
 
-    val actionName = aname
+    val actionName = aname()
     val now = Instant.now(Clock.systemUTC())
     val since = now.plusSeconds(10)
     val upto = now.plusSeconds(30)
@@ -275,7 +275,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     (1 to 2).map { i =>
       WhiskActivation(
         EntityPath(creds1.subject.asString),
-        aname,
+        aname(),
         creds1.subject,
         ActivationId(),
         start = Instant.now,
@@ -338,7 +338,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
   it should "get activation by id" in {
     implicit val tid = transid()
     val activation =
-      WhiskActivation(namespace, aname, creds.subject, ActivationId(), start = Instant.now, end = Instant.now)
+      WhiskActivation(namespace, aname(), creds.subject, ActivationId(), start = Instant.now, end = Instant.now)
     put(activationStore, activation)
 
     Get(s"$collectionPath/${activation.activationId.asString}") ~> Route.seal(routes(creds)) ~> check {
@@ -365,7 +365,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
   it should "get activation result by id" in {
     implicit val tid = transid()
     val activation =
-      WhiskActivation(namespace, aname, creds.subject, ActivationId(), start = Instant.now, end = Instant.now)
+      WhiskActivation(namespace, aname(), creds.subject, ActivationId(), start = Instant.now, end = Instant.now)
     put(activationStore, activation)
 
     Get(s"$collectionPath/${activation.activationId.asString}/result") ~> Route.seal(routes(creds)) ~> check {
@@ -379,7 +379,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
   it should "get activation logs by id" in {
     implicit val tid = transid()
     val activation =
-      WhiskActivation(namespace, aname, creds.subject, ActivationId(), start = Instant.now, end = Instant.now)
+      WhiskActivation(namespace, aname(), creds.subject, ActivationId(), start = Instant.now, end = Instant.now)
     put(activationStore, activation)
 
     Get(s"$collectionPath/${activation.activationId.asString}/logs") ~> Route.seal(routes(creds)) ~> check {
@@ -393,7 +393,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
   it should "reject request to get invalid activation resource" in {
     implicit val tid = transid()
     val activation =
-      WhiskActivation(namespace, aname, creds.subject, ActivationId(), start = Instant.now, end = Instant.now)
+      WhiskActivation(namespace, aname(), creds.subject, ActivationId(), start = Instant.now, end = Instant.now)
     put(entityStore, activation)
 
     Get(s"$collectionPath/${activation.activationId.asString}/bogus") ~> Route.seal(routes(creds)) ~> check {

--- a/tests/src/test/scala/whisk/core/controller/test/ActivationsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActivationsApiTests.scala
@@ -80,7 +80,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
       WhiskActivation(namespace, actionName, creds.subject, ActivationId(), start = Instant.now, end = Instant.now)
     }.toList
     activations foreach { put(activationStore, _) }
-    waitOnView(activationStore, namespace, 2)
+    waitOnView(activationStore, namespace.root, 2, WhiskActivation.collectionName)
     whisk.utils.retry {
       Get(s"$collectionPath") ~> Route.seal(routes(creds)) ~> check {
         status should be(OK)
@@ -152,7 +152,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
         response = ActivationResponse.success(Some(JsNumber(5))))
     }.toList
     activations foreach { put(activationStore, _) }
-    waitOnView(activationStore, namespace, 2)
+    waitOnView(activationStore, namespace.root, 2, WhiskActivation.collectionName)
 
     whisk.utils.retry {
       Get(s"$collectionPath?docs=true") ~> Route.seal(routes(creds)) ~> check {
@@ -216,7 +216,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
         start = now.plusSeconds(30),
         end = now.plusSeconds(20))) // should match
     activations foreach { put(activationStore, _) }
-    waitOnView(activationStore, namespace, activations.length)
+    waitOnView(activationStore, namespace.root, activations.length, WhiskActivation.collectionName)
 
     // get between two time stamps
     whisk.utils.retry {
@@ -292,7 +292,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
         end = Instant.now)
     }.toList
     activations foreach { put(activationStore, _) }
-    waitOnView(activationStore, namespace, 2)
+    waitOnView(activationStore, namespace.root, 2, WhiskActivation.collectionName)
 
     whisk.utils.retry {
       Get(s"$collectionPath?name=xyz") ~> Route.seal(routes(creds)) ~> check {

--- a/tests/src/test/scala/whisk/core/controller/test/migration/SequenceActionApiMigrationTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/migration/SequenceActionApiMigrationTests.scala
@@ -52,7 +52,7 @@ class SequenceActionApiMigrationTests
   val creds = WhiskAuthHelpers.newIdentity()
   val namespace = EntityPath(creds.subject.asString)
   val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
-  def aname = MakeName.next("seq_migration_tests")
+  def aname() = MakeName.next("seq_migration_tests")
 
   private def seqParameters(seq: Vector[String]) = Parameters("_actions", seq.toJson)
 
@@ -60,7 +60,7 @@ class SequenceActionApiMigrationTests
     implicit val tid = transid()
     val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c").map(stringToFullyQualifiedName(_))
     val actions = (1 to 2).map { i =>
-      WhiskAction(namespace, aname, sequence(components))
+      WhiskAction(namespace, aname(), sequence(components))
     }.toList
     actions foreach { put(entityStore, _) }
     waitOnView(entityStore, WhiskAction, namespace, 2)
@@ -78,7 +78,7 @@ class SequenceActionApiMigrationTests
   it should "get old-style sequence action by name in default namespace" in {
     implicit val tid = transid()
     val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c").map(stringToFullyQualifiedName(_))
-    val action = WhiskAction(namespace, aname, sequence(components))
+    val action = WhiskAction(namespace, aname(), sequence(components))
     put(entityStore, action)
     Get(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
@@ -92,7 +92,7 @@ class SequenceActionApiMigrationTests
     implicit val tid = transid()
     val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c")
     val seqComponents = components.map(stringToFullyQualifiedName(_))
-    val action = WhiskAction(namespace, aname, sequence(seqComponents), seqParameters(components))
+    val action = WhiskAction(namespace, aname(), sequence(seqComponents), seqParameters(components))
     val content = WhiskActionPut(Some(jsDefault("")), parameters = Some(Parameters("a", "A")))
     put(entityStore, action, false)
 
@@ -111,7 +111,7 @@ class SequenceActionApiMigrationTests
     implicit val tid = transid()
     val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c")
     val seqComponents = components.map(stringToFullyQualifiedName(_))
-    val action = WhiskAction(namespace, aname, sequence(seqComponents), seqParameters(components))
+    val action = WhiskAction(namespace, aname(), sequence(seqComponents), seqParameters(components))
     val content = WhiskActionPut(Some(jsDefault("")))
     put(entityStore, action, false)
 
@@ -129,7 +129,7 @@ class SequenceActionApiMigrationTests
     implicit val tid = transid()
     val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c")
     val seqComponents = components.map(stringToFullyQualifiedName(_))
-    val action = WhiskAction(namespace, aname, sequence(seqComponents))
+    val action = WhiskAction(namespace, aname(), sequence(seqComponents))
     val content = """{"annotations":[{"key":"old","value":"new"}]}""".parseJson.asJsObject
     put(entityStore, action, false)
 
@@ -151,14 +151,14 @@ class SequenceActionApiMigrationTests
   it should "update an old-style sequence with new sequence" in {
     implicit val tid = transid()
     // old sequence
-    val seqName = EntityName(s"${aname}_new")
+    val seqName = EntityName(s"${aname()}_new")
     val oldComponents = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c").map(stringToFullyQualifiedName(_))
     val oldSequence = WhiskAction(namespace, seqName, sequence(oldComponents))
     put(entityStore, oldSequence)
 
     // new sequence
     val limit = 5 // count of bogus actions in sequence
-    val bogus = s"${aname}_bogus"
+    val bogus = s"${aname()}_bogus"
     val bogusActionName = s"/_/${bogus}" // test that default namespace gets properly replaced
     // put the action in the entity store so it exists
     val bogusAction = WhiskAction(namespace, EntityName(bogus), jsDefault("??"), Parameters("x", "y"))

--- a/tests/src/test/scala/whisk/core/entity/test/ViewTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ViewTests.scala
@@ -22,7 +22,6 @@ import java.time.Instant
 
 import scala.concurrent.Await
 import scala.language.postfixOps
-import scala.util.Try
 
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfter
@@ -33,7 +32,6 @@ import org.scalatest.junit.JUnitRunner
 
 import common.StreamLogging
 import common.WskActorSystem
-import spray.json.JsObject
 import whisk.core.WhiskConfig
 import whisk.core.controller.test.WhiskAuthHelpers
 import whisk.core.database.ArtifactStore
@@ -53,8 +51,8 @@ class ViewTests
     with WskActorSystem
     with StreamLogging {
 
-  def aname = MakeName.next("viewtests")
-  def afullname(namespace: EntityPath) = FullyQualifiedEntityName(namespace, aname)
+  def aname() = MakeName.next("viewtests")
+  def afullname(namespace: EntityPath) = FullyQualifiedEntityName(namespace, aname())
 
   object MakeName {
     @volatile var counter = 1
@@ -99,7 +97,7 @@ class ViewTests
 
   def getEntitiesInNamespace(ns: EntityPath)(implicit entities: Seq[WhiskEntity]) = {
     implicit val tid = transid()
-    val map = Await.result(listEntitiesInNamespace(entityStore, ns, false), dbOpTimeout)
+    val map = Await.result(listAllInNamespace(entityStore, ns, false), dbOpTimeout)
     val result = map.values.toList flatMap { t =>
       t
     }
@@ -111,17 +109,25 @@ class ViewTests
     } should be(true)
   }
 
+  def resolveListMethodForKind(kind: String) = kind match {
+    case "actions"     => WhiskAction
+    case "packages"    => WhiskPackage
+    case "rules"       => WhiskRule
+    case "triggers"    => WhiskTrigger
+    case "activations" => WhiskActivation
+  }
+
   def getKindInNamespace[Au <: WhiskEntity](store: ArtifactStore[Au],
                                             ns: EntityPath,
                                             kind: String,
                                             f: (WhiskEntity) => Boolean)(implicit entities: Seq[WhiskEntity]) = {
     implicit val tid = transid()
-    val result =
-      Await.result(listCollectionInNamespace(store, kind, ns, 0, 0, stale = StaleParameter.No, convert = None) map {
-        _.left.get map { e =>
-          e
-        }
-      }, dbOpTimeout)
+    val q = resolveListMethodForKind(kind)
+    val result = Await.result(q.listCollectionInNamespace(store, ns, 0, 0, stale = StaleParameter.No) map {
+      _.left.get map { e =>
+        e
+      }
+    }, dbOpTimeout)
     val expected = entities filter { e =>
       f(e) && e.namespace.root.toPath == ns
     }
@@ -131,33 +137,16 @@ class ViewTests
     } should be(true)
   }
 
-  def getPublicPackages(implicit entities: Seq[WhiskEntity]) = {
+  def getKindInNamespaceWithDoc[T](ns: EntityPath, kind: String, f: (WhiskEntity) => Boolean)(
+    implicit entities: Seq[WhiskEntity]) = {
     implicit val tid = transid()
-    val result = Await.result(listCollectionInAnyNamespace(entityStore, "packages", 0, 0, true, convert = None) map {
-      _.left.get map { e =>
-        e
-      }
-    }, dbOpTimeout)
-    val expected = entities filter {
-      case (e: WhiskPackage) => e.publish && e.binding.isEmpty
-      case _                 => false
-    }
-    result.length should be >= (expected.length)
-    expected forall { e =>
-      result contains e.summaryAsJson
-    } should be(true)
-  }
-
-  def getKindInNamespaceWithDoc[T](ns: EntityPath,
-                                   kind: String,
-                                   f: (WhiskEntity) => Boolean,
-                                   convert: Option[JsObject => Try[T]])(implicit entities: Seq[WhiskEntity]) = {
-    implicit val tid = transid()
-    val result = Await.result(
-      listCollectionInNamespace(entityStore, kind, ns, 0, 0, stale = StaleParameter.No, convert = convert) map {
-        _.right.get
-      },
-      dbOpTimeout)
+    val q = resolveListMethodForKind(kind)
+    val result =
+      Await.result(
+        q.listCollectionInNamespace(entityStore, ns, 0, 0, includeDocs = true, stale = StaleParameter.No) map {
+          _.right.get
+        },
+        dbOpTimeout)
     val expected = entities filter { e =>
       f(e) && e.namespace.root.toPath == ns
     }
@@ -172,9 +161,31 @@ class ViewTests
                                                   kind: String,
                                                   name: EntityName,
                                                   f: (WhiskEntity) => Boolean)(implicit entities: Seq[WhiskEntity]) = {
+    require(kind == "actions") // currently only actions are permitted in packages
+    implicit val tid = transid()
+    val q = resolveListMethodForKind(kind)
+    val result =
+      Await.result(q.listCollectionInNamespace(store, ns.addPath(name), 0, 0, stale = StaleParameter.No) map {
+        _.left.get map { e =>
+          e
+        }
+      }, dbOpTimeout)
+    val expected = entities filter { e =>
+      f(e) && e.namespace.root.toPath == ns
+    }
+    result.length should be(expected.length)
+    expected forall { e =>
+      result contains e.summaryAsJson
+    } should be(true)
+  }
+
+  def getActivationsInNamespaceByName(store: ArtifactStore[WhiskActivation],
+                                      ns: EntityPath,
+                                      name: EntityName,
+                                      f: (WhiskEntity) => Boolean)(implicit entities: Seq[WhiskEntity]) = {
     implicit val tid = transid()
     val result =
-      Await.result(listCollectionByName(store, kind, ns, name, 0, 0, stale = StaleParameter.No, convert = None) map {
+      Await.result(WhiskActivation.listActivationsMatchingName(store, ns, name, 0, 0, stale = StaleParameter.No) map {
         _.left.get map { e =>
           e
         }
@@ -191,13 +202,12 @@ class ViewTests
   def getKindInPackage(ns: EntityPath, kind: String, f: (WhiskEntity) => Boolean)(
     implicit entities: Seq[WhiskEntity]) = {
     implicit val tid = transid()
-    val result = Await.result(
-      listCollectionInNamespace(entityStore, kind, ns, 0, 0, stale = StaleParameter.No, convert = None) map {
-        _.left.get map { e =>
-          e
-        }
-      },
-      dbOpTimeout)
+    val q = resolveListMethodForKind(kind)
+    val result = Await.result(q.listCollectionInNamespace(entityStore, ns, 0, 0, stale = StaleParameter.No) map {
+      _.left.get map { e =>
+        e
+      }
+    }, dbOpTimeout)
     val expected = entities filter { e =>
       f(e) && e.namespace == ns
     }
@@ -207,19 +217,19 @@ class ViewTests
     } should be(true)
   }
 
-  def getKindInNamespaceByNameSortedByDate[Au <: WhiskEntity](
-    store: ArtifactStore[Au],
-    ns: EntityPath,
-    kind: String,
-    name: EntityName,
-    skip: Int,
-    count: Int,
-    start: Option[Instant],
-    end: Option[Instant],
-    f: (WhiskEntity) => Boolean)(implicit entities: Seq[WhiskEntity]) = {
+  def getActivationsInNamespaceByNameSortedByDate(store: ArtifactStore[WhiskActivation],
+                                                  ns: EntityPath,
+                                                  kind: String,
+                                                  name: EntityName,
+                                                  skip: Int,
+                                                  count: Int,
+                                                  start: Option[Instant],
+                                                  end: Option[Instant],
+                                                  f: (WhiskEntity) => Boolean)(implicit entities: Seq[WhiskEntity]) = {
     implicit val tid = transid()
     val result = Await.result(
-      listCollectionByName(store, kind, ns, name, skip, count, start, end, StaleParameter.No, convert = None) map {
+      WhiskActivation
+        .listActivationsMatchingName(store, ns, name, skip, count, false, start, end, StaleParameter.No) map {
         _.left.get map { e =>
           e
         }
@@ -235,9 +245,9 @@ class ViewTests
   it should "query whisk view by namespace, collection and entity name in whisk actions db" in {
     implicit val tid = transid()
     val exec = bb("image")
-    val pkgname1 = namespace1.addPath(aname)
-    val pkgname2 = namespace2.addPath(aname)
-    val actionName = aname
+    val pkgname1 = namespace1.addPath(aname())
+    val pkgname2 = namespace2.addPath(aname())
+    val actionName = aname()
     def now = Instant.now(Clock.systemUTC())
 
     // creates 17 entities in each namespace as follows:
@@ -250,35 +260,35 @@ class ViewTests
     // - 2 packages in each namespace
     // - 2 package bindings in each namespace
     implicit val entities = Seq(
-      WhiskAction(namespace1, aname, exec),
-      WhiskAction(namespace1, aname, exec),
-      WhiskAction(namespace1.addPath(aname), aname, exec),
-      WhiskAction(namespace1.addPath(aname), aname, exec),
-      WhiskAction(pkgname1, aname, exec),
-      WhiskAction(pkgname1, aname, exec),
+      WhiskAction(namespace1, aname(), exec),
+      WhiskAction(namespace1, aname(), exec),
+      WhiskAction(namespace1.addPath(aname()), aname(), exec),
+      WhiskAction(namespace1.addPath(aname()), aname(), exec),
+      WhiskAction(pkgname1, aname(), exec),
+      WhiskAction(pkgname1, aname(), exec),
       WhiskAction(pkgname1, actionName, exec),
-      WhiskTrigger(namespace1, aname),
-      WhiskTrigger(namespace1, aname),
-      WhiskRule(namespace1, aname, trigger = afullname(namespace1), action = afullname(namespace1)),
-      WhiskRule(namespace1, aname, trigger = afullname(namespace1), action = afullname(namespace1)),
-      WhiskPackage(namespace1, aname),
-      WhiskPackage(namespace1, aname),
-      WhiskPackage(namespace1, aname, Some(Binding(namespace2.root, aname))),
-      WhiskPackage(namespace1, aname, Some(Binding(namespace2.root, aname))),
-      WhiskAction(namespace2, aname, exec),
-      WhiskAction(namespace2, aname, exec),
-      WhiskAction(namespace2.addPath(aname), aname, exec),
-      WhiskAction(namespace2.addPath(aname), aname, exec),
-      WhiskAction(pkgname2, aname, exec),
-      WhiskAction(pkgname2, aname, exec),
-      WhiskTrigger(namespace2, aname),
-      WhiskTrigger(namespace2, aname),
-      WhiskRule(namespace2, aname, trigger = afullname(namespace2), action = afullname(namespace2)),
-      WhiskRule(namespace2, aname, trigger = afullname(namespace2), action = afullname(namespace2)),
-      WhiskPackage(namespace2, aname),
-      WhiskPackage(namespace2, aname),
-      WhiskPackage(namespace2, aname, Some(Binding(namespace1.root, aname))),
-      WhiskPackage(namespace2, aname, Some(Binding(namespace1.root, aname))))
+      WhiskTrigger(namespace1, aname()),
+      WhiskTrigger(namespace1, aname()),
+      WhiskRule(namespace1, aname(), trigger = afullname(namespace1), action = afullname(namespace1)),
+      WhiskRule(namespace1, aname(), trigger = afullname(namespace1), action = afullname(namespace1)),
+      WhiskPackage(namespace1, aname()),
+      WhiskPackage(namespace1, aname()),
+      WhiskPackage(namespace1, aname(), Some(Binding(namespace2.root, aname()))),
+      WhiskPackage(namespace1, aname(), Some(Binding(namespace2.root, aname()))),
+      WhiskAction(namespace2, aname(), exec),
+      WhiskAction(namespace2, aname(), exec),
+      WhiskAction(namespace2.addPath(aname()), aname(), exec),
+      WhiskAction(namespace2.addPath(aname()), aname(), exec),
+      WhiskAction(pkgname2, aname(), exec),
+      WhiskAction(pkgname2, aname(), exec),
+      WhiskTrigger(namespace2, aname()),
+      WhiskTrigger(namespace2, aname()),
+      WhiskRule(namespace2, aname(), trigger = afullname(namespace2), action = afullname(namespace2)),
+      WhiskRule(namespace2, aname(), trigger = afullname(namespace2), action = afullname(namespace2)),
+      WhiskPackage(namespace2, aname()),
+      WhiskPackage(namespace2, aname()),
+      WhiskPackage(namespace2, aname(), Some(Binding(namespace1.root, aname()))),
+      WhiskPackage(namespace2, aname(), Some(Binding(namespace1.root, aname()))))
 
     entities foreach { put(entityStore, _) }
     waitOnView(entityStore, namespace1, 15)
@@ -337,15 +347,15 @@ class ViewTests
 
   it should "query whisk view by namespace, collection and entity name in whisk activations db" in {
     implicit val tid = transid()
-    val actionName = aname
+    val actionName = aname()
     def now = Instant.now(Clock.systemUTC())
 
     // creates 5 entities in each namespace as follows:
     // - some activations in each namespace (some may have prescribed action name to query by name)
     implicit val entities = Seq(
-      WhiskActivation(namespace1, aname, Subject(), ActivationId(), start = now, end = now),
-      WhiskActivation(namespace1, aname, Subject(), ActivationId(), start = now, end = now),
-      WhiskActivation(namespace2, aname, Subject(), ActivationId(), start = now, end = now),
+      WhiskActivation(namespace1, aname(), Subject(), ActivationId(), start = now, end = now),
+      WhiskActivation(namespace1, aname(), Subject(), ActivationId(), start = now, end = now),
+      WhiskActivation(namespace2, aname(), Subject(), ActivationId(), start = now, end = now),
       WhiskActivation(namespace2, actionName, Subject(), ActivationId(), start = now, end = now),
       WhiskActivation(namespace2, actionName, Subject(), ActivationId(), start = now, end = now))
 
@@ -364,7 +374,7 @@ class ViewTests
       case (e: WhiskActivation) => true
       case (_)                  => false
     })
-    getKindInNamespaceByName(activationStore, namespace2, "activations", actionName, {
+    getActivationsInNamespaceByName(activationStore, namespace2, actionName, {
       case (e: WhiskActivation) => (e.name == actionName)
       case (_)                  => false
     })
@@ -372,9 +382,8 @@ class ViewTests
 
   it should "query whisk view for activations sorted by date" in {
     implicit val tid = transid()
-    val actionName = aname
+    val actionName = aname()
     val now = Instant.now(Clock.systemUTC())
-    val others = Seq(WhiskAction(namespace1, aname, jsDefault("??")), WhiskAction(namespace1, aname, jsDefault("??")))
     implicit val entities = Seq(
       WhiskActivation(namespace1, actionName, Subject(), ActivationId(), start = now, end = now),
       WhiskActivation(
@@ -406,23 +415,25 @@ class ViewTests
         start = now.plusSeconds(30),
         end = now.plusSeconds(20)))
 
-    others foreach { put(entityStore, _) }
     entities foreach { put(activationStore, _) }
-    if (config.dbActivations == config.dbWhisk) {
-      waitOnView(entityStore, namespace1, others.length + entities.length)
-    } else {
-      waitOnView(entityStore, namespace1, others.length)
-      waitOnView(activationStore, namespace1, entities.length)
-    }
+    waitOnView(activationStore, namespace1, entities.length)
 
-    getKindInNamespaceByNameSortedByDate(activationStore, namespace1, "activations", actionName, 0, 5, None, None, {
-      case (e: WhiskActivation) => e.name == actionName
-      case (_)                  => false
-    })
+    getActivationsInNamespaceByNameSortedByDate(
+      activationStore,
+      namespace1,
+      "activations",
+      actionName,
+      0,
+      5,
+      None,
+      None, {
+        case (e: WhiskActivation) => e.name == actionName
+        case (_)                  => false
+      })
 
     val since = entities(1).start
     val upto = entities(4).start
-    getKindInNamespaceByNameSortedByDate(
+    getActivationsInNamespaceByNameSortedByDate(
       activationStore,
       namespace1,
       "activations",
@@ -440,36 +451,16 @@ class ViewTests
 
   it should "query whisk and retrieve full documents" in {
     implicit val tid = transid()
-    val actionName = aname
+    val actionName = aname()
     val now = Instant.now(Clock.systemUTC())
     implicit val entities =
-      Seq(WhiskAction(namespace1, aname, jsDefault("??")), WhiskAction(namespace1, aname, jsDefault("??")))
+      Seq(WhiskAction(namespace1, aname(), jsDefault("??")), WhiskAction(namespace1, aname(), jsDefault("??")))
 
     entities foreach { put(entityStore, _) }
     waitOnView(entityStore, namespace1, entities.length)
     getKindInNamespaceWithDoc[WhiskAction](namespace1, "actions", {
       case (e: WhiskAction) => true
       case (_)              => false
-    }, Some {
-      case (o: JsObject) => Try { WhiskAction.serdes.read(o) }
     })
-  }
-
-  it should "query whisk for public packages in all namespaces" in {
-    implicit val tid = transid()
-    implicit val entities = Seq(
-      WhiskPackage(namespace1, aname, publish = true),
-      WhiskPackage(namespace1, aname, publish = false),
-      WhiskPackage(namespace1, aname, Some(Binding(namespace2.root, aname)), publish = true),
-      WhiskPackage(namespace1, aname, Some(Binding(namespace2.root, aname))),
-      WhiskPackage(namespace2, aname, publish = true),
-      WhiskPackage(namespace2, aname, publish = false),
-      WhiskPackage(namespace2, aname, Some(Binding(namespace1.root, aname)), publish = true),
-      WhiskPackage(namespace2, aname, Some(Binding(namespace1.root, aname))))
-
-    entities foreach { put(entityStore, _) }
-    waitOnView(entityStore, namespace1, entities.length / 2)
-    waitOnView(entityStore, namespace2, entities.length / 2)
-    getPublicPackages(entities)
   }
 }


### PR DESCRIPTION
The views computed in the database have some redundancies. This will remove one entire view which is not necessary now that activations are not in the same database as the rest of the assets. It also removes a custom (read expensive) reduction for packages which we don't use either.

Replaces https://github.com/apache/incubator-openwhisk/pull/2691 - rebased to master and reformated code. Preserving old prs for the incremental commits and Travis ✅.