### PR TITLE
Fix parsing of application-json content type.

### DIFF
--- a/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
@@ -544,9 +544,13 @@ trait WhiskWebActionsApi extends Directives with ValidateRequestSize with PostAc
         case Empty =>
           process(None, isRawHttpAction)
 
-        case HttpEntity.Strict(ContentTypes.`application/json`, _) if !isRawHttpAction =>
-          entity(as[JsObject]) { body =>
-            process(Some(body), isRawHttpAction)
+        case HttpEntity.Strict(ContentTypes.`application/json`, json) if !isRawHttpAction =>
+          if (json.nonEmpty) {
+            entity(as[JsValue]) { body =>
+              process(Some(body), isRawHttpAction)
+            }
+          } else {
+            process(None, isRawHttpAction)
           }
 
         case HttpEntity.Strict(ContentType(MediaTypes.`application/x-www-form-urlencoded`, _), _) if !isRawHttpAction =>


### PR DESCRIPTION
Do not fail with content-type is set but the entity is empty. Also extend handling of application-json content to permit first class values e.g., array wont be base64 encoded.

Closes #2764.
FYI @akrabat.