### PR TITLE
Check if runc exists before using it ( WIP to fix #2788  )

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
@@ -147,8 +147,8 @@ class DockerContainer(id: ContainerId, ip: ContainerIp)(implicit docker: DockerA
   /** HTTP connection to the container, will be lazily established by callContainer */
   private var httpConnection: Option[HttpUtils] = None
 
-  def suspend()(implicit transid: TransactionId): Future[Unit] = runc.pause(id)
-  def resume()(implicit transid: TransactionId): Future[Unit] = runc.resume(id)
+  def suspend()(implicit transid: TransactionId): Future[Unit] = if (runc.isInstalled) runc.pause(id) else docker.pause(id)
+  def resume()(implicit transid: TransactionId): Future[Unit] = if (runc.isInstalled) runc.resume(id) else docker.unpause(id)
   def destroy()(implicit transid: TransactionId): Future[Unit] = {
     httpConnection.foreach(_.close())
     docker.rm(id)

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/RuncClientTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/RuncClientTests.scala
@@ -92,4 +92,20 @@ class RuncClientTests extends FlatSpec with Matchers with StreamLogging with Bef
     }
 
   }
+
+  def runcClientWithMissingBinary(result: Future[String]) = new RuncClient(global) {
+    override val runcBinary = "./openwhisk-invalid-runc"
+  }
+  it should "figure out if runc binary is missing from the system" in {
+    val rc = runcClientWithMissingBinary { Future.successful("")}
+    rc.isInstalled shouldBe false
+  }
+
+  def runcClientWithExistingBinary(result: Future[String]) = new RuncClient(global) {
+    override val runcBinary = "/bin/sh"
+  }
+  it should "figure out if runc binary exists on the system" in {
+    val rc = runcClientWithExistingBinary { Future.successful("")}
+    rc.isInstalled shouldBe true
+  }
 }


### PR DESCRIPTION
This is marked as WIP b/c the information whether `runc` exists on not should be cached, instead of checking over and over on each invocation. 

This PR should complement https://github.com/apache/incubator-openwhisk/pull/2793  on the premise that `docker-runc` is only mounted in the invoker ( `-v /usr/bin/runc:/usr/bin/docker-runc`) IFF `runc` exists on the host.