### PR TITLE
Increase the number of max open requests

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -9,7 +9,7 @@ akka.http {
 
     host-connection-pool {
         max-connections = 128
-        max-open-requests = 128
+        max-open-requests = 512
     }
 }
 

--- a/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
@@ -71,7 +71,7 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
 
   // This the the amount of allowed parallel requests for each entity, before batching starts. If there are already maxOpenDbRequests
   // and more documents need to be stored, then all arriving documents will be put into batches (if enabled) to avoid a long queue.
-  private val maxOpenDbRequests = system.settings.config.getInt("akka.http.host-connection-pool.max-open-requests") / 2
+  private val maxOpenDbRequests = system.settings.config.getInt("akka.http.host-connection-pool.max-connections") / 2
 
   private val batcher: Batcher[JsObject, Either[ArtifactStoreException, DocInfo]] =
     new Batcher(500, maxOpenDbRequests)(put(_)(TransactionId.unknown))


### PR DESCRIPTION
At the moment we divide the number of parallel requests across 3 stores that use CouchDB client: entity, authstore and activationStore, thanks to the fact that the number of requests is shared across all flow materialisations as per this doc:
https://doc.akka.io/docs/akka-http/current/scala/http/configuration.html

This PR should help to prevent dropping the connections if the number of parallel requests to couchdb exceeds the max number of open connections.  
> Common causes of pool overload: 
There are peaks in the request rate (prevent peaks by tuning the client application or increase max-open-requests to buffer short-term peaks)
https://doc.akka.io/docs/akka-http/current/scala/http/client-side/pool-overflow.html

@bwmcadams please correct me if this is not correct.  

Thanks. 