### PR TITLE
Improve garbage collector out-out-memory handling and debugging

### DIFF
--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -31,7 +31,7 @@
     restart_policy: "{{ docker.restart.policy }}"
     hostname: "controller{{ groups['controllers'].index(inventory_hostname) }}"
     env:
-      "JAVA_OPTS": "-Xmx{{ controller.heap }}"
+      "JAVA_OPTS": "-Xmx{{ controller.heap }} -XX:+CrashOnOutOfMemoryError -XX:+UseGCOverheadLimit -XX:ErrorFile=/logs/java_error.log"
       "CONTROLLER_OPTS": "{{ controller.arguments }}"
       "CONTROLLER_INSTANCES": "{{ controller.instances }}"
 

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -105,7 +105,7 @@
         --name invoker{{ groups['invokers'].index(inventory_hostname) }}
         --hostname invoker{{ groups['invokers'].index(inventory_hostname) }}
         --restart {{ docker.restart.policy }}
-        -e JAVA_OPTS='-Xmx{{ invoker.heap }}'
+        -e JAVA_OPTS='-Xmx{{ invoker.heap }} -XX:+CrashOnOutOfMemoryError -XX:+UseGCOverheadLimit -XX:ErrorFile=/logs/java_error.log'
         -e INVOKER_OPTS='{{ invoker.arguments }}'
         -e COMPONENT_NAME='invoker{{ groups['invokers'].index(inventory_hostname) }}'
         -e PORT='8080'

--- a/core/controller/build.gradle
+++ b/core/controller/build.gradle
@@ -21,4 +21,4 @@ tasks.withType(ScalaCompile) {
 }
 
 mainClassName = "whisk.core.controller.Controller"
-applicationDefaultJvmArgs = ["-XX:+CrashOnOutOfMemoryError", "-Djava.security.egd=file:/dev/./urandom"]
+applicationDefaultJvmArgs = ["-Djava.security.egd=file:/dev/./urandom"]

--- a/core/invoker/build.gradle
+++ b/core/invoker/build.gradle
@@ -20,4 +20,3 @@ tasks.withType(ScalaCompile) {
 }
 
 mainClassName = "whisk.core.invoker.Invoker"
-applicationDefaultJvmArgs = ["-XX:+CrashOnOutOfMemoryError"]


### PR DESCRIPTION
The new options ensure that the controller / invoker JVM crashes if the garbage collector is no more able to free up space. The resulting error log is written into the `/logs` directory which is visible on the system hosting the controller / invoker Docker container. The name of the error log file is fixed such that only one single file is kept even if multiple crashes occur.

Consolidated all options in `deploy.yml` because `-XX:ErrorFile` refers to the `/logs` directory mounted into the container. If this directory is changed, `-XX:ErrorFile` must be updated as well.

`-XX:+UseGCOverheadLimit`
Enables the use of a policy that limits the proportion of time spent by the JVM on GC before an OutOfMemoryError exception is thrown. This option is enabled, by default and the parallel GC will throw an OutOfMemoryError if more than 98% of the total time is spent on garbage collection and less than 2% of the heap is recovered. When the heap is small, this feature can be used to prevent applications from running for long periods of time with little or no progress. To disable this option, specify -XX:-UseGCOverheadLimit.

`-XX:+CrashOnOutOfMemoryError`
If this option is enabled, when an out-of-memory error occurs, the JVM crashes and produces text and binary crash files (if core files are enabled).

`-XX:ErrorFile=filename`
Specifies the path and file name to which error data is written when an irrecoverable error occurs. By default, this file is created in the current working directory and named hs_err_pidpid.log where pid is the identifier of the process that caused the error. The following example shows how to set the default log file (note that the identifier of the process is specified as %p):

-XX:ErrorFile=./hs_err_pid%p.log
The following example shows how to set the error log to /var/log/java/java_error.log:

-XX:ErrorFile=/var/log/java/java_error.log
If the file cannot be created in the specified directory (due to insufficient space, permission problem, or another issue), then the file is created in the temporary directory for the operating system. The temporary directory is /tmp.