### PR TITLE
Reduce the number of logs on info level

### DIFF
--- a/common/scala/src/main/scala/whisk/common/Scheduler.scala
+++ b/common/scala/src/main/scala/whisk/common/Scheduler.scala
@@ -61,7 +61,7 @@ object Scheduler {
       }
     }
     override def postStop() = {
-      logging.info(this, s"$name shutdown")
+      logging.debug(this, s"$name shutdown")
       lastSchedule.foreach(_.cancel())
     }
 

--- a/common/scala/src/main/scala/whisk/common/TransactionId.scala
+++ b/common/scala/src/main/scala/whisk/common/TransactionId.scala
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.math.BigDecimal.int2bigDecimal
 import scala.util.Try
-import akka.event.Logging.{InfoLevel, WarningLevel}
+import akka.event.Logging.{DebugLevel, InfoLevel, WarningLevel}
 import akka.event.Logging.LogLevel
 import spray.json._
 
@@ -53,11 +53,11 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
    * @param message An additional message that is written into the log, together with the other information.
    * @param logLevel The Loglevel, the message should have. Default is <code>InfoLevel</code>.
    */
-  def mark(from: AnyRef, marker: LogMarkerToken, message: String = "", logLevel: LogLevel = InfoLevel)(
+  def mark(from: AnyRef, marker: LogMarkerToken, message: String = "", logLevel: LogLevel = DebugLevel)(
     implicit logging: Logging) = {
 
     if (TransactionId.metricsLog) {
-      logging.emit(logLevel, this, from, createMessageWithMarker(message, LogMarker(marker, deltaToStart)))
+      logging.emit(InfoLevel, this, from, createMessageWithMarker(message, LogMarker(marker, deltaToStart)))
     } else if (message.nonEmpty) {
       logging.emit(logLevel, this, from, message)
     }
@@ -79,11 +79,11 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
    *
    * @return startMarker that has to be passed to the finished or failed method to calculate the time difference.
    */
-  def started(from: AnyRef, marker: LogMarkerToken, message: String = "", logLevel: LogLevel = InfoLevel)(
+  def started(from: AnyRef, marker: LogMarkerToken, message: String = "", logLevel: LogLevel = DebugLevel)(
     implicit logging: Logging): StartMarker = {
 
     if (TransactionId.metricsLog) {
-      logging.emit(logLevel, this, from, createMessageWithMarker(message, LogMarker(marker, deltaToStart)))
+      logging.emit(InfoLevel, this, from, createMessageWithMarker(message, LogMarker(marker, deltaToStart)))
     } else if (message.nonEmpty) {
       logging.emit(logLevel, this, from, message)
     }
@@ -107,7 +107,7 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
   def finished(from: AnyRef,
                startMarker: StartMarker,
                message: String = "",
-               logLevel: LogLevel = InfoLevel,
+               logLevel: LogLevel = DebugLevel,
                endTime: Instant = Instant.now(Clock.systemUTC))(implicit logging: Logging) = {
 
     val endMarker =
@@ -116,7 +116,7 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
 
     if (TransactionId.metricsLog) {
       logging.emit(
-        logLevel,
+        InfoLevel,
         this,
         from,
         createMessageWithMarker(message, LogMarker(endMarker, deltaToStart, Some(deltaToEnd))))

--- a/common/scala/src/main/scala/whisk/common/TransactionId.scala
+++ b/common/scala/src/main/scala/whisk/common/TransactionId.scala
@@ -57,6 +57,7 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
     implicit logging: Logging) = {
 
     if (TransactionId.metricsLog) {
+      // marker received with a debug level will be emitted on info level
       logging.emit(InfoLevel, this, from, createMessageWithMarker(message, LogMarker(marker, deltaToStart)))
     } else if (message.nonEmpty) {
       logging.emit(logLevel, this, from, message)
@@ -83,6 +84,7 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
     implicit logging: Logging): StartMarker = {
 
     if (TransactionId.metricsLog) {
+      // marker received with a debug level will be emitted on info level
       logging.emit(InfoLevel, this, from, createMessageWithMarker(message, LogMarker(marker, deltaToStart)))
     } else if (message.nonEmpty) {
       logging.emit(logLevel, this, from, message)

--- a/common/scala/src/main/scala/whisk/core/connector/MessageConsumer.scala
+++ b/common/scala/src/main/scala/whisk/core/connector/MessageConsumer.scala
@@ -212,7 +212,7 @@ class MessageFeed(description: String,
       val (topic, partition, offset, bytes) = outstandingMessages.head
       outstandingMessages = outstandingMessages.tail
 
-      if (logHandoff) logging.info(this, s"processing $topic[$partition][$offset] ($occupancy/$handlerCapacity)")
+      if (logHandoff) logging.debug(this, s"processing $topic[$partition][$offset] ($occupancy/$handlerCapacity)")
       handler(bytes)
       handlerCapacity -= 1
 

--- a/common/scala/src/main/scala/whisk/core/containerpool/Container.scala
+++ b/common/scala/src/main/scala/whisk/core/containerpool/Container.scala
@@ -40,6 +40,7 @@ import whisk.core.entity.ActivationResponse.ContainerResponse
 import whisk.core.entity.ByteSize
 import whisk.core.entity.size._
 import whisk.http.Messages
+import akka.event.Logging.InfoLevel
 
 /**
  * An OpenWhisk biased container abstraction. This is **not only** an abstraction
@@ -126,7 +127,8 @@ trait Container {
             this,
             start.copy(start = r.interval.start),
             s"running result: ${r.toBriefString}",
-            endTime = r.interval.end)
+            endTime = r.interval.end,
+            logLevel = InfoLevel)
         case Failure(t) =>
           transid.failed(this, start, s"run failed with $t")
       }

--- a/common/scala/src/main/scala/whisk/core/containerpool/Container.scala
+++ b/common/scala/src/main/scala/whisk/core/containerpool/Container.scala
@@ -80,7 +80,11 @@ trait Container {
 
   /** Initializes code in the container. */
   def initialize(initializer: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[Interval] = {
-    val start = transid.started(this, LoggingMarkers.INVOKER_ACTIVATION_INIT, s"sending initialization to $id $addr")
+    val start = transid.started(
+      this,
+      LoggingMarkers.INVOKER_ACTIVATION_INIT,
+      s"sending initialization to $id $addr",
+      logLevel = InfoLevel)
 
     val body = JsObject("value" -> initializer)
     callContainer("/init", body, timeout, retry = true)
@@ -90,7 +94,8 @@ trait Container {
             this,
             start.copy(start = r.interval.start),
             s"initialization result: ${r.toBriefString}",
-            endTime = r.interval.end)
+            endTime = r.interval.end,
+            logLevel = InfoLevel)
         case Failure(t) =>
           transid.failed(this, start, s"initializiation failed with $t")
       }
@@ -116,7 +121,11 @@ trait Container {
     implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
     val actionName = environment.fields.get("action_name").map(_.convertTo[String]).getOrElse("")
     val start =
-      transid.started(this, LoggingMarkers.INVOKER_ACTIVATION_RUN, s"sending arguments to $actionName at $id $addr")
+      transid.started(
+        this,
+        LoggingMarkers.INVOKER_ACTIVATION_RUN,
+        s"sending arguments to $actionName at $id $addr",
+        logLevel = InfoLevel)
 
     val parameterWrapper = JsObject("value" -> parameters)
     val body = JsObject(parameterWrapper.fields ++ environment.fields)

--- a/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
+++ b/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
@@ -315,7 +315,7 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
    *
    */
   private def makeNoteOfCacheHit(key: CacheKey)(implicit transid: TransactionId, logger: Logging) = {
-    transid.mark(this, LoggingMarkers.DATABASE_CACHE_HIT, s"[GET] serving from cache: $key")(logger)
+    transid.started(this, LoggingMarkers.DATABASE_CACHE_HIT, s"[GET] serving from cache: $key")(logger)
   }
 
   /**
@@ -323,7 +323,7 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
    *
    */
   private def makeNoteOfCacheMiss(key: CacheKey)(implicit transid: TransactionId, logger: Logging) = {
-    transid.mark(this, LoggingMarkers.DATABASE_CACHE_MISS, s"[GET] serving from datastore: $key")(logger)
+    transid.started(this, LoggingMarkers.DATABASE_CACHE_MISS, s"[GET] serving from datastore: $key")(logger)
   }
 
   /**

--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -250,10 +250,10 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
                       complete(InternalServerError, response)
                     }
                   case Failure(t: RecordTooLargeException) =>
-                    logging.info(this, s"[POST] action payload was too large")
+                    logging.debug(this, s"[POST] action payload was too large")
                     terminate(RequestEntityTooLarge)
                   case Failure(RejectRequest(code, message)) =>
-                    logging.info(this, s"[POST] action rejected with code $code: $message")
+                    logging.debug(this, s"[POST] action rejected with code $code: $message")
                     terminate(code, message)
                   case Failure(t: Throwable) =>
                     logging.error(this, s"[POST] action activation failed: ${t.getMessage}")
@@ -389,7 +389,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
     implicit transid: TransactionId) = {
     exec match {
       case Some(seq: SequenceExec) =>
-        logging.info(this, "checking if sequence components are accessible")
+        logging.debug(this, "checking if sequence components are accessible")
         entitlementProvider.check(user, right, referencedEntities(seq), noThrottle = true)
       case _ => Future.successful(true)
     }
@@ -516,10 +516,10 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
     // resolved namespace
     getEntity(WhiskPackage, entityStore, pkgName.toDocId, Some { (wp: WhiskPackage) =>
       val pkgns = wp.binding map { b =>
-        logging.info(this, s"list actions in package binding '${wp.name}' -> '$b'")
+        logging.debug(this, s"list actions in package binding '${wp.name}' -> '$b'")
         b.namespace.addPath(b.name)
       } getOrElse {
-        logging.info(this, s"list actions in package '${wp.name}'")
+        logging.debug(this, s"list actions in package '${wp.name}'")
         pkgName.path.addPath(wp.name)
       }
       // list actions in resolved namespace
@@ -541,7 +541,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
     wp.binding map {
       case b: Binding =>
         val docid = b.fullyQualifiedName.toDocId
-        logging.info(this, s"fetching package '$docid' for reference")
+        logging.debug(this, s"fetching package '$docid' for reference")
         // already checked that subject is authorized for package and binding;
         // this fetch is redundant but should hit the cache to ameliorate cost
         getEntity(WhiskPackage, entityStore, docid, Some {
@@ -554,7 +554,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
       val ns = wp.namespace.addPath(wp.name) // the package namespace
       val resource = Resource(ns, collection, Some { action.asString }, Some { params })
       val right = collection.determineRight(method, resource.entity)
-      logging.info(this, s"merged package parameters and rebased action to '$ns")
+      logging.debug(this, s"merged package parameters and rebased action to '$ns")
       dispatchOp(user, right, resource)
     }
   }

--- a/core/controller/src/main/scala/whisk/core/controller/Authenticate.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Authenticate.scala
@@ -59,7 +59,7 @@ trait Authenticate {
       Try {
         // authkey deserialization is wrapped in a try to guard against malformed values
         val authkey = AuthKey(UUID(pw.username), Secret(pw.password))
-        logging.debug(this, s"authenticate: ${authkey.uuid}")
+        logging.info(this, s"authenticate: ${authkey.uuid}")
         val future = Identity.get(authStore, authkey) map { result =>
           if (authkey == result.authkey) {
             logging.debug(this, s"authentication valid")

--- a/core/controller/src/main/scala/whisk/core/controller/Authenticate.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Authenticate.scala
@@ -59,25 +59,25 @@ trait Authenticate {
       Try {
         // authkey deserialization is wrapped in a try to guard against malformed values
         val authkey = AuthKey(UUID(pw.username), Secret(pw.password))
-        logging.info(this, s"authenticate: ${authkey.uuid}")
+        logging.debug(this, s"authenticate: ${authkey.uuid}")
         val future = Identity.get(authStore, authkey) map { result =>
           if (authkey == result.authkey) {
-            logging.info(this, s"authentication valid")
+            logging.debug(this, s"authentication valid")
             Some(result)
           } else {
-            logging.info(this, s"authentication not valid")
+            logging.debug(this, s"authentication not valid")
             None
           }
         } recover {
           case _: NoDocumentException | _: IllegalArgumentException =>
-            logging.info(this, s"authentication not valid")
+            logging.debug(this, s"authentication not valid")
             None
         }
         future onFailure { case t => logging.error(this, s"authentication error: $t") }
         future
       }.toOption
     } getOrElse {
-      credentials.foreach(_ => logging.info(this, s"credentials are malformed"))
+      credentials.foreach(_ => logging.debug(this, s"credentials are malformed"))
       Future.successful(None)
     }
   }

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -29,11 +29,8 @@ import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.server.Route
 import akka.stream.ActorMaterializer
 import spray.json._
-
 import spray.json.DefaultJsonProtocol._
-
 import kamon.Kamon
-
 import whisk.common.AkkaLogging
 import whisk.common.Logging
 import whisk.common.LoggingMarkers
@@ -51,6 +48,7 @@ import whisk.http.BasicHttpService
 import whisk.http.BasicRasService
 import whisk.spi.SpiLoader
 import whisk.core.containerpool.logging.LogStoreProvider
+import akka.event.Logging.InfoLevel
 
 /**
  * The Controller is the service that provides the REST API for OpenWhisk.
@@ -88,7 +86,8 @@ class Controller(val instance: InstanceId,
   TransactionId.controller.mark(
     this,
     LoggingMarkers.CONTROLLER_STARTUP(instance.toInt),
-    s"starting controller instance ${instance.toInt}")
+    s"starting controller instance ${instance.toInt}",
+    logLevel = InfoLevel)
 
   /**
    * A Route in Akka is technically a function taking a RequestContext as a parameter.

--- a/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
@@ -122,7 +122,7 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
             version = trigger.version,
             duration = None)
 
-          logging.info(this, s"[POST] trigger activated, writing activation record to datastore: $triggerActivationId")
+          logging.debug(this, s"[POST] trigger activated, writing activation record to datastore: $triggerActivationId")
           WhiskActivation.put(activationStore, triggerActivation) recover {
             case t =>
               logging.error(this, s"[POST] storing trigger activation $triggerActivationId failed: ${t.getMessage}")
@@ -178,7 +178,7 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
                         }
                       case NotFound =>
                         response.discardEntityBytes()
-                        logging.info(this, s"${rule.action} failed, action not found")
+                        logging.debug(this, s"${rule.action} failed, action not found")
                       case _ =>
                         Unmarshal(response.entity).to[String].map { error =>
                           logging.warn(this, s"${rule.action} failed due to $error")

--- a/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
@@ -658,7 +658,7 @@ trait WhiskWebActionsApi extends Directives with ValidateRequestSize with PostAc
       case Success(Left(activationId)) =>
         // blocking invoke which got queued instead
         // this should not happen, instead it should be a blocking invoke timeout
-        logging.info(this, "activation waiting period expired")
+        logging.debug(this, "activation waiting period expired")
         terminate(Accepted, Messages.responseNotReady)
 
       case Failure(t: RejectRequest) => terminate(t.code, t.message)
@@ -680,10 +680,10 @@ trait WhiskWebActionsApi extends Directives with ValidateRequestSize with PostAc
         // if the package lookup fails or the package doesn't conform to expected invariants,
         // fail the request with BadRequest so as not to leak information about the existence
         // of packages that are otherwise private
-        logging.info(this, s"package which does not exist")
+        logging.debug(this, s"package which does not exist")
         Future.failed(RejectRequest(NotFound))
       case _: NoSuchElementException =>
-        logging.warn(this, s"'$pkg' is a binding")
+        logging.debug(this, s"'$pkg' is a binding")
         Future.failed(RejectRequest(NotFound))
     }
   }
@@ -725,13 +725,13 @@ trait WhiskWebActionsApi extends Directives with ValidateRequestSize with PostAc
 
       if ((isExported && requiresAuthenticatedUser && authenticated) ||
           (isExported && !requiresAuthenticatedUser)) {
-        logging.info(this, s"${action.fullyQualifiedName(true)} is exported")
+        logging.debug(this, s"${action.fullyQualifiedName(true)} is exported")
         Future.successful(action)
       } else if (!isExported) {
-        logging.info(this, s"${action.fullyQualifiedName(true)} not exported")
+        logging.debug(this, s"${action.fullyQualifiedName(true)} not exported")
         Future.failed(RejectRequest(NotFound))
       } else {
-        logging.info(this, s"${action.fullyQualifiedName(true)} requires authentication")
+        logging.debug(this, s"${action.fullyQualifiedName(true)} requires authentication")
         Future.failed(RejectRequest(Unauthorized))
       }
     }

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
@@ -22,7 +22,6 @@ import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration._
 import scala.util.Failure
-
 import akka.actor.Actor
 import akka.actor.ActorRef
 import akka.actor.ActorSystem
@@ -40,6 +39,7 @@ import whisk.core.entity._
 import whisk.core.entity.types.ActivationStore
 import whisk.core.entity.types.EntityStore
 import whisk.utils.ExecutionContextFactory.FutureExtensions
+import akka.event.Logging.InfoLevel
 
 protected[actions] trait PrimitiveActions {
   /** The core collections require backend services to be injected in this trait. */
@@ -114,7 +114,8 @@ protected[actions] trait PrimitiveActions {
       this,
       waitForResponse
         .map(_ => LoggingMarkers.CONTROLLER_ACTIVATION_BLOCKING)
-        .getOrElse(LoggingMarkers.CONTROLLER_ACTIVATION))
+        .getOrElse(LoggingMarkers.CONTROLLER_ACTIVATION),
+      logLevel = InfoLevel)
     val startLoadbalancer =
       transid.started(this, LoggingMarkers.CONTROLLER_LOADBALANCER, s"action activation id: ${message.activationId}")
     val postedFuture = loadBalancer.publish(action, message)

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
@@ -163,7 +163,7 @@ protected[actions] trait PrimitiveActions {
       WhiskActivation.get(activationStore, docid)
     })
 
-    logging.info(this, s"action activation will block for result upto $totalWaitTime")
+    logging.debug(this, s"action activation will block for result upto $totalWaitTime")
 
     activeAckResponse map {
       case result @ Right(_) =>
@@ -277,7 +277,7 @@ protected[actions] object ActivationFinisher {
     }
 
     override def postStop() = {
-      logging.info(this, "finisher shutdown")
+      logging.debug(this, "finisher shutdown")
       preemptiveMsgs.foreach(_.cancel())
       preemptiveMsgs = Vector.empty
       context.stop(poller)

--- a/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
@@ -123,7 +123,7 @@ protected[actions] trait SequenceActions {
     if (topmost) { // need to deal with blocking and closing connection
       waitForOutermostResponse
         .map { timeout =>
-          logging.info(this, s"invoke sequence blocking topmost!")
+          logging.debug(this, s"invoke sequence blocking topmost!")
           futureSeqResult.withAlternativeAfterTimeout(
             timeout,
             Future.successful(Left(seqActivationId), atomicActionsCount))
@@ -174,9 +174,9 @@ protected[actions] trait SequenceActions {
    * Stores sequence activation to database.
    */
   private def storeSequenceActivation(activation: WhiskActivation)(implicit transid: TransactionId): Unit = {
-    logging.info(this, s"recording activation '${activation.activationId}'")
+    logging.debug(this, s"recording activation '${activation.activationId}'")
     WhiskActivation.put(activationStore, activation)(transid, notifier = None) onComplete {
-      case Success(id) => logging.info(this, s"recorded activation")
+      case Success(id) => logging.debug(this, s"recorded activation")
       case Failure(t) =>
         logging.error(
           this,

--- a/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
@@ -60,10 +60,12 @@ class ActivationThrottler(loadBalancer: LoadBalancer, defaultConcurrencyLimit: I
    */
   def isOverloaded()(implicit tid: TransactionId): Future[Boolean] = {
     loadBalancer.totalActiveActivations.map { concurrentActivations =>
-      logging.debug(
-        this,
-        s"concurrent activations in system = $concurrentActivations, below limit = $systemOverloadLimit")
-      concurrentActivations > systemOverloadLimit
+      val overloaded = concurrentActivations > systemOverloadLimit
+      if (overloaded)
+        logging.info(
+          this,
+          s"concurrent activations in system = $concurrentActivations, below limit = $systemOverloadLimit")
+      overloaded
     }
   }
 }

--- a/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
@@ -48,7 +48,7 @@ class ActivationThrottler(loadBalancer: LoadBalancer, defaultConcurrencyLimit: I
   def check(user: Identity)(implicit tid: TransactionId): Future[RateLimit] = {
     loadBalancer.activeActivationsFor(user.uuid).map { concurrentActivations =>
       val concurrencyLimit = user.limits.concurrentInvocations.getOrElse(defaultConcurrencyLimit)
-      logging.info(
+      logging.debug(
         this,
         s"namespace = ${user.uuid.asString}, concurrent activations = $concurrentActivations, below limit = $concurrencyLimit")
       ConcurrentRateLimit(concurrentActivations, concurrencyLimit)
@@ -60,7 +60,7 @@ class ActivationThrottler(loadBalancer: LoadBalancer, defaultConcurrencyLimit: I
    */
   def isOverloaded()(implicit tid: TransactionId): Future[Boolean] = {
     loadBalancer.totalActiveActivations.map { concurrentActivations =>
-      logging.info(
+      logging.debug(
         this,
         s"concurrent activations in system = $concurrentActivations, below limit = $systemOverloadLimit")
       concurrentActivations > systemOverloadLimit

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -338,7 +338,7 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
       if (limit.ok) {
         Future.successful(())
       } else {
-        logging.info(this, s"user '${user.namespace}' has exceeded its throttle limit")
+        logging.info(this, s"'${user.namespace}' has exceeded its throttle limit, ${limit.errorMsg}")
         Future.failed(RejectRequest(TooManyRequests, limit.errorMsg))
       }
     }

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -160,10 +160,10 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
    */
   protected[core] def checkThrottles(user: Identity)(implicit transid: TransactionId): Future[Unit] = {
 
-    logging.info(this, s"checking user '${user.subject}' has not exceeded activation quota")
+    logging.debug(this, s"checking user '${user.subject}' has not exceeded activation quota")
     checkSystemOverload(ACTIVATE)
-      .flatMap(_ => checkThrottleOverload(Future.successful(invokeRateThrottler.check(user))))
-      .flatMap(_ => checkThrottleOverload(concurrentInvokeThrottler.check(user)))
+      .flatMap(_ => checkThrottleOverload(Future.successful(invokeRateThrottler.check(user)), user))
+      .flatMap(_ => checkThrottleOverload(concurrentInvokeThrottler.check(user), user))
   }
 
   /**
@@ -218,7 +218,7 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
 
     val entitlementCheck: Future[Unit] = if (user.rights.contains(right)) {
       if (resources.nonEmpty) {
-        logging.info(this, s"checking user '$subject' has privilege '$right' for '${resources.mkString(", ")}'")
+        logging.debug(this, s"checking user '$subject' has privilege '$right' for '${resources.mkString(", ")}'")
         val throttleCheck =
           if (noThrottle) Future.successful(())
           else
@@ -234,7 +234,7 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
           })
       } else Future.successful(())
     } else if (right != REJECT) {
-      logging.info(
+      logging.debug(
         this,
         s"supplied authkey for user '$subject' does not have privilege '$right' for '${resources.mkString(", ")}'")
       Future.failed(unauthorizedOn(resources))
@@ -244,9 +244,9 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
 
     entitlementCheck andThen {
       case Success(rs) =>
-        logging.info(this, "authorized")
+        logging.debug(this, "authorized")
       case Failure(r: RejectRequest) =>
-        logging.info(this, s"not authorized: $r")
+        logging.debug(this, s"not authorized: $r")
       case Failure(t) =>
         logging.error(this, s"failed while checking entitlement: ${t.getMessage}")
     }
@@ -269,7 +269,7 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
         resource.collection.implicitRights(user, defaultNamespaces, right, resource) flatMap {
           case true => Future.successful(resource -> true)
           case false =>
-            logging.info(this, "checking explicit grants")
+            logging.debug(this, "checking explicit grants")
             entitled(user.subject, right, resource).flatMap(b => Future.successful(resource -> b))
         }
       }
@@ -307,9 +307,9 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
     implicit transid: TransactionId): Future[Unit] = {
     if (right == ACTIVATE) {
       if (resources.exists(_.collection.path == Collection.ACTIONS)) {
-        checkThrottleOverload(Future.successful(invokeRateThrottler.check(user)))
+        checkThrottleOverload(Future.successful(invokeRateThrottler.check(user)), user)
       } else if (resources.exists(_.collection.path == Collection.TRIGGERS)) {
-        checkThrottleOverload(Future.successful(triggerRateThrottler.check(user)))
+        checkThrottleOverload(Future.successful(triggerRateThrottler.check(user)), user)
       } else Future.successful(())
     } else Future.successful(())
   }
@@ -328,15 +328,17 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
   private def checkConcurrentUserThrottle(user: Identity, right: Privilege, resources: Set[Resource])(
     implicit transid: TransactionId): Future[Unit] = {
     if (right == ACTIVATE && resources.exists(_.collection.path == Collection.ACTIONS)) {
-      checkThrottleOverload(concurrentInvokeThrottler.check(user))
+      checkThrottleOverload(concurrentInvokeThrottler.check(user), user)
     } else Future.successful(())
   }
 
-  private def checkThrottleOverload(throttle: Future[RateLimit])(implicit transid: TransactionId): Future[Unit] = {
+  private def checkThrottleOverload(throttle: Future[RateLimit], user: Identity)(
+    implicit transid: TransactionId): Future[Unit] = {
     throttle.flatMap { limit =>
       if (limit.ok) {
         Future.successful(())
       } else {
+        logging.debug(this, s"user '${user.subject}' has exceeded its throttle limit")
         Future.failed(RejectRequest(TooManyRequests, limit.errorMsg))
       }
     }

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -338,7 +338,7 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
       if (limit.ok) {
         Future.successful(())
       } else {
-        logging.debug(this, s"user '${user.subject}' has exceeded its throttle limit")
+        logging.info(this, s"user '${user.namespace}' has exceeded its throttle limit")
         Future.failed(RejectRequest(TooManyRequests, limit.errorMsg))
       }
     }

--- a/core/controller/src/main/scala/whisk/core/entitlement/LocalEntitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/LocalEntitlement.scala
@@ -49,7 +49,7 @@ protected[core] class LocalEntitlementProvider(private val config: WhiskConfig, 
     synchronized {
       val key = (subject, resource.id)
       matrix.put(key, matrix.get(key) map { _ + right } getOrElse Set(right))
-      logging.info(this, s"granted user '$subject' privilege '$right' for '$resource'")
+      logging.debug(this, s"granted user '$subject' privilege '$right' for '$resource'")
       true
     }
   }
@@ -60,7 +60,7 @@ protected[core] class LocalEntitlementProvider(private val config: WhiskConfig, 
     synchronized {
       val key = (subject, resource.id)
       val newrights = matrix.get(key) map { _ - right } map { matrix.put(key, _) }
-      logging.info(this, s"revoked user '$subject' privilege '$right' for '$resource'")
+      logging.debug(this, s"revoked user '$subject' privilege '$right' for '$resource'")
       true
     }
   }

--- a/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
@@ -90,22 +90,22 @@ class PackageCollection(entityStore: EntityStore)(implicit logging: Logging) ext
     WhiskPackage.get(entityStore, doc) flatMap {
       case wp if wp.binding.isEmpty =>
         val allowed = wp.publish || isOwner
-        logging.info(this, s"entitlement check on package, '$right' allowed?: $allowed")
+        logging.debug(this, s"entitlement check on package, '$right' allowed?: $allowed")
         Future.successful(allowed)
       case wp =>
         if (isOwner) {
           val binding = wp.binding.get
           val pkgOwner = namespaces.contains(binding.namespace.asString)
           val pkgDocid = binding.docid
-          logging.info(this, s"checking subject has privilege '$right' for bound package '$pkgDocid'")
+          logging.debug(this, s"checking subject has privilege '$right' for bound package '$pkgDocid'")
           checkPackageReadPermission(namespaces, pkgOwner, pkgDocid)
         } else {
-          logging.info(this, s"entitlement check on package binding, '$right' allowed?: false")
+          logging.debug(this, s"entitlement check on package binding, '$right' allowed?: false")
           Future.successful(false)
         }
     } recoverWith {
       case t: NoDocumentException =>
-        logging.info(this, s"the package does not exist (owner? $isOwner)")
+        logging.debug(this, s"the package does not exist (owner? $isOwner)")
         // if owner, reject with not found, otherwise fail the future to reject with
         // unauthorized (this prevents information leaks about packages in other namespaces)
         if (isOwner) {
@@ -114,7 +114,7 @@ class PackageCollection(entityStore: EntityStore)(implicit logging: Logging) ext
           Future.successful(false)
         }
       case t: DocumentTypeMismatchException =>
-        logging.info(this, s"the requested binding is not a package (owner? $isOwner)")
+        logging.debug(this, s"the requested binding is not a package (owner? $isOwner)")
         // if owner, reject with not found, otherwise fail the future to reject with
         // unauthorized (this prevents information leaks about packages in other namespaces)
         if (isOwner) {

--- a/core/controller/src/main/scala/whisk/core/entitlement/RateThrottler.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/RateThrottler.scala
@@ -33,7 +33,7 @@ import java.util.concurrent.atomic.AtomicInteger
 class RateThrottler(description: String, defaultMaxPerMinute: Int, overrideMaxPerMinute: Identity => Option[Int])(
   implicit logging: Logging) {
 
-  logging.info(this, s"$description: defaultMaxPerMinute = $defaultMaxPerMinute")(TransactionId.controller)
+  logging.debug(this, s"$description: defaultMaxPerMinute = $defaultMaxPerMinute")(TransactionId.controller)
 
   /**
    * Maintains map of subject namespace to operations rates.

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/ContainerPoolBalancer.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/ContainerPoolBalancer.scala
@@ -34,6 +34,7 @@ import whisk.core.entity._
 import whisk.core.entity.types.EntityStore
 import whisk.core.{ConfigKeys, WhiskConfig}
 import whisk.spi.SpiLoader
+import akka.event.Logging.InfoLevel
 
 import scala.annotation.tailrec
 import scala.concurrent.duration._
@@ -202,11 +203,16 @@ class ContainerPoolBalancer(config: WhiskConfig, instance: InstanceId)(implicit 
     val start = transid.started(
       this,
       LoggingMarkers.CONTROLLER_KAFKA,
-      s"posting topic '$topic' with activation id '${msg.activationId}'")
+      s"posting topic '$topic' with activation id '${msg.activationId}'",
+      logLevel = InfoLevel)
 
     producer.send(topic, msg).andThen {
       case Success(status) =>
-        transid.finished(this, start, s"posted to ${status.topic()}[${status.partition()}][${status.offset()}]")
+        transid.finished(
+          this,
+          start,
+          s"posted to ${status.topic()}[${status.partition()}][${status.offset()}]",
+          logLevel = InfoLevel)
       case Failure(e) => transid.failed(this, start, s"error on posting to topic $topic")
     }
   }

--- a/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
@@ -37,6 +37,7 @@ import whisk.core.entity._
 import whisk.core.entity.size._
 import whisk.core.entity.ExecManifest.ImageName
 import whisk.http.Messages
+import akka.event.Logging.InfoLevel
 
 // States
 sealed trait ContainerState
@@ -379,7 +380,7 @@ class ContainerProxy(
     // Adds logs to the raw activation.
     val activationWithLogs: Future[Either[ActivationLogReadingError, WhiskActivation]] = activation
       .flatMap { activation =>
-        val start = tid.started(this, LoggingMarkers.INVOKER_COLLECT_LOGS)
+        val start = tid.started(this, LoggingMarkers.INVOKER_COLLECT_LOGS, logLevel = InfoLevel)
         collectLogs(tid, job.msg.user, activation, container, job.action)
           .andThen {
             case Success(_) => tid.finished(this, start)

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClient.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClient.scala
@@ -31,7 +31,7 @@ import scala.concurrent.Future
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
-import akka.event.Logging.ErrorLevel
+import akka.event.Logging.{ErrorLevel, InfoLevel}
 import pureconfig.loadConfigOrThrow
 import whisk.common.Logging
 import whisk.common.LoggingMarkers
@@ -180,7 +180,8 @@ class DockerClient(dockerHost: Option[String] = None,
     val start = transid.started(
       this,
       LoggingMarkers.INVOKER_DOCKER_CMD(args.head),
-      s"running ${cmd.mkString(" ")} (timeout: $timeout)")
+      s"running ${cmd.mkString(" ")} (timeout: $timeout)",
+      logLevel = InfoLevel)
     executeProcess(cmd, timeout).andThen {
       case Success(_) => transid.finished(this, start)
       case Failure(t) => transid.failed(this, start, t.getMessage, ErrorLevel)

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainerFactory.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainerFactory.scala
@@ -107,7 +107,7 @@ class DockerContainerFactory(config: WhiskConfig,
   private def removeAllActionContainers(): Unit = {
     implicit val transid = TransactionId.invoker
     val cleaning = docker.ps(filters = Seq("name" -> s"wsk${instance.toInt}_"), all = true).flatMap { containers =>
-      logging.debug(this, s"removing ${containers.size} action containers.")
+      logging.info(this, s"removing ${containers.size} action containers.")
       val removals = containers.map { id =>
         (if (config.invokerUseRunc) {
            runc.resume(id)

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainerFactory.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainerFactory.scala
@@ -107,7 +107,7 @@ class DockerContainerFactory(config: WhiskConfig,
   private def removeAllActionContainers(): Unit = {
     implicit val transid = TransactionId.invoker
     val cleaning = docker.ps(filters = Seq("name" -> s"wsk${instance.toInt}_"), all = true).flatMap { containers =>
-      logging.info(this, s"removing ${containers.size} action containers.")
+      logging.debug(this, s"removing ${containers.size} action containers.")
       val removals = containers.map { id =>
         (if (config.invokerUseRunc) {
            runc.resume(id)

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/RuncClient.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/RuncClient.scala
@@ -28,8 +28,8 @@ import scala.util.Success
 import whisk.common.LoggingMarkers
 import whisk.common.Logging
 import whisk.core.ConfigKeys
-import akka.event.Logging.ErrorLevel
 import pureconfig.loadConfigOrThrow
+import akka.event.Logging.{ErrorLevel, InfoLevel}
 import whisk.core.containerpool.ContainerId
 
 import scala.concurrent.duration.Duration
@@ -70,7 +70,7 @@ class RuncClient(timeouts: RuncClientTimeouts = loadConfigOrThrow[RuncClientTime
       LoggingMarkers.INVOKER_RUNC_CMD(args.head),
       s"running ${cmd.mkString(" ")} (timeout: $timeout)")
     executeProcess(cmd, timeout).andThen {
-      case Success(_) => transid.finished(this, start)
+      case Success(_) => transid.finished(this, start, logLevel = InfoLevel)
       case Failure(t) => transid.failed(this, start, t.getMessage, ErrorLevel)
     }
   }

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/RuncClient.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/RuncClient.scala
@@ -68,7 +68,8 @@ class RuncClient(timeouts: RuncClientTimeouts = loadConfigOrThrow[RuncClientTime
     val start = transid.started(
       this,
       LoggingMarkers.INVOKER_RUNC_CMD(args.head),
-      s"running ${cmd.mkString(" ")} (timeout: $timeout)")
+      s"running ${cmd.mkString(" ")} (timeout: $timeout)",
+      logLevel = InfoLevel)
     executeProcess(cmd, timeout).andThen {
       case Success(_) => transid.finished(this, start, logLevel = InfoLevel)
       case Failure(t) => transid.failed(this, start, t.getMessage, ErrorLevel)

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
@@ -49,6 +49,7 @@ import whisk.core.entity._
 import whisk.core.entity.size._
 import whisk.http.Messages
 import whisk.spi.SpiLoader
+import akka.event.Logging.InfoLevel
 
 class InvokerReactive(config: WhiskConfig, instance: InstanceId, producer: MessageProducer)(
   implicit actorSystem: ActorSystem,
@@ -164,7 +165,7 @@ class InvokerReactive(config: WhiskConfig, instance: InstanceId, producer: Messa
       .flatMap { msg =>
         implicit val transid = msg.transid
 
-        val start = transid.started(this, LoggingMarkers.INVOKER_ACTIVATION)
+        val start = transid.started(this, LoggingMarkers.INVOKER_ACTIVATION, logLevel = InfoLevel)
         val namespace = msg.action.path
         val name = msg.action.name
         val actionid = FullyQualifiedEntityName(namespace, name).toDocId.asDocInfo(msg.revision)

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
@@ -129,9 +129,9 @@ class InvokerReactive(config: WhiskConfig, instance: InstanceId, producer: Messa
   /** Stores an activation in the database. */
   val store = (tid: TransactionId, activation: WhiskActivation) => {
     implicit val transid = tid
-    logging.info(this, "recording the activation result to the data store")
+    logging.debug(this, "recording the activation result to the data store")
     WhiskActivation.put(activationStore, activation)(tid, notifier = None).andThen {
-      case Success(id) => logging.info(this, s"recorded activation")
+      case Success(id) => logging.debug(this, s"recorded activation")
       case Failure(t)  => logging.error(this, s"failed to record activation")
     }
   }
@@ -170,7 +170,7 @@ class InvokerReactive(config: WhiskConfig, instance: InstanceId, producer: Messa
         val actionid = FullyQualifiedEntityName(namespace, name).toDocId.asDocInfo(msg.revision)
         val subject = msg.user.subject
 
-        logging.info(this, s"${actionid.id} $subject ${msg.activationId}")
+        logging.debug(this, s"${actionid.id} $subject ${msg.activationId}")
 
         // caching is enabled since actions have revision id and an updated
         // action will not hit in the cache due to change in the revision id;

--- a/tests/src/test/scala/common/SimpleExec.scala
+++ b/tests/src/test/scala/common/SimpleExec.scala
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-package whisk.common
+package common
 
-import scala.sys.process.ProcessLogger
-import scala.sys.process.stringSeqToProcess
+import whisk.common.{Logging, TransactionId}
+
+import scala.sys.process.{stringSeqToProcess, ProcessLogger}
 
 /**
  * Utility to exec processes
@@ -46,7 +47,7 @@ object SimpleExec {
       errs.append("\n")
     })
 
-    logging.info(this, s"Done running command: ${cmd.mkString(" ")}")
+    logging.debug(this, s"Done running command: ${cmd.mkString(" ")}")
 
     def noLastNewLine(sb: StringBuilder) = {
       if (sb.isEmpty) "" else sb.substring(0, sb.size - 1)

--- a/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
@@ -22,25 +22,22 @@ import java.util.Base64
 
 import scala.util.Failure
 import scala.util.Try
-
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.junit.JUnitRunner
-
 import com.jayway.restassured.RestAssured
 import com.jayway.restassured.response.Header
-
 import common.TestHelpers
 import common.TestUtils
 import common.WhiskProperties
 import common.BaseWsk
 import common.WskProps
 import common.WskTestHelpers
+import common.SimpleExec
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import system.rest.RestUtil
 import whisk.common.PrintStreamLogging
-import whisk.common.SimpleExec
 import whisk.common.TransactionId
 import whisk.core.entity.Subject
 

--- a/tests/src/test/scala/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ControllerTestCommon.scala
@@ -96,35 +96,35 @@ protected trait ControllerTestCommon
 
   def deleteAction(doc: DocId)(implicit transid: TransactionId) = {
     Await.result(WhiskAction.get(entityStore, doc) flatMap { doc =>
-      logging.info(this, s"deleting ${doc.docinfo}")
+      logging.debug(this, s"deleting ${doc.docinfo}")
       WhiskAction.del(entityStore, doc.docinfo)
     }, dbOpTimeout)
   }
 
   def deleteActivation(doc: DocId)(implicit transid: TransactionId) = {
     Await.result(WhiskActivation.get(activationStore, doc) flatMap { doc =>
-      logging.info(this, s"deleting ${doc.docinfo}")
+      logging.debug(this, s"deleting ${doc.docinfo}")
       WhiskActivation.del(activationStore, doc.docinfo)
     }, dbOpTimeout)
   }
 
   def deleteTrigger(doc: DocId)(implicit transid: TransactionId) = {
     Await.result(WhiskTrigger.get(entityStore, doc) flatMap { doc =>
-      logging.info(this, s"deleting ${doc.docinfo}")
+      logging.debug(this, s"deleting ${doc.docinfo}")
       WhiskAction.del(entityStore, doc.docinfo)
     }, dbOpTimeout)
   }
 
   def deleteRule(doc: DocId)(implicit transid: TransactionId) = {
     Await.result(WhiskRule.get(entityStore, doc) flatMap { doc =>
-      logging.info(this, s"deleting ${doc.docinfo}")
+      logging.debug(this, s"deleting ${doc.docinfo}")
       WhiskRule.del(entityStore, doc.docinfo)
     }, dbOpTimeout)
   }
 
   def deletePackage(doc: DocId)(implicit transid: TransactionId) = {
     Await.result(WhiskPackage.get(entityStore, doc) flatMap { doc =>
-      logging.info(this, s"deleting ${doc.docinfo}")
+      logging.debug(this, s"deleting ${doc.docinfo}")
       WhiskPackage.del(entityStore, doc.docinfo)
     }, dbOpTimeout)
   }


### PR DESCRIPTION
This PR should provide a relief for controller while under load. We have reduced the number of log lines, which based on our performance measurements provides a 4x improvement on the throughput for long running tests and 2.5x throughput improvement for the short running tests. 

Here we also have made slight modification in the way log metrics are emitted. They could still be emitted in the following cases: 
* metricsLog is explicitely set to true
* the transaction timeout of 60 seconds is reached
* debug log level was selected
 
@mhenke1 

