### PR TITLE
fix ansible install errors in vagrant

### DIFF
--- a/tools/ubuntu-setup/ansible.sh
+++ b/tools/ubuntu-setup/ansible.sh
@@ -2,6 +2,7 @@
 set -e
 set -x
 
+sudo pip install --upgrade setuptools
 sudo apt-get install -y software-properties-common
 sudo apt-add-repository -y ppa:ansible/ansible
 sudo apt-get update

--- a/tools/ubuntu-setup/scala.sh
+++ b/tools/ubuntu-setup/scala.sh
@@ -2,7 +2,7 @@
 set -e
 set -x
 
-wget www.scala-lang.org/files/archive/scala-2.11.6.deb -O /tmp/scala-2.11.6.deb
-sudo dpkg -i /tmp/scala-2.11.6.deb
+wget www.scala-lang.org/files/archive/scala-2.11.8.deb -O /tmp/scala-2.11.8.deb
+sudo dpkg -i /tmp/scala-2.11.8.deb
 sudo apt-get update
 sudo apt-get install -y scala

--- a/tools/vagrant/Vagrantfile
+++ b/tools/vagrant/Vagrantfile
@@ -8,8 +8,7 @@
 # Don't use vagrant resume, it will run the provisioning a second producing errors
 # Use vagrant suspend and vagrant up (using up it skips provisioning)
 
-BOX = "ubuntu/trusty64-2"
-BOX_URL =  "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+BOX = "ubuntu/trusty64"
 BOX_MEMORY = ENV['BOX_MEMORY'] || '4096'
 BOX_CPUS = ENV['BOX_CPUS'] || '4'
 MACHINE_IP = ENV['MACHINE_IP'] || '192.168.33.13'
@@ -17,8 +16,6 @@ OW_DB = if ENV['OW_DB'] =~ (/^(cloudant|couchdb)$/i) then true else false end
 
 Vagrant.configure('2') do |config|
   config.vm.box = BOX
-  config.vm.box_url = BOX_URL
-
   config.vm.network :private_network, ip: MACHINE_IP
 
   # If true, then any SSH connections made will enable agent forwarding.


### PR DESCRIPTION
Fixes #2901

Related to #2891 

Fix to ansible error with crypto is `sudo pip install --upgrade setuptools`

We have mismatch version of scala, update to match `2.8.11`

Try using an official ubuntu 14 image from provider virtual box

Ubuntu 14 is LTS until April 2019 according to this site: https://wiki.ubuntu.com/Releases

So I proposed we keep using Ubuntu trusty, since it's the version we use CI/CD in Travis
