### PR TITLE
Fix bug when remove invoker

### DIFF
--- a/ansible/roles/invoker/tasks/clean.yml
+++ b/ansible/roles/invoker/tasks/clean.yml
@@ -13,9 +13,9 @@
 # In case the invoker could not clean up completely in time.
 - name: pause/resume at runc-level to restore docker consistency
   shell: |
-        DOCKER_PAUSED=$(docker ps --filter status=paused --filter name=wsk -q --no-trunc)
+        DOCKER_PAUSED=$(docker ps --filter status=paused --filter name=wsk{{ groups['invokers'].index(inventory_hostname) }} -q --no-trunc)
         for C in $DOCKER_PAUSED; do docker-runc pause $C; done
-        DOCKER_RUNNING=$(docker ps --filter status=running --filter name=wsk -q --no-trunc)
+        DOCKER_RUNNING=$(docker ps --filter status=running --filter name=wsk{{ groups['invokers'].index(inventory_hostname) }} -q --no-trunc)
         for C2 in $DOCKER_RUNNING; do docker-runc resume $C2; done
         TOTAL=$(($(echo $DOCKER_PAUSED | wc -w)+$(echo $DOCKER_RUNNING | wc -w)))
         echo "Handled $TOTAL remaining actions."
@@ -26,11 +26,11 @@
 - debug: msg="{{ runc_output.stdout }}"
 
 - name: unpause remaining actions
-  shell: "docker unpause $(docker ps -aq --filter status=paused --filter name=wsk)"
+  shell: "docker unpause $(docker ps -aq --filter status=paused --filter name=wsk{{ groups['invokers'].index(inventory_hostname) }})"
   failed_when: False
 
 - name: remove remaining actions
-  shell: "docker rm -f $(docker ps -aq --filter name=wsk)"
+  shell: "docker rm -f $(docker ps -aq --filter name=wsk{{ groups['invokers'].index(inventory_hostname) }})"
   failed_when: False
 
 - name: remove invoker log directory


### PR DESCRIPTION
If deploy mutilple invoker instances on one physical node, and  execute below `remove remaining actions`, exist problems
```
TASK [invoker : remove remaining actions] **************************************
Wednesday 15 November 2017  14:58:47 +0900 (0:00:00.618)       0:00:08.693 **** 
changed: [invoker0]

TASK [invoker : remove invoker log directory] **********************************
Wednesday 15 November 2017  15:08:45 +0900 (0:09:57.545)       0:10:06.239 **** 
changed: [invoker0]
```
1. `remove remaining actions` task will costs much time to execute(about cost 10 mins), becuase when remove `invoker0`, the task will remove action container `wsk0_, wsk1_, and so on`, on the other hand, `wsk1` is removed by `invoker1's stop hook` default, so that's the reason why it will cost much time.
2. it may remove other invoker's action container, this is wrong logic, righ logic is `inovker0 remove wsk0_xx`, `invoker1 remove wsk1_xx`, and so on.

So it is necessary to add `exact filter` to `wsk action container` when remove invoker. 