### PR TITLE
Deploy invoker on same docker network with cell container

### DIFF
--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -113,6 +113,7 @@
         --name invoker{{ groups['invokers'].index(inventory_hostname) }}
         --hostname invoker{{ groups['invokers'].index(inventory_hostname) }}
         --restart {{ docker.restart.policy }}
+        --network {{ invoker_container_network_name | default("bridge") }}
         -e JAVA_OPTS='-Xmx{{ invoker.heap }} -XX:+CrashOnOutOfMemoryError -XX:+UseGCOverheadLimit -XX:ErrorFile=/logs/java_error.log'
         -e INVOKER_OPTS='{{ invoker.arguments }}'
         -e COMPONENT_NAME='invoker{{ groups['invokers'].index(inventory_hostname) }}'


### PR DESCRIPTION
Edit ansible script to deploy invoker on same docker network with cell container.
Invoker can't connect to a cell container if they are on different docker network.

```
[DockerContainer] initialization result: ConnectionError(org.apache.http.conn.ConnectTimeoutException: Connect to 10.252.128.7:8080 [/10.252.128.7] failed: connect timed out) [marker:invoker_activationInit_finish:84866:60310]
```