### PR TITLE
Keep Cache invalidation messages in Kafka only for 5 minutes

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -131,6 +131,10 @@ kafka:
       segmentBytes: 536870912
       retentionBytes: "{{ kafka_topics_invoker_retentionBytes | default(1073741824) }}"
       retentionMS: 172800000
+    cacheInvalidation:
+      segmentBytes: 536870912
+      retentionBytes: 1073741824
+      retentionMS: 300000
 
 zookeeper:
   version: 3.4

--- a/ansible/roles/kafka/tasks/deploy.yml
+++ b/ansible/roles/kafka/tasks/deploy.yml
@@ -50,14 +50,16 @@
   retries: 10
   delay: 5
 
-- name: create the health topic
-  shell: "docker exec kafka bash -c 'unset JMX_PORT; kafka-topics.sh --create --topic {{ item }} --replication-factor 1 --partitions 1 --zookeeper {{ ansible_host }}:{{ zookeeper.port }} --config retention.bytes={{ kafka.topics.health.retentionBytes }} --config retention.ms={{ kafka.topics.health.retentionMS }} --config segment.bytes={{ kafka.topics.health.segmentBytes }}'"
+- name: create the health and the cacheInvalidation topic
+  shell: "docker exec kafka bash -c 'unset JMX_PORT; kafka-topics.sh --create --topic {{ item.name }} --replication-factor 1 --partitions 1 --zookeeper {{ ansible_host }}:{{ zookeeper.port }} --config retention.bytes={{ item.settings.retentionBytes }} --config retention.ms={{ item.settings.retentionMS }} --config segment.bytes={{ item.settings.segmentBytes }}'"
   register: command_result
   failed_when: "not ('Created topic' in command_result.stdout or 'already exists' in command_result.stdout)"
   changed_when: "'Created topic' in command_result.stdout"
   with_items:
-  - health
-  - cacheInvalidation
+  - name: health
+    settings: "{{ kafka.topics.health }}"
+  - name: cacheInvalidation
+    settings: "{{ kafka.topics.cacheInvalidation }}"
 
 - name: create the active-ack topics
   shell: "docker exec kafka bash -c 'unset JMX_PORT; kafka-topics.sh --create --topic completed{{ item.0 }} --replication-factor 1 --partitions 1 --zookeeper {{ ansible_host }}:{{ zookeeper.port }} --config retention.bytes={{ kafka.topics.completed.retentionBytes }} --config retention.ms={{ kafka.topics.completed.retentionMS }} --config segment.bytes={{ kafka.topics.completed.segmentBytes }}'"


### PR DESCRIPTION
Don't keep messages for the Cache Invalidation Kafka, that are older than 5 minutes.