### PR TITLE
make INVOKER_NAME optional

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -60,7 +60,7 @@ object Invoker {
       invokerContainerDns -> "",
       invokerContainerNetwork -> null,
       invokerUseRunc -> "true") ++
-      Map(invokerName -> null)
+      Map(invokerName -> "")
 
   def main(args: Array[String]): Unit = {
     implicit val ec = ExecutionContextFactory.makeCachedThreadPoolExecutionContext()

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -100,6 +100,9 @@ object Invoker {
             s"Must provide valid Redis host and port to use dynamicId assignment (${config.redisHostName}:${config.redisHostPort})")
         }
         val invokerName = config.invokerName
+        if (invokerName.trim.isEmpty) {
+          abort("Invoker name can't be empty to use dynamicId assignment.")
+        }
         val redisClient = new RedisClient(config.redisHostName, config.redisHostPort.toInt)
         val assignedId = redisClient
           .hget("controller:registar:idAssignments", invokerName)


### PR DESCRIPTION
This slipped in with the Redis changes and I don't think it's needed b/c the invoker already starts with an `id`. 

if `id arg` is provided, use it, and do NOT require INVOKER_NAME or REDIS_HOST configs; if `id arg` is NOT provided, then DO require INVOKER_NAME AND REDIS_HOST configs

Relates to: #2872 and https://github.com/apache/incubator-openwhisk-devtools/pull/62