### PR TITLE
invoker: use locally available image if docker pull fails

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClient.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClient.scala
@@ -103,12 +103,9 @@ class DockerClient(dockerHost: Option[String] = None)(executionContext: Executio
     })
 
   def imagePresent(image: String)(implicit transid: TransactionId): Future[String] = {
+    // --format only added to keep the output minimal
     val cmd = dockerCmd ++ Seq("inspect", "--format={{.Config.Image}}", image)
-    executeProcess(cmd: _*)/*.andThen {
-      case Success(_) => Future.successful(_)
-      case Failure(t) => Future.failed(_)
-    }*/
-    //runCmd("inspect", "--format={{.Config.Image}}", image).map(_ => ())
+    executeProcess(cmd: _*)
   }
 
   def isOomKilled(id: ContainerId)(implicit transid: TransactionId): Future[Boolean] =

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
@@ -89,7 +89,11 @@ object DockerContainer {
       params
     val pulled = if (userProvidedImage) {
       docker.pull(image).recoverWith {
-        case _ => Future.failed(BlackboxStartupError(s"Failed to pull container image '${image}'."))
+        case _ =>
+          // check if image exists locally and reuse that one
+          docker.imagePresent(image).recoverWith {
+            case _ => Future.failed(BlackboxStartupError(s"Failed to pull container image '${image}'."))
+          }
       }
     } else Future.successful(())
 

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
@@ -682,7 +682,7 @@ class DockerContainerTests
     }
 
     def imagePresent(image: String)(implicit transid: TransactionId): Future[String] = {
-      Future.successful("")
+      Future.failed(new Exception())
     }
 
     override def isOomKilled(id: ContainerId)(implicit transid: TransactionId): Future[Boolean] = ???

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
@@ -681,6 +681,10 @@ class DockerContainerTests
       Future.successful(())
     }
 
+    def imagePresent(image: String)(implicit transid: TransactionId): Future[String] = {
+      Future.successful("")
+    }
+
     override def isOomKilled(id: ContainerId)(implicit transid: TransactionId): Future[Boolean] = ???
 
     def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {


### PR DESCRIPTION
I have a local OW setup using devtools docker-compose and provide my own container via `--docker`. Currently, the invoker will always do `docker pull`, and if that fails to resolve, will fail the invocation, even if the image is available locally.

This patch will still do a `docker pull` first, to try and get the latest image, but if that fails, will check if the image is present by calling `docker inspect <image>` and check for the exit code (non-zero if image is not found). If it's not present, it will fail as before, but if present, it will continue with `docker run` (new behavior).

Beware, I am not very familiar with Scala. I feel this can probably be done better. It was just a quick proof of concept.