### PR TITLE
Mount docker/runc binaries from the host machine.

### DIFF
--- a/ansible/roles/invoker/files/docker-runc
+++ b/ansible/roles/invoker/files/docker-runc
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if $2 == 'resume'; then
+  docker unpause $3
+fi
+
+if $2 == 'pause'; then
+  docker pause $3
+fi

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -95,6 +95,30 @@
   with_items: "{{ invokerInfo }}"
   when: not invoker.allowMultipleInstances and item.Names[0] != "/invoker{{ groups['invokers'].index(inventory_hostname) }}"
 
+- name: "determine 'docker' binary location"
+  shell: which docker
+  register: dockerBinary
+
+- name: "determine 'docker-runc' binary location"
+  shell: which docker-runc
+  register: runcBinary
+  failed_when: false
+
+- set_fact:
+    runcMount: "-v {{ runcBinary.stdout }}:/usr/bin/docker-runc"
+  when: runcBinary.rc == 0
+
+- name: copy runc script to remote
+  copy:
+    src: "files/docker-runc"
+    dest: "{{ nginx.confdir }}"
+    mode: 111
+  when: runcBinary.rc != 0
+
+- set_fact:
+    runcMount: "-v '{{ nginx.confdir }}/docker-runc:/usr/bin/docker-runc'"
+  when: runcBinary.rc != 0
+
 - name: start invoker using docker cli
   shell: >
         docker run -d
@@ -132,6 +156,8 @@
         -e INVOKER_NUMCORE='{{ invoker.numcore }}'
         -e INVOKER_CORESHARE='{{ invoker.coreshare }}'
         -e WHISK_LOGS_DIR='{{ whisk_logs_dir }}'
+        {{ runcMount }}
+        -v {{ dockerBinary.stdout }}:/usr/bin/docker
         -v /sys/fs/cgroup:/sys/fs/cgroup
         -v /run/runc:/run/runc
         -v {{ whisk_logs_dir }}/invoker{{ groups['invokers'].index(inventory_hostname) }}:/logs

--- a/core/invoker/Dockerfile
+++ b/core/invoker/Dockerfile
@@ -1,16 +1,5 @@
 FROM scala
 
-ENV DOCKER_VERSION 1.12.0
-
-# Uncomment to fetch latest version of docker instead: RUN wget -qO- https://get.docker.com | sh
-# Install docker client
-RUN wget --no-verbose https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz && \
-tar --strip-components 1 -xvzf docker-${DOCKER_VERSION}.tgz -C /usr/bin docker/docker && \
-tar --strip-components 1 -xvzf docker-${DOCKER_VERSION}.tgz -C /usr/bin docker/docker-runc && \
-rm -f docker-${DOCKER_VERSION}.tgz && \
-chmod +x /usr/bin/docker && \
-chmod +x /usr/bin/docker-runc
-
 COPY build/distributions/invoker.tar ./
 RUN tar xf invoker.tar && \
 rm -f invoker.tar


### PR DESCRIPTION
Differing docker/runc server/client configurations can lead to unexpected results and/or to failing commands. Mounting the binaries from the host machine will effectively make them even no matter what.

Fixes #2788 