### PR TITLE
Removing 'Swift 3.1.1' from build.

### DIFF
--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -21,7 +21,7 @@ TERM=dumb ./gradlew checkScalafmtAll
 cd $ROOTDIR/ansible
 
 ANSIBLE_CMD="ansible-playbook -i environments/local -e docker_image_prefix=testing"
-GRADLE_PROJS_SKIP="-x :core:pythonAction:distDocker  -x :core:python2Action:distDocker -x :core:swift3Action:distDocker -x :core:javaAction:distDocker"
+GRADLE_PROJS_SKIP="-x :core:pythonAction:distDocker  -x :core:python2Action:distDocker -x :core:swift3Action:distDocker -x core:swift3.1.1Action:distDocker -x :core:javaAction:distDocker"
 
 $ANSIBLE_CMD setup.yml
 $ANSIBLE_CMD prereq.yml


### PR DESCRIPTION
Swift 3.1.1 build is safe to remove, since we're not running any tests there anyway and it buys 4 minutes of time in the process.

Kicked off a dev-list discussion here to solve the underlying root cause more efficiently: https://lists.apache.org/thread.html/f81150a4f19c3c6f0a4a4505ca13ac044e7b85bda01faf3f29f64614@%3Cdev.openwhisk.apache.org%3E