### PR TITLE
Adapt timeouts of controller and nginx.

### DIFF
--- a/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/ansible/roles/nginx/templates/nginx.conf.j2
@@ -64,7 +64,7 @@ http {
               rewrite    /(.*) /api/v1/web/${namespace}/$1 break;
             }
             proxy_pass http://controllers;
-            proxy_read_timeout 70s; # 60+10 additional seconds to allow controller to terminate request
+            proxy_read_timeout 75s; # 70+5 additional seconds to allow controller to terminate request
         }
 
         # proxy to 'public/html' web action by convention
@@ -73,7 +73,7 @@ http {
               rewrite    ^ /api/v1/web/${namespace}/public/index.html break;
             }
             proxy_pass http://controllers;
-            proxy_read_timeout 70s; # 60+10 additional seconds to allow controller to terminate request
+            proxy_read_timeout 75s; # 70+5 additional seconds to allow controller to terminate request
         }
 
         location /blackbox.tar.gz {

--- a/core/controller/src/main/resources/application.conf
+++ b/core/controller/src/main/resources/application.conf
@@ -22,7 +22,7 @@ akka.http {
     # The controller holds connections up to 60s for blocking invokes, and
     # all other operations are expected to complete quickly. We allow a grace
     # period in addition to the blocking invoke timeout.
-    request-timeout = 90s
+    request-timeout = 65s
 
     # The maximum number of concurrently accepted connections when using the
     # `Http().bindAndHandle` methods.
@@ -50,7 +50,7 @@ akka.http {
     #
     # Explaining the set value:
     # This must be greater than the request timeout.
-    idle-timeout = 120s
+    idle-timeout = 70s
 
     parsing {
       # This indirectly puts a bound on the name of entities


### PR DESCRIPTION
Lower the timeouts of the controller to match the proxy_read_timeout in nginx.

If the nginx proxy_read_timeout is lower than the controller timeout, this can result in issues with long requests.