### PR TITLE
option to use docker pause/unpause instead of docker-runc pause/unpause

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -159,6 +159,8 @@ invoker:
   instances: "{{ groups['invokers'] | length }}"
   # Specify if it is allowed to deploy more than 1 invoker on a single machine.
   allowMultipleInstances: "{{ invoker_allow_multiple_instances | default(false) }}"
+  # Specify if it should use docker-runc or docker to pause/unpause containers
+  useRunc: "{{ invoker_use_runc | default(true) }}"
   docker:
     become: "{{ invoker_docker_become | default(false) }}"
 

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -131,6 +131,7 @@
         -e INVOKER_CONTAINER_DNS='{{ invoker_container_network_dns_servers | default()}}'
         -e INVOKER_NUMCORE='{{ invoker.numcore }}'
         -e INVOKER_CORESHARE='{{ invoker.coreshare }}'
+        -e INVOKER_USE_RUNC='{{ invoker.useRunc }}'
         -e WHISK_LOGS_DIR='{{ whisk_logs_dir }}'
         -v /sys/fs/cgroup:/sys/fs/cgroup
         -v /run/runc:/run/runc

--- a/ansible/templates/whisk.properties.j2
+++ b/ansible/templates/whisk.properties.j2
@@ -62,6 +62,7 @@ invoker.container.policy={{ invoker_container_policy_name | default()}}
 invoker.container.dns={{ invoker_container_network_dns_servers | default()}}
 invoker.numcore={{ invoker.numcore }}
 invoker.coreshare={{ invoker.coreshare }}
+invoker.useRunc={{ invoker.useRunc }}
 invoker.instances={{ invoker.instances }}
 
 main.docker.endpoint={{ hostvars[groups["controllers"]|first].ansible_host }}:{{ docker.port }}

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -64,6 +64,7 @@ class WhiskConfig(requiredProperties: Map[String, String],
     if (this(WhiskConfig.invokerContainerDns) == "") Seq() else this(WhiskConfig.invokerContainerDns).split(" ").toSeq
   val invokerNumCore = this(WhiskConfig.invokerNumCore)
   val invokerCoreShare = this(WhiskConfig.invokerCoreShare)
+  val invokerUseRunc = this.getAsBoolean(WhiskConfig.invokerUseRunc, true)
 
   val wskApiHost = this(WhiskConfig.wskApiProtocol) + "://" + this(WhiskConfig.wskApiHostname) + ":" + this(
     WhiskConfig.wskApiPort)
@@ -188,6 +189,7 @@ object WhiskConfig {
   val invokerContainerDns = "invoker.container.dns"
   val invokerNumCore = "invoker.numcore"
   val invokerCoreShare = "invoker.coreshare"
+  val invokerUseRunc = "invoker.use.runc"
 
   val wskApiProtocol = "whisk.api.host.proto"
   val wskApiPort = "whisk.api.host.port"

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -54,7 +54,8 @@ object Invoker {
       invokerCoreShare -> "2",
       invokerContainerPolicy -> "",
       invokerContainerDns -> "",
-      invokerContainerNetwork -> null)
+      invokerContainerNetwork -> null,
+      invokerUseRunc -> "true")
 
   def main(args: Array[String]): Unit = {
     require(args.length == 1, "invoker instance required")


### PR DESCRIPTION
Restore config option to use docker pause/unpause instead of
docker-runc pause/unpause in the invoker.  Works around problem
of incompatible versions of docker-runc in invoker container and
hosting environment.