### PR TITLE
Bump idle-timeout for HTTP clients in test.

### DIFF
--- a/tests/src/test/resources/application.conf
+++ b/tests/src/test/resources/application.conf
@@ -3,3 +3,6 @@ whisk.spi {
   MissingSpi = whisk.spi.MissingImpl
   MissingModule = missing.module
 }
+
+# Blocking requests fall back to non-blocking after ~60s
+akka.http.client.idle-timeout = 90 s


### PR DESCRIPTION
A blocking request will be open for at most 60 seconds before it falls back to a non-blocking request. The default idle-timeout is at 60 seconds so a racy failure happens in tests, where a blocking fallback is provoked.