### PR TITLE
Reject requests to create packages having the name 'default'

### DIFF
--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -106,7 +106,9 @@ object Messages {
   val bindingCannotReferenceBinding = "Cannot bind to another package binding."
   val requestedBindingIsNotValid = "Cannot bind to a resource that is not a package."
   val notAllowedOnBinding = "Operation not permitted on package binding."
-  val packageDefaultIsReserved = "Package name 'default' is reserved."
+  def packageNameIsReserved(name: String) = {
+    s"Package name '$name' is reserved."
+  }
 
   /** Error messages for sequence activations. */
   def sequenceRetrieveActivationTimeout(id: ActivationId) =

--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -106,6 +106,7 @@ object Messages {
   val bindingCannotReferenceBinding = "Cannot bind to another package binding."
   val requestedBindingIsNotValid = "Cannot bind to a resource that is not a package."
   val notAllowedOnBinding = "Operation not permitted on package binding."
+  val packageDefaultIsReserved = "Package name 'default' is reserved."
 
   /** Error messages for sequence activations. */
   def sequenceRetrieveActivationTimeout(id: ActivationId) =

--- a/core/controller/src/main/scala/whisk/core/controller/Packages.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Packages.scala
@@ -43,6 +43,8 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
 
   protected override val collection = Collection(Collection.PACKAGES)
 
+  protected[core] val RESERVED_NAMES = Array("default")
+
   /** Database service to CRUD packages. */
   protected val entityStore: EntityStore
 
@@ -76,9 +78,8 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
    */
   override def create(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
     parameter('overwrite ? false) { overwrite =>
-      if (!overwrite && entityName.name.toString == "default") {
-        logging.info(this, "attempt to create a package named 'default'")
-        terminate(BadRequest, Messages.packageDefaultIsReserved)
+      if (!overwrite && (RESERVED_NAMES contains entityName.name.asString)) {
+        terminate(BadRequest, Messages.packageNameIsReserved(entityName.name.asString))
       } else {
         entity(as[WhiskPackagePut]) { content =>
           val request = content.resolve(entityName.namespace)

--- a/tests/src/test/scala/whisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/PackagesApiTests.scala
@@ -370,6 +370,20 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     }
   }
 
+  it should "reject create package when package name is 'default'" in {
+    implicit val tid = transid()
+    def defname() = MakeName.next("default")
+    val provider = WhiskPackage(namespace, defname(), None)
+    Put(s"$collectionPath/${provider.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      val response = responseAs[String]
+      println(s"Default failure response: '${response}'")
+      response should include {
+        Messages.packageDefaultIsReserved
+      }
+    }
+  }
+
   it should "create package reference with explicit namespace" in {
     implicit val tid = transid()
     val provider = WhiskPackage(namespace, aname())

--- a/tests/src/test/scala/whisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/PackagesApiTests.scala
@@ -41,7 +41,6 @@ import whisk.http.Messages
  * These tests exercise a fresh instance of the service object in memory -- these
  * tests do NOT communication with a whisk deployment.
  *
- *
  * @Idioglossia
  * "using Specification DSL to write unit tests, as in should, must, not, be"
  * "using Specs2RouteTest DSL to chain HTTP requests for unit testing, as in ~>"
@@ -370,16 +369,30 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     }
   }
 
-  it should "reject create package when package name is 'default'" in {
+  it should "reject create package when package name is a reserved name" in {
     implicit val tid = transid()
-    def defname() = MakeName.next("default")
-    val provider = WhiskPackage(namespace, defname(), None)
-    Put(s"$collectionPath/${provider.name}") ~> Route.seal(routes(creds)) ~> check {
-      status should be(BadRequest)
-      val response = responseAs[String]
-      println(s"Default failure response: '${response}'")
-      response should include {
-        Messages.packageDefaultIsReserved
+    RESERVED_NAMES foreach { reservedName =>
+      val provider = WhiskPackage(namespace, EntityName(s"$reservedName"), None)
+      val content = WhiskPackagePut()
+      Put(s"$collectionPath/${provider.name}", content) ~> Route.seal(routes(creds)) ~> check {
+        status should be(BadRequest)
+        val response = responseAs[String]
+        response should include {
+          Messages.packageNameIsReserved(reservedName)
+        }
+      }
+    }
+  }
+
+  it should "allow package update even when package name a reserved name" in {
+    implicit val tid = transid()
+    RESERVED_NAMES foreach { reservedName =>
+      val provider = WhiskPackage(namespace, EntityName(s"$reservedName"), None)
+      val content = WhiskPackagePut()
+      Put(s"$collectionPath/${provider.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[WhiskPackage]
+        response should be(provider)
       }
     }
   }


### PR DESCRIPTION
Updates to existing packages named "default" are still permitted.

Fixes #1785 