### PR TITLE
Fix kamon env vars

### DIFF
--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -79,8 +79,6 @@
       "RUNTIMES_MANIFEST": "{{ runtimesManifest | to_json }}"
       "CONTROLLER_LOCALBOOKKEEPING": "{{ controller.localBookkeeping }}"
       "AKKA_CLUSTER_SEED_NODES": "{{seed_nodes_list | join(' ') }}"
-      "METRICS_KAMON": "{{ metrics.kamon.enabled }}"
-      "METRICS_LOG": "{{ metrics.log.enabled }}"
       "CONTROLLER_HA": "{{ controller.ha }}"
 
       "METRICS_KAMON": "{{ metrics.kamon.enabled }}"

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -151,8 +151,8 @@
         -e WHISK_LOGS_DIR='{{ whisk_logs_dir }}'
         -e METRICS_KAMON='{{ metrics.kamon.enabled }}'
         -e METRICS_LOG='{{ metrics.log.enabled }}'
-        -e METRICS_KAMON_HOST='{{ metrics.kamon.host }}'
-        -e METRICS_KAMON_PORT='{{ metrics.kamon.port }}'
+        -e CONFIG_kamon_statsd_hostname='{{ metrics.kamon.host }}'
+        -e CONFIG_kamon_statsd_port='{{ metrics.kamon.port }}'
         -v /sys/fs/cgroup:/sys/fs/cgroup
         -v /run/runc:/run/runc
         -v {{ whisk_logs_dir }}/invoker{{ groups['invokers'].index(inventory_hostname) }}:/logs


### PR DESCRIPTION
There were some missing properties that prevented invokers from sending out metrics via kamon. I've added them and removed the unused ones in invokers and controllers. 