### PR TITLE
Revert "Use an asynchronous process runner to spawn container command…

### DIFF
--- a/core/invoker/build.gradle
+++ b/core/invoker/build.gradle
@@ -13,8 +13,6 @@ repositories {
 dependencies {
     compile "org.scala-lang:scala-library:${gradle.scala.version}"
     compile project(':common:scala')
-
-    compile "com.zaxxer:nuprocess:1.1.2"
 }
 
 tasks.withType(ScalaCompile) {

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/ProcessRunner.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/ProcessRunner.scala
@@ -17,13 +17,11 @@
 
 package whisk.core.containerpool.docker
 
-import java.nio.ByteBuffer
-
-import akka.util.ByteString
-import com.zaxxer.nuprocess.{NuAbstractProcessHandler, NuProcessBuilder}
-
-import scala.collection.JavaConverters._
-import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.collection.mutable
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.blocking
+import scala.sys.process._
 
 trait ProcessRunner {
 
@@ -37,30 +35,19 @@ trait ProcessRunner {
    * @param args command to be run including arguments
    * @return a future completing according to the command's exit code
    */
-  protected def executeProcess(args: String*)(implicit ec: ExecutionContext): Future[String] = {
-    val promise = Promise[String]()
-    val pb: NuProcessBuilder = new NuProcessBuilder(args.asJava)
-    pb.setProcessListener(new NuAbstractProcessHandler {
-      var out = ByteString.empty
-      var err = ByteString.empty
+  protected def executeProcess(args: String*)(implicit ec: ExecutionContext) =
+    Future(blocking {
+      val out = new mutable.ListBuffer[String]
+      val err = new mutable.ListBuffer[String]
+      val exitCode = args ! ProcessLogger(o => out += o, e => err += e)
 
-      override def onExit(code: Int): Unit = code match {
-        case 0 => promise.success(out.utf8String.trim)
-        case _ => promise.failure(ProcessRunningException(code, out.utf8String.trim, err.utf8String.trim))
-      }
-
-      override def onStderr(buffer: ByteBuffer, closed: Boolean) = {
-        err = err ++ ByteString.fromByteBuffer(buffer)
-      }
-
-      override def onStdout(buffer: ByteBuffer, closed: Boolean): Unit = {
-        out = out ++ ByteString.fromByteBuffer(buffer)
-      }
-    })
-
-    pb.start()
-    promise.future
-  }
+      (exitCode, out.mkString("\n"), err.mkString("\n"))
+    }).flatMap {
+      case (0, stdout, _) =>
+        Future.successful(stdout)
+      case (code, stdout, stderr) =>
+        Future.failed(ProcessRunningException(code, stdout, stderr))
+    }
 }
 
 case class ProcessRunningException(exitCode: Int, stdout: String, stderr: String)


### PR DESCRIPTION
…s. (#2752)"

This reverts commit 6b0c03725b43d5454dc07ccc51318675b6b0905e.

This got accidently merged before proper testing and introduced a regression in container command runtime as I feared.