### PR TITLE
remove invoker.instances from whisk.properties template

### DIFF
--- a/ansible/templates/whisk.properties.j2
+++ b/ansible/templates/whisk.properties.j2
@@ -64,7 +64,6 @@ invoker.container.dns={{ invoker_container_network_dns_servers | default()}}
 invoker.numcore={{ invoker.numcore }}
 invoker.coreshare={{ invoker.coreshare }}
 invoker.useRunc={{ invoker.useRunc }}
-invoker.instances={{ invoker.instances }}
 
 main.docker.endpoint={{ hostvars[groups["controllers"]|first].ansible_host }}:{{ docker.port }}
 


### PR DESCRIPTION
The number of invoker instances may be a dynamic property of
the deployment; we shouldn't be exposing it in whisk.properties.

Closes #2867 