### PR TITLE
ansible fix for #2788 for docker for mac 

### DIFF
--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -71,7 +71,7 @@
 - name: define options when deploying invoker on Ubuntu
   set_fact:
     linuxOptions: "-v /usr/lib/x86_64-linux-gnu/libapparmor.so.1:/usr/lib/x86_64-linux-gnu/libapparmor.so.1"
-  when: ansible_distribution == "Ubuntu"
+  when: (ansible_distribution == "Ubuntu") and (whisk_version_name != "local")
 
 - name: get running invoker information
   uri: url="http://{{ ansible_host }}:{{ docker.port }}/containers/json?filters={{ '{"name":[ "invoker" ],"ancestor":[ "invoker" ]}' | urlencode }}" return_content=yes
@@ -128,6 +128,28 @@
   when: jmx.enabled
   set_fact:
     invoker_args: "{{ invoker.arguments }} {{ invoker.jmxremote.jvmArgs }}"
+
+- name: "determine 'docker' binary location"
+  shell: which docker
+  register: dockerBinary
+  when: ansible_distribution != 'MacOSX'
+
+- name: "determine 'runc' binary location"
+  shell: which runc || which docker-runc
+  register: runcBinaryNative
+  when: ansible_distribution != 'MacOSX'
+
+# in local environments where docker host is a VM, we're interested to get the paths from the VM, not the local machine
+# and hence we use docker run to find out the paths on the VM
+- name: "determine 'runc' binary location (on docker host)"
+  shell: docker run --privileged --pid=host --userns=host debian nsenter -t 1 -m -u -n -i sh -c "which runc || which docker-runc"
+  register: runcBinaryOnVM
+  when: ansible_distribution == 'MacOSX'
+
+# this step is needed b/c Ansible messes the variable when a task is skipped https://github.com/ansible/ansible/issues/4297
+- name: "determine the final runc binary location"
+  set_fact:
+    runcBinary: "{{ runcBinaryNative if ansible_distribution != 'MacOSX' else runcBinaryOnVM }}"
 
 - name: start invoker using docker cli
   shell: >
@@ -193,6 +215,7 @@
         -e CONFIG_whisk_memory_std='{{ limit_action_memory_std | default() }}'
         -e CONFIG_whisk_activation_payload_max='{{ limit_activation_payload | default() }}'
         -v /sys/fs/cgroup:/sys/fs/cgroup
+        -v {{ runcBinary.stdout }}:/usr/bin/docker-runc
         -v /run/runc:/run/runc
         -v {{ whisk_logs_dir }}/invoker{{ groups['invokers'].index(inventory_hostname) }}:/logs
         -v {{ invoker.confdir }}/invoker{{ groups['invokers'].index(inventory_hostname) }}:/conf

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -129,17 +129,12 @@
   set_fact:
     invoker_args: "{{ invoker.arguments }} {{ invoker.jmxremote.jvmArgs }}"
 
-- name: "determine 'docker' binary location"
-  shell: which docker
-  register: dockerBinary
-  when: ansible_distribution != 'MacOSX'
-
 - name: "determine 'runc' binary location"
   shell: which runc || which docker-runc
   register: runcBinaryNative
   when: ansible_distribution != 'MacOSX'
 
-# in local environments where docker host is a VM, we're interested to get the paths from the VM, not the local machine
+# in local environments where docker host is a VM, we need to get the path from the VM, not the local machine
 # and hence we use docker run to find out the paths on the VM
 - name: "determine 'runc' binary location (on docker host)"
   shell: docker run --privileged --pid=host --userns=host debian nsenter -t 1 -m -u -n -i sh -c "which runc || which docker-runc"


### PR DESCRIPTION
This relates to https://github.com/apache/incubator-openwhisk/pull/2793 by mounting the `docker` and `runc` binaries from the host.

It doesn't yet update the dockerfile with the invoker as that's handled in #2793 , but this shows what's needed to fix #2788 . We can discuss how we want to merge all changes eventually.