### PR TITLE
Treat action code as attachments for created/updated actions

### DIFF
--- a/ansible/files/runtimes.json
+++ b/ansible/files/runtimes.json
@@ -6,7 +6,11 @@
                 "image": {
                     "name": "nodejsaction"
                 },
-                "deprecated": true
+                "deprecated": true,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
             },
             {
                 "kind": "nodejs:6",
@@ -14,7 +18,11 @@
                 "image": {
                     "name": "nodejs6action"
                 },
-                "deprecated": false
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
             },
             {
                 "kind": "nodejs:8",
@@ -22,7 +30,11 @@
                 "image": {
                     "name": "action-nodejs-v8"
                 },
-                "deprecated": false
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
             }
         ],
         "python": [
@@ -31,7 +43,11 @@
                 "image": {
                     "name": "python2action"
                 },
-                "deprecated": false
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
             },
             {
                 "kind": "python:2",
@@ -39,14 +55,22 @@
                 "image": {
                     "name": "python2action"
                 },
-                "deprecated": false
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
             },
             {
                 "kind": "python:3",
                 "image": {
                     "name": "python3action"
                 },
-                "deprecated": false
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
             }
         ],
         "swift": [
@@ -55,21 +79,33 @@
                 "image": {
                     "name": "swiftaction"
                 },
-                "deprecated": true
+                "deprecated": true,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
             },
             {
                 "kind": "swift:3",
                 "image": {
                     "name": "swift3action"
                 },
-                "deprecated": true
+                "deprecated": true,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
             },
             {
                 "kind": "swift:3.1.1",
                 "image": {
                     "name": "action-swift-v3.1.1"
                 },
-                "deprecated": false
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
             },
             {
                 "kind": "swift:4.1",
@@ -77,7 +113,11 @@
                 "image": {
                     "name": "action-swift-v4.1"
                 },
-                "deprecated": false
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
             }
         ],
         "java": [
@@ -89,8 +129,8 @@
                 },
                 "deprecated": false,
                 "attached": {
-                    "attachmentName": "jarfile",
-                    "attachmentType": "application/java-archive"
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
                 },
                 "sentinelledLogs": false,
                 "requireMain": true
@@ -101,6 +141,10 @@
                 "kind": "php:7.1",
                 "default": true,
                 "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                },
                 "image": {
                     "name": "action-php-v7.1"
                 }

--- a/common/scala/src/main/scala/whisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Exec.scala
@@ -30,6 +30,8 @@ import whisk.core.entity.size.SizeInt
 import whisk.core.entity.size.SizeOptionString
 import whisk.core.entity.size.SizeString
 
