### PR TITLE
Fix Kafka values in WhiskConfig

### DIFF
--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -242,12 +242,12 @@ object WhiskConfig {
 
   val runtimesManifest = "runtimes.manifest"
 
-  val kafkaTopicsInvokerRetentionBytes = "kafka.topics.invoker.retentionBytes"
-  val kafkaTopicsInvokerRetentionMS = "kafka.topics.invoker.retentionMS"
-  val kafkaTopicsInvokerSegmentBytes = "kafka.topics.invoker.segmentBytes"
-  val kafkaTopicsCompletedRetentionBytes = "kafka.topics.completed.retentionBytes"
-  val kafkaTopicsCompletedRetentionMS = "kafka.topics.completed.retentionMS"
-  val kafkaTopicsCompletedSegmentBytes = "kafka.topics.completed.segmentBytes"
+  val kafkaTopicsInvokerRetentionBytes = "kafka.topics.invoker.retention.bytes"
+  val kafkaTopicsInvokerRetentionMS = "kafka.topics.invoker.retention.ms"
+  val kafkaTopicsInvokerSegmentBytes = "kafka.topics.invoker.segment.bytes"
+  val kafkaTopicsCompletedRetentionBytes = "kafka.topics.completed.retention.bytes"
+  val kafkaTopicsCompletedRetentionMS = "kafka.topics.completed.retention.ms"
+  val kafkaTopicsCompletedSegmentBytes = "kafka.topics.completed.segment.bytes"
   val kafkaReplicationFactor = "kafka.replicationFactor"
 
   val actionSequenceMaxLimit = "limits.actions.sequence.maxLength"


### PR DESCRIPTION
Kafka settings are not taken from the environment, because the Strings in WhiskConfig are wrong. This PR fixes this.

Setting`retention.ms` value with ansible and printing the map:

with master:
`Map(retention.bytes -> 1073741824, retention.ms -> 3600000, replicationFactor -> 1, numPartitions -> 1, segment.bytes -> 536870912)`

with this PR:
`Map(retention.bytes -> 1073741824, retention.ms -> 300000, replicationFactor -> 1, numPartitions -> 1, segment.bytes -> 536870912)`