### PR TITLE
Optionally fetch code when getting an action

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Exec.scala
@@ -384,13 +384,7 @@ protected[core] object ExecMetaDataBase extends ArgNormalizer[ExecMetaDataBase] 
               throw new DeserializationException(
                 s"'image' must be a string defined in 'exec' for '${Exec.BLACKBOX}' actions")
           }
-          val code: Option[String] = obj.fields.get("code") match {
-            case Some(JsString(i)) => if (i.trim.nonEmpty) Some(i) else None
-            case Some(_) =>
-              throw new DeserializationException(
-                s"if defined, 'code' must a string defined in 'exec' for '${Exec.BLACKBOX}' actions")
-            case None => None
-          }
+
           val native = execManifests.blackboxImages.contains(image)
           BlackBoxExecMetaData(native)
 
@@ -403,28 +397,9 @@ protected[core] object ExecMetaDataBase extends ArgNormalizer[ExecMetaDataBase] 
 
           manifest.attached
             .map { a =>
-              val jar: Attachment[String] = {
-                // java actions once stored the attachment in "jar" instead of "code"
-                obj.fields.get("code").orElse(obj.fields.get("jar"))
-              } map {
-                attFmt[String].read(_)
-              } getOrElse {
-                throw new DeserializationException(
-                  s"'code' must be a valid base64 string in 'exec' for '$kind' actions")
-              }
-              val main = optMainField.orElse {
-                if (manifest.requireMain.exists(identity)) {
-                  throw new DeserializationException(s"'main' must be a string defined in 'exec' for '$kind' actions")
-                } else None
-              }
               CodeExecMetaDataAsAttachment(manifest)
             }
             .getOrElse {
-              val code: String = obj.fields.get("code") match {
-                case Some(JsString(c)) => c
-                case _ =>
-                  throw new DeserializationException(s"'code' must be a string defined in 'exec' for '$kind' actions")
-              }
               CodeExecMetaDataAsString(manifest)
             }
       }

--- a/core/controller/src/main/resources/apiv1swagger.json
+++ b/core/controller/src/main/resources/apiv1swagger.json
@@ -203,6 +203,13 @@
                         "description": "Name of action to fetch",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "name": "code",
+                        "in": "query",
+                        "description": "Include action code in the result",
+                        "required": false,
+                        "type": "boolean"
                     }
                 ],
                 "produces": [

--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -294,10 +294,19 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
    */
   override def fetch(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(
     implicit transid: TransactionId) = {
-    getEntity(WhiskAction, entityStore, entityName.toDocId, Some { action: WhiskAction =>
-      val mergedAction = env map { action inherit _ } getOrElse action
-      complete(OK, mergedAction)
-    })
+    parameter('code ? true) { code =>
+      if (code) {
+        getEntity(WhiskAction, entityStore, entityName.toDocId, Some { action: WhiskAction =>
+          val mergedAction = env map { action inherit _ } getOrElse action
+          complete(OK, mergedAction)
+        })
+      } else {
+        getEntity(WhiskActionMetaData, entityStore, entityName.toDocId, Some { action: WhiskActionMetaData =>
+          val mergedAction = env map { action inherit _ } getOrElse action
+          complete(OK, mergedAction)
+        })
+      }
+    }
   }
 
   /**

--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -295,16 +295,21 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
   override def fetch(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(
     implicit transid: TransactionId) = {
     parameter('code ? true) { code =>
-      if (code) {
-        getEntity(WhiskAction, entityStore, entityName.toDocId, Some { action: WhiskAction =>
-          val mergedAction = env map { action inherit _ } getOrElse action
-          complete(OK, mergedAction)
-        })
-      } else {
-        getEntity(WhiskActionMetaData, entityStore, entityName.toDocId, Some { action: WhiskActionMetaData =>
-          val mergedAction = env map { action inherit _ } getOrElse action
-          complete(OK, mergedAction)
-        })
+      code match {
+        case true =>
+          getEntity(WhiskAction, entityStore, entityName.toDocId, Some { action: WhiskAction =>
+            val mergedAction = env map {
+              action inherit _
+            } getOrElse action
+            complete(OK, mergedAction)
+          })
+        case false =>
+          getEntity(WhiskActionMetaData, entityStore, entityName.toDocId, Some { action: WhiskActionMetaData =>
+            val mergedAction = env map {
+              action inherit _
+            } getOrElse action
+            complete(OK, mergedAction)
+          })
       }
     }
   }

--- a/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
@@ -167,11 +167,13 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
       status should be(OK)
       val response = responseAs[JsObject]
       response.fields("exec").asJsObject.fields should not(contain key "code")
+      responseAs[WhiskActionMetaData] shouldBe a[WhiskActionMetaData]
     }
     Get(s"$collectionPath/${action.name}?code=true") ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[JsObject]
       response.fields("exec").asJsObject.fields("code") should be("??".toJson)
+      responseAs[WhiskAction] shouldBe a[WhiskAction]
     }
   }
 

--- a/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
@@ -162,18 +162,23 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
   it should "get action using code query parameter" in {
     implicit val tid = transid()
     val action = WhiskAction(namespace, aname(), jsDefault("??"), Parameters("x", "b"))
+
     put(entityStore, action)
+
     Get(s"$collectionPath/${action.name}?code=false") ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[JsObject]
       response.fields("exec").asJsObject.fields should not(contain key "code")
       responseAs[WhiskActionMetaData] shouldBe a[WhiskActionMetaData]
     }
-    Get(s"$collectionPath/${action.name}?code=true") ~> Route.seal(routes(creds)) ~> check {
-      status should be(OK)
-      val response = responseAs[JsObject]
-      response.fields("exec").asJsObject.fields("code") should be("??".toJson)
-      responseAs[WhiskAction] shouldBe a[WhiskAction]
+
+    Seq(s"$collectionPath/${action.name}", s"$collectionPath/${action.name}?code=true").foreach { path =>
+      Get(path) ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[JsObject]
+        response.fields("exec").asJsObject.fields("code") should be("??".toJson)
+        responseAs[WhiskAction] shouldBe a[WhiskAction]
+      }
     }
   }
 

--- a/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
@@ -159,6 +159,22 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     }
   }
 
+  it should "get action using code query parameter" in {
+    implicit val tid = transid()
+    val action = WhiskAction(namespace, aname(), jsDefault("??"), Parameters("x", "b"))
+    put(entityStore, action)
+    Get(s"$collectionPath/${action.name}?code=false") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[JsObject]
+      response.fields("exec").asJsObject.fields should not(contain key "code")
+    }
+    Get(s"$collectionPath/${action.name}?code=true") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[JsObject]
+      response.fields("exec").asJsObject.fields("code") should be("??".toJson)
+    }
+  }
+
   it should "report NotFound for get non existent action" in {
     implicit val tid = transid()
     Get(s"$collectionPath/xyz") ~> Route.seal(routes(creds)) ~> check {


### PR DESCRIPTION
Provides optional query parameter for getting an action that specifies whether or not action code should be fetched and returned. When the query parameter is present, WhiskActionMetadata will be used to fetch the action. Otherwise, WhiskAction will be used to retrieve the action.

Fetch the action with the code as is today:
`https://192.168.99.100/api/v1/namespaces/_/actions/actionName`
or
`https://192.168.99.100/api/v1/namespaces/_/actions/actionName?code=true`

Fetch action metadata without code:
`https://192.168.99.100/api/v1/namespaces/_/actions/actionName?code=false`

Depends on https://github.com/apache/incubator-openwhisk/pull/2730.