### PR TITLE
Reenable retry on delete of an entity after test, if there is a confl…

### DIFF
--- a/tests/src/test/scala/common/WskTestHelpers.scala
+++ b/tests/src/test/scala/common/WskTestHelpers.scala
@@ -31,6 +31,7 @@ import spray.json._
 
 import TestUtils.RunResult
 import TestUtils.CONFLICT
+import akka.http.scaladsl.model.StatusCodes
 
 /**
  * An arbitrary response of a whisk action. Includes the result as a JsObject as the
@@ -173,8 +174,9 @@ trait WskTestHelpers extends Matchers {
               case _: BasePackage if delete =>
                 val rr = cli.delete(n)(wskprops)
                 rr.exitCode match {
-                  case CONFLICT => whisk.utils.retry(cli.delete(n)(wskprops), 5, Some(1.second))
-                  case _        => rr
+                  case CONFLICT | StatusCodes.Conflict.intValue =>
+                    whisk.utils.retry(cli.delete(n)(wskprops), 5, Some(1.second))
+                  case _ => rr
                 }
               case _ => if (delete) cli.delete(n)(wskprops) else cli.sanitize(n)(wskprops)
             }


### PR DESCRIPTION
…ict.

We are currently seeing issues in travis with conflicts. I looked at some tests, and some of them failed, because the cleanup did not work.
The reason is, that the retry is not executed anymore, since we use the RestWsk tests.

This PR is only an intermittent solution to make travis passing again more often with several controllers.
I think we need to rework all the Exitcodes, to make them work with the CLI and the RestClient, without always adding both values in these helpers, that are using CLI and Rest.