### PR TITLE
Use proper host for Wsk REST tests

### DIFF
--- a/tests/src/test/resources/application.conf
+++ b/tests/src/test/resources/application.conf
@@ -1,3 +1,4 @@
+akka.ssl-config.hostnameVerifierClass = common.rest.AcceptAllHostNameVerifier
 
 whisk.spi {
   SimpleSpi = whisk.spi.SimpleSpiImpl

--- a/tests/src/test/scala/common/rest/WskRest.scala
+++ b/tests/src/test/scala/common/rest/WskRest.scala
@@ -1126,7 +1126,7 @@ class WskRestApi extends RunWskRestCmd with BaseApi {
 
   def getApi(basepathOrApiName: String, params: Map[String, String] = Map(), expectedExitCode: Int = OK.intValue)(
     implicit wp: WskProps): RestResult = {
-    val whiskUrl = Uri(s"${WhiskProperties.getApiHostForAction}")
+    val whiskUrl = Uri(WhiskProperties.getApiHostForAction)
     val path = Path(s"/api/${wp.authKey.split(":")(0)}$basepathOrApiName/path")
     val resp = requestEntity(GET, path, params, whiskUrl = whiskUrl)
     val result = new RestResult(resp.status, getRespData(resp))
@@ -1138,7 +1138,7 @@ class RunWskRestCmd() extends FlatSpec with RunWskCmd with Matchers with ScalaFu
 
   implicit val config = PatienceConfig(100 seconds, 15 milliseconds)
   implicit val materializer = ActorMaterializer()
-  val whiskRestUrl = Uri(s"${WhiskProperties.getApiHostForAction}")
+  val whiskRestUrl = Uri(WhiskProperties.getApiHostForAction)
   val basePath = Path("/api/v1")
   val connectionContext = new HttpsConnectionContext(SSL.nonValidatingContext)
 

--- a/tests/src/test/scala/common/rest/WskRest.scala
+++ b/tests/src/test/scala/common/rest/WskRest.scala
@@ -1139,6 +1139,10 @@ class RunWskRestCmd() extends FlatSpec with RunWskCmd with Matchers with ScalaFu
   implicit val materializer = ActorMaterializer()
   val whiskRestUrl = Uri(s"https://${WhiskProperties.getEdgeHost}")
   val basePath = Path("/api/v1")
+  val sslConfig = AkkaSSLConfig().mapSettings { s =>
+    s.withLoose(s.loose.withAcceptAnyCertificate(true).withDisableHostnameVerification(true))
+  }
+  val connectionContext = new HttpsConnectionContext(SSL.nonValidatingContext, Some(sslConfig))
 
   def validateStatusCode(expectedExitCode: Int, statusCode: Int) = {
     if ((expectedExitCode != DONTCARE_EXIT) && (expectedExitCode != ANY_ERROR_EXIT))
@@ -1160,10 +1164,6 @@ class RunWskRestCmd() extends FlatSpec with RunWskCmd with Matchers with ScalaFu
               uri: Uri,
               body: Option[String] = None,
               creds: BasicHttpCredentials): Future[HttpResponse] = {
-    val sslConfig = AkkaSSLConfig().mapSettings { s =>
-      s.withLoose(s.loose.withAcceptAnyCertificate(true).withDisableHostnameVerification(true))
-    }
-    val connectionContext = new HttpsConnectionContext(SSL.nonValidatingContext, Some(sslConfig))
     val entity = body map { b =>
       HttpEntity(ContentTypes.`application/json`, b)
     } getOrElse HttpEntity(ContentTypes.`application/json`, "")

--- a/tests/src/test/scala/common/rest/WskRest.scala
+++ b/tests/src/test/scala/common/rest/WskRest.scala
@@ -956,7 +956,7 @@ class WskRestApi extends RunWskRestCmd with BaseApi {
     val r = action match {
       case Some(action) => {
         val (ns, actionName) = this.getNamespaceEntityName(action)
-        val actionUrl = s"https://${WhiskProperties.getEdgeHost}/$basePath/web/$ns/default/$actionName.http"
+        val actionUrl = s"${WhiskProperties.getApiHostForAction}/$basePath/web/$ns/default/$actionName.http"
         val actionAuthKey = this.getAuthKey(wp)
         val testaction = Some(
           ApiAction(name = actionName, namespace = ns, backendUrl = actionUrl, authkey = actionAuthKey))
@@ -1125,7 +1125,7 @@ class WskRestApi extends RunWskRestCmd with BaseApi {
 
   def getApi(basepathOrApiName: String, params: Map[String, String] = Map(), expectedExitCode: Int = OK.intValue)(
     implicit wp: WskProps): RestResult = {
-    val whiskUrl = Uri(s"https://${WhiskProperties.getEdgeHost}")
+    val whiskUrl = Uri(s"${WhiskProperties.getApiHostForAction}")
     val path = Path(s"/api/${wp.authKey.split(":")(0)}$basepathOrApiName/path")
     val resp = requestEntity(GET, path, params, whiskUrl = whiskUrl)
     val result = new RestResult(resp.status, getRespData(resp))
@@ -1137,7 +1137,7 @@ class RunWskRestCmd() extends FlatSpec with RunWskCmd with Matchers with ScalaFu
 
   implicit val config = PatienceConfig(100 seconds, 15 milliseconds)
   implicit val materializer = ActorMaterializer()
-  val whiskRestUrl = Uri(s"https://${WhiskProperties.getEdgeHost}")
+  val whiskRestUrl = Uri(s"${WhiskProperties.getApiHostForAction}")
   val basePath = Path("/api/v1")
   val sslConfig = AkkaSSLConfig().mapSettings { s =>
     s.withLoose(s.loose.withAcceptAnyCertificate(true).withDisableHostnameVerification(true))

--- a/tests/src/test/scala/common/rest/WskRest.scala
+++ b/tests/src/test/scala/common/rest/WskRest.scala
@@ -93,6 +93,8 @@ import whisk.utils.retry
 
 import javax.net.ssl.{HostnameVerifier, KeyManager, SSLContext, SSLSession, X509TrustManager}
 
+import com.typesafe.sslconfig.akka.AkkaSSLConfig
+
 class AcceptAllHostNameVerifier extends HostnameVerifier {
   def verify(s: String, sslSession: SSLSession) = true
 }
@@ -1140,7 +1142,11 @@ class RunWskRestCmd() extends FlatSpec with RunWskCmd with Matchers with ScalaFu
   implicit val materializer = ActorMaterializer()
   val whiskRestUrl = Uri(WhiskProperties.getApiHostForAction)
   val basePath = Path("/api/v1")
-  val connectionContext = new HttpsConnectionContext(SSL.nonValidatingContext)
+
+  val sslConfig = AkkaSSLConfig().mapSettings { s =>
+    s.withLoose(s.loose.withAcceptAnyCertificate(true).withDisableHostnameVerification(true))
+  }
+  val connectionContext = new HttpsConnectionContext(SSL.nonValidatingContext, Some(sslConfig))
 
   def validateStatusCode(expectedExitCode: Int, statusCode: Int) = {
     if ((expectedExitCode != DONTCARE_EXIT) && (expectedExitCode != ANY_ERROR_EXIT))

--- a/tests/src/test/scala/common/rest/WskRest.scala
+++ b/tests/src/test/scala/common/rest/WskRest.scala
@@ -91,10 +91,11 @@ import common.WskProps
 import whisk.core.entity.ByteSize
 import whisk.utils.retry
 
-import com.typesafe.sslconfig.akka.AkkaSSLConfig
+import javax.net.ssl.{HostnameVerifier, KeyManager, SSLContext, SSLSession, X509TrustManager}
 
-import javax.net.ssl.{SSLContext, X509TrustManager}
-import javax.net.ssl.KeyManager
+class AcceptAllHostNameVerifier extends HostnameVerifier {
+  def verify(s: String, sslSession: SSLSession) = true
+}
 
 object SSL {
   lazy val nonValidatingContext: SSLContext = {
@@ -1139,10 +1140,7 @@ class RunWskRestCmd() extends FlatSpec with RunWskCmd with Matchers with ScalaFu
   implicit val materializer = ActorMaterializer()
   val whiskRestUrl = Uri(s"${WhiskProperties.getApiHostForAction}")
   val basePath = Path("/api/v1")
-  val sslConfig = AkkaSSLConfig().mapSettings { s =>
-    s.withLoose(s.loose.withAcceptAnyCertificate(true).withDisableHostnameVerification(true))
-  }
-  val connectionContext = new HttpsConnectionContext(SSL.nonValidatingContext, Some(sslConfig))
+  val connectionContext = new HttpsConnectionContext(SSL.nonValidatingContext)
 
   def validateStatusCode(expectedExitCode: Int, statusCode: Int) = {
     if ((expectedExitCode != DONTCARE_EXIT) && (expectedExitCode != ANY_ERROR_EXIT))


### PR DESCRIPTION
- `WhiskProperties.getApiHostForAction` should be used instead of `WhiskProperties.getBaseControllerAddress` for WskRest.

- Disables certificate checking for WskRest tests.