### PR TITLE
Display content-type in __ow_headers for web actions

### DIFF
--- a/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
@@ -371,11 +371,14 @@ trait WhiskWebActionsApi extends Directives with ValidateRequestSize with PostAc
     `Access-Control-Allow-Methods`(OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH),
     `Access-Control-Allow-Headers`(`Authorization`.name, `Content-Type`.name))
 
-  private def contentTypeFromEntity(entity: HttpEntity) =
+  private def contentTypeFromEntity(entity: HttpEntity) = {
+    val noContentType = ContentType(MediaType.customBinary("none", "none", MediaType.NotCompressible))
+
     entity.contentType match {
-      case ct if ct == ContentType(MediaType.customBinary("none", "none", MediaType.NotCompressible)) => Seq()
-      case ct                                                                                         => Seq(RawHeader(`Content-Type`.lowercaseName, ct.toString))
+      case ct if ct == noContentType => Seq()
+      case ct                        => Seq(RawHeader(`Content-Type`.lowercaseName, ct.toString))
     }
+  }
 
   /** Extracts the HTTP method, headers, query params and unmatched (remaining) path. */
   private val requestMethodParamsAndPath = {

--- a/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
@@ -371,13 +371,9 @@ trait WhiskWebActionsApi extends Directives with ValidateRequestSize with PostAc
     `Access-Control-Allow-Methods`(OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH),
     `Access-Control-Allow-Headers`(`Authorization`.name, `Content-Type`.name))
 
-  private def contentTypeFromEntity(entity: HttpEntity) = {
-    val noContentType = ContentType(MediaType.customBinary("none", "none", MediaType.NotCompressible))
-
-    entity.contentType match {
-      case ct if ct == noContentType => Seq()
-      case ct                        => Seq(RawHeader(`Content-Type`.lowercaseName, ct.toString))
-    }
+  private def contentTypeFromEntity(entity: HttpEntity) = entity.contentType match {
+    case ct if ct == ContentTypes.NoContentType => None
+    case ct                                     => Some(RawHeader(`Content-Type`.lowercaseName, ct.toString))
   }
 
   /** Extracts the HTTP method, headers, query params and unmatched (remaining) path. */

--- a/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
@@ -371,13 +371,19 @@ trait WhiskWebActionsApi extends Directives with ValidateRequestSize with PostAc
     `Access-Control-Allow-Methods`(OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH),
     `Access-Control-Allow-Headers`(`Authorization`.name, `Content-Type`.name))
 
+  private def contentTypeFromEntity(entity: HttpEntity) =
+    entity.contentType match {
+      case ct if ct == ContentType(MediaType.customBinary("none", "none", MediaType.NotCompressible)) => Seq()
+      case ct                                                                                         => Seq(RawHeader(`Content-Type`.lowercaseName, ct.toString))
+    }
+
   /** Extracts the HTTP method, headers, query params and unmatched (remaining) path. */
   private val requestMethodParamsAndPath = {
     extract { ctx =>
       val method = ctx.request.method
       val query = ctx.request.uri.query()
       val path = ctx.unmatchedPath.toString
-      val headers = ctx.request.headers
+      val headers = ctx.request.headers ++ contentTypeFromEntity(ctx.request.entity)
       Context(webApiDirectives, method, headers, path, query)
     }
   }

--- a/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
@@ -59,7 +59,7 @@ class WskWebActionsTests extends TestHelpers with WskTestHelpers with RestUtil w
 
   behavior of "Wsk Web Actions"
 
-  it should "ensure received headers contains content-type" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "ensure received headers contain content-type" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
     val name = "webContenttype"
     val file = Some(TestUtils.getTestActionFilename("echo.js"))
     val bodyContent = JsObject("key" -> "value".toJson)

--- a/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
@@ -506,7 +506,8 @@ trait WebActionsApiTests extends ControllerTestCommon with BeforeAndAfterEach wi
                   m.method.name.toLowerCase,
                   if (arg.nonEmpty && arg != "{}") JsObject(webApiDirectives.body -> arg.parseJson) else JsObject(),
                   creds,
-                  pkgName = "proxy"))
+                  pkgName = "proxy",
+                  headers = List(`Content-Type`(ContentTypes.`application/json`))))
             }
           }
         }

--- a/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
@@ -470,8 +470,7 @@ trait WebActionsApiTests extends ControllerTestCommon with BeforeAndAfterEach wi
           val content = JsObject("extra" -> "read all about it".toJson, "yummy" -> true.toJson)
           val p = if (path.endsWith("/")) "/" else ""
           invocationsAllowed += 1
-          m(s"$testRoutePath/$path", HttpEntity(ContentTypes.`application/json`, content.compactPrint)) ~> Route.seal(
-            routes(creds)) ~> check {
+          m(s"$testRoutePath/$path", content) ~> Route.seal(routes(creds)) ~> check {
             status should be(OK)
             val response = responseAs[JsObject]
             response shouldBe JsObject(
@@ -522,8 +521,7 @@ trait WebActionsApiTests extends ControllerTestCommon with BeforeAndAfterEach wi
           val content = JsObject("extra" -> "read all about it".toJson, "yummy" -> true.toJson)
           invocationsAllowed += 1
 
-          m(s"$testRoutePath/$path", HttpEntity(ContentTypes.`application/json`, content.compactPrint)) ~> Route.seal(
-            routes(creds)) ~> check {
+          m(s"$testRoutePath/$path", content) ~> Route.seal(routes(creds)) ~> check {
             status should be(OK)
             val response = responseAs[JsObject]
             response shouldBe JsObject(
@@ -1409,9 +1407,7 @@ trait WebActionsApiTests extends ControllerTestCommon with BeforeAndAfterEach wi
             pkgName = "proxy"))
       }
 
-      Post(
-        s"$testRoutePath/$systemId/proxy/export_c.json?a=b&c=d",
-        HttpEntity(ContentTypes.`application/json`, JsObject().compactPrint)) ~> Route.seal(routes(creds)) ~> check {
+      Post(s"$testRoutePath/$systemId/proxy/export_c.json?a=b&c=d", JsObject()) ~> Route.seal(routes(creds)) ~> check {
         status should be(OK)
         val response = responseAs[JsObject]
         response shouldBe JsObject(
@@ -1546,9 +1542,7 @@ trait WebActionsApiTests extends ControllerTestCommon with BeforeAndAfterEach wi
 
       Post(
         s"$testRoutePath/$systemId/proxy/raw_export_c.json",
-        HttpEntity(
-          ContentTypes.`application/json`,
-          JsObject("x" -> "overriden".toJson, "key2" -> "value2".toJson).compactPrint)) ~> Route.seal(routes(creds)) ~> check {
+        JsObject("x" -> "overriden".toJson, "key2" -> "value2".toJson)) ~> Route.seal(routes(creds)) ~> check {
         status should be(OK)
         val response = responseAs[JsObject]
         response shouldBe JsObject(


### PR DESCRIPTION
Manually adds content-type sent to web action into the web action's __ow_headers.

Closes https://github.com/apache/incubator-openwhisk/issues/2690