### PR TITLE
Add check to controller and invoker that required databases exist

### DIFF
--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -16,6 +16,15 @@
     mode: 0777
   become: "{{ logs.dir.become }}"
 
+- name: check, that required databases exist
+  include: "{{ openwhisk_home }}/ansible/tasks/db/checkDb.yml"
+  vars:
+    dbName: "{{ item }}"
+  with_items:
+  - "{{ db.whisk.actions }}"
+  - "{{ db.whisk.auth }}"
+  - "{{ db.whisk.activations }}"
+
 - name: create seed nodes list
   set_fact:
     seed_nodes_list: "{{ seed_nodes_list | default([]) }} + [ \"{{item.1}}:{{controller.akka.cluster.basePort+item.0}}\" ]"

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -53,6 +53,14 @@
     mode: 0777
   become: "{{ logs.dir.become }}"
 
+- name: check, that required databases exist
+  include: "{{ openwhisk_home }}/ansible/tasks/db/checkDb.yml"
+  vars:
+    dbName: "{{ item }}"
+  with_items:
+  - "{{ db.whisk.actions }}"
+  - "{{ db.whisk.activations }}"
+
 - name: define options when deploying invoker on Ubuntu
   set_fact:
     linuxOptions: "-v /usr/lib/x86_64-linux-gnu/libapparmor.so.1:/usr/lib/x86_64-linux-gnu/libapparmor.so.1"

--- a/ansible/tasks/db/checkDb.yml
+++ b/ansible/tasks/db/checkDb.yml
@@ -1,0 +1,12 @@
+---
+# Checks, that the Database exists
+# dbName - name of the database to check
+
+- name: check if {{ dbName }} with {{ db_provider }} exists
+  uri:
+    url: "{{ db_protocol }}://{{ db_host }}:{{ db_port }}/{{ dbName }}"
+    method: HEAD
+    status_code: 200
+    user: "{{ db_username }}"
+    password: "{{ db_password }}"
+    force_basic_auth: yes


### PR DESCRIPTION
This PR adds a check to the deployment playbooks of the controller and the invoker to check if all reuqired databases exist.
Otherwise the deployment will fail.

PG3#1170 is 🔵 .