### PR TITLE
Add maven plugin to build.grade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,14 @@ subprojects {
                 from sourceSets.main.allSource
             }
 
+            task testSourcesJar(type: Jar, dependsOn: testClasses) {
+                classifier = 'test-sources'
+                from sourceSets.test.allSource
+            }
+
             artifacts {
                 archives sourcesJar
+                archives testSourcesJar
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,9 @@ subprojects {
     apply plugin: 'scalafmt'
     scalafmt.configFilePath = gradle.scalafmt.config
 
+    group 'org.apache.openwhisk'
+    version '0.0.1-SNAPSHOT'
+
     afterEvaluate {
         if (project.plugins.hasPlugin('application')
                 && project.plugins.hasPlugin('scala')) {
@@ -18,6 +21,17 @@ subprojects {
                 doLast {
                     unixScript.text = configureUnixClasspath(unixScript)
                 }
+            }
+        }
+
+        if (project.plugins.hasPlugin('maven')) {
+            task sourcesJar(type: Jar, dependsOn: classes) {
+                classifier = 'sources'
+                from sourceSets.main.allSource
+            }
+
+            artifacts {
+                archives sourcesJar
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,22 @@ subprojects {
                 archives testSourcesJar
             }
         }
+
+        if (project.plugins.hasPlugin('application')) {
+            //Ensure that dist archive name does not contain version
+            distTar {
+                archiveName = "${project.name}.tar"
+            }
+
+            //Avoid generating the zip files from maven installations
+            distZip {
+                enabled false
+            }
+
+            configurations.archives.with {
+                artifacts.remove artifacts.find { it.archiveTask.is distZip }
+            }
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,9 +35,15 @@ subprojects {
                 from sourceSets.test.allSource
             }
 
+            task testClassesJar(type: Jar, dependsOn: testClasses) {
+                classifier = 'tests'
+                from sourceSets.test.output
+            }
+
             artifacts {
                 archives sourcesJar
                 archives testSourcesJar
+                archives testClassesJar
             }
         }
 

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -5,6 +5,8 @@ apply plugin: 'maven'
 ext.dockerImageName = 'scala'
 apply from: '../../gradle/docker.gradle'
 
+project.archivesBaseName = "openwhisk-common"
+
 repositories {
     mavenCentral()
 }

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'scala'
 apply plugin: 'eclipse'
+apply plugin: 'maven'
 
 ext.dockerImageName = 'scala'
 apply from: '../../gradle/docker.gradle'

--- a/core/controller/build.gradle
+++ b/core/controller/build.gradle
@@ -7,6 +7,8 @@ ext.dockerImageName = 'controller'
 apply from: '../../gradle/docker.gradle'
 distDocker.dependsOn ':common:scala:distDocker', 'distTar'
 
+project.archivesBaseName = "openwhisk-controller"
+
 repositories {
     mavenCentral()
 }

--- a/core/controller/build.gradle
+++ b/core/controller/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'scala'
 apply plugin: 'application'
 apply plugin: 'eclipse'
+apply plugin: 'maven'
 
 ext.dockerImageName = 'controller'
 apply from: '../../gradle/docker.gradle'

--- a/core/invoker/build.gradle
+++ b/core/invoker/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'scala'
 apply plugin: 'application'
 apply plugin: 'eclipse'
+apply plugin: 'maven'
 
 ext.dockerImageName = 'invoker'
 apply from: '../../gradle/docker.gradle'

--- a/core/invoker/build.gradle
+++ b/core/invoker/build.gradle
@@ -7,6 +7,8 @@ ext.dockerImageName = 'invoker'
 apply from: '../../gradle/docker.gradle'
 distDocker.dependsOn ':common:scala:distDocker', 'distTar'
 
+project.archivesBaseName = "openwhisk-invoker"
+
 repositories {
     mavenCentral()
 }

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -7,6 +7,8 @@ repositories {
     mavenCentral()
 }
 
+project.archivesBaseName = "openwhisk-tests"
+
 tasks.withType(Test) {
     systemProperties(System.getProperties())
 

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'scala'
 apply plugin: 'eclipse'
+apply plugin: 'maven'
 compileTestScala.options.encoding = 'UTF-8'
 
 repositories {


### PR DESCRIPTION
- Adds `maven` plugin to build.gradle files for common, controller and
invoker.
- Enables support for generating source jars
- Uses `org.apache.openwhisk` as groupId
- Uses `0.0.1-SNAPSHOT` as current version

PR for #3060 