### PR TITLE
Remove heisenbug from test.

### DIFF
--- a/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -319,7 +319,10 @@ class WskBasicUsageTests extends TestHelpers with WskTestHelpers {
       withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
         val cmd = Seq("activation", "logs", "--strip", activation.activationId)
         val run = wsk.cli(cmd ++ wskprops.overrides ++ auth, expectedExitCode = SUCCESS_EXIT)
-        run.stdout shouldBe "this is stdout\nthis is stderr\n"
+        run.stdout should {
+          be("this is stdout\nthis is stderr\n") or
+            be("this is stderr\nthis is stdout\n")
+        }
       }
   }
 


### PR DESCRIPTION
The strip logs test checked both stdout and stderr for stripped timestamps but was expecting stdout to come first and stderr second. I observed twice in Travis (here's [one](https://s3.amazonaws.com/archive.travis-ci.org/jobs/276129446/log.txt?X-Amz-Expires=30&X-Amz-Date=20170916T025333Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJRYRXRSVGNKPKO5A/20170916/us-east-1/s3/aws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=e2a846eacf2284a8b7788eb7bf76b733849b7dfa8db4efcf0af3c372f8916869) that the streams may be flushed in the opposite order so relax the test accordingly.

```
Exception occurred during test execution: org.scalatest.exceptions.TestFailedException:
 "this is std[err
    this is stdout]
    " was not equal to "this is std[out
    this is stderr]
    "
```