### PR TITLE
Do not cache invalidate when adding a DB attachment

### DIFF
--- a/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
+++ b/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
@@ -112,7 +112,7 @@ trait DocumentFactory[W <: DocumentRevisionProvider] extends MultipleReadersSing
 
       cacheUpdate(doc, key, db.put(doc) map { newDocInfo =>
         doc.revision[W](newDocInfo.rev)
-        docInfo.copy(rev = newDocInfo.rev)
+        doc.docinfo
       })
     } match {
       case Success(f) => f
@@ -140,7 +140,7 @@ trait DocumentFactory[W <: DocumentRevisionProvider] extends MultipleReadersSing
 
       cacheUpdate(doc, key, db.attach(docInfo, attachmentName, contentType, src) map { newDocInfo =>
         doc.revision[W](newDocInfo.rev)
-        docInfo.copy(rev = newDocInfo.rev)
+        doc.docinfo
       })
     } match {
       case Success(f) => f

--- a/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
+++ b/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
@@ -108,15 +108,12 @@ trait DocumentFactory[W <: DocumentRevisionProvider] extends MultipleReadersSing
       implicit val ec = db.executionContext
 
       val key = CacheKey(doc)
+      val docInfo = doc.docinfo
 
-      cacheUpdate(doc, key, db.put(doc) map { docInfo =>
-        doc match {
-          // if doc has a revision id, update it with new version
-          case w: DocumentRevisionProvider => w.revision[W](docInfo.rev)
-        }
-        docInfo
+      cacheUpdate(doc, key, db.put(doc) map { newDocInfo =>
+        doc.revision[W](newDocInfo.rev)
+        docInfo.copy(rev = newDocInfo.rev)
       })
-
     } match {
       case Success(f) => f
       case Failure(t) => Future.failed(t)

--- a/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
+++ b/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
@@ -174,7 +174,7 @@ trait DocumentFactory[W] extends MultipleReadersSingleWriterCache[W, DocInfo] {
 
     Try {
       require(db != null, "db undefined")
-      require(doc != null, "entity undefined")
+      require(doc != null, "doc undefined")
       require(docInfo != null, "docInfo undefined")
     } map { _ =>
       implicit val logger = db.logging

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -315,7 +315,7 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
           val manifest = exec.manifest.attached.get
 
           for (i1 <- super.put(db, newDoc);
-               i2 <- attach[A](db, i1, manifest.attachmentName, manifest.attachmentType, stream)) yield i2
+               i2 <- attach[A](db, newDoc, i1, manifest.attachmentName, manifest.attachmentType, stream)) yield i2
 
         case _ =>
           super.put(db, doc)

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -315,7 +315,8 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
           val manifest = exec.manifest.attached.get
 
           for (i1 <- super.put(db, newDoc);
-               i2 <- attach[A](db, newDoc, i1, manifest.attachmentName, manifest.attachmentType, stream)) yield i2
+               i2 <- attach[A](db, newDoc.revision(i1.rev), manifest.attachmentName, manifest.attachmentType, stream))
+            yield i2
 
         case _ =>
           super.put(db, doc)

--- a/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
@@ -503,133 +503,75 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     }
   }
 
-  it should "put and then get action from cache" in {
-    val action = WhiskAction(namespace, aname(), jsDefault("??"), Parameters("x", "b"))
-    val content = WhiskActionPut(
-      Some(action.exec),
-      Some(action.parameters),
-      Some(ActionLimitsOption(Some(action.limits.timeout), Some(action.limits.memory), Some(action.limits.logs))))
-    val name = action.name
-
-    // first request invalidates any previous entries and caches new result
-    Put(s"$collectionPath/$name", content) ~> Route.seal(routes(creds)(transid())) ~> check {
-      status should be(OK)
-      val response = responseAs[WhiskAction]
-      response should be(
-        WhiskAction(
-          action.namespace,
-          action.name,
-          action.exec,
-          action.parameters,
-          action.limits,
-          action.version,
-          action.publish,
-          action.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6)))
-    }
-    stream.toString should include(s"caching ${CacheKey(action)}")
-    stream.reset()
-
-    // second request should fetch from cache
-    Get(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
-      status should be(OK)
-      val response = responseAs[WhiskAction]
-      response should be(
-        WhiskAction(
-          action.namespace,
-          action.name,
-          action.exec,
-          action.parameters,
-          action.limits,
-          action.version,
-          action.publish,
-          action.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6)))
-    }
-
-    stream.toString should include(s"serving from cache: ${CacheKey(action)}")
-    stream.reset()
-
-    // delete should invalidate cache
-    Delete(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
-      status should be(OK)
-      val response = responseAs[WhiskAction]
-      response should be(
-        WhiskAction(
-          action.namespace,
-          action.name,
-          action.exec,
-          action.parameters,
-          action.limits,
-          action.version,
-          action.publish,
-          action.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6)))
-    }
-    stream.toString should include(s"invalidating ${CacheKey(action)}")
-    stream.reset()
-  }
-
-  it should "put and then get a Java action from cache" in {
-    val action =
+  it should "put and then get an action from cache" in {
+    val javaAction =
       WhiskAction(namespace, aname(), javaDefault("ZHViZWU=", Some("hello")), annotations = Parameters("exec", "java"))
-    val content = WhiskActionPut(
-      Some(action.exec),
-      Some(action.parameters),
-      Some(ActionLimitsOption(Some(action.limits.timeout), Some(action.limits.memory), Some(action.limits.logs))))
-    val name = action.name
+    val nodeAction = WhiskAction(namespace, aname(), jsDefault("??"), Parameters("x", "b"))
+    val actions = Seq((javaAction, JAVA_DEFAULT), (nodeAction, NODEJS6))
 
-    // first request invalidates any previous entries and caches new result
-    Put(s"$collectionPath/$name", content) ~> Route.seal(routes(creds)(transid())) ~> check {
-      status should be(OK)
-      val response = responseAs[WhiskAction]
-      response should be(
-        WhiskAction(
-          action.namespace,
-          action.name,
-          action.exec,
-          action.parameters,
-          action.limits,
-          action.version,
-          action.publish,
-          action.annotations ++ Parameters(WhiskAction.execFieldName, JAVA_DEFAULT)))
-    }
-    stream.toString should include(s"caching ${CacheKey(action)}")
-    stream.toString should not include (s"invalidating ${CacheKey(action)} on delete")
-    stream.reset()
+    actions.foreach {
+      case (action, kind) =>
+        val content = WhiskActionPut(
+          Some(action.exec),
+          Some(action.parameters),
+          Some(ActionLimitsOption(Some(action.limits.timeout), Some(action.limits.memory), Some(action.limits.logs))))
+        val name = action.name
 
-    // second request should fetch from cache
-    Get(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
-      status should be(OK)
-      val response = responseAs[WhiskAction]
-      response should be(
-        WhiskAction(
-          action.namespace,
-          action.name,
-          action.exec,
-          action.parameters,
-          action.limits,
-          action.version,
-          action.publish,
-          action.annotations ++ Parameters(WhiskAction.execFieldName, JAVA_DEFAULT)))
-    }
-    stream.toString should include(s"serving from cache: ${CacheKey(action)}")
-    stream.reset()
+        // first request invalidates any previous entries and caches new result
+        Put(s"$collectionPath/$name", content) ~> Route.seal(routes(creds)(transid())) ~> check {
+          status should be(OK)
+          val response = responseAs[WhiskAction]
+          response should be(
+            WhiskAction(
+              action.namespace,
+              action.name,
+              action.exec,
+              action.parameters,
+              action.limits,
+              action.version,
+              action.publish,
+              action.annotations ++ Parameters(WhiskAction.execFieldName, kind)))
+        }
+        stream.toString should include(s"caching ${CacheKey(action)}")
+        stream.toString should not include (s"invalidating ${CacheKey(action)} on delete")
+        stream.reset()
 
-    // delete should invalidate cache
-    Delete(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
-      status should be(OK)
-      val response = responseAs[WhiskAction]
-      response should be(
-        WhiskAction(
-          action.namespace,
-          action.name,
-          action.exec,
-          action.parameters,
-          action.limits,
-          action.version,
-          action.publish,
-          action.annotations ++ Parameters(WhiskAction.execFieldName, JAVA_DEFAULT)))
+        // second request should fetch from cache
+        Get(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
+          status should be(OK)
+          val response = responseAs[WhiskAction]
+          response should be(
+            WhiskAction(
+              action.namespace,
+              action.name,
+              action.exec,
+              action.parameters,
+              action.limits,
+              action.version,
+              action.publish,
+              action.annotations ++ Parameters(WhiskAction.execFieldName, kind)))
+        }
+        stream.toString should include(s"serving from cache: ${CacheKey(action)}")
+        stream.reset()
+
+        // delete should invalidate cache
+        Delete(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
+          status should be(OK)
+          val response = responseAs[WhiskAction]
+          response should be(
+            WhiskAction(
+              action.namespace,
+              action.name,
+              action.exec,
+              action.parameters,
+              action.limits,
+              action.version,
+              action.publish,
+              action.annotations ++ Parameters(WhiskAction.execFieldName, kind)))
+        }
+        stream.toString should include(s"invalidating ${CacheKey(action)}")
+        stream.reset()
     }
-    stream.toString should include(s"invalidating ${CacheKey(action)}")
-    stream.reset()
   }
 
   it should "reject put with conflict for pre-existing action" in {

--- a/tests/src/test/scala/whisk/core/database/test/DbUtils.scala
+++ b/tests/src/test/scala/whisk/core/database/test/DbUtils.scala
@@ -29,16 +29,11 @@ import scala.language.postfixOps
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
-
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import whisk.common.TransactionCounter
 import whisk.common.TransactionId
-import whisk.core.database.ArtifactStore
-import whisk.core.database.CouchDbRestClient
-import whisk.core.database.DocumentFactory
-import whisk.core.database.NoDocumentException
-import whisk.core.database.StaleParameter
+import whisk.core.database._
 import whisk.core.entity._
 import whisk.core.entity.types.AuthStore
 import whisk.core.entity.types.EntityStore
@@ -180,10 +175,12 @@ trait DbUtils extends TransactionCounter {
   /**
    * Gets document by id from datastore, and add it to gc queue to delete after the test completes.
    */
-  def get[A, Au >: A](db: ArtifactStore[Au], docid: DocId, factory: DocumentFactory[A], garbageCollect: Boolean = true)(
-    implicit transid: TransactionId,
-    timeout: Duration = 10 seconds,
-    ma: Manifest[A]): A = {
+  def get[A <: DocumentRevisionProvider, Au >: A](db: ArtifactStore[Au],
+                                                  docid: DocId,
+                                                  factory: DocumentFactory[A],
+                                                  garbageCollect: Boolean = true)(implicit transid: TransactionId,
+                                                                                  timeout: Duration = 10 seconds,
+                                                                                  ma: Manifest[A]): A = {
     val docFuture = factory.get(db, docid)
     val doc = Await.result(docFuture, timeout)
     assert(doc != null)
@@ -215,10 +212,12 @@ trait DbUtils extends TransactionCounter {
   /**
    * Puts a document 'entity' into the datastore, then do a get to retrieve it and confirm the identity.
    */
-  def putGetCheck[A, Au >: A](db: ArtifactStore[Au], entity: A, factory: DocumentFactory[A], gc: Boolean = true)(
-    implicit transid: TransactionId,
-    timeout: Duration = 10 seconds,
-    ma: Manifest[A]): (DocInfo, A) = {
+  def putGetCheck[A <: DocumentRevisionProvider, Au >: A](db: ArtifactStore[Au],
+                                                          entity: A,
+                                                          factory: DocumentFactory[A],
+                                                          gc: Boolean = true)(implicit transid: TransactionId,
+                                                                              timeout: Duration = 10 seconds,
+                                                                              ma: Manifest[A]): (DocInfo, A) = {
     val doc = put(db, entity, gc)
     assert(doc != null && doc.id.asString != null && doc.rev.asString != null)
     val future = factory.get(db, doc.id, doc.rev)

--- a/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
@@ -27,6 +27,9 @@ import whisk.core.entity._
 import whisk.core.entity.ArgNormalizer.trim
 import whisk.core.entity.ExecManifest._
 
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+
 trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
   self: Suite =>
 
@@ -38,6 +41,9 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
   protected val SWIFT = "swift"
   protected val SWIFT3 = "swift:3.1.1"
   protected val SWIFT3_IMAGE = "action-swift-v3.1.1"
+  protected val JAVA_DEFAULT = "java"
+
+  private def attFmt[T: JsonFormat] = Attachments.serdes[T]
 
   protected def imagename(name: String) = {
     var image = s"${name}action".replace(":", "")
@@ -69,6 +75,13 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
 
   protected def jsDefaultMetaData(code: String, main: Option[String] = None) = {
     js6MetaData(code, main)
+  }
+
+  protected def javaDefault(code: String, main: Option[String] = None) = {
+    val attachment = attFmt[String].read(code.trim.toJson)
+    val manifest = ExecManifest.runtimesManifest.resolveDefaultRuntime(JAVA_DEFAULT).get
+
+    CodeExecAsAttachment(manifest, attachment, main.map(_.trim))
   }
 
   protected def swift(code: String, main: Option[String] = None) = {


### PR DESCRIPTION
Currently when an entity that has an attachment is created or updated, the corresponding entity is not cached. This change caches the created entity.

For instance, creating or updating a java action will create a database entry of the entity and the entity will be cached. Immediately after the jar file is added as an attachment in the DB and the previously cached entity is removed from the cache. That means quickly making a call after action creation, such as action get would have to fetch the entire entity from the DB instead of the local cache.

Instead these  changes will not remove the cached entity when a DB attachment is added to the entity.