### PR TITLE
Replace basic runtimes with REST implementation

### DIFF
--- a/tests/src/test/scala/system/basic/WskBasicJavaTests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicJavaTests.scala
@@ -24,7 +24,7 @@ import common.TestUtils
 import common.TestUtils.ANY_ERROR_EXIT
 import common.WskTestHelpers
 import common.WskProps
-import common.Wsk
+import common.BaseWsk
 
 import org.junit.runner.RunWith
 import org.scalatest.Matchers
@@ -33,10 +33,10 @@ import org.scalatest.junit.JUnitRunner
 import spray.json.JsString
 
 @RunWith(classOf[JUnitRunner])
-class WskBasicJavaTests extends TestHelpers with WskTestHelpers with Matchers {
+abstract class WskBasicJavaTests extends TestHelpers with WskTestHelpers with Matchers {
 
   implicit val wskprops = WskProps()
-  val wsk = new Wsk
+  val wsk: BaseWsk
   val expectedDuration = 120.seconds
   val activationPollDuration = 60.seconds
 

--- a/tests/src/test/scala/system/basic/WskBasicNodeTests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicNodeTests.scala
@@ -25,17 +25,17 @@ import common.TestHelpers
 import common.TestUtils
 import common.TestUtils.ANY_ERROR_EXIT
 import common.TestUtils.RunResult
-import common.Wsk
+import common.BaseWsk
 import common.WskProps
 import common.WskTestHelpers
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
 @RunWith(classOf[JUnitRunner])
-class WskBasicNodeTests extends TestHelpers with WskTestHelpers with JsHelpers {
+abstract class WskBasicNodeTests extends TestHelpers with WskTestHelpers with JsHelpers {
 
   implicit val wskprops = WskProps()
-  val wsk = new Wsk
+  val wsk: BaseWsk
   val defaultAction = Some(TestUtils.getTestActionFilename("hello.js"))
   val currentNodeJsDefaultKind = "nodejs:6"
 

--- a/tests/src/test/scala/system/basic/WskBasicPythonTests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicPythonTests.scala
@@ -26,16 +26,16 @@ import spray.json.DefaultJsonProtocol.StringJsonFormat
 import common.JsHelpers
 import common.TestHelpers
 import common.TestUtils
-import common.Wsk
+import common.BaseWsk
 import common.WskProps
 import common.WskTestHelpers
 import common.WhiskProperties
 
 @RunWith(classOf[JUnitRunner])
-class WskBasicPythonTests extends TestHelpers with WskTestHelpers with Matchers with JsHelpers {
+abstract class WskBasicPythonTests extends TestHelpers with WskTestHelpers with Matchers with JsHelpers {
 
   implicit val wskprops = WskProps()
-  val wsk = new Wsk
+  val wsk: BaseWsk
 
   behavior of "Native Python Action"
 

--- a/tests/src/test/scala/system/basic/WskBasicSwift3Tests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicSwift3Tests.scala
@@ -23,7 +23,7 @@ import org.scalatest.junit.JUnitRunner
 import common.JsHelpers
 import common.TestHelpers
 import common.TestUtils
-import common.Wsk
+import common.BaseWsk
 import common.WskProps
 import common.WskTestHelpers
 import spray.json.pimpString
@@ -32,11 +32,11 @@ import common.TestUtils.RunResult
 import spray.json.JsObject
 
 @RunWith(classOf[JUnitRunner])
-class WskBasicSwift3Tests extends TestHelpers with WskTestHelpers with JsHelpers {
+abstract class WskBasicSwift3Tests extends TestHelpers with WskTestHelpers with JsHelpers {
 
-  implicit val wskprops = WskProps()
-  val wsk = new Wsk
-  val defaultAction = Some(TestUtils.getTestActionFilename("hello.swift"))
+  implicit val wskprops: common.WskProps = WskProps()
+  val wsk: BaseWsk
+  val defaultAction: Some[String] = Some(TestUtils.getTestActionFilename("hello.swift"))
   lazy val currentSwiftDefaultKind = "swift:3"
 
   behavior of "Swift runtime"

--- a/tests/src/test/scala/system/basic/WskCliBasicJavaTests.scala
+++ b/tests/src/test/scala/system/basic/WskCliBasicJavaTests.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package system.basic
+
+import common.Wsk
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class WskCliBasicJavaTests extends WskBasicJavaTests {
+  override val wsk: Wsk = new Wsk
+}

--- a/tests/src/test/scala/system/basic/WskCliBasicNodeTests.scala
+++ b/tests/src/test/scala/system/basic/WskCliBasicNodeTests.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package system.basic
+
+import common.Wsk
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class WskCliBasicNodeTests extends WskBasicNodeTests {
+  override val wsk: Wsk = new Wsk
+}

--- a/tests/src/test/scala/system/basic/WskCliBasicPythonTests.scala
+++ b/tests/src/test/scala/system/basic/WskCliBasicPythonTests.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package system.basic
+
+import common.Wsk
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class WskCliBasicPythonTests extends WskBasicPythonTests {
+  override val wsk: common.Wsk = new Wsk
+}

--- a/tests/src/test/scala/system/basic/WskCliBasicSwift311Tests.scala
+++ b/tests/src/test/scala/system/basic/WskCliBasicSwift311Tests.scala
@@ -17,16 +17,13 @@
 
 package system.basic
 
+import common.Wsk
+
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
-import common.JsHelpers
-import common.WskTestHelpers
-
 @RunWith(classOf[JUnitRunner])
-class WskUnicodeSwift3Tests extends WskUnicodeTests with WskTestHelpers with JsHelpers {
-
-  override lazy val actionKind = "swift:3"
-  override lazy val actionSource = "unicode.swift"
-
+class WskCliBasicSwift311Tests extends WskBasicSwift3Tests {
+  override val wsk = new Wsk
+  override lazy val currentSwiftDefaultKind: String = "swift:3.1.1"
 }

--- a/tests/src/test/scala/system/basic/WskCliBasicSwift3Tests.scala
+++ b/tests/src/test/scala/system/basic/WskCliBasicSwift3Tests.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package system.basic
+
+import common.Wsk
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class WskCliBasicSwift3Tests extends WskBasicSwift3Tests {
+  override val wsk: common.Wsk = new Wsk
+}

--- a/tests/src/test/scala/system/basic/WskCliUnicodeJavaTests.scala
+++ b/tests/src/test/scala/system/basic/WskCliUnicodeJavaTests.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package system.basic
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import common.JsHelpers
+import common.WskTestHelpers
+import common.Wsk
+
+@RunWith(classOf[JUnitRunner])
+class WskCliUnicodeJavaTests extends WskUnicodeTests with WskTestHelpers with JsHelpers {
+
+  override val wsk: Wsk = new Wsk
+  override lazy val actionKind = "java"
+  override lazy val actionSource = "unicode.jar"
+
+}

--- a/tests/src/test/scala/system/basic/WskCliUnicodeNodeTests.scala
+++ b/tests/src/test/scala/system/basic/WskCliUnicodeNodeTests.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package system.basic
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import common.JsHelpers
+import common.WskTestHelpers
+import common.Wsk
+
+@RunWith(classOf[JUnitRunner])
+class WskCliUnicodeNodeTests extends WskUnicodeTests with WskTestHelpers with JsHelpers {
+
+  override val wsk: common.Wsk = new Wsk
+  override lazy val actionKind = "nodejs:6"
+  override lazy val actionSource = "unicode.js"
+
+}

--- a/tests/src/test/scala/system/basic/WskCliUnicodePython2Tests.scala
+++ b/tests/src/test/scala/system/basic/WskCliUnicodePython2Tests.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package system.basic
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import common.JsHelpers
+import common.WskTestHelpers
+import common.Wsk
+
+@RunWith(classOf[JUnitRunner])
+class WskCliUnicodePython2Tests extends WskUnicodeTests with WskTestHelpers with JsHelpers {
+
+  override val wsk: common.Wsk = new Wsk
+  override lazy val actionKind: String = "python:2"
+  override lazy val actionSource: String = "unicode2.py"
+
+}

--- a/tests/src/test/scala/system/basic/WskCliUnicodePython3Tests.scala
+++ b/tests/src/test/scala/system/basic/WskCliUnicodePython3Tests.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package system.basic
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import common.JsHelpers
+import common.WskTestHelpers
+import common.Wsk
+
+@RunWith(classOf[JUnitRunner])
+class WskCliUnicodePython3Tests extends WskUnicodeTests with WskTestHelpers with JsHelpers {
+
+  override val wsk: common.Wsk = new Wsk
+  override lazy val actionKind: String = "python:3"
+  override lazy val actionSource: String = "unicode3.py"
+
+}

--- a/tests/src/test/scala/system/basic/WskCliUnicodeSwift311Tests.scala
+++ b/tests/src/test/scala/system/basic/WskCliUnicodeSwift311Tests.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package system.basic
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import common.JsHelpers
+import common.WskTestHelpers
+import common.Wsk
+
+@RunWith(classOf[JUnitRunner])
+class WskCliUnicodeSwift311Tests extends WskUnicodeTests with WskTestHelpers with JsHelpers {
+
+  override val wsk: common.Wsk = new Wsk
+  override lazy val actionKind = "swift:3.1.1"
+  override lazy val actionSource = "unicode.swift"
+
+}

--- a/tests/src/test/scala/system/basic/WskCliUnicodeSwift3Tests.scala
+++ b/tests/src/test/scala/system/basic/WskCliUnicodeSwift3Tests.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package system.basic
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import common.JsHelpers
+import common.WskTestHelpers
+import common.Wsk
+
+@RunWith(classOf[JUnitRunner])
+class WskCliUnicodeSwift3Tests extends WskUnicodeTests with WskTestHelpers with JsHelpers {
+
+  override val wsk: common.Wsk = new Wsk
+  override lazy val actionKind = "swift:3"
+  override lazy val actionSource = "unicode.swift"
+
+}

--- a/tests/src/test/scala/system/basic/WskConsoleTests.scala
+++ b/tests/src/test/scala/system/basic/WskConsoleTests.scala
@@ -42,7 +42,7 @@ import spray.json.pimpAny
 @RunWith(classOf[JUnitRunner])
 abstract class WskConsoleTests extends TestHelpers with WskTestHelpers {
 
-  implicit val wskprops: common.WskProps = WskProps()
+  implicit val wskprops = WskProps()
   val wsk: BaseWsk
   val guestNamespace = wskprops.namespace
 

--- a/tests/src/test/scala/system/basic/WskRestBasicJavaTests.scala
+++ b/tests/src/test/scala/system/basic/WskRestBasicJavaTests.scala
@@ -17,16 +17,12 @@
 
 package system.basic
 
+import common.rest.WskRest
+
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
-import common.JsHelpers
-import common.WskTestHelpers
-
 @RunWith(classOf[JUnitRunner])
-class WskUnicodePython2Tests extends WskUnicodeTests with WskTestHelpers with JsHelpers {
-
-  override lazy val actionKind = "python:2"
-  override lazy val actionSource = "unicode2.py"
-
+class WskRestBasicJavaTests extends WskBasicJavaTests {
+  override val wsk: common.rest.WskRest = new WskRest
 }

--- a/tests/src/test/scala/system/basic/WskRestBasicNodeTests.scala
+++ b/tests/src/test/scala/system/basic/WskRestBasicNodeTests.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package system.basic
+
+import common.rest.WskRest
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class WskRestBasicNodeTests extends WskBasicNodeTests {
+  override val wsk: common.rest.WskRest = new WskRest
+}

--- a/tests/src/test/scala/system/basic/WskRestBasicPythonTests.scala
+++ b/tests/src/test/scala/system/basic/WskRestBasicPythonTests.scala
@@ -17,16 +17,12 @@
 
 package system.basic
 
+import common.rest.WskRest
+
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
-import common.JsHelpers
-import common.WskTestHelpers
-
 @RunWith(classOf[JUnitRunner])
-class WskUnicodeSwift311Tests extends WskUnicodeTests with WskTestHelpers with JsHelpers {
-
-  override lazy val actionKind = "swift:3.1.1"
-  override lazy val actionSource = "unicode.swift"
-
+class WskRestBasicPythonTests extends WskBasicPythonTests {
+  override val wsk: common.rest.WskRest = new WskRest
 }

--- a/tests/src/test/scala/system/basic/WskRestBasicSwift311Tests.scala
+++ b/tests/src/test/scala/system/basic/WskRestBasicSwift311Tests.scala
@@ -17,16 +17,13 @@
 
 package system.basic
 
+import common.rest.WskRest
+
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
-import common.JsHelpers
-import common.WskTestHelpers
-
 @RunWith(classOf[JUnitRunner])
-class WskUnicodePython3Tests extends WskUnicodeTests with WskTestHelpers with JsHelpers {
-
-  override lazy val actionKind = "python:3"
-  override lazy val actionSource = "unicode3.py"
-
+class WskRestBasicSwift311Tests extends WskBasicSwift3Tests {
+  override val wsk: common.rest.WskRest = new WskRest
+  override lazy val currentSwiftDefaultKind = "swift:3.1.1"
 }

--- a/tests/src/test/scala/system/basic/WskRestBasicSwift3Tests.scala
+++ b/tests/src/test/scala/system/basic/WskRestBasicSwift3Tests.scala
@@ -17,16 +17,12 @@
 
 package system.basic
 
+import common.rest.WskRest
+
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
-import common.JsHelpers
-import common.WskTestHelpers
-
 @RunWith(classOf[JUnitRunner])
-class WskUnicodeJavaTests extends WskUnicodeTests with WskTestHelpers with JsHelpers {
-
-  override lazy val actionKind = "java"
-  override lazy val actionSource = "unicode.jar"
-
+class WskRestBasicSwift3Tests extends WskBasicSwift3Tests {
+  override val wsk: common.rest.WskRest = new WskRest
 }

--- a/tests/src/test/scala/system/basic/WskRestUnicodeJavaTests.scala
+++ b/tests/src/test/scala/system/basic/WskRestUnicodeJavaTests.scala
@@ -22,11 +22,13 @@ import org.scalatest.junit.JUnitRunner
 
 import common.JsHelpers
 import common.WskTestHelpers
+import common.rest.WskRest
 
 @RunWith(classOf[JUnitRunner])
-class WskUnicodeNodeTests extends WskUnicodeTests with WskTestHelpers with JsHelpers {
+class WskRestUnicodeJavaTests extends WskUnicodeTests with WskTestHelpers with JsHelpers {
 
-  override lazy val actionKind = "nodejs:6"
-  override lazy val actionSource = "unicode.js"
+  override val wsk: common.rest.WskRest = new WskRest
+  override lazy val actionKind = "java"
+  override lazy val actionSource = "unicode.jar"
 
 }

--- a/tests/src/test/scala/system/basic/WskRestUnicodeNodeTests.scala
+++ b/tests/src/test/scala/system/basic/WskRestUnicodeNodeTests.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package system.basic
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import common.JsHelpers
+import common.WskTestHelpers
+import common.rest.WskRest
+
+@RunWith(classOf[JUnitRunner])
+class WskRestUnicodeNodeTests extends WskUnicodeTests with WskTestHelpers with JsHelpers {
+
+  override val wsk: common.rest.WskRest = new WskRest
+  override lazy val actionKind = "nodejs:6"
+  override lazy val actionSource = "unicode.js"
+
+}

--- a/tests/src/test/scala/system/basic/WskRestUnicodePython2Tests.scala
+++ b/tests/src/test/scala/system/basic/WskRestUnicodePython2Tests.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package system.basic
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import common.JsHelpers
+import common.WskTestHelpers
+import common.rest.WskRest
+
+@RunWith(classOf[JUnitRunner])
+class WskRestUnicodePython2Tests extends WskUnicodeTests with WskTestHelpers with JsHelpers {
+
+  override val wsk: common.rest.WskRest = new WskRest
+  override lazy val actionKind = "python:2"
+  override lazy val actionSource = "unicode2.py"
+
+}

--- a/tests/src/test/scala/system/basic/WskRestUnicodePython3Tests.scala
+++ b/tests/src/test/scala/system/basic/WskRestUnicodePython3Tests.scala
@@ -20,8 +20,15 @@ package system.basic
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
-class WskBasicSwift311Tests extends WskBasicSwift3Tests {
+import common.JsHelpers
+import common.WskTestHelpers
+import common.rest.WskRest
 
-  override lazy val currentSwiftDefaultKind = "swift:3.1.1"
+@RunWith(classOf[JUnitRunner])
+class WskRestUnicodePython3Tests extends WskUnicodeTests with WskTestHelpers with JsHelpers {
+
+  override val wsk: common.rest.WskRest = new WskRest
+  override lazy val actionKind = "python:3"
+  override lazy val actionSource = "unicode3.py"
+
 }

--- a/tests/src/test/scala/system/basic/WskRestUnicodeSwift311Tests.scala
+++ b/tests/src/test/scala/system/basic/WskRestUnicodeSwift311Tests.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package system.basic
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import common.JsHelpers
+import common.WskTestHelpers
+import common.rest.WskRest
+
+@RunWith(classOf[JUnitRunner])
+class WskRestUnicodeSwift311Tests extends WskUnicodeTests with WskTestHelpers with JsHelpers {
+
+  override val wsk: common.rest.WskRest = new WskRest
+  override lazy val actionKind = "swift:3.1.1"
+  override lazy val actionSource = "unicode.swift"
+
+}

--- a/tests/src/test/scala/system/basic/WskRestUnicodeSwift3Tests.scala
+++ b/tests/src/test/scala/system/basic/WskRestUnicodeSwift3Tests.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package system.basic
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import common.JsHelpers
+import common.WskTestHelpers
+import common.rest.WskRest
+
+@RunWith(classOf[JUnitRunner])
+class WskRestUnicodeSwift3Tests extends WskUnicodeTests with WskTestHelpers with JsHelpers {
+
+  override val wsk: common.rest.WskRest = new WskRest
+  override lazy val actionKind = "swift:3"
+  override lazy val actionSource = "unicode.swift"
+
+}

--- a/tests/src/test/scala/system/basic/WskUnicodeTests.scala
+++ b/tests/src/test/scala/system/basic/WskUnicodeTests.scala
@@ -23,7 +23,7 @@ import org.scalatest.junit.JUnitRunner
 import common.JsHelpers
 import common.TestHelpers
 import common.TestUtils
-import common.Wsk
+import common.BaseWsk
 import common.WskProps
 import common.WskTestHelpers
 import spray.json._
@@ -34,8 +34,8 @@ abstract class WskUnicodeTests extends TestHelpers with WskTestHelpers with JsHe
   val actionKind: String
   val actionSource: String
 
-  implicit val wskprops = WskProps()
-  val wsk = new Wsk
+  implicit val wskprops: common.WskProps = WskProps()
+  val wsk: BaseWsk
 
   s"$actionKind action" should "Ensure that UTF-8 in supported in source files, input params, logs, and output results" in withAssetCleaner(
     wskprops) { (wp, assetHelper) =>


### PR DESCRIPTION
Swift3, Swift311, Python, Node and Java are not cli related tests.
We do not have to maintain them as cli test suites, so a straight
replacement of wsk with wskrest will be sufficient for them.