### PR TITLE
Update openwhisk javacript SDK to version 3.7.0

### DIFF
--- a/core/nodejs6Action/Dockerfile
+++ b/core/nodejs6Action/Dockerfile
@@ -46,7 +46,7 @@ nano@6.2.0 \
 node-uuid@1.4.7 \
 nodemailer@2.6.4 \
 oauth2-server@2.4.1 \
-openwhisk@3.3.2 \
+openwhisk@3.7.0 \
 pkgcloud@1.4.0 \
 process@0.11.9 \
 pug@">=2.0.0-beta6 <2.0.1" \


### PR DESCRIPTION
The current installed version of the Openwhisk Javascript SDK is 3.3.2 (2017.03.09)
https://github.com/apache/incubator-openwhisk-client-js/releases