### PR TITLE
attempt to fix couchdb clustering

### DIFF
--- a/ansible/couchdb.yml
+++ b/ansible/couchdb.yml
@@ -2,5 +2,6 @@
 # This playbook deploys a CouchDB for Openwhisk.  
 
 - hosts: db
+  serial: 1
   roles:
   - couchdb

--- a/ansible/environments/local/hosts
+++ b/ansible/environments/local/hosts
@@ -23,7 +23,8 @@ invoker1            ansible_host=172.17.0.1 ansible_connection=local
 
 ; db group is only used if db_provider is CouchDB
 [db]
-172.17.0.1          ansible_host=172.17.0.1 ansible_connection=local
+db0          ansible_host=172.17.0.1 ansible_connection=local
+db1          ansible_host=172.17.0.1 ansible_connection=local
 
 [redis]
 172.17.0.1          ansible_host=172.17.0.1 ansible_connection=local

--- a/ansible/roles/couchdb/tasks/deploy.yml
+++ b/ansible/roles/couchdb/tasks/deploy.yml
@@ -4,6 +4,7 @@
 - name: "Set the coordinator to the first node"
   set_fact:
     coordinator: "{{ groups['db'][0] }}"
+    db_port: "{{ db_port|int + groups['db'].index(inventory_hostname) }}"
 
 - name: check if db credentials are valid for CouchDB
   fail: msg="The db provider in your {{ inventory_dir }}/group_vars/all is {{ db_provider }}, it has to be CouchDB, pls double check"
@@ -28,7 +29,7 @@
 
 - name: (re)start CouchDB
   docker_container:
-    name: couchdb
+    name: couchdb{{ groups['db'].index(inventory_hostname) }}
     image: apache/couchdb:{{ couchdb.version }}
     state: started
     recreate: true
@@ -36,8 +37,8 @@
     volumes: "{{volume_dir | default([])}}"
     ports:
       - "{{ db_port }}:5984"
-      - "4369:4369"
-      - "9100:9100"
+      - "{{ 4369 + groups['db'].index(inventory_hostname) }}:4369"
+      - "{{ 9100 + groups['db'].index(inventory_hostname) }}:9100"
     env:
       COUCHDB_USER: "{{ db_username }}"
       COUCHDB_PASSWORD: "{{ db_password }}"
@@ -62,11 +63,11 @@
     user: "{{ db_username }}"
     password: "{{ db_password }}"
     force_basic_auth: yes
-  when: inventory_hostname == coordinator
+  when: (inventory_hostname == coordinator) and (db.instances|int >= 2) 
 
 - name: add remote nodes to the cluster
   uri:
-    url: "{{ db_protocol }}://{{ coordinator }}:{{ db_port }}/_cluster_setup"
+    url: "{{ db_protocol }}://{{ hostvars[groups['db'] | first].ansible_host }}:{{ db_port }}/_cluster_setup"
     method: POST
     body: >
         {"action": "add_node", "host":"{{ ansible_host }}", "port": {{ db_port }}, "username": "{{ db_username }}", "password":"{{ db_password }}"}
@@ -75,7 +76,7 @@
     user: "{{ db_username }}"
     password: "{{ db_password }}"
     force_basic_auth: yes
-  when: inventory_hostname != coordinator
+  when: db.instances|int >= 2
 
 - name: finish the cluster setup mode
   uri:
@@ -88,7 +89,7 @@
     user: "{{ db_username }}"
     password: "{{ db_password }}"
     force_basic_auth: yes
-  when: inventory_hostname == coordinator
+  when: (inventory_hostname == coordinator) and (db.instances|int >= 2)
 
 - name: disable reduce limit on views
   uri:

--- a/ansible/roles/couchdb/tasks/deploy.yml
+++ b/ansible/roles/couchdb/tasks/deploy.yml
@@ -76,7 +76,7 @@
     user: "{{ db_username }}"
     password: "{{ db_password }}"
     force_basic_auth: yes
-  when: db.instances|int >= 2
+  when: (inventory_hostname != coordinator) and (db.instances|int >= 2)
 
 - name: finish the cluster setup mode
   uri:


### PR DESCRIPTION
Here is an attempt:
but getting error

TASK [couchdb : add remote nodes to the cluster] *********************************************************************************************************************
Wednesday 29 November 2017  15:33:30 -0500 (0:00:00.323)       0:00:36.662 ****
fatal: [db0]: FAILED! => {"cache_control": "must-revalidate", "changed": false, "connection": "close", "content": "{\"error\":\"conflict\",\"reason\":\"Document update conflict.\"}\n", "content_length": "58", "content_type": "application/json", "date": "Wed, 29 Nov 2017 20:33:31 GMT", "failed": true, "json": {"error": "conflict","reason": "Document update conflict."}, "msg": "Status code was not [201]: HTTP Error 409: Conflict", "redirected": false, "server": "CouchDB/2.1.1 (Erlang OTP/17)","status": 409, "url": "http://172.17.0.1:5984/_cluster_setup", "x_couch_request_id": "d6757efe56", "x_couchdb_body_time": "0"}

