### PR TITLE
Echo Access-Control-Request-Headers as Access-Control-Allow-Headers 

### DIFF
--- a/docs/webactions.md
+++ b/docs/webactions.md
@@ -393,11 +393,13 @@ $ curl -k -H "content-type: application" -X POST -d "Decoded body" https://${API
 
 By default, an OPTIONS request made to a web action will result in CORS headers being automatically added to the
 response headers. These headers allow all origins and the options, get, delete, post, put, head, and patch HTTP verbs.
-The headers are shown below:
+In addition, the header `Access-Control-Request-Headers` is echoed back as the header `Access-Control-Allow-Headers`
+if it is present in the HTTP request. Otherwise, a default value is generated as shown below.
 
 ```
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH
+Access-Control-Allow-Headers: Authorization, Content-Type
 ```
 
 Alternatively, OPTIONS requests can be handled manually by a web action. To enable this option add a

--- a/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
@@ -188,11 +188,28 @@ class WskWebActionsTests extends TestHelpers with WskTestHelpers with RestUtil w
       action.create(name, file, web = Some("true"))
     }
 
-    val responses = Seq(
-      RestAssured.given().config(sslconfig).options(s"$url.http"),
-      RestAssured.given().config(sslconfig).get(s"$url.json"))
+    Seq(
+      RestAssured
+        .given()
+        .config(sslconfig)
+        .header("Access-Control-Request-Headers", "x-custom-header")
+        .options(s"$url.http"),
+      RestAssured
+        .given()
+        .config(sslconfig)
+        .header("Access-Control-Request-Headers", "x-custom-header")
+        .get(s"$url.json")).foreach { response =>
+      response.statusCode shouldBe 200
+      response.header("Access-Control-Allow-Origin") shouldBe "*"
+      response.header("Access-Control-Allow-Methods") shouldBe "OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH"
+      response.header("Access-Control-Allow-Headers") shouldBe "x-custom-header"
+      response.header("Location") shouldBe null
+      response.header("Set-Cookie") shouldBe null
+    }
 
-    responses.foreach { response =>
+    Seq(
+      RestAssured.given().config(sslconfig).options(s"$url.http"),
+      RestAssured.given().config(sslconfig).get(s"$url.json")).foreach { response =>
       response.statusCode shouldBe 200
       response.header("Access-Control-Allow-Origin") shouldBe "*"
       response.header("Access-Control-Allow-Methods") shouldBe "OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH"


### PR DESCRIPTION
Instead of hardcoding the header value for `Access-Control-Allow-Headers`, echo back the request headers from the request when `Access-Control-Request-Headers` is present.

Closes #2653.
FYI @akrabat 