### PR TITLE
AWS deployment

### DIFF
--- a/ansible/provision_aws.yml
+++ b/ansible/provision_aws.yml
@@ -1,0 +1,15 @@
+---
+
+- name: "Provisioning and config set-up"
+  hosts: localhost
+  gather_facts: no
+  vars:
+    ansible_host: localhost
+  roles:
+    - aws
+
+- name: "Further instance-specific set-up"
+  hosts: all
+  gather_facts: no
+  roles:
+    - disks

--- a/ansible/roles/aws/defaults/main.yml
+++ b/ansible/roles/aws/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+
+aws_region: eu-west-1
+
+# Note, this is an AMI for Ubuntu 14.04 in eu-west-1
+#
+# You can go to http://cloud-images.ubuntu.com/locator/ec2/, enter
+# "14.04 LTS HVM EBS" in the search box then use the region filter
+# to find an appropriate AMI for you.
+aws_ubuntu_image: ami-d53697ac
+
+aws_priv_key_name: openwhisk-key
+aws_priv_key_local: "{{ lookup('env','HOME') }}/.ssh/openwhisk_key.pem"

--- a/ansible/roles/aws/tasks/config.yml
+++ b/ansible/roles/aws/tasks/config.yml
@@ -1,0 +1,12 @@
+---
+
+- name: "Template the new hosts file"
+  template:
+    src: hosts.j2
+    dest: "environments/distributed/hosts"
+
+- name: "Template group vars"
+  template:
+    src: group_vars.j2
+    dest: "environments/distributed/group_vars/{{ item.name }}"
+  with_items: "{{ instances }}"

--- a/ansible/roles/aws/tasks/main.yml
+++ b/ansible/roles/aws/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+
+- include: security_group.yml
+
+- include: private_key.yml
+
+- include: provision.yml
+
+- include: config.yml
+
+- name: "Refresh the inventory to pick up new config"
+  meta: refresh_inventory

--- a/ansible/roles/aws/tasks/private_key.yml
+++ b/ansible/roles/aws/tasks/private_key.yml
@@ -1,0 +1,14 @@
+---
+
+- name: "Create an EC2 key"
+  ec2_key:
+    name: "{{ aws_priv_key_name }}"
+    region: "{{ aws_region }}"
+  register: private_key
+
+- name: "Save the key to local disk"
+  copy:
+    content: "{{ private_key.key.private_key }}"
+    dest: "{{ aws_priv_key_local }}"
+    mode: 0600
+  when: private_key.changed

--- a/ansible/roles/aws/tasks/provision.yml
+++ b/ansible/roles/aws/tasks/provision.yml
@@ -1,0 +1,22 @@
+---
+
+- name: "Provision EC2 instances"
+  ec2:
+    region: "{{ aws_region }}"
+    key_name: "{{ aws_priv_key_name }}"
+    group: "openwhisk-dev"
+    instance_type: "{{ item.flavor }}"
+    image: "{{ aws_ubuntu_image }}"
+    wait: yes
+    exact_count: "{{ item.num_instances }}"
+    count_tag:
+      Name: "openwhisk-{{ item.name }}"
+    instance_tags:
+      Name: "openwhisk-{{ item.name }}"
+    volumes:
+      - device_name: "{{ (item.volume | default({})).name | default('/dev/xvda') }}"
+        device_type: "gp2"
+        volume_size: "{{ (item.volume | default({})).size | default('8') }}"
+        delete_on_termination: true
+  with_items: "{{ instances }}"
+  register: ec2_list

--- a/ansible/roles/aws/tasks/security_group.yml
+++ b/ansible/roles/aws/tasks/security_group.yml
@@ -1,0 +1,19 @@
+---
+
+# TODO - avoid wide-open security group
+
+- name: "Create openwhisk security group"
+  ec2_group:
+    name: "openwhisk-dev"
+    description: "Group for Openwhisk dev"
+    region: "{{ aws_region }}"
+    rules:
+      - proto: all
+        from_port: 0
+        to_port: 65535
+        cidr_ip: 0.0.0.0/0
+    rules_egress:
+      - proto: all
+        from_port: 0
+        to_port: 65535
+        cidr_ip: 0.0.0.0/0

