### PR TITLE
Remove empty continuation line to avoid error

### DIFF
--- a/sdk/docker/Dockerfile
+++ b/sdk/docker/Dockerfile
@@ -10,7 +10,6 @@ RUN apk add --no-cache --virtual .build-deps \
         bzip2-dev \
         gcc \
         libc-dev \
-### Compile source file(s)
  && cd /action; gcc -o exec example.c \
  && apk del .build-deps
 


### PR DESCRIPTION
Otherwise you get the following error when building the docker image:

```
[WARNING]: Empty continuation line found in:
    RUN apk add --no-cache --virtual .build-deps         bzip2-dev         gcc         lib
c-dev  && cd /action; gcc -o exec example.c  && apk del .build-deps
[WARNING]: Empty continuation lines will become errors in a future release.
```