### PR TITLE
Make logging hot paths lighter.

### DIFF
--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -85,15 +85,10 @@ trait Logging {
  */
 class AkkaLogging(loggingAdapter: LoggingAdapter) extends Logging {
   def emit(loglevel: LogLevel, id: TransactionId, from: AnyRef, message: String) = {
-    val name = if (from.isInstanceOf[String]) from else Logging.getCleanSimpleClassName(from.getClass)
-
-    val logMessage = Seq(message).collect {
-      case msg if msg.nonEmpty =>
-        msg.split('\n').map(_.trim).mkString(" ")
+    if (loggingAdapter.isEnabled(loglevel)) {
+      val name = if (from.isInstanceOf[String]) from else Logging.getCleanSimpleClassName(from.getClass)
+      loggingAdapter.log(loglevel, s"[$id] [$name] $message")
     }
-
-    val parts = Seq(s"[$id]") ++ Seq(s"[$name]") ++ logMessage
-    loggingAdapter.log(loglevel, parts.mkString(" "))
   }
 }
 

--- a/common/scala/src/main/scala/whisk/common/TransactionId.scala
+++ b/common/scala/src/main/scala/whisk/common/TransactionId.scala
@@ -137,9 +137,7 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
    * @param message: The log message without the marker
    * @param marker: The marker to add to the message
    */
-  private def createMessageWithMarker(message: String, marker: LogMarker): String = {
-    (Option(message).filter(_.trim.nonEmpty) ++ Some(marker)).mkString(" ")
-  }
+  private def createMessageWithMarker(message: String, marker: LogMarker): String = s"$message $marker"
 }
 
 /**


### PR DESCRIPTION
Logging is **the** hotspot in our application today. This takes a first stab at making the overhead a bit smaller by respecting the set log-level as early as currently possible and not do any extranous throwaway computation.

It also reduces a bit of unnecessary boxing for the sake of just trying to keep a single space out of the message.