### PR TITLE
Convert inline code to attachment in database

### DIFF
--- a/tools/db/README.md
+++ b/tools/db/README.md
@@ -143,20 +143,7 @@ To replay a snapshot, swap `--sourceDbUrl` and `--targetDbUrl` and call the scri
 
 To reduce the memory consumption in the OpenWhisk controller, all code inlined in action documents has been moved to attachments. This change allows only metadata for actions to be fetched instead of the entire action. Though the OpenWhisk controller supports both mentioned schemas, it is ideal to update existing databases to use the new schema for memory consumption relief.
 
-1. The design document provided below will return all actions that are using the old schema. This design document needs to be manually to the related CouchDB
-```
-{
-  "_id": "_design/actionMigrate",
-  "language": "javascript",
-  "views": {
-    "actions": {
-      "map": "function (doc) {   var isAction = function (doc) {     return (doc.exec !== undefined)   };   var isMigrated = function (doc) {     return (doc._attachments !== undefined && doc._attachments.codefile !== undefined && typeof doc.code != 'string')   };   if (isAction(doc) && !isMigrated(doc)) try {     emit([doc.name]);   } catch (e) {} }"
-    }
-  }
-}
-```
-
-2. Run the `moveCodeToAttachment.py` to complete the schema update. Two parameters are required:
+Run `moveCodeToAttachment.py` to update actions in an existing database to the new action schema. Two parameters are required:
 
 * `--dbUrl`: Server URL of the database. E.g. 'https://xxx:yyy@domain.couch.com:443'.
 * `--dbName`: Name of the Database to update.

--- a/tools/db/moveCodeToAttachment.py
+++ b/tools/db/moveCodeToAttachment.py
@@ -63,10 +63,10 @@ def updateNonJavaAction(db, doc, id):
 
 def createNonMigratedDoc(db):
     try:
-        db['_design/nonMigrated2']
+        db['_design/nonMigrated']
     except ResourceNotFound:
         db.save({
-            '_id': '_design/nonMigrated2',
+            '_id': '_design/nonMigrated',
             'language': 'javascript',
             'views': {
                 'actions': {
@@ -74,6 +74,9 @@ def createNonMigratedDoc(db):
                 }
             }
         })
+
+def deleteNonMigratedDoc(db):
+    del db['_design/nonMigrated']
 
 def main(args):
     db = couchdb.client.Server(args.dbUrl)[args.dbName]
@@ -103,6 +106,8 @@ def main(args):
                 print('Action already updated: "{0}"'.format(id))
 
         docIndex = docIndex + 1
+
+    deleteNonMigratedDoc(db)
 
 parser = argparse.ArgumentParser(description='Utility to update database action schema.')
 parser.add_argument('--dbUrl', required=True, help='Server URL of the database. E.g. \"https://xxx:yyy@domain.couch.com:443\"')

--- a/tools/db/moveCodeToAttachment.py
+++ b/tools/db/moveCodeToAttachment.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+'''Python script update actions.
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the 'License'); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'''
+
+import argparse
+import couchdb.client
+import time
+import base64
+
+def updateJavaAction(db, doc, id):
+    updated = False
+    attachment = db.get_attachment(doc, 'jarfile')
+
+    if attachment != None:
+        print('Updating Java action: "{0}"'.format(id))
+        encodedAttachment = base64.b64encode(attachment.getvalue())
+        db.put_attachment(doc, encodedAttachment, 'codefile', 'text/plain')
+        doc = db.get(id)
+        doc['exec']['code'] = {
+            'attachmentName': 'codefile',
+            'attachmentType': 'text/plain'
+        }
+        if 'jar' in doc['exec']:
+            del doc['exec']['jar']
+        db.save(doc)
+        db.delete_attachment(doc, 'jarfile')
+        updated = True
+
+    return updated
+
+def updateNonJavaAction(db, doc, id):
+    updated = False
+    code = doc['exec']['code']
+
+    if not isinstance(code, dict):
+        print('Updating action: "{0}"'.format(id))
+        db.put_attachment(doc, code, 'codefile', 'text/plain')
+        doc = db.get(id)
+        doc['exec']['code'] = {
+            'attachmentName': 'codefile',
+            'attachmentType': 'text/plain'
+        }
+        db.save(doc)
+        updated = True
+
+    return updated
+
+def main(args):
+    db = couchdb.client.Server(args.dbUrl)[args.dbName]
+    docs = db.view('_all_docs')
+    docCount = len(docs)
+    docIndex = 1
+
+    print('Number of docs: {}'.format(docCount))
+
+    for row in docs:
+        id = row.id
+        doc = db.get(id)
+
+        print('Checking if document {0}/{1} is an action: "{2}"'.format(docIndex, docCount, id))
+
+        if 'exec' in doc and 'code' in doc['exec']:
+            print('Document is an action: "{0}"'.format(id))
+
+            if doc['exec']['kind'] != 'java':
+                updated = updateNonJavaAction(db, doc, id)
+            else:
+                updated = updateJavaAction(db, doc, id)
+
+            if updated:
+                print('Updated action: "{0}"'.format(id))
+                time.sleep(.700)
+            else:
+                print('Action already updated: "{0}"'.format(id))
+
+        docIndex = docIndex + 1
+
+parser = argparse.ArgumentParser(description='Utility to update database action schema.')
+parser.add_argument('--dbUrl', required=True, help='Server URL of the database. E.g. \"https://xxx:yyy@domain.couch.com:443\"')
+parser.add_argument('--dbName', required=True, help='Name of the Database to update.')
+args = parser.parse_args()
+
+main(args)


### PR DESCRIPTION
Updates actions in database to move code from being inlined in the document to an attachment. The associated code for Java actions are already attachments. These changes Base64 encode Java attachments. In addition, the old exec.jar field is removed from Java actions.

Depends on https://github.com/apache/incubator-openwhisk/pull/2847