### PR TITLE
Make blackbox invoker fraction configurable via Ansible

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -106,7 +106,7 @@ controller:
   basePort: 10001
   heap: "{{ controller_heap | default('2g') }}"
   arguments: "{{ controller_arguments | default('') }}"
-  blackboxFraction: 0.10
+  blackboxFraction: "{{ controller_blackbox_fraction | default(0.10) }}"
   instances: "{{ groups['controllers'] | length }}"
 
 registry:

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -54,6 +54,7 @@
       "LIMITS_ACTIONS_INVOKES_CONCURRENTINSYSTEM": "{{ limits.concurrentInvocationsSystem }}"
       "LIMITS_TRIGGERS_FIRES_PERMINUTE": "{{ limits.firesPerMinute }}"
       "LIMITS_ACTIONS_SEQUENCE_MAXLENGTH": "{{ limits.sequenceMaxLength }}"
+      "CONTROLLER_BLACKBOXFRACTION": "{{ controller.blackboxFraction }}"
       "LOADBALANCER_INVOKERBUSYTHRESHOLD": "{{ invoker.busyThreshold }}"
 
       "RUNTIMES_MANIFEST": "{{ runtimesManifest | to_json }}"

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -196,7 +196,7 @@ object WhiskConfig {
 
   val mainDockerEndpoint = "main.docker.endpoint"
 
-  private val controllerBlackboxFraction = "controller.blackboxFraction"
+  val controllerBlackboxFraction = "controller.blackboxFraction"
   val controllerInstances = "controller.instances"
 
   val loadbalancerInvokerBusyThreshold = "loadbalancer.invokerBusyThreshold"

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -313,7 +313,8 @@ class LoadBalancerService(config: WhiskConfig, instance: InstanceId, entityStore
 }
 
 object LoadBalancerService {
-  def requiredProperties = kafkaHost ++ Map(loadbalancerInvokerBusyThreshold -> null)
+  def requiredProperties =
+    kafkaHost ++ Map(loadbalancerInvokerBusyThreshold -> null, controllerBlackboxFraction -> null)
 
   /** Memoizes the result of `f` for later use. */
   def memoize[I, O](f: I => O): I => O = new scala.collection.mutable.HashMap[I, O]() {


### PR DESCRIPTION
Extend Ansible deploy playbook for controller role such that it passes the blackbox fraction
setting as environment variable when running the controller container. Make the blackbox fraction
a required property of the LoadBalancerService such that the setting is read from the environment.
Allow overriding of the default blackbox fraction in Ansible.

All this is needed to vary the proportion between managed and blackbox invokers to accomodate
usage in production.

I tested the change by adding the setting `controller_blackbox_fraction: 0.5` to file `ansible/environments/docker-machine/group_vars/all` and re-deploying the controller. As a result, the controller creates the following log entry indicating that the setting was picked up properly:

```
[2017-09-15T12:55:35.122Z] [INFO] [#sid_120] [LoadBalancerService] blackboxFraction = 0.5
```