### PR TITLE
Make Docker action container cleanup during invoker startup / shutdown more robust

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainerFactory.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainerFactory.scala
@@ -78,8 +78,7 @@ class DockerContainerFactory(config: WhiskConfig, instance: InstanceId, paramete
     try {
       removeAllActionContainers()
     } catch {
-      case e @ (_: TimeoutException | _: InterruptedException) =>
-        logging.error(this, s"Failed to remove action containers: ${e.getMessage}")
+      case e: Exception => logging.error(this, s"Failed to remove action containers: ${e.getMessage}")
     }
   }
 

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainerFactory.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainerFactory.scala
@@ -31,6 +31,7 @@ import whisk.core.entity.ByteSize
 import whisk.core.entity.ExecManifest
 import whisk.core.entity.InstanceId
 import scala.concurrent.duration._
+import java.util.concurrent.TimeoutException
 
 class DockerContainerFactory(config: WhiskConfig, instance: InstanceId, parameters: Map[String, Set[String]])(
   implicit actorSystem: ActorSystem,
@@ -69,27 +70,53 @@ class DockerContainerFactory(config: WhiskConfig, instance: InstanceId, paramete
   }
 
   /** Perform cleanup on init */
-  override def init(): Unit = cleanup()
+  override def init(): Unit = removeAllActionContainers()
 
-  /** Cleans up all running wsk_ containers */
+  /** Perform cleanup on exit - to be registered as shutdown hook */
   override def cleanup(): Unit = {
-    val cleaning = docker.ps(Seq("name" -> s"wsk${instance.toInt}_"))(TransactionId.invokerNanny).flatMap {
-      containers =>
-        val removals = containers.map { id =>
-          (if (config.invokerUseRunc) {
-             runc.resume(id)(TransactionId.invokerNanny)
-           } else {
-             docker.unpause(id)(TransactionId.invokerNanny)
-           })
-            .recoverWith {
-              // Ignore resume failures and try to remove anyway
-              case _ => Future.successful(())
-            }
-            .flatMap { _ =>
-              docker.rm(id)(TransactionId.invokerNanny)
-            }
-        }
-        Future.sequence(removals)
+    implicit val transid = TransactionId.invoker
+    try {
+      removeAllActionContainers()
+    } catch {
+      case e @ (_: TimeoutException | _: InterruptedException) =>
+        logging.error(this, s"Failed to remove action containers: ${e.getMessage}")
+    }
+  }
+
+  /**
+   * Removes all wsk_ containers - regardless of their state
+   *
+   * If the system in general or Docker in particular has a very
+   * high load, commands may take longer than the specified time
+   * resulting in an exception.
+   *
+   * There is no checking whether container removal was successful
+   * or not.
+   *
+   * @throws InterruptedException     if the current thread is interrupted while waiting
+   * @throws TimeoutException         if after waiting for the specified time this `Awaitable` is still not ready
+   */
+  @throws(classOf[TimeoutException])
+  @throws(classOf[InterruptedException])
+  private def removeAllActionContainers(): Unit = {
+    implicit val transid = TransactionId.invoker
+    val cleaning = docker.ps(filters = Seq("name" -> s"wsk${instance.toInt}_"), all = true).flatMap { containers =>
+      logging.info(this, s"removing ${containers.size} action containers.")
+      val removals = containers.map { id =>
+        (if (config.invokerUseRunc) {
+           runc.resume(id)
+         } else {
+           docker.unpause(id)
+         })
+          .recoverWith {
+            // Ignore resume failures and try to remove anyway
+            case _ => Future.successful(())
+          }
+          .flatMap { _ =>
+            docker.rm(id)
+          }
+      }
+      Future.sequence(removals)
     }
     Await.ready(cleaning, 30.seconds)
   }

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -112,8 +112,7 @@ object Invoker {
                 id.toInt - 1
               }
               .getOrElse {
-                logger.error(this, "Failed to increment invokerId")
-                abort()
+                abort("Failed to increment invokerId")
               }
             redisClient.hset("controller:registar:idAssignments", invokerName, newId)
             logger.info(this, s"invokerReg: invoker ${invokerName} was assigned invokerId ${newId}")


### PR DESCRIPTION
Remove all Docker containers on the system that match the naming filter `wsk<invoker instance number>_` at startup and shutdown. In the past, only running containers matching the filter were removed - paused containers are considered to be running. The new strategy will also remove containers that are stopped or could never be started properly for any reason. From time to time, we see action containers that are not running but should be cleaned up.

If Docker commands used to remove containers (`docker ps`, `docker-runc resume` and `docker rm`) do not return within 30 seconds during startup, abort startup and let Docker re-start the invoker container. We have seen systems with heavy load where Docker commands take too long to complete. In that situation, we need a defined behavior, i.e. re-start and re-try the cleanup. At the moment, an uncaught exception will end the main thread leaving the invoker inoperational.

Also changed the invoker initialization sequence such that Docker action container cleanup is performed as soon as possible - in particular, before starting other tasks / actors. At the moment, a cleanup timeout would end the main thread while the activation message feed is already running and consuming messsages that will never be processed.