### PR TITLE
Add a controller simulator to drive invoker benchmarks.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -17,6 +17,8 @@ include 'tests'
 include 'tests:dat:blackbox:badaction'
 include 'tests:dat:blackbox:badproxy'
 
+include 'tools:benchmark'
+
 rootProject.name = 'openwhisk'
 
 gradle.ext.scala = [

--- a/tools/benchmark/build.gradle
+++ b/tools/benchmark/build.gradle
@@ -9,6 +9,8 @@ repositories {
 dependencies {
     compile "org.scala-lang:scala-library:${gradle.scala.version}"
     compile project(':common:scala')
+
+    compile "org.scalanlp:breeze_2.11:0.13.2"
 }
 
 tasks.withType(ScalaCompile) {
@@ -16,4 +18,3 @@ tasks.withType(ScalaCompile) {
 }
 
 mainClassName = "whisk.core.benchmark.ControllerSimulator"
-applicationDefaultJvmArgs = ["-XX:+CrashOnOutOfMemoryError"]

--- a/tools/benchmark/build.gradle
+++ b/tools/benchmark/build.gradle
@@ -1,0 +1,19 @@
+apply plugin: 'scala'
+apply plugin: 'application'
+apply plugin: 'eclipse'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile "org.scala-lang:scala-library:${gradle.scala.version}"
+    compile project(':common:scala')
+}
+
+tasks.withType(ScalaCompile) {
+    scalaCompileOptions.additionalParameters = gradle.scala.compileFlags
+}
+
+mainClassName = "whisk.core.benchmark.ControllerSimulator"
+applicationDefaultJvmArgs = ["-XX:+CrashOnOutOfMemoryError"]

--- a/tools/benchmark/src/main/scala/whisk/core/benchmark/ControllerSimulator.scala
+++ b/tools/benchmark/src/main/scala/whisk/core/benchmark/ControllerSimulator.scala
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.benchmark
+
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+
+import akka.actor.{ActorSystem, Props}
+import whisk.common.{AkkaLogging, Logging, TransactionId}
+import whisk.core.WhiskConfig
+import whisk.core.connector.{ActivationMessage, CompletionMessage, MessageFeed, MessagingProvider}
+import whisk.core.database.NoDocumentException
+import whisk.core.entity._
+import whisk.spi.SpiLoader
+
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+
+object ControllerSimulator {
+  def between(start: Instant, end: Instant): Duration =
+    Duration.fromNanos(java.time.Duration.between(start, end).toNanos)
+
+  def main(args: Array[String]): Unit = {
+    implicit val as: ActorSystem = ActorSystem()
+    implicit val ec: ExecutionContext = as.dispatcher
+    implicit val log: Logging = new AkkaLogging(as.log)
+    implicit val tid: TransactionId = TransactionId.controller
+
+    val messageCount = sys.env.get("INVOCATIONS").map(_.toInt).getOrElse(10)
+    val controllerToSimulate = InstanceId(sys.env.get("CONTROLLER_ID").map(_.toInt).getOrElse(0))
+    val invokerToUse = InstanceId(sys.env.get("INVOKER_ID").map(_.toInt).getOrElse(0))
+
+    val topic = s"invoker${invokerToUse.toInt}"
+
+    val config = new WhiskConfig(
+      WhiskConfig.kafkaHost ++ ExecManifest.requiredProperties ++ WhiskEntityStore.requiredProperties)
+
+    /**
+     * INITIALIZE MESSAGING
+     */
+    val messaging = SpiLoader.get[MessagingProvider]
+    val producer = messaging.getProducer(config, as.dispatcher)
+    val consumer = messaging.getConsumer(config, "completions", s"completed${controllerToSimulate.toInt}", 1000000)
+
+    // Stores all invoked activations to track their completion.
+    val activations = TrieMap[ActivationId, Promise[Unit]]()
+
+    as.actorOf(Props {
+      new MessageFeed(
+        "acks",
+        log,
+        consumer,
+        1000000,
+        500.milliseconds,
+        bytes => {
+          CompletionMessage.parse(new String(bytes, StandardCharsets.UTF_8)).foreach { msg =>
+            val id = msg.response.fold(id => id, _.activationId)
+            activations.get(id).foreach(_.success(()))
+          }
+          Future.successful(())
+        })
+    })
+
+    /**
+     * INITIALIZE TESTACTION
+     */
+    val identity = Identity(Subject(), EntityName("test"), AuthKey(), Set())
+
+    ExecManifest.initialize(config)
+    val action = ExecManifest.runtimesManifest
+      .resolveDefaultRuntime("nodejs:6")
+      .map { manifest =>
+        new WhiskAction(
+          namespace = identity.namespace.toPath,
+          name = EntityName("noop"),
+          exec = CodeExecAsString(manifest, """function main() { return {}; }""", None))
+      }
+      .get
+
+    val db = WhiskEntityStore.datastore(config)
+    val actionF = WhiskAction
+      .get(db, action.docid)
+      .flatMap { oldAction =>
+        WhiskAction.put(db, action.revision(oldAction.rev))(tid, notifier = None)
+      }
+      .recoverWith {
+        case _: NoDocumentException => WhiskAction.put(db, action)(tid, notifier = None)
+      }
+
+    val actionInfo: DocInfo = Await.result(actionF, 10.minutes)
+    log.info(this, "testaction created successfully")
+
+    /**
+     * INITIALIZE TESTMESSAGE
+     */
+    val baseMessage = ActivationMessage(
+      transid = TransactionId.unknown, // to be replaced by the testrunner
+      action = action.fullyQualifiedName(true),
+      revision = actionInfo.rev,
+      user = identity,
+      activationId = ActivationId(), // to be replaced by the testrunner
+      activationNamespace = identity.namespace.toPath,
+      rootControllerIndex = controllerToSimulate,
+      blocking = true,
+      content = None)
+
+    log.info(this, "sending testprobe to rule out Kafka rebalancing")
+    val activationId = ActivationId()
+    val firstSend =
+      producer.send(topic, baseMessage.copy(transid = TransactionId(0), activationId = activationId)).andThen {
+        case _ => activations.put(activationId, Promise[Unit]())
+      }
+
+    Await.ready(firstSend, 10.minutes)
+    Await.ready(activations(activationId).future, 10.minutes)
+
+    val begin = Instant.now
+    log.info(this, s"sending $messageCount messages")
+
+    val sends = (1 to messageCount).par.map { i =>
+      val activationId = ActivationId()
+      producer.send(topic, baseMessage.copy(transid = TransactionId(i), activationId = activationId)).andThen {
+        case _ => activations.put(activationId, Promise[Unit]())
+      }
+    }
+
+    // Sends are out
+    Await.ready(Future.sequence(sends.seq), 10.minutes)
+
+    log.info(this, "sending finished")
+
+    // Await all activations
+    Await.ready(Future.sequence(activations.mapValues(_.future).values), 10.minutes)
+    val end = Instant.now
+
+    log.info(this, "invocations finished, dumping report")
+
+    println("===== REPORT =====")
+    println("")
+    println(s"Took ${between(begin, end)}")
+    println(s"Requests/sec: ${messageCount.toDouble / between(begin, end).toMillis * 1000} ")
+    println("")
+    println("==================")
+
+    producer.close()
+    consumer.close()
+    as.terminate()
+  }
+}

--- a/tools/benchmark/src/main/scala/whisk/core/benchmark/ControllerSimulator.scala
+++ b/tools/benchmark/src/main/scala/whisk/core/benchmark/ControllerSimulator.scala
@@ -46,6 +46,8 @@ object ControllerSimulator {
     val controllerToSimulate = InstanceId(sys.env.get("CONTROLLER_ID").map(_.toInt).getOrElse(0))
     val invokerToUse = InstanceId(sys.env.get("INVOKER_ID").map(_.toInt).getOrElse(0))
 
+    val actionCode = sys.env.getOrElse("ACTION_CODE", "function main() { return {}; }")
+
     val topic = s"invoker${invokerToUse.toInt}"
 
     val config = new WhiskConfig(
@@ -89,7 +91,7 @@ object ControllerSimulator {
         new WhiskAction(
           namespace = identity.namespace.toPath,
           name = EntityName("noop"),
-          exec = CodeExecAsString(manifest, """function main() { return {}; }""", None))
+          exec = CodeExecAsString(manifest, actionCode, None))
       }
       .get
 


### PR DESCRIPTION
In order to test the invokers in isolation, it is important to measure correctly. This adds a stubbed out controller which produces messages as fast as possible and additionally reads the answers of the invoker to correctly measure throughput of a single invoker instance.

I know it is unpleasant that we have benchmark tooling in different places, but at the moment it is super inconvenient to build a dependency against the main repo from another repo, code-wise.