### PR TITLE
Create the required CouchDB system databases

### DIFF
--- a/ansible/roles/couchdb/tasks/deploy.yml
+++ b/ansible/roles/couchdb/tasks/deploy.yml
@@ -60,3 +60,19 @@
     user: "{{ db_username }}"
     password: "{{ db_password }}"
     force_basic_auth: yes
+
+- name: create the couchdb system databases
+  uri:
+    url: "{{ db_protocol }}://{{ ansible_host }}:{{ db_port }}/{{ item }}"
+    method: PUT
+    body: >
+        "false"
+    body_format: json
+    status_code: 201
+    user: "{{ db_username }}"
+    password: "{{ db_password }}"
+    force_basic_auth: yes
+  with_items:
+    - _users
+    - _replicator
+    - _global_changes

--- a/ansible/roles/couchdb/tasks/deploy.yml
+++ b/ansible/roles/couchdb/tasks/deploy.yml
@@ -65,9 +65,6 @@
   uri:
     url: "{{ db_protocol }}://{{ ansible_host }}:{{ db_port }}/{{ item }}"
     method: PUT
-    body: >
-        "false"
-    body_format: json
     status_code: 201
     user: "{{ db_username }}"
     password: "{{ db_password }}"


### PR DESCRIPTION
As of CouchDB 2.0, system databases don't automatically get created on
startup and you have to do this manually. The process differs a bit
for single nodes vs clusters, but since everything else in the Ansible
scripts seems to assume single node this just sets things up that way.

See the CouchDB docs at
http://docs.couchdb.org/en/2.0.0/install/#single-node-setup for more
info.

This prevents errors constantly being logged by CouchDB with messages
like `Error in process <0.22878.7> on node 'couchdb@couchdb0' with
exit value: {database_does_not_exist ...` and `chttpd_auth_cache
changes listener died database_does_not_exist` which can end up
chewing through a lot of log disk space.