### PR TITLE
Drop using an Enumeration for Privilege.

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entitlement/Privilege.scala
+++ b/common/scala/src/main/scala/whisk/core/entitlement/Privilege.scala
@@ -24,14 +24,27 @@ import spray.json.JsString
 import spray.json.JsValue
 import spray.json.RootJsonFormat
 
+sealed trait Privilege
+
 /** An enumeration of privileges available to subjects. */
 protected[core] object Privilege extends Enumeration {
-  type Privilege = Value
 
-  val READ, PUT, DELETE, ACTIVATE, REJECT = Value
+  case object READ extends Privilege
+  case object PUT extends Privilege
+  case object DELETE extends Privilege
+  case object ACTIVATE extends Privilege
+  case object REJECT extends Privilege
 
-  val CRUD = Set(READ, PUT, DELETE)
-  val ALL = CRUD + ACTIVATE
+  val CRUD: Set[Privilege] = Set(READ, PUT, DELETE)
+  val ALL: Set[Privilege] = CRUD + ACTIVATE
+
+  def fromName(name: String) = name match {
+    case "READ"     => READ
+    case "PUT"      => PUT
+    case "DELETE"   => DELETE
+    case "ACTIVATE" => ACTIVATE
+    case "REJECT"   => REJECT
+  }
 
   implicit val serdes = new RootJsonFormat[Privilege] {
     def write(p: Privilege) = JsString(p.toString)
@@ -39,7 +52,7 @@ protected[core] object Privilege extends Enumeration {
     def read(json: JsValue) =
       Try {
         val JsString(str) = json
-        Privilege.withName(str.trim.toUpperCase)
+        Privilege.fromName(str.trim.toUpperCase)
       } getOrElse {
         throw new DeserializationException("Privilege must be a valid string")
       }

--- a/common/scala/src/main/scala/whisk/core/entity/Identity.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Identity.scala
@@ -28,7 +28,6 @@ import whisk.core.database.MultipleReadersSingleWriterCache
 import whisk.core.database.NoDocumentException
 import whisk.core.database.StaleParameter
 import whisk.core.entitlement.Privilege
-import whisk.core.entitlement.Privilege.Privilege
 
 case class UserLimits(invocationsPerMinute: Option[Int] = None,
                       concurrentInvocations: Option[Int] = None,

--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -50,8 +50,6 @@ import whisk.http.Messages
 import whisk.http.Messages._
 import whisk.core.entitlement.Resource
 import whisk.core.entitlement.Collection
-import whisk.core.entitlement.Privilege.Privilege
-import whisk.core.entitlement.Privilege._
 
 /**
  * A singleton object which defines the properties that must be present in a configuration

--- a/core/controller/src/main/scala/whisk/core/controller/Activations.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Activations.scala
@@ -23,7 +23,6 @@ import scala.language.postfixOps
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
-
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport.sprayJsonMarshaller
 import akka.http.scaladsl.model.StatusCodes.BadRequest
 import akka.http.scaladsl.server.Directives
@@ -33,10 +32,8 @@ import spray.json.DefaultJsonProtocol.RootJsObjectFormat
 import spray.json.DeserializationException
 import whisk.common.TransactionId
 import whisk.core.database.StaleParameter
-import whisk.core.entitlement.Collection
-import whisk.core.entitlement.Privilege.Privilege
+import whisk.core.entitlement.{Collection, Privilege, Resource}
 import whisk.core.entitlement.Privilege.READ
-import whisk.core.entitlement.Resource
 import whisk.core.entity._
 import whisk.core.entity.types.ActivationStore
 import whisk.http.ErrorResponse.terminate

--- a/core/controller/src/main/scala/whisk/core/controller/AuthorizedRouteDispatcher.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/AuthorizedRouteDispatcher.scala
@@ -31,7 +31,6 @@ import akka.http.scaladsl.server.RouteResult
 import akka.http.scaladsl.model.StatusCodes.InternalServerError
 import akka.http.scaladsl.server.Directive1
 
-import whisk.core.entitlement.Privilege.Privilege
 import whisk.core.entitlement.Collection
 import whisk.common.TransactionId
 import whisk.core.entitlement._

--- a/core/controller/src/main/scala/whisk/core/controller/Entities.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Entities.scala
@@ -31,7 +31,7 @@ import akka.http.scaladsl.server.RouteResult
 import spray.json.JsonPrinter
 import whisk.common.TransactionId
 import whisk.core.entitlement.Privilege._
-import whisk.core.entitlement.Privilege.Privilege
+import whisk.core.entitlement.Privilege
 import whisk.core.entitlement.Privilege.READ
 import whisk.core.entitlement.Resource
 import whisk.core.entity._

--- a/core/controller/src/main/scala/whisk/core/controller/Namespaces.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Namespaces.scala
@@ -20,20 +20,15 @@ package whisk.core.controller
 import scala.concurrent.Future
 import scala.util.Failure
 import scala.util.Success
-
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server.Directives
 import akka.http.scaladsl.server.RequestContext
 import akka.http.scaladsl.server.RouteResult
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-
 import spray.json.DefaultJsonProtocol._
-
 import whisk.common.TransactionId
-import whisk.core.entitlement.Collection
-import whisk.core.entitlement.Privilege.Privilege
+import whisk.core.entitlement.{Collection, Privilege, Resource}
 import whisk.core.entitlement.Privilege.READ
-import whisk.core.entitlement.Resource
 import whisk.core.entity.EntityPath
 import whisk.core.entity.Identity
 import whisk.core.entity.WhiskAction

--- a/core/controller/src/main/scala/whisk/core/entitlement/ActionCollection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/ActionCollection.scala
@@ -17,8 +17,6 @@
 
 package whisk.core.entitlement
 
-import whisk.core.entitlement.Privilege._
-
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 

--- a/core/controller/src/main/scala/whisk/core/entitlement/Collection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Collection.scala
@@ -71,8 +71,8 @@ protected[core] case class Collection protected (val path: String, val listLimit
     }
   }
 
-  protected val allowedCollectionRights = Set(Privilege.READ)
-  protected val allowedEntityRights = {
+  protected val allowedCollectionRights: Set[Privilege] = Set(Privilege.READ)
+  protected val allowedEntityRights: Set[Privilege] = {
     Set(Privilege.READ, Privilege.PUT, Privilege.ACTIVATE, Privilege.DELETE)
   }
 
@@ -133,7 +133,7 @@ protected[core] object Collection {
         if (op == GET) Privilege.READ else Privilege.REJECT
       }
 
-      protected override val allowedEntityRights = Set(Privilege.READ)
+      protected override val allowedEntityRights: Set[Privilege] = Set(Privilege.READ)
     })
 
     register(new Collection(NAMESPACES) {
@@ -146,7 +146,7 @@ protected[core] object Collection {
         }
       }
 
-      protected override val allowedEntityRights = Set(Privilege.READ)
+      protected override val allowedEntityRights: Set[Privilege] = Set(Privilege.READ)
     })
   }
 }

--- a/core/controller/src/main/scala/whisk/core/entitlement/LocalEntitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/LocalEntitlement.scala
@@ -22,7 +22,6 @@ import scala.concurrent.Future
 
 import akka.actor.ActorSystem
 
-import whisk.core.entitlement.Privilege._
 import whisk.common.Logging
 import whisk.common.TransactionId
 import whisk.core.WhiskConfig

--- a/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
@@ -22,7 +22,6 @@ import scala.concurrent.Future
 
 import akka.http.scaladsl.model.StatusCodes._
 
-import whisk.core.entitlement.Privilege._
 import whisk.common.Logging
 import whisk.common.TransactionId
 import whisk.core.controller.RejectRequest
@@ -34,7 +33,7 @@ import whisk.http.Messages
 
 class PackageCollection(entityStore: EntityStore)(implicit logging: Logging) extends Collection(Collection.PACKAGES) {
 
-  protected override val allowedEntityRights = {
+  protected override val allowedEntityRights: Set[Privilege] = {
     Set(Privilege.READ, Privilege.PUT, Privilege.DELETE)
   }
 

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
@@ -24,9 +24,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Success
-
 import org.apache.kafka.clients.producer.RecordMetadata
-
 import akka.actor.Actor
 import akka.actor.ActorRef
 import akka.actor.ActorRefFactory
@@ -37,13 +35,12 @@ import akka.actor.FSM.Transition
 import akka.actor.Props
 import akka.pattern.pipe
 import akka.util.Timeout
-
 import whisk.common.AkkaLogging
 import whisk.common.LoggingMarkers
 import whisk.common.RingBuffer
 import whisk.common.TransactionId
 import whisk.core.connector._
-import whisk.core.entitlement.Privilege.Privilege
+import whisk.core.entitlement.Privilege
 import whisk.core.entity.ActivationId.ActivationIdGenerator
 import whisk.core.entity._
 

--- a/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
@@ -58,7 +58,6 @@ import whisk.core.controller.WebApiDirectives
 import whisk.core.database.NoDocumentException
 import whisk.core.entitlement.EntitlementProvider
 import whisk.core.entitlement.Privilege
-import whisk.core.entitlement.Privilege._
 import whisk.core.entitlement.Resource
 import whisk.core.entity._
 import whisk.core.entity.size._

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/InvokerSupervisionTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/InvokerSupervisionTests.scala
@@ -21,7 +21,6 @@ import scala.collection.mutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.concurrent.Future
-
 import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.kafka.common.TopicPartition
 import org.junit.runner.RunWith
@@ -30,7 +29,6 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FlatSpecLike
 import org.scalatest.Matchers
 import org.scalatest.junit.JUnitRunner
-
 import akka.actor.ActorRef
 import akka.actor.ActorRefFactory
 import akka.actor.ActorSystem
@@ -49,7 +47,6 @@ import whisk.common.TransactionId
 import whisk.core.WhiskConfig
 import whisk.core.connector.ActivationMessage
 import whisk.core.connector.PingMessage
-import whisk.core.entitlement.Privilege.Privilege
 import whisk.core.entity.ActivationId.ActivationIdGenerator
 import whisk.core.entity.AuthKey
 import whisk.core.entity.DocRevision
@@ -73,6 +70,7 @@ import whisk.core.loadBalancer.Offline
 import whisk.core.loadBalancer.UnHealthy
 import whisk.utils.retry
 import whisk.core.connector.test.TestConnector
+import whisk.core.entitlement.Privilege
 
 @RunWith(classOf[JUnitRunner])
 class InvokerSupervisionTests


### PR DESCRIPTION
Enumerations are a mess in Scala and generally ADTs are more flexible and easier to grasp. Additionally, the current use of `Enumeration` in `Privilege` results in thread-contention because one of its inner parts `ofName` is `synchronized` and used heavily on our hot path.