### PR TITLE
Implement bulk write of activations in the Invoker.

### DIFF
--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -233,6 +233,7 @@ object LoggingMarkers {
   val DATABASE_CACHE_HIT = LogMarkerToken(database, "cacheHit", count)
   val DATABASE_CACHE_MISS = LogMarkerToken(database, "cacheMiss", count)
   val DATABASE_SAVE = LogMarkerToken(database, "saveDocument", start)
+  val DATABASE_BULK_SAVE = LogMarkerToken(database, "saveDocumentBulk", start)
   val DATABASE_DELETE = LogMarkerToken(database, "deleteDocument", start)
   val DATABASE_GET = LogMarkerToken(database, "getDocument", start)
   val DATABASE_QUERY = LogMarkerToken(database, "queryView", start)

--- a/common/scala/src/main/scala/whisk/core/database/ArtifactStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/ArtifactStore.scala
@@ -55,6 +55,17 @@ trait ArtifactStore[DocumentAbstraction] {
   protected[database] def put(d: DocumentAbstraction)(implicit transid: TransactionId): Future[DocInfo]
 
   /**
+   * Puts (saves) documents to database in bulk using a future.
+   * If the operation is successful, the future completes with DocId else an appropriate exception.
+   *
+   * @param ds the documents to put in the database
+   * @param transid the transaction id for logging
+   * @return a future that completes either with DocId
+   */
+  protected[database] def put(ds: Seq[DocumentAbstraction])(
+    implicit transid: TransactionId): Future[Seq[Either[DocumentConflictException, DocInfo]]]
+
+  /**
    * Deletes document from database using a future.
    * If the operation is successful, the future completes with true.
    *

--- a/common/scala/src/main/scala/whisk/core/database/Batcher.scala
+++ b/common/scala/src/main/scala/whisk/core/database/Batcher.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.database
+
+import scala.collection.immutable.Queue
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.{Failure, Success}
+
+import akka.stream.{ActorMaterializer, OverflowStrategy}
+import akka.stream.scaladsl.{Sink, Source}
+
+/**
+ * Enables batching of a type T.
+ *
+ * Batches are being created using a maximum batchSize. If there is back-pressure (concurrency is
+ * maxed out and it is waiting for the operations to complete) a batch will be build up and
+ * then handled accordingly. Batching will only happen under back-pressure so there is no latency
+ * being traded off for batching in a non back-pressured case.
+ *
+ * The given concurrency controls how many batches are handled in parallel. (example: How many
+ * batches of records are written to the database in parallel.)
+ *
+ * The operation-function takes a batch of T and does something to it that results in a sequence
+ * of the same size of the batch. (example: Writing a batch of database records results in a sequence
+ * of database responses). These results will be assigned to the relevant element in the batch.
+ * (example: Putting a database record in batches will give you the database response for each record
+ * respectively)
+ *
+ * @param batchSize maximum size of a batch
+ * @param concurrency number of batches being handled in parallel
+ * @param operation operation taking the batch
+
+ * @tparam T the type to be batched
+ * @tparam R return type of a single element after operation
+ */
+class Batcher[T, R](batchSize: Int, concurrency: Int)(operation: Seq[T] => Future[Seq[R]])(
+  implicit materializer: ActorMaterializer,
+  ec: ExecutionContext) {
+
+  private val stream = Source
+    .actorRef[(T, Promise[R])](Int.MaxValue, OverflowStrategy.dropNew)
+    .batch(batchSize, Queue(_))((queue, element) => queue :+ element)
+    .mapAsyncUnordered(concurrency) { els =>
+      val elements = els.map(_._1)
+      val promises = els.map(_._2)
+
+      val f = operation(elements)
+      f.onComplete {
+        case Success(results) => results.zip(promises).foreach { case (result, p) => p.success(result) }
+        case Failure(e)       => promises.foreach(_.failure(e))
+      }
+      // Recover Future to not abort stream in case of a failure
+      f.recover { case _ => () }
+    }
+    .to(Sink.ignore)
+    .run()
+
+  /**
+   * Adds an element to be batch-processed.
+   *
+   * @param el the element to process
+   * @return a future containing the response of the database for this specific element
+   */
+  def put(el: T): Future[R] = {
+    val promise = Promise[R]()
+    stream ! (el, promise)
+    promise.future
+  }
+}

--- a/common/scala/src/main/scala/whisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/whisk/core/database/CouchDbRestClient.scala
@@ -168,6 +168,10 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
   def putDoc(id: String, rev: String, doc: JsObject): Future[Either[StatusCode, JsObject]] =
     requestJson[JsObject](mkJsonRequest(HttpMethods.PUT, uri(db, id), doc, forRev = Some(rev)))
 
+  // http://docs.couchdb.org/en/2.1.0/api/database/bulk-api.html#inserting-documents-in-bulk
+  def putDocs(docs: Seq[JsObject]): Future[Either[StatusCode, JsArray]] =
+    requestJson[JsArray](mkJsonRequest(HttpMethods.POST, uri(db, "_bulk_docs"), JsObject("docs" -> docs.toJson)))
+
   // http://docs.couchdb.org/en/1.6.1/api/document/common.html#get--db-docid
   def getDoc(id: String): Future[Either[StatusCode, JsObject]] =
     requestJson[JsObject](mkRequest(HttpMethods.GET, uri(db, id)))

--- a/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
+++ b/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
@@ -164,6 +164,14 @@ trait DocumentFactory[W] extends MultipleReadersSingleWriterCache[W, DocInfo] {
     }
   }
 
+  def put[Wsuper >: W](db: ArtifactStore[Wsuper], docs: Seq[W])(
+    implicit transid: TransactionId): Future[Seq[Either[DocumentConflictException, DocInfo]]] = {
+    implicit val logger = db.logging
+    implicit val ec = db.executionContext
+
+    db.put(docs)
+  }
+
   def attach[Wsuper >: W](
     db: ArtifactStore[Wsuper],
     doc: DocInfo,

--- a/common/scala/src/main/scala/whisk/core/entity/DocInfo.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/DocInfo.scala
@@ -24,6 +24,7 @@ import spray.json.RootJsonFormat
 import spray.json.JsNull
 import spray.json.JsString
 import spray.json.deserializationError
+import spray.json.DefaultJsonProtocol
 
 /**
  * A DocId is the document id === primary key in the datastore.
@@ -126,7 +127,7 @@ protected[core] object DocRevision {
   }
 }
 
-protected[core] object DocInfo {
+protected[core] object DocInfo extends DefaultJsonProtocol {
 
   /**
    * Creates a DocInfo with id set to the argument and no revision.
@@ -147,4 +148,6 @@ protected[core] object DocInfo {
    */
   @throws[IllegalArgumentException]
   protected[core] def !(id: String, rev: String): DocInfo = DocInfo(DocId(id), DocRevision(rev))
+
+  implicit val serdes = jsonFormat2(DocInfo.apply)
 }

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
@@ -19,14 +19,15 @@ package whisk.core.invoker
 
 import java.nio.charset.StandardCharsets
 import java.time.Instant
+
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.util.Failure
-import scala.util.Success
+import scala.util.{Failure, Success}
 import org.apache.kafka.common.errors.RecordTooLargeException
 import akka.actor.ActorRefFactory
 import akka.actor.ActorSystem
 import akka.actor.Props
+import akka.stream.ActorMaterializer
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import whisk.common.Logging
@@ -43,7 +44,7 @@ import whisk.core.containerpool.ContainerPool
 import whisk.core.containerpool.ContainerProxy
 import whisk.core.containerpool.PrewarmingConfig
 import whisk.core.containerpool.Run
-import whisk.core.database.NoDocumentException
+import whisk.core.database.{Batcher, DocumentConflictException, NoDocumentException}
 import whisk.core.entity._
 import whisk.core.entity.size._
 import whisk.http.Messages
@@ -116,13 +117,23 @@ class InvokerReactive(config: WhiskConfig, instance: InstanceId, producer: Messa
     }
   }
 
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
+  // In worst case we need "maximumContainers" connections to load actions from the database. The remaining
+  // connections can safely be used for writing activations.
+  val maxOpenDbRequests = actorSystem.settings.config.getInt("akka.http.host-connection-pool.max-open-requests")
+  val maxOpenActivationRequests = (maxOpenDbRequests - maximumContainers) max (maxOpenDbRequests / 2)
+  val batcher: Batcher[WhiskActivation, Either[DocumentConflictException, DocInfo]] =
+    new Batcher(500, maxOpenActivationRequests)(WhiskActivation.put(activationStore, _)(TransactionId.invoker))
+
   /** Stores an activation in the database. */
   val store = (tid: TransactionId, activation: WhiskActivation) => {
     implicit val transid = tid
     logging.info(this, "recording the activation result to the data store")
-    WhiskActivation.put(activationStore, activation)(tid, notifier = None).andThen {
-      case Success(id) => logging.info(this, s"recorded activation")
-      case Failure(t)  => logging.error(this, s"failed to record activation")
+
+    batcher.put(activation).andThen {
+      case Success(Right(_)) => logging.info(this, s"recorded activation")
+      case Success(Left(t))  => logging.error(this, s"failed to record activation, $t")
+      case Failure(t)        => logging.error(this, s"failed to record activation, $t")
     }
   }
 

--- a/tests/src/test/scala/common/LoggedFunction.scala
+++ b/tests/src/test/scala/common/LoggedFunction.scala
@@ -28,6 +28,15 @@ import scala.collection.mutable
  *     func.calls should have size 1
  *     func.calls.head shouldBe (1, 2)
  */
+class LoggedFunction1[A1, B](body: A1 => B) extends Function1[A1, B] {
+  val calls = mutable.Buffer[A1]()
+
+  override def apply(v1: A1): B = {
+    calls += (v1)
+    body(v1)
+  }
+}
+
 class LoggedFunction2[A1, A2, B](body: (A1, A2) => B) extends Function2[A1, A2, B] {
   val calls = mutable.Buffer[(A1, A2)]()
 
@@ -65,6 +74,7 @@ class LoggedFunction5[A1, A2, A3, A4, A5, B](body: (A1, A2, A3, A4, A5) => B) ex
 }
 
 object LoggedFunction {
+  def apply[A1, B](body: (A1) => B) = new LoggedFunction1(body)
   def apply[A1, A2, B](body: (A1, A2) => B) = new LoggedFunction2(body)
   def apply[A1, A2, A3, B](body: (A1, A2, A3) => B) = new LoggedFunction3(body)
   def apply[A1, A2, A3, A4, B](body: (A1, A2, A3, A4) => B) = new LoggedFunction4(body)

--- a/tests/src/test/scala/whisk/core/database/test/BatcherTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/BatcherTests.scala
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.database.test
+
+import akka.stream.ActorMaterializer
+import common.WskActorSystem
+import org.junit.runner.RunWith
+import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.junit.JUnitRunner
+
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+import whisk.core.database.Batcher
+import whisk.utils.retry
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+import common.LoggedFunction
+
+@RunWith(classOf[JUnitRunner])
+class BatcherTests extends FlatSpec with Matchers with WskActorSystem {
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
+  implicit val ec: ExecutionContext = actorSystem.dispatcher
+
+  def await[V](f: Future[V]) = Await.result(f, 10.seconds)
+
+  def between(start: Instant, end: Instant) =
+    Duration.fromNanos(java.time.Duration.between(start, end).toNanos)
+
+  behavior of "Batcher"
+
+  it should "batch based on batch size" in {
+    val p = Promise[Unit]()
+
+    val transform = (i: Int) => i + 1
+
+    val batchOperation = LoggedFunction((els: Seq[Int]) => {
+      p.future.map(_ => els.map(transform))
+    })
+
+    val batcher = new Batcher[Int, Int](2, 1)(batchOperation)
+
+    val values = (1 to 5)
+    val results = values.map(batcher.put)
+
+    retry(batchOperation.calls should have size 1, 100)
+    p.success(())
+
+    await(Future.sequence(results)) shouldBe values.map(transform)
+    batchOperation.calls should have size 3
+    batchOperation.calls(0) should have size 1
+    batchOperation.calls(1) should have size 2
+    batchOperation.calls(2) should have size 2
+  }
+
+  it should "run batches through the operation in parallel" in {
+    val p = Promise[Unit]()
+    val parallel = new AtomicInteger(0)
+    val concurrency = 2
+
+    val batcher = new Batcher[Int, Int](1, concurrency)(els => {
+      parallel.incrementAndGet()
+      p.future.map(_ => els)
+    })
+
+    val values = (1 to 3)
+    val results = values.map(batcher.put)
+
+    // Before we resolve the promise, 2 batches should have entered the batch operation
+    // which is now hanging and waiting for the promise to be resolved.
+    retry(parallel.get shouldBe concurrency, 100)
+
+    p.success(())
+
+    await(Future.sequence(results)) shouldBe values
+  }
+
+  it should "complete batched values with the thrown exception" in {
+    val batcher = new Batcher[Int, Int](2, 1)(_ => Future.failed(new Exception))
+
+    val r1 = batcher.put(1)
+    val r2 = batcher.put(2)
+
+    an[Exception] should be thrownBy await(r1)
+    an[Exception] should be thrownBy await(r2)
+
+    // the batcher is still intact
+    val r3 = batcher.put(3)
+    val r4 = batcher.put(4)
+
+    an[Exception] should be thrownBy await(r3)
+    an[Exception] should be thrownBy await(r4)
+  }
+}


### PR DESCRIPTION
Writing activations in the Invoker is not time critical and can be greatly optimized by batching the activations to reduce the number of connections used towards the database. That enables a lot of optimizations on the database side and is in general a good practice.

Signed-off-by: Christian Bickel <cbickel@de.ibm.com>