### PR TITLE
Vagrant base image update to latest Ubuntu Xenial LTS

### DIFF
--- a/tools/ubuntu-setup/all.sh
+++ b/tools/ubuntu-setup/all.sh
@@ -13,9 +13,6 @@ echo "*** installing python dependences"
 echo "*** installing java"
 "$SCRIPTDIR/java8.sh"
 
-echo "*** install scala"
-"$SCRIPTDIR/scala.sh"
-
 echo "*** installing docker"
 "$SCRIPTDIR/docker.sh"
 

--- a/tools/ubuntu-setup/docker.sh
+++ b/tools/ubuntu-setup/docker.sh
@@ -20,15 +20,9 @@ sudo apt-get -y install linux-image-extra-$(uname -r) linux-image-extra-virtual
 # DOCKER
 sudo apt-get install -y --force-yes docker-ce
 
-# enable (security - use 127.0.0.1)
-#sudo -E bash -c 'echo '\''DOCKER_OPTS="-H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock --storage-driver=aufs"'\'' >> /etc/default/docker'
 sudo gpasswd -a `whoami` docker
 
-# Set DOCKER_HOST as an environment variable
-#sudo -E bash -c 'echo '\''export DOCKER_HOST="tcp://0.0.0.0:4243"'\'' >> /etc/bash.bashrc'
-#source /etc/bash.bashrc
-
-#sudo service docker restart
+sudo service docker restart
 
 # do not run this command without a vagrant reload during provisioning
 # it gives an error that docker is not up (which the reload fixes).

--- a/tools/ubuntu-setup/docker.sh
+++ b/tools/ubuntu-setup/docker.sh
@@ -3,28 +3,32 @@ set -e
 set -x
 
 sudo apt-get -y install apt-transport-https ca-certificates
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
-sudo sh -c "echo deb https://apt.dockerproject.org/repo ubuntu-trusty main  > /etc/apt/sources.list.d/docker.list"
+
+# Docker GPG Key
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+
+sudo add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+
 sudo apt-get -y update -qq
 
-sudo apt-get purge lxc-docker
-sudo apt-cache policy docker-engine
-
 # AUFS
-sudo apt-get -y install linux-image-extra-$(uname -r)
+sudo apt-get -y install linux-image-extra-$(uname -r) linux-image-extra-virtual
 
 # DOCKER
-sudo apt-get install -y --force-yes docker-engine=1.12.0-0~trusty
+sudo apt-get install -y --force-yes docker-ce
 
 # enable (security - use 127.0.0.1)
-sudo -E bash -c 'echo '\''DOCKER_OPTS="-H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock --storage-driver=aufs"'\'' >> /etc/default/docker'
+#sudo -E bash -c 'echo '\''DOCKER_OPTS="-H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock --storage-driver=aufs"'\'' >> /etc/default/docker'
 sudo gpasswd -a `whoami` docker
 
 # Set DOCKER_HOST as an environment variable
-sudo -E bash -c 'echo '\''export DOCKER_HOST="tcp://0.0.0.0:4243"'\'' >> /etc/bash.bashrc'
-source /etc/bash.bashrc
+#sudo -E bash -c 'echo '\''export DOCKER_HOST="tcp://0.0.0.0:4243"'\'' >> /etc/bash.bashrc'
+#source /etc/bash.bashrc
 
-sudo service docker restart
+#sudo service docker restart
 
 # do not run this command without a vagrant reload during provisioning
 # it gives an error that docker is not up (which the reload fixes).

--- a/tools/ubuntu-setup/scala.sh
+++ b/tools/ubuntu-setup/scala.sh
@@ -2,7 +2,8 @@
 set -e
 set -x
 
-wget www.scala-lang.org/files/archive/scala-2.11.6.deb -O /tmp/scala-2.11.6.deb
-sudo dpkg -i /tmp/scala-2.11.6.deb
+#wget www.scala-lang.org/files/archive/scala-2.11.6.deb -O /tmp/scala-2.11.6.deb
+wget https://downloads.lightbend.com/scala/2.11.11/scala-2.11.11.deb -O /tmp/scala-2.11.11.deb
+sudo dpkg -i /tmp/scala-2.11.11.deb
 sudo apt-get update
 sudo apt-get install -y scala

--- a/tools/vagrant/Vagrantfile
+++ b/tools/vagrant/Vagrantfile
@@ -8,8 +8,7 @@
 # Don't use vagrant resume, it will run the provisioning a second producing errors
 # Use vagrant suspend and vagrant up (using up it skips provisioning)
 
-BOX = "ubuntu/trusty64-2"
-BOX_URL =  "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+BOX = "bento/ubuntu-16.10"
 BOX_MEMORY = ENV['BOX_MEMORY'] || '4096'
 BOX_CPUS = ENV['BOX_CPUS'] || '4'
 MACHINE_IP = ENV['MACHINE_IP'] || '192.168.33.13'
@@ -17,7 +16,6 @@ OW_DB = if ENV['OW_DB'] =~ (/^(cloudant|couchdb)$/i) then true else false end
 
 Vagrant.configure('2') do |config|
   config.vm.box = BOX
-  config.vm.box_url = BOX_URL
 
   config.vm.network :private_network, ip: MACHINE_IP
 


### PR DESCRIPTION
- Update Vagrant image to latest Ubuntu LTS release; adjust Docker tools accordingly
    - The version of Ubuntu being used was 14.04 (Trusty) which is EOL and 3+ years old
       - Updated to 16.04, Xenial, which is most current LTS
       - Moved from Ubuntu images to Chef Bento – Ubuntu's images after 14.04 started
         breaking Vagrant convention by not creating a "vagrant" user. Chef Bento images
         keep with Vagrant convention and obviate the need for extra "create user" scripts
    - Updated Ubuntu Tools Docker image accordingly
- Updated to retrieve same version of Scala as project Gradle
    - was 2.11.6, updated to 2.11.11