### PR TITLE
Tweak error message for failing to invoke an action

### DIFF
--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -186,6 +186,7 @@ object Messages {
   }
 
   val actionRemovedWhileInvoking = "Action could not be found or may have been deleted."
+  val actionMismatchWhileInvoking = "Action version is not compatible and cannot be invoked."
 }
 
 /** Replaces rejections with Json object containing cause and transaction id. */

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
@@ -202,7 +202,7 @@ class InvokerReactive(config: WhiskConfig, instance: InstanceId, producer: Messa
               // errors and should cause the invoker to be considered unhealthy.
               val response = t match {
                 case _: NoDocumentException => ActivationResponse.applicationError(Messages.actionRemovedWhileInvoking)
-                case _                      => ActivationResponse.whiskError(Messages.actionRemovedWhileInvoking)
+                case _                      => ActivationResponse.whiskError(Messages.actionMismatchWhileInvoking)
               }
               val now = Instant.now
               val causedBy = if (msg.causedBySequence) Parameters("causedBy", "sequence".toJson) else Parameters()


### PR DESCRIPTION
 if its type of an action has changed or cannot be deserialized because of a runtime-manifest/schema mismatch with controller, report a different error that is more useful.