### PR TITLE
Update trigger fire REST API swagger

### DIFF
--- a/core/controller/src/main/resources/apiv1swagger.json
+++ b/core/controller/src/main/resources/apiv1swagger.json
@@ -928,7 +928,7 @@
                     }
                 ],
                 "responses": {
-                    "200": {
+                    "202": {
                         "description": "Activation id",
                         "schema": {
                             "$ref": "#/definitions/ItemId"


### PR DESCRIPTION
Successful POST `/namespaces/{namespace}/triggers/{triggerName}` responds with 202 instead of 200

Related to PR #3031 