### PR TITLE
Make the log level configurable via ansible

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -124,6 +124,7 @@ controller:
       seedNodes: "{{ groups['controllers'] | map('extract', hostvars, 'ansible_host') | list }}"
   # We recommend to enable HA for the controllers only, if bookkeeping data are shared too. (localBookkeeping: false)
   ha: "{{ controller_enable_ha | default(True) and groups['controllers'] | length > 1 }}"
+  loglevel: "{{ controller_loglevel | default(whisk_loglevel) | default('INFO') }}"
 
 registry:
   confdir: "{{ config_root_dir }}/registry"
@@ -166,6 +167,7 @@ invoker:
   useRunc: "{{ invoker_use_runc | default(true) }}"
   docker:
     become: "{{ invoker_docker_become | default(false) }}"
+  loglevel: "{{ invoker_loglevel | default(whisk_loglevel) | default('INFO') }}"
 
 userLogs:
   spi: "{{ userLogs_spi | default('whisk.core.containerpool.logging.DockerToActivationLogStoreProvider') }}"

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -51,8 +51,6 @@
       "WHISK_VERSION_DATE": "{{ whisk.version.date }}"
       "WHISK_VERSION_BUILDNO": "{{ docker.image.tag }}"
 
-      "WHISK_LOG_LEVEL": "{{ controller.loglevel }}"
-
       "KAFKA_HOSTS": "{{ kafka_connect_string }}"
       "CONFIG_whisk_kafka_replicationFactor": "{{ kafka.replicationFactor | default() }}"
       "CONFIG_whisk_kafka_topics_cacheInvalidation_retentionBytes": "{{ kafka_topics_cacheInvalidation_retentionBytes | default() }}"
@@ -104,6 +102,8 @@
       "CONFIG_kamon_statsd_port": "{{ metrics.kamon.port }}"
 
       "CONFIG_whisk_spi_LogStoreProvider": "{{ userLogs.spi }}"
+      
+      "CONFIG_logback_log_level": "{{ controller.loglevel }}"
     volumes:
       - "{{ whisk_logs_dir }}/controller{{ groups['controllers'].index(inventory_hostname) }}:/logs"
     ports:

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -51,6 +51,8 @@
       "WHISK_VERSION_DATE": "{{ whisk.version.date }}"
       "WHISK_VERSION_BUILDNO": "{{ docker.image.tag }}"
 
+      "WHISK_LOG_LEVEL": "{{ controller.loglevel }}"
+
       "KAFKA_HOSTS": "{{ kafka_connect_string }}"
       "CONFIG_whisk_kafka_replicationFactor": "{{ kafka.replicationFactor | default() }}"
       "CONFIG_whisk_kafka_topics_cacheInvalidation_retentionBytes": "{{ kafka_topics_cacheInvalidation_retentionBytes | default() }}"

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -154,6 +154,7 @@
         -e CONFIG_kamon_statsd_hostname='{{ metrics.kamon.host }}'
         -e CONFIG_kamon_statsd_port='{{ metrics.kamon.port }}'
         -e CONFIG_whisk_spi_LogStoreProvider='{{ userLogs.spi }}'
+        -e CONFIG_logback_log_level='{{ invoker.loglevel }}'
         -v /sys/fs/cgroup:/sys/fs/cgroup
         -v /run/runc:/run/runc
         -v {{ whisk_logs_dir }}/invoker{{ groups['invokers'].index(inventory_hostname) }}:/logs

--- a/common/scala/src/main/resources/logback.xml
+++ b/common/scala/src/main/resources/logback.xml
@@ -11,10 +11,8 @@
 
   <!-- Kafka -->
   <logger name="org.apache.kafka" level="ERROR" />
-
-  <variable name="WHISK_LOG_LEVEL" value="${WHISK_LOG_LEVEL:-INFO}" />
   
-  <root level="${WHISK_LOG_LEVEL}">
+  <root level="${logback.log.level:-INFO}">
     <appender-ref ref="console" />
   </root>
 </configuration>

--- a/common/scala/src/main/resources/logback.xml
+++ b/common/scala/src/main/resources/logback.xml
@@ -11,8 +11,10 @@
 
   <!-- Kafka -->
   <logger name="org.apache.kafka" level="ERROR" />
+
+  <variable name="WHISK_LOG_LEVEL" value="${WHISK_LOG_LEVEL:-INFO}" />
   
-  <root level="info">
+  <root level="${WHISK_LOG_LEVEL}">
     <appender-ref ref="console" />
   </root>
 </configuration>


### PR DESCRIPTION
This PR makes the log level configurable via ansible.
The log level is configurable for the controller (`controller_loglevel) `
the invoker (`invoker_loglevel`) 
or for both components (`whisk_loglevel`).

The default log level is still set to INFO level.