### PR TITLE
Return 202 for trigger fire requests

### DIFF
--- a/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
@@ -21,7 +21,6 @@ import java.time.Clock
 import java.time.Instant
 
 import scala.concurrent.Future
-import scala.util.{Failure, Success}
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
@@ -144,9 +143,8 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
             duration = None)
 
           logging.info(this, s"[POST] trigger activated, writing activation record to datastore: $triggerActivationId")
-          WhiskActivation.put(activationStore, triggerActivation) onComplete {
-            case Success(_) =>
-            case Failure(t: Throwable) =>
+          WhiskActivation.put(activationStore, triggerActivation) recover {
+            case t =>
               logging.error(this, s"[POST] storing trigger activation $triggerActivationId failed: ${t.getMessage}")
           }
 
@@ -172,9 +170,8 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
                 logging.info(
                   this,
                   s"[POST] rule ${ruleName} activated, writing activation record to datastore: $ruleActivationId")
-                WhiskActivation.put(activationStore, ruleActivation) onComplete {
-                  case Success(_) =>
-                  case Failure(t: Throwable) =>
+                WhiskActivation.put(activationStore, ruleActivation) recover {
+                  case t =>
                     logging.error(this, s"[POST] storing rule activation $ruleActivationId failed: ${t.getMessage}")
                 }
 

--- a/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
@@ -167,9 +167,6 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
                   response = ActivationResponse.success(),
                   version = trigger.version,
                   duration = None)
-                logging.info(
-                  this,
-                  s"[POST] rule ${ruleName} activated, writing activation record to datastore: $ruleActivationId")
                 WhiskActivation.put(activationStore, ruleActivation) recover {
                   case t =>
                     logging.error(this, s"[POST] storing rule activation $ruleActivationId failed: ${t.getMessage}")

--- a/tests/src/test/scala/common/rest/WskRest.scala
+++ b/tests/src/test/scala/common/rest/WskRest.scala
@@ -510,7 +510,7 @@ class WskRestTrigger
   override def fire(name: String,
                     parameters: Map[String, JsValue] = Map(),
                     parameterFile: Option[String] = None,
-                    expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
+                    expectedExitCode: Int = Accepted.intValue)(implicit wp: WskProps): RestResult = {
     val path = getNamePath(noun, name)
     val params = parameterFile map { l =>
       val input = FileUtils.readFileToString(new File(l))

--- a/tests/src/test/scala/whisk/core/controller/test/TriggersApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/TriggersApiTests.scala
@@ -316,7 +316,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
     val content = JsObject("xxx" -> "yyy".toJson)
     put(entityStore, trigger)
     Post(s"$collectionPath/${trigger.name}", content) ~> Route.seal(routes(creds)) ~> check {
-      status should be(OK)
+      status should be(Accepted)
       val response = responseAs[JsObject]
       val JsString(id) = response.fields("activationId")
       val activationId = ActivationId(id)

--- a/tests/src/test/scala/whisk/core/controller/test/TriggersApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/TriggersApiTests.scala
@@ -324,7 +324,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
       response.fields("activationId") should not be None
 
       val activationDoc = DocId(WhiskEntity.qualifiedName(namespace, activationId))
-      whisk.utils.retry( {
+      whisk.utils.retry({
         println(s"trying to obtain async activation doc: '${activationDoc}'")
         val activation = get(activationStore, activationDoc, WhiskActivation, garbageCollect = false)
         del(activationStore, DocId(WhiskEntity.qualifiedName(namespace, activationId)), WhiskActivation)

--- a/tests/src/test/scala/whisk/core/controller/test/TriggersApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/TriggersApiTests.scala
@@ -327,7 +327,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
       whisk.utils.retry({
         println(s"trying to obtain async activation doc: '${activationDoc}'")
         val activation = get(activationStore, activationDoc, WhiskActivation, garbageCollect = false)
-        del(activationStore, DocId(WhiskEntity.qualifiedName(namespace, activationId)), WhiskActivation)
+        del(activationStore, activationDoc, WhiskActivation)
         activation.end should be(Instant.EPOCH)
         activation.response.result should be(Some(content))
       }, 30, Some(1.second))
@@ -342,8 +342,12 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
       val response = responseAs[JsObject]
       val JsString(id) = response.fields("activationId")
       val activationId = ActivationId(id)
-      del(activationStore, DocId(WhiskEntity.qualifiedName(namespace, activationId)), WhiskActivation)
-      response.fields("activationId") should not be None
+      val activationDoc = DocId(WhiskEntity.qualifiedName(namespace, activationId))
+      whisk.utils.retry({
+        println(s"trying to delete async activation doc: '${activationDoc}'")
+        del(activationStore, activationDoc, WhiskActivation)
+        response.fields("activationId") should not be None
+      }, 30, Some(1.second))
     }
   }
 


### PR DESCRIPTION
Currently, trigger fire requests are blocked by db writes (storing trigger activation).  In times of extreme db latency, a storm of trigger fire retries can occur - further stressing the system.  This PR relaxes the trigger fire response dependency on the trigger activation db write avoiding unnecessary trigger retries when activation writes are excessively backed up.

- Return 202 for trigger fire requests.  Still include activation id in response body as before
- asynchronously write the trigger activation record to the db
  - db write failures continue to be logged to the backend log