### PR TITLE
add WhiskActivation.Outcome, hiding Either[ActivationId, WhiskActivation] impl

### DIFF
--- a/common/scala/src/main/scala/whisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/whisk/core/connector/Message.scala
@@ -92,7 +92,7 @@ object ActivationMessage extends DefaultJsonProtocol {
  * The whisk activation field will have its logs stripped.
  */
 case class CompletionMessage(override val transid: TransactionId,
-                             response: Either[ActivationId, WhiskActivation],
+                             response: WhiskActivation.Outcome,
                              invoker: InstanceId)
     extends Message {
 

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
@@ -123,6 +123,13 @@ object WhiskActivation
     with WhiskEntityQueries[WhiskActivation]
     with DefaultJsonProtocol {
 
+  /**
+   * The invoker's result for an activation might only be an ActivationId,
+   * e.g. in the case of RecordTooLargeException; see InvokerReactive
+   *
+   */
+  type Outcome = Either[ActivationId, WhiskActivation]
+
   private implicit val instantSerdes = new RootJsonFormat[Instant] {
     def write(t: Instant) = t.toEpochMilli.toJson
 

--- a/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
@@ -624,7 +624,7 @@ trait WhiskWebActionsApi extends Directives with ValidateRequestSize with PostAc
     completeRequest(queuedActivation, projectResultField(context, responseType), responseType)
   }
 
-  private def completeRequest(queuedActivation: Future[Either[ActivationId, WhiskActivation]],
+  private def completeRequest(queuedActivation: Future[WhiskActivation.Outcome],
                               projectResultField: => List[String],
                               responseType: MediaExtension)(implicit transid: TransactionId) = {
     onComplete(queuedActivation) {

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PostActionActivation.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PostActionActivation.scala
@@ -49,7 +49,7 @@ protected[core] trait PostActionActivation extends PrimitiveActions with Sequenc
     action: WhiskActionMetaData,
     payload: Option[JsObject],
     waitForResponse: Option[FiniteDuration],
-    cause: Option[ActivationId])(implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
+    cause: Option[ActivationId])(implicit transid: TransactionId): Future[WhiskActivation.Outcome] = {
     action.toExecutableWhiskAction match {
       // this is a topmost sequence
       case None =>

--- a/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
@@ -66,7 +66,7 @@ protected[actions] trait SequenceActions {
     action: WhiskActionMetaData,
     payload: Option[JsObject],
     waitForResponse: Option[FiniteDuration],
-    cause: Option[ActivationId])(implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]]
+    cause: Option[ActivationId])(implicit transid: TransactionId): Future[WhiskActivation.Outcome]
 
   /**
    * Executes a sequence by invoking in a blocking fashion each of its components.
@@ -90,7 +90,7 @@ protected[actions] trait SequenceActions {
     waitForOutermostResponse: Option[FiniteDuration],
     cause: Option[ActivationId],
     topmost: Boolean,
-    atomicActionsCount: Int)(implicit transid: TransactionId): Future[(Either[ActivationId, WhiskActivation], Int)] = {
+    atomicActionsCount: Int)(implicit transid: TransactionId): Future[(WhiskActivation.Outcome, Int)] = {
     require(action.exec.kind == Exec.SEQUENCE, "this method requires an action sequence")
 
     // create new activation id that corresponds to the sequence
@@ -98,7 +98,7 @@ protected[actions] trait SequenceActions {
     logging.info(this, s"invoking sequence $action topmost $topmost activationid '$seqActivationId'")
 
     val start = Instant.now(Clock.systemUTC())
-    val futureSeqResult: Future[(Either[ActivationId, WhiskActivation], Int)] = {
+    val futureSeqResult: Future[(WhiskActivation.Outcome, Int)] = {
       // even though the result of completeSequenceActivation is Right[WhiskActivation],
       // use a more general type for futureSeqResult in case a blocking invoke takes
       // longer than expected and we must return Left[ActivationId] instead

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerData.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerData.scala
@@ -24,7 +24,7 @@ import scala.concurrent.{Future, Promise}
 case class ActivationEntry(id: ActivationId,
                            namespaceId: UUID,
                            invokerName: InstanceId,
-                           promise: Promise[Either[ActivationId, WhiskActivation]])
+                           promise: Promise[WhiskActivation.Outcome])
 trait LoadBalancerData {
 
   /** Get the number of activations across all namespaces. */

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
@@ -113,7 +113,7 @@ class InvokerReactive(config: WhiskConfig, instance: InstanceId, producer: Messa
              controllerInstance: InstanceId) => {
     implicit val transid = tid
 
-    def send(res: Either[ActivationId, WhiskActivation], recovery: Boolean = false) = {
+    def send(res: WhiskActivation.Outcome, recovery: Boolean = false) = {
       val msg = CompletionMessage(transid, res, instance)
 
       producer.send(s"completed${controllerInstance.toInt}", msg).andThen {

--- a/tests/src/test/scala/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ControllerTestCommon.scala
@@ -185,7 +185,7 @@ class DegenerateLoadBalancerService(config: WhiskConfig)(implicit ec: ExecutionC
   override def activeActivationsFor(namespace: UUID) = Future.successful(0)
 
   override def publish(action: ExecutableWhiskActionMetaData, msg: ActivationMessage)(
-    implicit transid: TransactionId): Future[Future[Either[ActivationId, WhiskActivation]]] =
+    implicit transid: TransactionId): Future[Future[WhiskActivation.Outcome]] =
     Future.successful {
       whiskActivationStub map {
         case (timeout, activation) =>

--- a/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
@@ -245,7 +245,7 @@ trait WebActionsApiBaseTests extends ControllerTestCommon with BeforeAndAfterEac
     action: WhiskActionMetaData,
     payload: Option[JsObject],
     waitForResponse: Option[FiniteDuration],
-    cause: Option[ActivationId])(implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
+    cause: Option[ActivationId])(implicit transid: TransactionId): Future[WhiskActivation.Outcome] = {
     invocationCount = invocationCount + 1
 
     if (failActivation == 0) {

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/LoadBalancerDataTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/LoadBalancerDataTests.scala
@@ -31,7 +31,7 @@ import scala.concurrent.duration._
 
 class LoadBalancerDataTests extends FlatSpec with Matchers with StreamLogging {
 
-  val activationIdPromise = Promise[Either[ActivationId, WhiskActivation]]()
+  val activationIdPromise = Promise[WhiskActivation.Outcome]()
   val firstEntry: ActivationEntry = ActivationEntry(ActivationId(), UUID(), InstanceId(0), activationIdPromise)
   val secondEntry: ActivationEntry = ActivationEntry(ActivationId(), UUID(), InstanceId(1), activationIdPromise)
 


### PR DESCRIPTION
Currently, the implementation of the datatype of the active ack return flow from the Invoker is transparent, and spread across a dozen files: `Either[ActivationId, WhiskActivation]`

this PR introduces `WhiskActivation.Outcome`, an opaque data type that hides the impl.

the goal of this PR is to enable future work that may change the impl, without those PRs each having to change a dozen files. let's pay that cost once, in this PR.

PG3 1424