### PR TITLE
Exclude sequence actions from log cleanup view.

### DIFF
--- a/ansible/files/activations_design_document_for_activations_db.json
+++ b/ansible/files/activations_design_document_for_activations_db.json
@@ -2,7 +2,7 @@
   "_id": "_design/activations",
   "views": {
     "byDate": {
-      "map": "function (doc) {\n  var PATHSEP = \"/\";\n\n  var isActivation = function (doc) { return (doc.activationId !== undefined) };\n\n  if (isActivation(doc)) try {\n    emit(doc.start, [doc._id, doc._rev])\n  } catch (e) {}\n}"
+      "map": "function (doc) {\n  if (doc.activationId !== undefined) try {\n    emit(doc.start, [doc._id, doc._rev]);\n  } catch (e) {}\n}"
     }
   },
   "language": "javascript"

--- a/ansible/files/logCleanup_design_document_for_activations_db.json
+++ b/ansible/files/logCleanup_design_document_for_activations_db.json
@@ -2,7 +2,7 @@
   "_id": "_design/logCleanup",
   "views": {
     "byDateWithLogs": {
-      "map": "function (doc) {\n  if (doc.activationId !== undefined && doc.logs && doc.logs.length > 0) {\n    emit(doc.start, doc._id);\n  }\n}"
+      "map": "function (doc) {\n  if (doc.activationId !== undefined && doc.logs && doc.logs.length > 0) try {\n    var deleteLogs = true;\n    for (i = 0; i < doc.annotations.length; i++) {\n      var a = doc.annotations[i];\n      if (a.key == \"kind\") {\n        deleteLogs = a.value != \"sequence\";\n        break;\n      }\n    }\n    if (deleteLogs) {\n      emit(doc.start, doc._id);\n    }\n  } catch (e) {}\n}"
     }
   },
   "language": "javascript"


### PR DESCRIPTION
Sequence activation logs are system generated, have bounded size, and provide causality tracking between activations. Exclude them from log deletion.

Here is the update view for convenience:

```js
function (doc) {
  if (doc.activationId !== undefined && doc.logs && doc.logs.length > 0) try {
    var deleteLogs = true;
    for (i = 0; i < doc.annotations.length; i++) {
      var a = doc.annotations[i];
      if (a.key == "kind") {
        deleteLogs = a.value != "sequence";
        break;
      }
    }
    if (deleteLogs) {
      emit(doc.start, doc._id);
    }
  } catch (e) {}
}
```

Closes #2800.