--- a/ansible/roles/aws/templates/group_vars.j2
+++ b/ansible/roles/aws/templates/group_vars.j2
@@ -1,0 +1,13 @@
+# Group vars file generated automatically by provisioning AWS EC2 instances
+
+whisk_name: {{ item.name }}
+whisk_num_instances: {{ item.num_instances }}
+whisk_flavor: {{ item.flavor }}
+
+{% if item.volume is defined and item.volume.fsmount != '/' %}
+whisk_volume:
+  name: {{ item.volume.name }}
+  size: {{ item.volume.size }}
+  fstype: {{ item.volume.fstype }}
+  fsmount: {{ item.volume.fsmount }}
+{% endif %}

--- a/ansible/roles/aws/templates/hosts.j2
+++ b/ansible/roles/aws/templates/hosts.j2
@@ -1,0 +1,17 @@
+# Inventory file generated automatically by provisioning AWS EC2 instances
+
+{% for ec2 in ec2_list.results %}
+[{{ ec2.item.name }}]
+{% for host in ec2.tagged_instances %}
+{{ host.public_dns_name }}    ansible_host={{ host.public_dns_name }}
+
+{% endfor %}
+{% endfor %}
+
+# Predefined groups
+
+[apigateway:children]
+edge
+
+[redis:children]
+edge

--- a/ansible/roles/disks/tasks/main.yml
+++ b/ansible/roles/disks/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+
+- include: mount.yml
+  when: whisk_volume is defined

--- a/ansible/roles/disks/tasks/mount.yml
+++ b/ansible/roles/disks/tasks/mount.yml
@@ -1,0 +1,29 @@
+
+- name: "Ensure host is up and running"
+  wait_for:
+    host: "{{ inventory_hostname }}"
+    port: 22
+
+- name: "Get list of configured disks"
+  shell: df -h
+  register: disks
+
+- name: "Create mount point directory"
+  become: yes
+  file:
+    path: "{{ whisk_volume.fsmount }}"
+    state: directory
+
+- name: "Create filesystem on volume"
+  become: yes
+  shell: "mkfs -t {{ whisk_volume.fstype }} {{ whisk_volume.name }}"
+  when: "whisk_volume.name not in disks.stdout"
+
+- name: "Mount the volume"
+  become: yes
+  mount:
+    src: "{{ whisk_volume.name }}"
+    path: "{{ whisk_volume.fsmount }}"
+    fstype: "{{ whisk_volume.fstype }}"
+    state: mounted
+  when: "whisk_volume.name not in disks.stdout"

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -103,6 +103,10 @@
   with_items: "{{ invokerInfo }}"
   when: not invoker.allowMultipleInstances and item.Names[0] != "/invoker{{ groups['invokers'].index(inventory_hostname) }}"
 
+- name: kill any existing containers
+  shell: "docker rm -f invoker{{ groups['invokers'].index(inventory_hostname) }}"
+  ignore_errors: yes
+
 - name: start invoker using docker cli
   shell: >
         docker run -d


### PR DESCRIPTION
Adds automated AWS provisioning of distributed OpenWhisk (similar to existing Openstack support).

I've not changed anything related to the existing distributed deployment work for fear of breaking it. To achieve this I've had to do a couple of work-arounds that could be avoided with a couple more tweaks:

1. Implement the `TODO` open in `environments/distributed/group_vars/all` to move instance properties to `group_vars`. I agree this would be useful and had to add a templating step in this PR that puts them in place
2. Reuse the new `disks` role I've created instead of the inline code in `provision_env_dist.yml`. There is another open `TODO` in that file mentioning that this would be useful.

Other than that I hope it should be pretty straightforward. I found the following config to be the minimum I could get away with for testing (set this in `ansible/environments/distributed/group_vars/all`):

```
instances:
  - name: registry
    num_instances: 1
    flavor: t2.medium
    volume:
      name: /dev/sda1
      size: 100
      fsmount: /

  - name: edge
    num_instances: 1
    flavor: t2.micro

  - name: controllers
    num_instances: 1
    flavor: t2.medium

  - name: kafka
    num_instances: 1
    flavor: t2.medium

  - name: invokers
    num_instances: 2
    flavor: t2.micro
    volume:
      name: /dev/sda1
      size: 50
      fsmount: /

  - name: db
    num_instances: 1
    flavor: t2.micro
    volume:
      name: /dev/xvdb
      size: 10
      fstype: ext4
      fsmount: /mnt/db
```

