### PR TITLE
Clean up all the test cases

### DIFF
--- a/tests/src/test/scala/whisk/core/cli/test/WskApiGwTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskApiGwTests.scala
@@ -35,7 +35,7 @@ import common.WskProps
  * Tests for basic CLI usage. Some of these tests require a deployed backend.
  */
 @RunWith(classOf[JUnitRunner])
-class WskCliApiGwTests extends BaseApiGwTests with WskActorSystem with JsHelpers with StreamLogging {
+class WskApiGwTests extends BaseApiGwTests with WskActorSystem with JsHelpers with StreamLogging {
 
   val systemId: String = "whisk.system"
   override implicit val wskprops = WskProps(authKey = WskAdmin.listKeys(systemId)(0)._1, namespace = systemId)


### PR DESCRIPTION
The PRs before replace all the rest of the wsk inplementation with REST
implementation for test cases in openwhisk. This PR cleans up some
leftover for the WskRest migration work. After this PR, no more test
case needs to be changed any longer, and cli in openwhisk core is ready
to departure.