### PR TITLE
Invokers only require Redis if using dynamic Id assignment

### DIFF
--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -221,7 +221,6 @@ object WhiskConfig {
   val edgeHost = Map(edgeHostName -> null, edgeHostApiPort -> null)
   val invokerHosts = Map(invokerHostsList -> null)
   val kafkaHost = Map(kafkaHostName -> null, kafkaHostPort -> null)
-  val redisHost = Map(redisHostName -> null, redisHostPort -> null)
 
   val runtimesManifest = "runtimes.manifest"
 

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -50,7 +50,7 @@ object Invoker {
       WhiskEntityStore.requiredProperties ++
       WhiskActivationStore.requiredProperties ++
       kafkaHost ++
-      redisHost ++
+      Map(redisHostName -> "", redisHostPort -> "") ++
       wskApiHost ++ Map(
       dockerImageTag -> "latest",
       invokerNumCore -> "4",
@@ -94,6 +94,12 @@ object Invoker {
         id
       }
       .getOrElse {
+        if (config.redisHostName.trim.isEmpty || config.redisHostPort.trim.isEmpty) {
+          logger.error(
+            this,
+            s"Must provide valid Redis host and port to use dynamicId assignment (${config.redisHostName}:${config.redisHostPort})")
+          abort()
+        }
         val invokerName = config.invokerName
         val redisClient = new RedisClient(config.redisHostName, config.redisHostPort.toInt)
         val assignedId = redisClient


### PR DESCRIPTION
Make REDIS_HOST_NAME and REDIS_HOST_PORT optional for the invoker
and only trap as a configuration error when the invoker actually
tries to perform dynamicId assignment.