### PR TITLE
Notify the user if a container is killed due to memory exhaustion.

### DIFF
--- a/common/scala/src/main/scala/whisk/core/containerpool/Container.scala
+++ b/common/scala/src/main/scala/whisk/core/containerpool/Container.scala
@@ -57,7 +57,7 @@ trait Container {
   protected implicit val ec: ExecutionContext
 
   /** HTTP connection to the container, will be lazily established by callContainer */
-  private var httpConnection: Option[HttpUtils] = None
+  protected var httpConnection: Option[HttpUtils] = None
 
   /** Stops the container from consuming CPU cycles. */
   def suspend()(implicit transid: TransactionId): Future[Unit]
@@ -147,10 +147,8 @@ trait Container {
    * @param timeout timeout of the request
    * @param retry whether or not to retry the request
    */
-  protected def callContainer(path: String,
-                              body: JsObject,
-                              timeout: FiniteDuration,
-                              retry: Boolean = false): Future[RunResult] = {
+  protected def callContainer(path: String, body: JsObject, timeout: FiniteDuration, retry: Boolean = false)(
+    implicit transid: TransactionId): Future[RunResult] = {
     val started = Instant.now()
     val http = httpConnection.getOrElse {
       val conn = new HttpUtils(s"${addr.host}:${addr.port}", timeout, 1.MB)

--- a/common/scala/src/main/scala/whisk/core/containerpool/HttpUtils.scala
+++ b/common/scala/src/main/scala/whisk/core/containerpool/HttpUtils.scala
@@ -49,7 +49,7 @@ import whisk.core.entity.size.SizeLong
  * determined why that is.
  *
  * @param hostname the host name
- * @param timeoutMsec the timeout in msecs to wait for a response
+ * @param timeout the timeout in msecs to wait for a response
  * @param maxResponse the maximum size in bytes the connection will accept
  */
 protected[core] class HttpUtils(hostname: String, timeout: FiniteDuration, maxResponse: ByteSize) {
@@ -68,7 +68,7 @@ protected[core] class HttpUtils(hostname: String, timeout: FiniteDuration, maxRe
    * @param retry whether or not to retry on connection failure
    * @return Left(Error Message) or Right(Status Code, Response as UTF-8 String)
    */
-  def post(endpoint: String, body: JsValue, retry: Boolean): Either[ContainerConnectionError, ContainerResponse] = {
+  def post(endpoint: String, body: JsValue, retry: Boolean): Either[ContainerHttpError, ContainerResponse] = {
     val entity = new StringEntity(body.compactPrint, StandardCharsets.UTF_8)
     entity.setContentType("application/json")
 
@@ -81,7 +81,7 @@ protected[core] class HttpUtils(hostname: String, timeout: FiniteDuration, maxRe
 
   private def execute(request: HttpRequestBase,
                       timeoutMsec: Integer,
-                      retry: Boolean): Either[ContainerConnectionError, ContainerResponse] = {
+                      retry: Boolean): Either[ContainerHttpError, ContainerResponse] = {
     Try(connection.execute(request)).map { response =>
       val containerResponse = Option(response.getEntity)
         .map { entity =>

--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -112,6 +112,7 @@ object Messages {
   /** Error messages for activations. */
   val abnormalInitialization = "The action did not initialize and exited unexpectedly."
   val abnormalRun = "The action did not produce a valid response and exited unexpectedly."
+  val memoryExhausted = "The action exhausted its memory and was aborted."
   def badEntityName(value: String) = s"Parameter is not a valid value for a entity name: $value"
   def badNamespace(value: String) = s"Parameter is not a valid value for a namespace: $value"
   def badEpoch(value: String) = s"Parameter is not a valid value for epoch seconds: $value"

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClientWithFileAccess.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClientWithFileAccess.scala
@@ -130,6 +130,11 @@ class DockerClientWithFileAccess(
     }
   }
 
+  override def isOomKilled(id: ContainerId)(implicit transid: TransactionId): Future[Boolean] =
+    configFileContents(containerConfigFile(id))
+      .map(_.fields("State").asJsObject.fields("OOMKilled").convertTo[Boolean])
+      .recover { case _ => false }
+
   // See extended trait for description
   def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = Future {
     blocking { // Needed due to synchronous file operations

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
@@ -146,7 +146,7 @@ class DockerContainer(protected val id: ContainerId, protected val addr: Contain
    * Was the container killed due to memory exhaustion?
    *
    * Retries because as all docker state-relevant operations, they won't
-   * be reflected by the respective commands immediatly but will take
+   * be reflected by the respective commands immediately but will take
    * some time to be propagated.
    *
    * @param retries number of retries to make

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
@@ -18,8 +18,10 @@
 package whisk.core.containerpool.docker
 
 import java.nio.charset.StandardCharsets
+import java.time.Instant
 
 import akka.actor.ActorSystem
+import spray.json._
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -27,11 +29,8 @@ import scala.concurrent.duration._
 import scala.util.Failure
 import whisk.common.Logging
 import whisk.common.TransactionId
-import whisk.core.containerpool.BlackboxStartupError
-import whisk.core.containerpool.Container
-import whisk.core.containerpool.ContainerId
-import whisk.core.containerpool.ContainerAddress
-import whisk.core.containerpool.WhiskContainerStartupError
+import whisk.core.containerpool._
+import whisk.core.entity.ActivationResponse.{ConnectionError, MemoryExhausted}
 import whisk.core.entity.ByteSize
 import whisk.core.entity.size._
 
@@ -132,14 +131,53 @@ class DockerContainer(protected val id: ContainerId, protected val addr: Contain
   /** The last read-position in the log file */
   private var logFileOffset = 0L
 
-  protected val logsRetryCount = 15
-  protected val logsRetryWait = 100.millis
+  protected val waitForLogs = 2.seconds
+  protected val waitForOomState = 2.seconds
+  protected val filePollInterval = 100.milliseconds
 
   def suspend()(implicit transid: TransactionId): Future[Unit] = runc.pause(id)
   def resume()(implicit transid: TransactionId): Future[Unit] = runc.resume(id)
   override def destroy()(implicit transid: TransactionId): Future[Unit] = {
     super.destroy()
     docker.rm(id)
+  }
+
+  private def isOomKilled(retries: Int = (waitForOomState / filePollInterval).toInt)(
+    implicit transid: TransactionId): Future[Boolean] = {
+    docker.isOomKilled(id)(TransactionId.invoker).flatMap { killed =>
+      if (killed) Future.successful(killed)
+      else if (retries > 0) akka.pattern.after(filePollInterval, as.scheduler)(isOomKilled(retries - 1))
+      else Future.successful(killed)
+    }
+  }
+
+  override protected def callContainer(path: String, body: JsObject, timeout: FiniteDuration, retry: Boolean = false)(
+    implicit transid: TransactionId): Future[RunResult] = {
+    val started = Instant.now()
+    val http = httpConnection.getOrElse {
+      val conn = new HttpUtils(s"${addr.host}:${addr.port}", timeout, 1.MB)
+      httpConnection = Some(conn)
+      conn
+    }
+    Future {
+      http.post(path, body, retry)
+    }.flatMap { response =>
+      val finished = Instant.now()
+
+      response.left
+        .map {
+          case t: ConnectionError =>
+            isOomKilled().map {
+              case true =>
+                logging.info(this, "connection abruptly terminated, checking for memory exhaustion")
+                MemoryExhausted()
+              case false => t
+            }
+          case t => Future.successful(t)
+        }
+        .fold(_.map(Left(_)), right => Future.successful(Right(right)))
+        .map(res => RunResult(Interval(started, finished), res))
+    }
   }
 
   /**
@@ -176,7 +214,7 @@ class DockerContainer(protected val id: ContainerId, protected val addr: Contain
 
           if (retries > 0 && !isComplete && !isTruncated) {
             logging.info(this, s"log cursor advanced but missing sentinel, trying $retries more times")
-            akka.pattern.after(logsRetryWait, as.scheduler)(readLogs(retries - 1))
+            akka.pattern.after(filePollInterval, as.scheduler)(readLogs(retries - 1))
           } else {
             logFileOffset += rawLogBytes.position - rawLogBytes.arrayOffset
             Future.successful(formattedLogs)
@@ -188,7 +226,7 @@ class DockerContainer(protected val id: ContainerId, protected val addr: Contain
         }
     }
 
-    readLogs(logsRetryCount)
+    readLogs((waitForLogs / filePollInterval).toInt)
   }
 
 }

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
@@ -76,14 +76,15 @@ class DockerContainerTests
     retryCount: Int = 0)(implicit docker: DockerApiWithFileAccess, runc: RuncApi): DockerContainer = {
 
     new DockerContainer(id, addr) {
-      override protected def callContainer(path: String,
-                                           body: JsObject,
-                                           timeout: FiniteDuration,
-                                           retry: Boolean = false): Future[RunResult] = {
+      override protected def callContainer(
+        path: String,
+        body: JsObject,
+        timeout: FiniteDuration,
+        retry: Boolean = false)(implicit transid: TransactionId): Future[RunResult] = {
         ccRes
       }
-      override protected val logsRetryCount = retryCount
-      override protected val logsRetryWait = 0.milliseconds
+      override protected val waitForLogs = retryCount.milliseconds
+      override protected val filePollInterval = 1.millisecond
     }
   }
 
@@ -679,6 +680,8 @@ class DockerContainerTests
       pulls += image
       Future.successful(())
     }
+
+    override def isOomKilled(id: ContainerId)(implicit transid: TransactionId): Future[Boolean] = ???
 
     def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
       rawContainerLogsInvocations += ((containerId, fromPos))


### PR DESCRIPTION
If a user-container runs out of memory, the HTTP connections is abruptly aborted and the user has no chance to get further evidence into why her action failed.

Docker actually provides that information so it can be checked on an abrupt connection termination whether the container was indeed aborted by the OOM killer.

Fixes: #2652