### PR TITLE
Change the idle timeout to 90 seconds for client connection settings

### DIFF
--- a/tests/src/test/resources/application.conf
+++ b/tests/src/test/resources/application.conf
@@ -6,3 +6,5 @@ whisk.spi {
 
 # Blocking requests fall back to non-blocking after ~60s
 akka.http.client.idle-timeout = 90 s
+akka.http.host-connection-pool.idle-timeout = 90 s
+akka.http.host-connection-pool.client.idle-timeout = 90 s

--- a/tests/src/test/scala/common/rest/WskRest.scala
+++ b/tests/src/test/scala/common/rest/WskRest.scala
@@ -63,7 +63,6 @@ import akka.http.scaladsl.model.HttpMethods.POST
 import akka.http.scaladsl.model.HttpMethods.PUT
 import akka.http.scaladsl.HttpsConnectionContext
 import akka.http.scaladsl.settings.ConnectionPoolSettings
-import akka.http.scaladsl.settings.ClientConnectionSettings
 
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Keep, Sink, Source}
@@ -1182,7 +1181,7 @@ class RunWskRestCmd() extends FlatSpec with RunWskCmd with Matchers with ScalaFu
 
   implicit val config = PatienceConfig(100 seconds, 15 milliseconds)
   implicit val materializer = ActorMaterializer()
-  val idleTimeout = 5 minutes
+  val idleTimeout = 90 seconds
   val queueSize = 10
   val maxOpenRequest = 1024
   val basePath = Path("/api/v1")
@@ -1226,12 +1225,8 @@ class RunWskRestCmd() extends FlatSpec with RunWskCmd with Matchers with ScalaFu
       HttpEntity(ContentTypes.`application/json`, b)
     } getOrElse HttpEntity(ContentTypes.`application/json`, "")
     val request = HttpRequest(method, uri, List(Authorization(creds)), entity = entity)
-    val connectionSettings = ClientConnectionSettings(actorSystem).withIdleTimeout(idleTimeout)
     val connectionPoolSettings =
-      ConnectionPoolSettings(actorSystem)
-        .withMaxOpenRequests(maxOpenRequest)
-        .withIdleTimeout(idleTimeout)
-        .withConnectionSettings(connectionSettings)
+      ConnectionPoolSettings(actorSystem).withMaxOpenRequests(maxOpenRequest).withIdleTimeout(idleTimeout)
     val pool = Http().cachedHostConnectionPoolHttps[Promise[HttpResponse]](
       host = WhiskProperties.getApiHost,
       connectionContext = connectionContext,

--- a/tests/src/test/scala/common/rest/WskRest.scala
+++ b/tests/src/test/scala/common/rest/WskRest.scala
@@ -63,6 +63,7 @@ import akka.http.scaladsl.model.HttpMethods.POST
 import akka.http.scaladsl.model.HttpMethods.PUT
 import akka.http.scaladsl.HttpsConnectionContext
 import akka.http.scaladsl.settings.ConnectionPoolSettings
+import akka.http.scaladsl.settings.ClientConnectionSettings
 
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Keep, Sink, Source}
@@ -1225,8 +1226,12 @@ class RunWskRestCmd() extends FlatSpec with RunWskCmd with Matchers with ScalaFu
       HttpEntity(ContentTypes.`application/json`, b)
     } getOrElse HttpEntity(ContentTypes.`application/json`, "")
     val request = HttpRequest(method, uri, List(Authorization(creds)), entity = entity)
+    val connectionSettings = ClientConnectionSettings(actorSystem).withIdleTimeout(idleTimeout)
     val connectionPoolSettings =
-      ConnectionPoolSettings(actorSystem).withMaxOpenRequests(maxOpenRequest).withIdleTimeout(idleTimeout)
+      ConnectionPoolSettings(actorSystem)
+        .withMaxOpenRequests(maxOpenRequest)
+        .withIdleTimeout(idleTimeout)
+        .withConnectionSettings(connectionSettings)
     val pool = Http().cachedHostConnectionPoolHttps[Promise[HttpResponse]](
       host = WhiskProperties.getApiHost,
       connectionContext = connectionContext,


### PR DESCRIPTION
This PR makes sure the idle timeout is long enough for the action invocation to complete. By default, the idle timeout for a client connection is 1 minute. This PR changes it to 90 seconds in order to give enough time for the action call to finish. As an Akka client,  the idle timeout needs to be configured for both of clientConnectionSettings and connectionPoolSettings.

Closes: #3016