### PR TITLE
WIP Support retrieving status and configuration of feed triggers in CLI

### DIFF
--- a/docs/feeds.md
+++ b/docs/feeds.md
@@ -38,7 +38,7 @@ but technically distinct concepts.
 #  Implementing Feed Actions
 
 The *feed action* is a normal OpenWhisk *action*, but it should accept the following parameters:
-* **lifecycleEvent**: one of 'CREATE', 'DELETE', 'PAUSE', or 'UNPAUSE'.
+* **lifecycleEvent**: one of 'CREATE', 'READ', 'DELETE', 'PAUSE', or 'UNPAUSE'.
 * **triggerName**: the fully-qualified name of the trigger which contains events produced from this feed.
 * **authKey**: the Basic auth credentials of the OpenWhisk user who owns the trigger just mentioned.
 
@@ -58,7 +58,7 @@ The feed action named *changes* takes these parameters, and is expected to take 
 
 For the Cloudant *changes* feed, the action happens to talk directly to a *cloudant trigger* service we've implemented with a connection-based architecture.   We'll discuss the other architectures below.
 
-A similar feed action protocol occurs for `wsk trigger delete`.    
+A similar feed action protocol occurs for `wsk trigger delete` and `wsk trigger get`.    
 
 # Implementing Feeds with Hooks
 

--- a/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -1156,11 +1156,6 @@ class WskBasicUsageTests extends TestHelpers with WskTestHelpers with Inside {
       action.create(actionName, Some(TestUtils.getTestActionFilename("echo.js")))
     }
     val triggerCreateResult = wsk.trigger.create(triggerName, feed = Some(actionName))
