### PR TITLE
Re-implement the non-cli test cases with REST

### DIFF
--- a/tests/src/test/resources/application.conf
+++ b/tests/src/test/resources/application.conf
@@ -1,5 +1,3 @@
-akka.ssl-config.hostnameVerifierClass = common.rest.AcceptAllHostNameVerifier
-
 whisk.spi {
   SimpleSpi = whisk.spi.SimpleSpiImpl
   MissingSpi = whisk.spi.MissingImpl

--- a/tests/src/test/scala/common/WhiskProperties.java
+++ b/tests/src/test/scala/common/WhiskProperties.java
@@ -200,11 +200,20 @@ public class WhiskProperties {
         return whiskProperties.getProperty("router.host");
     }
 
+    public static String getApiProto() {
+        return whiskProperties.getProperty("whisk.api.host.proto");
+    }
+
+    public static String getApiHost() {
+        return whiskProperties.getProperty("whisk.api.host.name");
+    }
+
+    public static String getApiPort() {
+        return whiskProperties.getProperty("whisk.api.host.port");
+    }
+
     public static String getApiHostForAction() {
-        String proto = whiskProperties.getProperty("whisk.api.host.proto");
-        String port = whiskProperties.getProperty("whisk.api.host.port");
-        String host = whiskProperties.getProperty("whisk.api.host.name");
-        return proto + "://" + host + ":" + port;
+        return getApiProto() + "://" + getApiHost() + ":" + getApiPort();
     }
 
     public static String getApiHostForClient(String subdomain, boolean includeProtocol) {
@@ -235,11 +244,11 @@ public class WhiskProperties {
     }
 
     public static String getBaseControllerHost() {
-    	return getControllerHosts().split(",")[0];
+        return getControllerHosts().split(",")[0];
     }
 
     public static String getBaseControllerAddress() {
-    	return getBaseControllerHost() + ":" + getControllerBasePort();
+        return getBaseControllerHost() + ":" + getControllerBasePort();
     }
 
     public static int getMaxActionInvokesPerMinute() {

--- a/tests/src/test/scala/ha/ShootComponentsTests.scala
+++ b/tests/src/test/scala/ha/ShootComponentsTests.scala
@@ -36,7 +36,7 @@ import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.ActorMaterializer
 import common.TestUtils
 import common.WhiskProperties
-import common.Wsk
+import common.rest.WskRest
 import common.WskActorSystem
 import common.WskProps
 import common.WskTestHelpers
@@ -47,7 +47,7 @@ import whisk.utils.retry
 class ShootComponentsTests extends FlatSpec with Matchers with WskTestHelpers with ScalaFutures with WskActorSystem {
 
   implicit val wskprops = WskProps()
-  val wsk = new Wsk
+  val wsk = new WskRest
   val defaultAction = Some(TestUtils.getTestActionFilename("hello.js"))
 
   implicit val materializer = ActorMaterializer()

--- a/tests/src/test/scala/limits/ThrottleTests.scala
+++ b/tests/src/test/scala/limits/ThrottleTests.scala
@@ -19,6 +19,8 @@ package limits
 
 import java.time.Instant
 
+import akka.http.scaladsl.model.StatusCodes.TooManyRequests
+
 import scala.collection.parallel.immutable.ParSeq
 import scala.concurrent.Future
 import scala.concurrent.Promise
@@ -34,7 +36,7 @@ import common.TestHelpers
 import common.TestUtils
 import common.TestUtils._
 import common.WhiskProperties
-import common.Wsk
+import common.rest.WskRest
 import common.WskActorSystem
 import common.WskProps
 import common.WskTestHelpers
@@ -65,7 +67,7 @@ class ThrottleTests
 
   implicit val testConfig = PatienceConfig(5.minutes)
   implicit val wskprops = WskProps()
-  val wsk = new Wsk
+  val wsk = new WskRest
   val defaultAction = Some(TestUtils.getTestActionFilename("hello.js"))
 
   val throttleWindow = 1.minute
@@ -296,7 +298,7 @@ class NamespaceSpecificThrottleTests
     with LocalHelper {
 
   val wskadmin = new RunWskAdminCmd {}
-  val wsk = new Wsk
+  val wsk = new WskRest
 
   val defaultAction = Some(TestUtils.getTestActionFilename("hello.js"))
 
@@ -346,10 +348,10 @@ class NamespaceSpecificThrottleTests
       trigger.create(triggerName)
     }
 
-    wsk.action.invoke(actionName, expectedExitCode = TestUtils.THROTTLED).stderr should {
+    wsk.action.invoke(actionName, expectedExitCode = TooManyRequests.intValue).stderr should {
       include(prefix(tooManyRequests(0, 0))) and include("allowed: 0")
     }
-    wsk.trigger.fire(triggerName, expectedExitCode = TestUtils.THROTTLED).stderr should {
+    wsk.trigger.fire(triggerName, expectedExitCode = TooManyRequests.intValue).stderr should {
       include(prefix(tooManyRequests(0, 0))) and include("allowed: 0")
     }
   }
@@ -401,7 +403,7 @@ class NamespaceSpecificThrottleTests
       action.create(actionName, defaultAction)
     }
 
-    wsk.action.invoke(actionName, expectedExitCode = TestUtils.THROTTLED).stderr should {
+    wsk.action.invoke(actionName, expectedExitCode = TooManyRequests.intValue).stderr should {
       include(prefix(tooManyConcurrentRequests(0, 0))) and include("allowed: 0")
     }
   }

--- a/tests/src/test/scala/services/HeadersTests.scala
+++ b/tests/src/test/scala/services/HeadersTests.scala
@@ -31,7 +31,7 @@ import org.scalatest.time.Span.convertDurationToSpan
 
 import common.TestUtils
 import common.WhiskProperties
-import common.Wsk
+import common.rest.WskRest
 import common.WskProps
 import common.WskTestHelpers
 
@@ -82,7 +82,7 @@ class HeadersTests extends FlatSpec with Matchers with ScalaFutures with WskActo
 
   val basePath = Path("/api/v1")
   implicit val wskprops = WskProps()
-  val wsk = new Wsk
+  val wsk = new WskRest
 
   /**
    * Checks, if the required headers are in the list of all headers.

--- a/tests/src/test/scala/system/rest/ActionSchemaTests.scala
+++ b/tests/src/test/scala/system/rest/ActionSchemaTests.scala
@@ -29,7 +29,7 @@ import com.jayway.restassured.RestAssured
 
 import common.TestUtils
 import common.WhiskProperties
-import common.Wsk
+import common.rest.WskRest
 import common.WskProps
 import common.WskTestHelpers
 import spray.json.JsArray
@@ -43,7 +43,7 @@ import spray.json.pimpString
 class ActionSchemaTests extends FlatSpec with Matchers with RestUtil with JsonSchema with WskTestHelpers {
 
   implicit val wskprops = WskProps()
-  val wsk = new Wsk
+  val wsk = new WskRest
   val guestNamespace = wskprops.namespace
 
   it should "respond to GET /actions as documented in swagger" in withAssetCleaner(wskprops) { (wp, assetHelper) =>

--- a/tests/src/test/scala/whisk/core/admin/WskAdminTests.scala
+++ b/tests/src/test/scala/whisk/core/admin/WskAdminTests.scala
@@ -25,7 +25,7 @@ import org.scalatest.junit.JUnitRunner
 
 import common.RunWskAdminCmd
 import common.TestHelpers
-import common.Wsk
+import common.rest.WskRest
 import common.WskAdmin
 import common.WskProps
 import whisk.core.entity.AuthKey
@@ -87,7 +87,7 @@ class WskAdminTests extends TestHelpers with Matchers {
   it should "verify guest account installed correctly" in {
     val wskadmin = new RunWskAdminCmd {}
     implicit val wskprops = WskProps()
-    val wsk = new Wsk
+    val wsk = new WskRest
     val ns = wsk.namespace.whois()
     wskadmin.cli(Seq("user", "get", ns)).stdout.trim should be(wskprops.authKey)
   }

--- a/tests/src/test/scala/whisk/core/database/test/CacheConcurrencyTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/CacheConcurrencyTests.scala
@@ -17,6 +17,8 @@
 
 package whisk.core.database.test
 
+import akka.http.scaladsl.model.StatusCodes.NotFound
+
 import scala.collection.parallel._
 import scala.concurrent.forkjoin.ForkJoinPool
 
@@ -27,7 +29,7 @@ import org.scalatest.junit.JUnitRunner
 
 import common.TestUtils
 import common.TestUtils._
-import common.Wsk
+import common.rest.WskRest
 import common.WskProps
 import common.WskTestHelpers
 import spray.json.JsString
@@ -40,7 +42,7 @@ class CacheConcurrencyTests extends FlatSpec with WskTestHelpers with BeforeAndA
 
   implicit private val transId = TransactionId.testing
   implicit private val wp = WskProps()
-  private val wsk = new Wsk
+  private val wsk = new WskRest
 
   val nExternalIters = 1
   val nInternalIters = 5
@@ -97,7 +99,7 @@ class CacheConcurrencyTests extends FlatSpec with WskTestHelpers with BeforeAndA
       }
 
       run("get after delete") { name =>
-        wsk.action.get(name, expectedExitCode = NOT_FOUND)
+        wsk.action.get(name, expectedExitCode = NotFound.intValue)
       }
 
       run("recreate") { name =>

--- a/tests/src/test/scala/whisk/core/limits/ActionLimitsTests.scala
+++ b/tests/src/test/scala/whisk/core/limits/ActionLimitsTests.scala
@@ -17,6 +17,9 @@
 
 package whisk.core.limits
 
+import akka.http.scaladsl.model.StatusCodes.RequestEntityTooLarge
+import akka.http.scaladsl.model.StatusCodes.BadGateway
+
 import java.io.File
 import java.io.PrintWriter
 
@@ -29,9 +32,8 @@ import org.scalatest.junit.JUnitRunner
 import common.ActivationResult
 import common.TestHelpers
 import common.TestUtils
-import common.TestUtils.TOO_LARGE
 import common.WhiskProperties
-import common.Wsk
+import common.rest.WskRest
 import common.WskProps
 import common.WskTestHelpers
 import spray.json._
@@ -47,7 +49,7 @@ import whisk.http.Messages
 class ActionLimitsTests extends TestHelpers with WskTestHelpers {
 
   implicit val wskprops = WskProps()
-  val wsk = new Wsk()
+  val wsk = new WskRest
 
   val defaultDosAction = TestUtils.getTestActionFilename("timeout.js")
   val allowedActionDuration = 10 seconds
@@ -148,10 +150,10 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers {
 
       // this tests an active ack failure to post from invoker
       val args = Map("size" -> (allowedSize + 1).toJson, "char" -> "a".toJson)
-      val code = if (blocking) TestUtils.APP_ERROR else TestUtils.SUCCESS_EXIT
+      val code = if (blocking) BadGateway.intValue else TestUtils.ACCEPTED
       val rr = wsk.action.invoke(name, args, blocking = blocking, expectedExitCode = code)
       if (blocking) {
-        checkResponse(wsk.parseJsonString(rr.stderr).convertTo[ActivationResult])
+        checkResponse(wsk.parseJsonString(rr.respData).convertTo[ActivationResult])
       } else {
         withActivation(wsk.activation, rr, totalWait = 120 seconds) { checkResponse(_) }
       }
@@ -187,7 +189,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers {
     pw.close
 
     assetHelper.withCleaner(wsk.action, name, confirmDelete = false) { (action, _) =>
-      action.create(name, Some(actionCode.getAbsolutePath), expectedExitCode = TOO_LARGE)
+      action.create(name, Some(actionCode.getAbsolutePath), expectedExitCode = RequestEntityTooLarge.intValue)
     }
 
     actionCode.delete

--- a/tests/src/test/scala/whisk/core/limits/MaxActionDurationTests.scala
+++ b/tests/src/test/scala/whisk/core/limits/MaxActionDurationTests.scala
@@ -24,7 +24,7 @@ import org.scalatest.junit.JUnitRunner
 
 import common.TestHelpers
 import common.TestUtils
-import common.Wsk
+import common.rest.WskRest
 import common.WskProps
 import common.WskTestHelpers
 import whisk.core.entity._
@@ -40,7 +40,7 @@ import whisk.core.entity.TimeLimit
 class MaxActionDurationTests extends TestHelpers with WskTestHelpers {
 
   implicit val wskprops = WskProps()
-  val wsk = new Wsk
+  val wsk = new WskRest
 
   // swift is not tested, because it uses the same proxy like python
   "node-, python, and java-action" should "run up to the max allowed duration" in withAssetCleaner(wskprops) {


### PR DESCRIPTION
The test cases changed in this PR are non-CLI test cases, which should use
the REST only to access the openwhisk services. This PR replaces the Wsk
with WskRest in order to make it happen.