+import java.util.Base64
+
 /**
  * Exec encodes the executable details of an action. For black
  * box container, an image name is required. For Javascript and Python
@@ -140,19 +142,24 @@ protected[core] case class CodeExecMetaDataAsString(manifest: RuntimeManifest,
 
 protected[core] case class CodeExecAsAttachment(manifest: RuntimeManifest,
                                                 override val code: Attachment[String],
-                                                override val entryPoint: Option[String])
+                                                override val entryPoint: Option[String],
+                                                override val binary: Boolean = false)
     extends CodeExec[Attachment[String]] {
   override val kind = manifest.kind
   override val image = manifest.image
   override val sentinelledLogs = manifest.sentinelledLogs.getOrElse(true)
   override val deprecated = manifest.deprecated.getOrElse(false)
   override val pull = false
-  override lazy val binary = true
   override def codeAsJson = code.toJson
 
   def inline(bytes: Array[Byte]): CodeExecAsAttachment = {
-    val encoded = new String(bytes, StandardCharsets.UTF_8)
-    copy(code = Inline(encoded))
+    val code = new String(bytes, StandardCharsets.UTF_8)
+
+    if (kind == "java" && !Exec.isBinaryCode(code)) {
+      val encoded = Base64.getEncoder.encodeToString(bytes)
+      copy(code = Inline(encoded))
+    } else
+      copy(code = Inline(code))
   }
 
   def attach: CodeExecAsAttachment = {
@@ -304,21 +311,29 @@ protected[core] object Exec extends ArgNormalizer[Exec] with DefaultJsonProtocol
 
           manifest.attached
             .map { a =>
-              val jar: Attachment[String] = {
-                // java actions once stored the attachment in "jar" instead of "code"
-                obj.fields.get("code").orElse(obj.fields.get("jar"))
+              val code = obj.fields.get("code")
+              val binary: Boolean = code match {
+                case Some(JsString(c)) => isBinaryCode(c)
+                case _ =>
+                  obj.fields.get("binary") match {
+                    case Some(JsBoolean(b)) => b
+                    case _                  => false
+                  }
+              }
+              val attachment: Attachment[String] = {
+                code
               } map {
                 attFmt[String].read(_)
               } getOrElse {
-                throw new DeserializationException(
-                  s"'code' must be a valid base64 string in 'exec' for '$kind' actions")
+                throw new DeserializationException(s"'code' must be a string defined in 'exec' for '$kind' actions")
               }
               val main = optMainField.orElse {
                 if (manifest.requireMain.exists(identity)) {
                   throw new DeserializationException(s"'main' must be a string defined in 'exec' for '$kind' actions")
                 } else None
               }
-              CodeExecAsAttachment(manifest, jar, main)
+
+              CodeExecAsAttachment(manifest, attachment, main, binary)
             }
             .getOrElse {
               val code: String = obj.fields.get("code") match {

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -332,7 +332,7 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
           val newDoc = doc.copy(exec = exec.attach)
           newDoc.revision(doc.rev)
 
-          val stream = new ByteArrayInputStream(code.getBytes)
+          val stream = new ByteArrayInputStream(code.getBytes("UTF-8"))
           val manifest = exec.manifest.attached.get
 
           for (i1 <- super.put(db, newDoc);

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -19,7 +19,6 @@ package whisk.core.entity
 
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
-import java.util.Base64
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -326,14 +325,14 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
       require(doc != null, "doc undefined")
     } map { _ =>
       doc.exec match {
-        case exec @ CodeExecAsAttachment(_, Inline(code), _) =>
+        case exec @ CodeExecAsAttachment(_, Inline(code), _, _) =>
           implicit val logger = db.logging
           implicit val ec = db.executionContext
 
           val newDoc = doc.copy(exec = exec.attach)
           newDoc.revision(doc.rev)
 
-          val stream = new ByteArrayInputStream(Base64.getDecoder().decode(code))
+          val stream = new ByteArrayInputStream(code.getBytes)
           val manifest = exec.manifest.attached.get
 
           for (i1 <- super.put(db, newDoc);
@@ -362,12 +361,10 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
 
     fa.flatMap { action =>
       action.exec match {
-        case exec @ CodeExecAsAttachment(_, Attached(attachmentName, _), _) =>
+        case exec @ CodeExecAsAttachment(_, Attached(attachmentName, _), _, _) =>
           val boas = new ByteArrayOutputStream()
-          val b64s = Base64.getEncoder().wrap(boas)
 
-          getAttachment[A](db, action.docinfo, attachmentName, b64s).map { _ =>
-            b64s.close()
+          getAttachment[A](db, action.docinfo, attachmentName, boas).map { _ =>
             val newAction = action.copy(exec = exec.inline(boas.toByteArray))
             newAction.revision(action.rev)
             newAction

--- a/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
@@ -758,8 +758,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         val cacheKey = s"${CacheKey(action)}".replace("(", "\\(").replace(")", "\\)")
         val expectedPutLog = Seq(
           s"caching $cacheKey",
-          s"uploading attachment 'codefile' of document 'id: ${action.namespace}/${action.name}",
-          s"completed uploading attachment 'codefile' of document 'id: ${action.namespace}/${action.name}")
+          s"uploading attachment 'codefile' of document 'id: ${action.namespace}/${action.name}")
           .mkString("(?s).*")
         val expectedGetLog =
           Seq(s"finding attachment 'codefile' of document 'id: ${action.namespace}/${action.name}").mkString("(?s).*")
@@ -830,10 +829,9 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           Some(actionOldSchema.limits.timeout),
           Some(actionOldSchema.limits.memory),
           Some(actionOldSchema.limits.logs))))
-    val expectedPutLog = Seq(
-      s"uploading attachment 'codefile' of document 'id: ${actionOldSchema.namespace}/${actionOldSchema.name}",
-      s"completed uploading attachment 'codefile' of document 'id: ${actionOldSchema.namespace}/${actionOldSchema.name}")
-      .mkString("(?s).*")
+    val expectedPutLog =
+      Seq(s"uploading attachment 'codefile' of document 'id: ${actionOldSchema.namespace}/${actionOldSchema.name}")
+        .mkString("(?s).*")
 
     put(entityStore, actionOldSchema)
 

--- a/tests/src/test/scala/whisk/core/database/test/CacheConcurrencyTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/CacheConcurrencyTests.scala
@@ -127,7 +127,11 @@ class CacheConcurrencyTests extends FlatSpec with WskTestHelpers with BeforeAndA
         para.tasksupport = new ForkJoinTaskSupport(new ForkJoinPool(nThreads))
         para.map { i =>
           if (i != 16) {
-            wsk.action.get(name)
+            val rr = wsk.action.get(name, expectedExitCode = DONTCARE_EXIT)
+            withClue(s"expecting get to either succeed or fail with not found: $rr") {
+              // some will succeed and some should fail with not found
+              rr.exitCode should (be(SUCCESS_EXIT) or be(NOT_FOUND))
+            }
           } else {
             wsk.action.create(name, None, parameters = Map("color" -> JsString("blue")), update = true)
           }

--- a/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
@@ -53,8 +53,15 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
     ExecManifest.ImageName(image, Some("openwhisk"), Some("latest"))
   }
 
-  protected def js(code: String, main: Option[String] = None) = {
+  protected def jsOld(code: String, main: Option[String] = None) = {
     CodeExecAsString(RuntimeManifest(NODEJS, imagename(NODEJS), deprecated = Some(true)), trim(code), main.map(_.trim))
+  }
+
+  protected def js(code: String, main: Option[String] = None) = {
+    val attachment = attFmt[String].read(code.trim.toJson)
+    val manifest = ExecManifest.runtimesManifest.resolveDefaultRuntime(NODEJS).get
+
+    CodeExecAsAttachment(manifest, attachment, main.map(_.trim), Exec.isBinaryCode(code))
   }
 
   protected def js6Old(code: String, main: Option[String] = None) = {
@@ -74,11 +81,17 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
     js6(code, main)
   }
 
-  protected def js6MetaData(main: Option[String] = None, binary: Boolean) = {
+  protected def js6MetaDataOld(main: Option[String] = None, binary: Boolean) = {
     CodeExecMetaDataAsString(
       RuntimeManifest(NODEJS6, imagename(NODEJS6), default = Some(true), deprecated = Some(false)),
       binary,
       main.map(_.trim))
+  }
+
+  protected def js6MetaData(main: Option[String] = None, binary: Boolean) = {
+    val manifest = ExecManifest.runtimesManifest.resolveDefaultRuntime(NODEJS6).get
+
+    CodeExecMetaDataAsAttachment(manifest, binary, main.map(_.trim))
   }
 
   protected def javaDefault(code: String, main: Option[String] = None) = {
@@ -94,8 +107,15 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
     CodeExecMetaDataAsAttachment(manifest, binary, main.map(_.trim))
   }
 
-  protected def swift(code: String, main: Option[String] = None) = {
+  protected def swiftOld(code: String, main: Option[String] = None) = {
     CodeExecAsString(RuntimeManifest(SWIFT, imagename(SWIFT), deprecated = Some(true)), trim(code), main.map(_.trim))
+  }
+
+  protected def swift(code: String, main: Option[String] = None) = {
+    val attachment = attFmt[String].read(code.trim.toJson)
+    val manifest = ExecManifest.runtimesManifest.resolveDefaultRuntime(SWIFT).get
+
+    CodeExecAsAttachment(manifest, attachment, main.map(_.trim), Exec.isBinaryCode(code))
   }
 
   protected def swift3(code: String, main: Option[String] = None) = {

--- a/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
@@ -57,11 +57,17 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
     CodeExecAsString(RuntimeManifest(NODEJS, imagename(NODEJS), deprecated = Some(true)), trim(code), main.map(_.trim))
   }
 
-  protected def js6(code: String, main: Option[String] = None) = {
+  protected def js6Old(code: String, main: Option[String] = None) = {
     CodeExecAsString(
       RuntimeManifest(NODEJS6, imagename(NODEJS6), default = Some(true), deprecated = Some(false)),
       trim(code),
       main.map(_.trim))
+  }
+  protected def js6(code: String, main: Option[String] = None) = {
+    val attachment = attFmt[String].read(code.trim.toJson)
+    val manifest = ExecManifest.runtimesManifest.resolveDefaultRuntime(NODEJS6).get
+
+    CodeExecAsAttachment(manifest, attachment, main.map(_.trim), Exec.isBinaryCode(code))
   }
 
   protected def jsDefault(code: String, main: Option[String] = None) = {
@@ -79,7 +85,7 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
     val attachment = attFmt[String].read(code.trim.toJson)
     val manifest = ExecManifest.runtimesManifest.resolveDefaultRuntime(JAVA_DEFAULT).get
 
-    CodeExecAsAttachment(manifest, attachment, main.map(_.trim))
+    CodeExecAsAttachment(manifest, attachment, main.map(_.trim), Exec.isBinaryCode(code))
   }
 
   protected def javaMetaData(main: Option[String] = None, binary: Boolean) = {
@@ -93,11 +99,10 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
   }
 
   protected def swift3(code: String, main: Option[String] = None) = {
-    val default = ExecManifest.runtimesManifest.resolveDefaultRuntime(SWIFT3).flatMap(_.default)
-    CodeExecAsString(
-      RuntimeManifest(SWIFT3, imagename(SWIFT3), default = default, deprecated = Some(false)),
-      trim(code),
-      main.map(_.trim))
+    val attachment = attFmt[String].read(code.trim.toJson)
+    val manifest = ExecManifest.runtimesManifest.resolveDefaultRuntime(SWIFT3).get
+
+    CodeExecAsAttachment(manifest, attachment, main.map(_.trim), Exec.isBinaryCode(code))
   }
 
   protected def sequence(components: Vector[FullyQualifiedEntityName]) = SequenceExec(components)


### PR DESCRIPTION
Save action code as attachments in the database for new or updated actions.

Depends on https://github.com/apache/incubator-openwhisk/pull/2832 to get `whisk.core.controller.test.ActionsApiTests > Actions API should put and then get action from cache` test to pass.

I combined these changes with https://github.com/apache/incubator-openwhisk/pull/2730 and performed profiling on the controller.

Here is a graph of the heap monitoring when invoking a 34MB zipped action:

<img width="582" alt="screen shot 2017-10-10 at 11 59 37 am" src="https://user-images.githubusercontent.com/11520887/31397126-2965c282-adb3-11e7-85e6-6cd260e734fd.png">

Previously invoking a 34MB non-cached action would result in a spike in heap usage when only using changes in https://github.com/apache/incubator-openwhisk/pull/2730:

<img width="509" alt="30878095-c7623960-a2c9-11e7-9cc0-f17af3120f67" src="https://user-images.githubusercontent.com/11520887/31397236-7b8bce76-adb3-11e7-8366-b43084cde8f8.png">