### PR TITLE
Cache database attachments

### DIFF
--- a/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
+++ b/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
@@ -120,12 +120,14 @@ trait DocumentFactory[W <: DocumentRevisionProvider] extends MultipleReadersSing
     }
   }
 
-  def attach[Wsuper >: W](
-    db: ArtifactStore[Wsuper],
-    doc: W,
-    attachmentName: String,
-    contentType: ContentType,
-    bytes: InputStream)(implicit transid: TransactionId, notifier: Option[CacheChangeNotification]): Future[DocInfo] = {
+  def attach[Wsuper >: W](db: ArtifactStore[Wsuper],
+                          doc: W,
+                          attachmentName: String,
+                          contentType: ContentType,
+                          bytes: InputStream,
+                          postProcess: Option[W => W] = None)(
+    implicit transid: TransactionId,
+    notifier: Option[CacheChangeNotification]): Future[DocInfo] = {
 
     Try {
       require(db != null, "db undefined")
@@ -137,10 +139,11 @@ trait DocumentFactory[W <: DocumentRevisionProvider] extends MultipleReadersSing
       val key = CacheKey(doc)
       val docInfo = doc.docinfo
       val src = StreamConverters.fromInputStream(() => bytes)
+      val cacheDoc = postProcess map { _(doc) } getOrElse doc
 
-      cacheUpdate(doc, key, db.attach(docInfo, attachmentName, contentType, src) map { newDocInfo =>
-        doc.revision[W](newDocInfo.rev)
-        doc.docinfo
+      cacheUpdate(cacheDoc, key, db.attach(docInfo, attachmentName, contentType, src) map { newDocInfo =>
+        cacheDoc.revision[W](newDocInfo.rev)
+        cacheDoc.docinfo
       })
     } match {
       case Success(f) => f
@@ -202,26 +205,37 @@ trait DocumentFactory[W <: DocumentRevisionProvider] extends MultipleReadersSing
     }
   }
 
-  def getAttachment[Wsuper >: W](db: ArtifactStore[Wsuper],
-                                 doc: DocInfo,
-                                 attachmentName: String,
-                                 outputStream: OutputStream)(implicit transid: TransactionId): Future[Unit] = {
+  def getAttachment[Wsuper >: W](
+    db: ArtifactStore[Wsuper],
+    doc: W,
+    attachmentName: String,
+    outputStream: OutputStream,
+    postProcess: Option[W => W] = None)(implicit transid: TransactionId, mw: Manifest[W]): Future[W] = {
 
     implicit val ec = db.executionContext
+    implicit val notifier: Option[CacheChangeNotification] = None
 
     Try {
       require(db != null, "db defined")
       require(doc != null, "doc undefined")
     } map { _ =>
+      implicit val logger = db.logging
+      implicit val ec = db.executionContext
+
+      val key = CacheKey(doc)
+      val docInfo = doc.docinfo
       val sink = StreamConverters.fromOutputStream(() => outputStream)
-      db.readAttachment[IOResult](doc, attachmentName, sink).map {
-        case (_, r) =>
-          if (!r.wasSuccessful) {
-            // FIXME...
-            // Figure out whether OutputStreams are even a decent model.
+
+      db.readAttachment[IOResult](docInfo, attachmentName, sink).map {
+        case _ =>
+          val cacheDoc = postProcess map { _(doc) } getOrElse doc
+
+          cacheUpdate(cacheDoc, key, Future.successful(docInfo)) map { newDocInfo =>
+            cacheDoc.revision[W](newDocInfo.rev)
           }
-          ()
+          cacheDoc
       }
+
     } match {
       case Success(f) => f
       case Failure(t) => Future.failed(t)

--- a/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
+++ b/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
@@ -222,8 +222,8 @@ trait DocumentFactory[W <: DocumentRevisionProvider] extends MultipleReadersSing
       implicit val logger = db.logging
       implicit val ec = db.executionContext
 
-      val key = CacheKey(doc)
       val docInfo = doc.docinfo
+      val key = CacheKey(docInfo)
       val sink = StreamConverters.fromOutputStream(() => outputStream)
 
       db.readAttachment[IOResult](docInfo, attachmentName, sink).map {

--- a/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
@@ -758,7 +758,6 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     val expectedPutLog = Seq(
       s"caching $cacheKey",
       s"uploading attachment 'jarfile' of document 'id: ${action.namespace}/${action.name}",
-      s"completed uploading attachment 'jarfile' of document 'id: ${action.namespace}/${action.name}",
       s"caching $cacheKey").mkString("(?s).*")
     val notExpectedGetLog = Seq(
       s"finding document: 'id: ${action.namespace}/${action.name}",
@@ -888,7 +887,6 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     val expectedPutLog = Seq(
       s"caching $cacheKey",
       s"uploading attachment 'jarfile' of document 'id: ${action.namespace}/${action.name}",
-      s"completed uploading attachment 'jarfile' of document 'id: ${action.namespace}/${action.name}",
       s"caching $cacheKey").mkString("(?s).*")
 
     action.exec match {

--- a/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
@@ -40,6 +40,10 @@ import whisk.core.entitlement.Collection
 import whisk.http.ErrorResponse
 import whisk.http.Messages
 
+import java.io.ByteArrayInputStream
+import java.util.Base64
+import akka.stream.scaladsl._
+
 /**
  * Tests Actions API.
  *
@@ -740,6 +744,203 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         stream.toString should include(s"invalidating ${CacheKey(action)}")
         stream.reset()
     }
+  }
+
+  it should "put and then get an action with attachment from cache" in {
+    val action =
+      WhiskAction(namespace, aname(), javaDefault("ZHViZWU=", Some("hello")), annotations = Parameters("exec", "java"))
+    val content = WhiskActionPut(
+      Some(action.exec),
+      Some(action.parameters),
+      Some(ActionLimitsOption(Some(action.limits.timeout), Some(action.limits.memory), Some(action.limits.logs))))
+    val name = action.name
+    val cacheKey = s"${CacheKey(action)}".replace("(", "\\(").replace(")", "\\)")
+    val expectedPutLog = Seq(
+      s"caching $cacheKey",
+      s"uploading attachment 'jarfile' of document 'id: ${action.namespace}/${action.name}",
+      s"completed uploading attachment 'jarfile' of document 'id: ${action.namespace}/${action.name}",
+      s"caching $cacheKey").mkString("(?s).*")
+    val notExpectedGetLog = Seq(
+      s"finding document: 'id: ${action.namespace}/${action.name}",
+      s"finding attachment 'jarfile' of document 'id: ${action.namespace}/${action.name}").mkString("(?s).*")
+
+    // first request invalidates any previous entries and caches new result
+    Put(s"$collectionPath/$name", content) ~> Route.seal(routes(creds)(transid())) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response should be(
+        WhiskAction(
+          action.namespace,
+          action.name,
+          action.exec,
+          action.parameters,
+          action.limits,
+          action.version,
+          action.publish,
+          action.annotations ++ Parameters(WhiskAction.execFieldName, JAVA_DEFAULT)))
+    }
+
+    stream.toString should not include (s"invalidating ${CacheKey(action)} on delete")
+    stream.toString should include regex (expectedPutLog)
+    stream.reset()
+
+    // second request should fetch from cache
+    Get(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response should be(
+        WhiskAction(
+          action.namespace,
+          action.name,
+          action.exec,
+          action.parameters,
+          action.limits,
+          action.version,
+          action.publish,
+          action.annotations ++ Parameters(WhiskAction.execFieldName, JAVA_DEFAULT)))
+    }
+
+    stream.toString should include(s"serving from cache: ${CacheKey(action)}")
+    stream.toString should not include regex(notExpectedGetLog)
+    stream.reset()
+
+    // delete should invalidate cache
+    Delete(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response should be(
+        WhiskAction(
+          action.namespace,
+          action.name,
+          action.exec,
+          action.parameters,
+          action.limits,
+          action.version,
+          action.publish,
+          action.annotations ++ Parameters(WhiskAction.execFieldName, JAVA_DEFAULT)))
+    }
+    stream.toString should include(s"invalidating ${CacheKey(action)}")
+    stream.reset()
+  }
+
+  it should "get an action with attachment that is not cached" in {
+    implicit val tid = transid()
+    val code = "ZHViZWU="
+    val action =
+      WhiskAction(namespace, aname(), javaDefault(code, Some("hello")), annotations = Parameters("exec", "java"))
+    val content = WhiskActionPut(
+      Some(action.exec),
+      Some(action.parameters),
+      Some(ActionLimitsOption(Some(action.limits.timeout), Some(action.limits.memory), Some(action.limits.logs))))
+    val name = action.name
+    val cacheKey = s"${CacheKey(action)}".replace("(", "\\(").replace(")", "\\)")
+    val expectedGetLog = Seq(
+      s"finding document: 'id: ${action.namespace}/${action.name}",
+      s"finding attachment 'jarfile' of document 'id: ${action.namespace}/${action.name}").mkString("(?s).*")
+
+    action.exec match {
+      case exec @ CodeExecAsAttachment(_, _, _) =>
+        val newAction = action.copy(exec = exec.attach)
+        newAction.revision(action.rev)
+
+        val doc1 = put(entityStore, newAction, false)
+
+        val stream = new ByteArrayInputStream(Base64.getDecoder().decode(code))
+        val manifest = exec.manifest.attached.get
+        val src = StreamConverters.fromInputStream(() => stream)
+
+        attach(entityStore, doc1, manifest.attachmentName, manifest.attachmentType, src)
+
+      case _ =>
+    }
+
+    // second request should fetch from cache
+    Get(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response should be(
+        WhiskAction(
+          action.namespace,
+          action.name,
+          action.exec,
+          action.parameters,
+          action.limits,
+          action.version,
+          action.publish,
+          action.annotations ++ Parameters(WhiskAction.execFieldName, JAVA_DEFAULT)))
+    }
+
+    stream.toString should include regex (expectedGetLog)
+    stream.reset()
+  }
+
+  it should "update an existing action with attachment that is not cached" in {
+    implicit val tid = transid()
+    val code = "ZHViZWU="
+    val action =
+      WhiskAction(namespace, aname(), javaDefault(code, Some("hello")), annotations = Parameters("exec", "java"))
+    val content = WhiskActionPut(
+      Some(action.exec),
+      Some(action.parameters),
+      Some(ActionLimitsOption(Some(action.limits.timeout), Some(action.limits.memory), Some(action.limits.logs))))
+    val name = action.name
+    val cacheKey = s"${CacheKey(action)}".replace("(", "\\(").replace(")", "\\)")
+    val expectedPutLog = Seq(
+      s"caching $cacheKey",
+      s"uploading attachment 'jarfile' of document 'id: ${action.namespace}/${action.name}",
+      s"completed uploading attachment 'jarfile' of document 'id: ${action.namespace}/${action.name}",
+      s"caching $cacheKey").mkString("(?s).*")
+
+    action.exec match {
+      case exec @ CodeExecAsAttachment(_, _, _) =>
+        val newAction = action.copy(exec = exec.attach)
+        newAction.revision(action.rev)
+
+        val doc = put(entityStore, newAction)
+
+        val stream = new ByteArrayInputStream(Base64.getDecoder().decode(code))
+        val manifest = exec.manifest.attached.get
+        val src = StreamConverters.fromInputStream(() => stream)
+
+        attach(entityStore, doc, manifest.attachmentName, manifest.attachmentType, src)
+
+      case _ =>
+    }
+
+    Put(s"$collectionPath/$name?overwrite=true", content) ~> Route.seal(routes(creds)(transid())) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response should be(
+        WhiskAction(
+          action.namespace,
+          action.name,
+          action.exec,
+          action.parameters,
+          action.limits,
+          action.version.upPatch,
+          action.publish,
+          action.annotations ++ Parameters(WhiskAction.execFieldName, JAVA_DEFAULT)))
+    }
+    stream.toString should include regex (expectedPutLog)
+    stream.reset()
+
+    // delete should invalidate cache
+    Delete(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response should be(
+        WhiskAction(
+          action.namespace,
+          action.name,
+          action.exec,
+          action.parameters,
+          action.limits,
+          action.version.upPatch,
+          action.publish,
+          action.annotations ++ Parameters(WhiskAction.execFieldName, JAVA_DEFAULT)))
+    }
+    stream.toString should include(s"invalidating ${CacheKey(action)}")
+    stream.reset()
   }
 
   it should "reject put with conflict for pre-existing action" in {

--- a/tests/src/test/scala/whisk/core/database/test/DbUtils.scala
+++ b/tests/src/test/scala/whisk/core/database/test/DbUtils.scala
@@ -39,6 +39,10 @@ import whisk.core.entity._
 import whisk.core.entity.types.AuthStore
 import whisk.core.entity.types.EntityStore
 
+import akka.http.scaladsl.model.ContentType
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+
 /**
  * WARNING: the put/get/del operations in this trait operate directly on the datastore,
  * and in the presence of a cache, there will be inconsistencies if one mixes these
@@ -192,6 +196,20 @@ trait DbUtils extends TransactionCounter {
     assert(doc != null)
     if (garbageCollect) docsToDelete += ((db, doc))
     doc
+  }
+
+  def attach[A, Au >: A](
+    db: ArtifactStore[Au],
+    doc: DocInfo,
+    name: String,
+    contentType: ContentType,
+    docStream: Source[ByteString, _],
+    garbageCollect: Boolean = true)(implicit transid: TransactionId, timeout: Duration = 10 seconds): DocInfo = {
+    val docFuture = db.attach(doc, name, contentType, docStream)
+    val newDoc = Await.result(docFuture, timeout)
+    assert(newDoc != null)
+    if (garbageCollect) docsToDelete += ((db, newDoc))
+    newDoc
   }
 
   /**


### PR DESCRIPTION
Caches attachments with corresponding actions when an action is created/updated. The attachment is also cached on a fetch if it is not already cached.

Depends on https://github.com/apache/incubator-openwhisk/pull/2832
  
Closes https://github.com/apache/incubator-openwhisk/issues/2672