### PR TITLE
Reduce number of kafka instance temporarily

### DIFF
--- a/ansible/environments/local/hosts
+++ b/ansible/environments/local/hosts
@@ -11,7 +11,6 @@ controller0         ansible_host=172.17.0.1 ansible_connection=local
 
 [kafkas]
 kafka0              ansible_host=172.17.0.1 ansible_connection=local
-kafka1              ansible_host=172.17.0.1 ansible_connection=local
 
 [zookeepers:children]
 kafkas


### PR DESCRIPTION
Not to break master build status, reduce number of kafka to 1 until we
can ensure that we solve it.
There's heisenbug in KafkaConnectorTests(#3022) when we use two kafka instance and
also two kafka instances affect Travis with high load.