### PR TITLE
cleanup: remove unused redis host/port from WhiskConfig

### DIFF
--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -76,8 +76,6 @@ class WhiskConfig(requiredProperties: Map[String, String],
 
   val edgeHost = this(WhiskConfig.edgeHostName) + ":" + this(WhiskConfig.edgeHostApiPort)
   val kafkaHosts = this(WhiskConfig.kafkaHostList)
-  val redisHostName = this(WhiskConfig.redisHostName)
-  val redisHostPort = this(WhiskConfig.redisHostPort)
 
   val edgeHostName = this(WhiskConfig.edgeHostName)
 
@@ -227,10 +225,8 @@ object WhiskConfig {
 
   val kafkaHostList = "kafka.hosts"
   val zookeeperHostList = "zookeeper.hosts"
-  val redisHostName = "redis.host"
 
   private val edgeHostApiPort = "edge.host.apiport"
-  val redisHostPort = "redis.host.port"
 
   val invokerHostsList = "invoker.hosts"
   val dbHostsList = "db.hostsList"


### PR DESCRIPTION
I should have removed these when we switched to using zookeeper
as the persistent store for invoker id assignment.  They are not used.