### PR TITLE
Compute UUIDs in a non-blocking fashion.

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     compile 'org.apache.zookeeper:zookeeper:3.4.10'
     compile 'org.apache.kafka:kafka-clients:0.10.2.1'
     compile 'org.apache.httpcomponents:httpclient:4.4.1'
+    compile 'com.fasterxml.uuid:java-uuid-generator:3.1.3'
     compile 'com.github.ben-manes.caffeine:caffeine:2.4.0'
     compile 'com.google.code.findbugs:jsr305:3.0.2'
 }

--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaProducerConnector.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaProducerConnector.scala
@@ -18,29 +18,27 @@
 package whisk.connector.kafka
 
 import java.util.Properties
-import java.util.UUID
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.util.Failure
 import scala.util.Success
-
 import org.apache.kafka.clients.producer.Callback
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.kafka.common.serialization.StringSerializer
-
 import whisk.common.Counter
 import whisk.common.Logging
 import whisk.core.connector.Message
 import whisk.core.connector.MessageProducer
+import whisk.core.entity.UUIDs
 
 class KafkaProducerConnector(kafkahost: String,
                              implicit val executionContext: ExecutionContext,
-                             id: String = UUID.randomUUID().toString)(implicit logging: Logging)
+                             id: String = UUIDs.randomUUID().toString)(implicit logging: Logging)
     extends MessageProducer {
 
   override def sentCount() = sentCounter.cur

--- a/common/scala/src/main/scala/whisk/core/entity/ActivationId.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ActivationId.scala
@@ -49,7 +49,7 @@ protected[whisk] class ActivationId private (private val id: java.util.UUID) ext
 protected[core] object ActivationId extends ArgNormalizer[ActivationId] {
 
   protected[core] trait ActivationIdGenerator {
-    def make(): ActivationId = new ActivationId(java.util.UUID.randomUUID())
+    def make(): ActivationId = new ActivationId(UUIDs.randomUUID())
   }
 
   /**
@@ -77,7 +77,7 @@ protected[core] object ActivationId extends ArgNormalizer[ActivationId] {
    *
    * @return new ActivationId
    */
-  protected[core] def apply(): ActivationId = new ActivationId(java.util.UUID.randomUUID())
+  protected[core] def apply(): ActivationId = new ActivationId(UUIDs.randomUUID())
 
   /**
    * Overrides factory method so that string is not interpreted as number

--- a/common/scala/src/main/scala/whisk/core/entity/UUID.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/UUID.scala
@@ -17,8 +17,11 @@
 
 package whisk.core.entity
 
-import scala.util.Try
+import java.security.SecureRandom
 
+import com.fasterxml.uuid.Generators
+
+import scala.util.Try
 import spray.json.JsString
 import spray.json.JsValue
 import spray.json.RootJsonFormat
@@ -59,7 +62,7 @@ protected[core] object UUID extends ArgNormalizer[UUID] {
    *
    * @return new UUID
    */
-  protected[core] def apply(): UUID = new UUID(java.util.UUID.randomUUID())
+  protected[core] def apply(): UUID = new UUID(UUIDs.randomUUID())
 
   implicit val serdes = new RootJsonFormat[UUID] {
     def write(u: UUID) = u.toJson
@@ -70,4 +73,20 @@ protected[core] object UUID extends ArgNormalizer[UUID] {
         UUID(u)
       } getOrElse deserializationError("uuid malformed")
   }
+}
+
+object UUIDs {
+  private val generator = new ThreadLocal[SecureRandom] {
+    override def initialValue() = new SecureRandom()
+  }
+
+  /**
+   * Static factory to retrieve a type 4 (pseudo randomly generated) UUID.
+   *
+   * The {@code java.util.UUID} is generated using a pseudo random number
+   * generator local to the thread.
+   *
+   * @return  A randomly generated {@code java.util.UUID}
+   */
+  def randomUUID(): java.util.UUID = Generators.randomBasedGenerator(generator.get()).generate()
 }

--- a/core/controller/build.gradle
+++ b/core/controller/build.gradle
@@ -20,4 +20,4 @@ tasks.withType(ScalaCompile) {
 }
 
 mainClassName = "whisk.core.controller.Controller"
-applicationDefaultJvmArgs = ["-XX:+CrashOnOutOfMemoryError"]
+applicationDefaultJvmArgs = ["-XX:+CrashOnOutOfMemoryError", "-Djava.security.egd=file:/dev/./urandom"]


### PR DESCRIPTION
Java's UUID.randomUUID() is known the be `synchronized` and blocking which causes thread-contention and thus performance problems.

`SecureRandom.nextBytes` is the synchronized piece, so using a `ThreadLocal` instance resolves thread contention there. Switching Java's randomness source to the non-blocking `/dev/urandom` resolves blocking of the computation itself.

Switching to `/dev/urandom` is [not a problem](https://unix.stackexchange.com/a/324210).

Supposed to fix #2747.