-//
-//      withActivation(wsk.activation, triggerCreateResult) {
-//        activation =>
-//          activation.response.success shouldBe true
-//      }
     val triggerDeleteResult = wsk.trigger.delete(triggerName)
 
     withActivation(wsk.activation, triggerDeleteResult) { activation =>

--- a/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -45,14 +45,13 @@ import whisk.core.entity.TimeLimit._
 import whisk.core.entity.size.SizeInt
 import whisk.utils.retry
 import JsonArgsForTests._
-import org.scalatest.Inside
 import whisk.http.Messages
 
 /**
  * Tests for basic CLI usage. Some of these tests require a deployed backend.
  */
 @RunWith(classOf[JUnitRunner])
-class WskBasicUsageTests extends TestHelpers with WskTestHelpers with Inside {
+class WskBasicUsageTests extends TestHelpers with WskTestHelpers {
 
   implicit val wskprops = WskProps()
   val wsk = new Wsk
@@ -1124,7 +1123,7 @@ class WskBasicUsageTests extends TestHelpers with WskTestHelpers with Inside {
     }
   }
 
-  it should "invoke a feed action with the correct lifecyle event when creating a feed trigger" in withAssetCleaner(
+  it should "invoke a feed action with the correct lifecyle event when creating, retrieving and deleting a feed trigger" in withAssetCleaner(
     wskprops) { (wp, assetHelper) =>
     val actionName = "echo"
     val triggerName = "feedTest"
@@ -1133,61 +1132,12 @@ class WskBasicUsageTests extends TestHelpers with WskTestHelpers with Inside {
       action.create(actionName, Some(TestUtils.getTestActionFilename("echo.js")))
     }
 
-    val triggerCreateResult = assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
-      trigger.create(triggerName, feed = Some(actionName))
-    }
+    try {
+      wsk.trigger.create(triggerName, feed = Some(actionName)).stdout should include(""""lifecycleEvent": "CREATE"""")
 
-    withActivation(wsk.activation, triggerCreateResult) { activation =>
-      activation.response.success shouldBe true
-
-      inside(activation.response.result) {
-        case Some(result) =>
-          result.fields should contain("lifecycleEvent" -> "CREATE".toJson)
-      }
-    }
-  }
-
-  it should "invoke a feed action with the correct lifecycle event when deleting a feed trigger" in withAssetCleaner(
-    wskprops) { (wp, assetHelper) =>
-    val actionName = "echo"
-    val triggerName = "feedTest"
-
-    assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
-      action.create(actionName, Some(TestUtils.getTestActionFilename("echo.js")))
-    }
-    val triggerCreateResult = wsk.trigger.create(triggerName, feed = Some(actionName))
-    val triggerDeleteResult = wsk.trigger.delete(triggerName)
-
-    withActivation(wsk.activation, triggerDeleteResult) { activation =>
-      activation.response.success shouldBe true
-
-      inside(activation.response.result) {
-        case Some(result) =>
-          result.fields should contain("lifecycleEvent" -> "DELETE".toJson)
-      }
-    }
-  }
-
-  it should "invoke a feed action with the correct lifecycle event when retrieving a feed trigger" in withAssetCleaner(
-    wskprops) { (wp, assetHelper) =>
-    val actionName = "echo"
-    val triggerName = "feedTest"
-
-    assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
-      action.create(actionName, Some(TestUtils.getTestActionFilename("echo.js")))
-    }
-    assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
-      trigger.create(triggerName, feed = Some(actionName))
-    }
-    val triggerGetResult = wsk.trigger.get(triggerName)
-
-    withActivation(wsk.activation, triggerGetResult) { activation =>
-      activation.response.success shouldBe true
-
-      inside(activation.response.result) {
-        case Some(result) =>
-          result.fields should contain("lifecycleEvent" -> "READ".toJson)
-      }
+      wsk.trigger.get(triggerName).stdout should include(""""lifecycleEvent": "READ"""")
+    } finally {
+      wsk.trigger.delete(triggerName).stdout should include(""""lifecycleEvent": "DELETE"""")
     }
   }
 

--- a/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -1124,85 +1124,76 @@ class WskBasicUsageTests extends TestHelpers with WskTestHelpers with Inside {
     }
   }
 
-  it should "invoke a feed action with the correct lifecyle event when creating a feed trigger" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val actionName = "echo"
-      val triggerName = "feedTest"
+  it should "invoke a feed action with the correct lifecyle event when creating a feed trigger" in withAssetCleaner(
+    wskprops) { (wp, assetHelper) =>
+    val actionName = "echo"
+    val triggerName = "feedTest"
 
-      assetHelper.withCleaner(wsk.action, actionName) {
-        (action, _) =>
-          action.create(actionName, Some(TestUtils.getTestActionFilename("echo.js")))
+    assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
+      action.create(actionName, Some(TestUtils.getTestActionFilename("echo.js")))
+    }
+
+    val triggerCreateResult = assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
+      trigger.create(triggerName, feed = Some(actionName))
+    }
+
+    withActivation(wsk.activation, triggerCreateResult) { activation =>
+      activation.response.success shouldBe true
+
+      inside(activation.response.result) {
+        case Some(result) =>
+          result.fields should contain("lifecycleEvent" -> "CREATE".toJson)
       }
-
-      val triggerCreateResult = assetHelper.withCleaner(wsk.trigger, triggerName) {
-        (trigger, _) =>
-          trigger.create(triggerName, feed = Some(actionName))
-      }
-
-      withActivation(wsk.activation, triggerCreateResult) {
-        activation =>
-          activation.response.success shouldBe true
-
-          inside (activation.response.result) {
-            case Some(result) =>
-              result.fields should contain ("lifecycleEvent" -> "CREATE".toJson)
-          }
-      }
+    }
   }
 
-  it should "invoke a feed action with the correct lifecycle event when deleting a feed trigger" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val actionName = "echo"
-      val triggerName = "feedTest"
+  it should "invoke a feed action with the correct lifecycle event when deleting a feed trigger" in withAssetCleaner(
+    wskprops) { (wp, assetHelper) =>
+    val actionName = "echo"
+    val triggerName = "feedTest"
 
-      assetHelper.withCleaner(wsk.action, actionName) {
-        (action, _) =>
-          action.create(actionName, Some(TestUtils.getTestActionFilename("echo.js")))
-      }
-      val triggerCreateResult = wsk.trigger.create(triggerName, feed = Some(actionName))
+    assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
+      action.create(actionName, Some(TestUtils.getTestActionFilename("echo.js")))
+    }
+    val triggerCreateResult = wsk.trigger.create(triggerName, feed = Some(actionName))
 //
 //      withActivation(wsk.activation, triggerCreateResult) {
 //        activation =>
 //          activation.response.success shouldBe true
 //      }
-      val triggerDeleteResult = wsk.trigger.delete(triggerName)
+    val triggerDeleteResult = wsk.trigger.delete(triggerName)
 
-      withActivation(wsk.activation, triggerDeleteResult) {
-        activation =>
-          activation.response.success shouldBe true
+    withActivation(wsk.activation, triggerDeleteResult) { activation =>
+      activation.response.success shouldBe true
 
-          inside (activation.response.result) {
-            case Some(result) =>
-              result.fields should contain ("lifecycleEvent" -> "DELETE".toJson)
-          }
+      inside(activation.response.result) {
+        case Some(result) =>
+          result.fields should contain("lifecycleEvent" -> "DELETE".toJson)
       }
+    }
   }
 
-  it should "invoke a feed action with the correct lifecycle event when retrieving a feed trigger" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val actionName = "echo"
-      val triggerName = "feedTest"
+  it should "invoke a feed action with the correct lifecycle event when retrieving a feed trigger" in withAssetCleaner(
+    wskprops) { (wp, assetHelper) =>
+    val actionName = "echo"
+    val triggerName = "feedTest"
 
-      assetHelper.withCleaner(wsk.action, actionName) {
-        (action, _) =>
-          action.create(actionName, Some(TestUtils.getTestActionFilename("echo.js")))
+    assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
+      action.create(actionName, Some(TestUtils.getTestActionFilename("echo.js")))
+    }
+    assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
+      trigger.create(triggerName, feed = Some(actionName))
+    }
+    val triggerGetResult = wsk.trigger.get(triggerName)
+
+    withActivation(wsk.activation, triggerGetResult) { activation =>
+      activation.response.success shouldBe true
+
+      inside(activation.response.result) {
+        case Some(result) =>
+          result.fields should contain("lifecycleEvent" -> "READ".toJson)
       }
-      assetHelper.withCleaner(wsk.trigger, triggerName) {
-        (trigger, _) =>
-          trigger.create(triggerName, feed = Some(actionName))
-      }
-      val triggerGetResult = wsk.trigger.get(triggerName)
-
-      withActivation(wsk.activation, triggerGetResult) {
-        activation =>
-
-          activation.response.success shouldBe true
-
-          inside (activation.response.result) {
-            case Some(result) =>
-              result.fields should contain ("lifecycleEvent" -> "READ".toJson)
-          }
-      }
+    }
   }
 
   it should "denote bound trigger parameters for trigger summaries" in withAssetCleaner(wskprops) { (wp, assetHelper) =>

--- a/tools/cli/go-whisk-cli/commands/trigger.go
+++ b/tools/cli/go-whisk-cli/commands/trigger.go
@@ -332,23 +332,22 @@ var triggerGetCmd = &cobra.Command{
         // Get full feed name from trigger get request as it is needed to get the feed
         if retTrigger != nil && retTrigger.Annotations != nil {
             fullFeedName = getValueString(retTrigger.Annotations, "feed")
+        }
 
-            if len(fullFeedName) > 0 {
-                origParams = flags.common.param
-                fullTriggerName := fmt.Sprintf("/%s/%s", qualifiedName.GetNamespace(), qualifiedName.GetEntityName())
-                flags.common.param = append(flags.common.param, getFormattedJSON(FEED_LIFECYCLE_EVENT, FEED_READ))
-                flags.common.param = append(flags.common.param, getFormattedJSON(FEED_TRIGGER_NAME, fullTriggerName))
-                flags.common.param = append(flags.common.param, getFormattedJSON(FEED_AUTH_KEY, Client.Config.AuthToken))
+        if len(fullFeedName) > 0 {
+            origParams = flags.common.param
+            fullTriggerName := fmt.Sprintf("/%s/%s", qualifiedName.GetNamespace(), qualifiedName.GetEntityName())
+            flags.common.param = append(flags.common.param, getFormattedJSON(FEED_LIFECYCLE_EVENT, FEED_READ))
+            flags.common.param = append(flags.common.param, getFormattedJSON(FEED_TRIGGER_NAME, fullTriggerName))
+            flags.common.param = append(flags.common.param, getFormattedJSON(FEED_AUTH_KEY, Client.Config.AuthToken))
 
-                err = configureFeed(qualifiedName.GetEntityName(), fullFeedName)
-                if err != nil {
-                    whisk.Debug(whisk.DbgError, "configureFeed(%s, %s) failed: %s\n", qualifiedName.GetEntityName(), fullFeedName, err)
-                }
-
-                flags.common.param = origParams
-                Client.Namespace = qualifiedName.GetNamespace()
+            err = configureFeed(qualifiedName.GetEntityName(), fullFeedName)
+            if err != nil {
+                whisk.Debug(whisk.DbgError, "configureFeed(%s, %s) failed: %s\n", qualifiedName.GetEntityName(), fullFeedName, err)
             }
 
+            flags.common.param = origParams
+            Client.Namespace = qualifiedName.GetNamespace()
         } else {
             if (flags.trigger.summary) {
                 printSummary(retTrigger)

--- a/tools/cli/go-whisk-cli/commands/trigger.go
+++ b/tools/cli/go-whisk-cli/commands/trigger.go
@@ -32,6 +32,7 @@ const FEED_LIFECYCLE_EVENT  = "lifecycleEvent"
 const FEED_TRIGGER_NAME     = "triggerName"
 const FEED_AUTH_KEY         = "authKey"
 const FEED_CREATE           = "CREATE"
+const FEED_READ             = "READ"
 const FEED_DELETE           = "DELETE"
 
 // triggerCmd represents the trigger command
@@ -294,6 +295,8 @@ var triggerGetCmd = &cobra.Command{
     RunE: func(cmd *cobra.Command, args []string) error {
         var err error
         var field string
+        var fullFeedName string
+        var origParams []string
         var qualifiedName = new(QualifiedName)
 
         if whiskErr := CheckArgs(args, 1, 2, "Trigger get", wski18n.T("A trigger name is required.")); whiskErr != nil {
@@ -326,19 +329,41 @@ var triggerGetCmd = &cobra.Command{
             return werr
         }
 
-        if (flags.trigger.summary) {
-            printSummary(retTrigger)
-        } else {
-            if len(field) > 0 {
-                fmt.Fprintf(color.Output, wski18n.T("{{.ok}} got trigger {{.name}}, displaying field {{.field}}\n",
-                    map[string]interface{}{"ok": color.GreenString("ok:"), "name": boldString(qualifiedName.GetEntityName()),
-                    "field": boldString(field)}))
-                printField(retTrigger, field)
-            } else {
-                fmt.Fprintf(color.Output, wski18n.T("{{.ok}} got trigger {{.name}}\n",
-                        map[string]interface{}{"ok": color.GreenString("ok:"), "name": boldString(qualifiedName.GetEntityName())}))
-                printJSON(retTrigger)
+        // Get full feed name from trigger get request as it is needed to get the feed
+        if retTrigger != nil && retTrigger.Annotations != nil {
+            fullFeedName = getValueString(retTrigger.Annotations, "feed")
+
+            if len(fullFeedName) > 0 {
+                origParams = flags.common.param
+                fullTriggerName := fmt.Sprintf("/%s/%s", qualifiedName.GetNamespace(), qualifiedName.GetEntityName())
+                flags.common.param = append(flags.common.param, getFormattedJSON(FEED_LIFECYCLE_EVENT, FEED_READ))
+                flags.common.param = append(flags.common.param, getFormattedJSON(FEED_TRIGGER_NAME, fullTriggerName))
+                flags.common.param = append(flags.common.param, getFormattedJSON(FEED_AUTH_KEY, Client.Config.AuthToken))
+
+                err = configureFeed(qualifiedName.GetEntityName(), fullFeedName)
+                if err != nil {
+                    whisk.Debug(whisk.DbgError, "configureFeed(%s, %s) failed: %s\n", qualifiedName.GetEntityName(), fullFeedName, err)
+                }
+
+                flags.common.param = origParams
+                Client.Namespace = qualifiedName.GetNamespace()
             }
+
+        } else {
+            if (flags.trigger.summary) {
+                printSummary(retTrigger)
+            } else {
+                if len(field) > 0 {
+                    fmt.Fprintf(color.Output, wski18n.T("{{.ok}} got trigger {{.name}}, displaying field {{.field}}\n",
+                        map[string]interface{}{"ok": color.GreenString("ok:"), "name": boldString(qualifiedName.GetEntityName()),
+                        "field": boldString(field)}))
+                    printField(retTrigger, field)
+                } else {
+                    fmt.Fprintf(color.Output, wski18n.T("{{.ok}} got trigger {{.name}}\n",
+                            map[string]interface{}{"ok": color.GreenString("ok:"), "name": boldString(qualifiedName.GetEntityName())}))
+                    printJSON(retTrigger)
+                }
+            }   
         }
 
         return nil

--- a/tools/cli/go-whisk-cli/commands/trigger.go
+++ b/tools/cli/go-whisk-cli/commands/trigger.go
@@ -345,9 +345,6 @@ var triggerGetCmd = &cobra.Command{
             if err != nil {
                 whisk.Debug(whisk.DbgError, "configureFeed(%s, %s) failed: %s\n", qualifiedName.GetEntityName(), fullFeedName, err)
             }
-
-            flags.common.param = origParams
-            Client.Namespace = qualifiedName.GetNamespace()
         } else {
             if (flags.trigger.summary) {
                 printSummary(retTrigger)
@@ -362,7 +359,7 @@ var triggerGetCmd = &cobra.Command{
                             map[string]interface{}{"ok": color.GreenString("ok:"), "name": boldString(qualifiedName.GetEntityName())}))
                     printJSON(retTrigger)
                 }
-            }   
+            }
         }
 
         return nil

--- a/tools/cli/go-whisk-cli/commands/trigger.go
+++ b/tools/cli/go-whisk-cli/commands/trigger.go
@@ -296,7 +296,6 @@ var triggerGetCmd = &cobra.Command{
         var err error
         var field string
         var fullFeedName string
-        var origParams []string
         var qualifiedName = new(QualifiedName)
 
         if whiskErr := CheckArgs(args, 1, 2, "Trigger get", wski18n.T("A trigger name is required.")); whiskErr != nil {
@@ -335,7 +334,6 @@ var triggerGetCmd = &cobra.Command{
         }
 
         if len(fullFeedName) > 0 {
-            origParams = flags.common.param
             fullTriggerName := fmt.Sprintf("/%s/%s", qualifiedName.GetNamespace(), qualifiedName.GetEntityName())
             flags.common.param = append(flags.common.param, getFormattedJSON(FEED_LIFECYCLE_EVENT, FEED_READ))
             flags.common.param = append(flags.common.param, getFormattedJSON(FEED_TRIGGER_NAME, fullTriggerName))


### PR DESCRIPTION
This PR is to add support for retrieving the status and configuration of a feed trigger

Support has been implemented in the feed providers with the following:

https://github.com/apache/incubator-openwhisk-package-kafka/pull/217 <-- Merged
https://github.com/apache/incubator-openwhisk-package-cloudant/pull/137 <-- Merged
https://github.com/apache/incubator-openwhisk-package-alarms/pull/101 <-- Merged
