### PR TITLE
Don't fail if no Docker containers running

### DIFF
--- a/ansible/roles/invoker/tasks/clean.yml
+++ b/ansible/roles/invoker/tasks/clean.yml
@@ -44,8 +44,8 @@
 # Remove inactive files older than 60 minutes
 - name: "Clean orphaned ifstate.veth* files on Ubuntu 14.04"
   shell: |
-    ACTIVE_IFACES_REGEXP=$(ip -oneline link show | grep --only-matching --extended-regexp 'veth[0-9a-f]+' | tr '\n' '|' | sed -e 's/.$//' | xargs -I '{}' /bin/echo '/run/network/ifstate\.({})')
-    find /run/network -regextype posix-egrep \( -not -regex ${ACTIVE_IFACES_REGEXP} \) -and -name 'ifstate.veth*' -and -mmin +60 -delete
-  ignore_errors: True
+    ACTIVE_VETH_IFACES=$(ip -oneline link show | grep --only-matching --extended-regexp 'veth[0-9a-f]+' | tr '\n' '|' | sed -e 's/.$//')
+    EXCLUDE_REGEX=$(if [ -z ${ACTIVE_VETH_IFACES} ]; then echo 'No active veth interfaces found' >&2; else printf '( -not -regex  /run/network/ifstate\.(%s) ) -and ' ${ACTIVE_VETH_IFACES}; fi)
+    find /run/network -regextype posix-egrep ${EXCLUDE_REGEX} -name 'ifstate.veth*' -and -mmin +60 -delete
   become: True
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '14.04'


### PR DESCRIPTION
The initial version failed if no Docker containers were running because an invalid regular expression was constructed for `find` command.

With this change, the regular expression for filtering active virtual ethernet interfaces is only included active interfaces can be found. If Docker containers are running, there are always active interfaces. If no Docker containers are running, there may be no actives interfaces.

Also see https://github.com/apache/incubator-openwhisk/pull/3007 for a discussion and test results.