### PR TITLE
Emit counter metrics for start and error cases

### DIFF
--- a/common/scala/src/main/scala/whisk/common/TransactionId.scala
+++ b/common/scala/src/main/scala/whisk/common/TransactionId.scala
@@ -88,6 +88,10 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
       logging.emit(logLevel, this, from, message)
     }
 
+    if (TransactionId.metricsKamon) {
+      MetricEmitter.emitCounterMetric(marker)
+    }
+
     StartMarker(Instant.now, marker)
   }
 
@@ -152,6 +156,7 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
 
     if (TransactionId.metricsKamon) {
       MetricEmitter.emitHistogramMetric(endMarker, deltaToEnd)
+      MetricEmitter.emitCounterMetric(endMarker)
     }
   }
 


### PR DESCRIPTION
Hello, 

this change enables emitting counter metrics for started and failed transaction, since in some InfluxDB/Grafana versions histogram values cannot be counted.

regards, Vadim. 