### PR TITLE
Fix the example of default parameters

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -258,7 +258,7 @@ Rather than pass all the parameters to an action every time, you can bind certai
   ```json
   {
     "name": "Bernie",
-    "place": "Vermont"
+    "place": "Washington, DC"
   }
   ```
 


### PR DESCRIPTION
Update example that has place name overwritten by 'Washington, DC'