### PR TITLE
Bump go cli to 1.8.4

### DIFF
--- a/tools/cli/Dockerfile
+++ b/tools/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8
+FROM golang:1.8.4
 
 # Install zip
 RUN apt-get -y update && \


### PR DESCRIPTION
- Fix for security issue https://github.com/golang/go/issues/22125