### PR TITLE
fix genssl.sh usage output

### DIFF
--- a/ansible/roles/nginx/files/genssl.sh
+++ b/ansible/roles/nginx/files/genssl.sh
@@ -4,8 +4,9 @@ set -e
 
 SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
 
-if [ "$#" -ne 1 ]; then
-    echo "usage: $0 [common name: host or ip]"
+if [ "$#" -lt 2 ]; then
+    echo "usage: $0 <common name: host or ip> [server|client]"
+    exit
 fi
 CN=$1
 TYPE=$2


### PR DESCRIPTION
`genssl.sh` shows the usage even if the right number of arguments are given. Over in [devtools/docker-compose](https://github.com/apache/incubator-openwhisk-devtools/tree/master/docker-compose) that gives a usage warning from the Makefile, even though everything is fine.

- 1 argument is required, exit otherwise – without CN does not make sense AFAICS, and it seems always called with at least 1 arg
- document optional 2nd argument
