### PR TITLE
Remove synthetic header.

### DIFF
--- a/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
@@ -38,6 +38,7 @@ import akka.http.scaladsl.model.HttpEntity
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.headers.`Content-Type`
+import akka.http.scaladsl.model.headers.`Timeout-Access`
 import akka.http.scaladsl.model.ContentType
 import akka.http.scaladsl.model.ContentTypes
 import akka.http.scaladsl.model.FormData
@@ -108,7 +109,12 @@ private case class Context(propertyMap: WebApiDirectives,
   def metadata(user: Option[Identity]): Map[String, JsValue] = {
     Map(
       propertyMap.method -> method.value.toLowerCase.toJson,
-      propertyMap.headers -> headers.map(h => h.lowercaseName -> h.value).toMap.toJson,
+      propertyMap.headers -> headers
+        .collect {
+          case h if h.name != `Timeout-Access`.name => h.lowercaseName -> h.value
+        }
+        .toMap
+        .toJson,
       propertyMap.path -> path.toJson) ++
       user.map(u => propertyMap.namespace -> u.namespace.asString.toJson)
   }


### PR DESCRIPTION
Removes timeout-access from headers:

```
> curl -k -X POST https://guest.localhost/default/echo.json -H "Content-Type: application/json" -d '["a"]'
{
  "__ow_method": "post",
  "__ow_query": "",
  "__ow_body": "WyJhIl0=",
  "__ow_headers": {
    "host": "controllers",
    "user-agent": "curl/7.43.0",
    "accept": "*/*",
    "timeout-access": "<function1>" <---- this one
  },
  "__ow_path": ""
}
```

Fixes #2636.
For reference: https://github.com/akka/akka-http/issues/64