### PR TITLE
Use an asynchronous process runner to spawn container commands.

### DIFF
--- a/core/invoker/build.gradle
+++ b/core/invoker/build.gradle
@@ -13,6 +13,8 @@ repositories {
 dependencies {
     compile "org.scala-lang:scala-library:${gradle.scala.version}"
     compile project(':common:scala')
+
+    compile "com.zaxxer:nuprocess:1.1.2"
 }
 
 tasks.withType(ScalaCompile) {


### PR DESCRIPTION
**Note:** Measurements of the impacts of this are not yet done. I thought it makes sense to open the PR though for feedback.

`scala.sys.Process` only has a blocking interface which blocks one thread for the runtime of the command. Furthermore, each of those processes open another thread to handle the output streams of the started process. Under load, the system churns through a **lot** of threads, which can cause efficiency problems.

NuProcess is supposed to fix this by providing an epoll interface, to make waiting on process completion asynchronous and its own (small) threadpool to maintain state and handle streams.