### PR TITLE
Enable ssl on the path between edge and controllers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,9 +60,13 @@ ansible/db_local.ini*
 ansible/tmp/*
 ansible/roles/nginx/files/openwhisk-client*
 ansible/roles/nginx/files/*.csr
+ansible/roles/nginx/files/*.p12
 ansible/roles/nginx/files/*cert.pem
 ansible/roles/nginx/files/*p12
 ansible/roles/kafka/files/*
+ansible/roles/controller/files/*.pem
+ansible/roles/controller/files/*.key
+ansible/roles/controller/files/*.p12
 
 # .zip files must be explicited whitelisted
 *.zip

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -66,6 +66,25 @@ controller:
   loadbalancer:
     spi: "{{ controller_loadbalancer_spi | default('') }}"
   loglevel: "{{ controller_loglevel | default(whisk_loglevel) | default('INFO') }}"
+  protocol: "{{ controllerProtocolForSetup }}"
+  ssl:
+    cn: openwhisk-controllers
+    cert: "{{ controller_ca_cert | default('controller-openwhisk-server-cert.pem') }}"
+    key: "{{ controller_key | default('controller-openwhisk-server-key.pem') }}"
+    clientAuth: "{{ controller_client_auth | default('true') }}"
+    storeFlavor: PKCS12
+    keystore:
+      password: "{{ controllerKeystorePassword }}"
+      path: "/conf/{{ controllerKeystoreName }}"
+# keystore and truststore are the same as long as controller and nginx share the certificate
+    truststore:
+      password: "{{ controllerKeystorePassword }}"
+      path: "/conf/{{ controllerKeystoreName }}"
+# move controller protocol outside to not evaluate controller variables during execution of setup.yml
+controllerProtocolForSetup: "{{ controller_protocol | default('https') }}"
+controllerKeystoreName: "{{ controllerKeyPrefix }}openwhisk-keystore.p12"
+controllerKeyPrefix: "controller-"
+controllerKeystorePassword: openwhisk
 
 jmx:
   basePortController: 15000

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -51,6 +51,25 @@
     src: "{{ openwhisk_home }}/ansible/roles/kafka/files/{{ kafka.ssl.keystore.name }}"
     dest: "{{ controller.confdir }}/controller{{ groups['controllers'].index(inventory_hostname) }}"
 
+- name: copy nginx certificate keystore
+  when: controller.protocol == 'https'
+  copy:
+    src: files/{{ controllerKeystoreName }}
+    mode: 0666
+    dest: "{{ controller.confdir }}/controller{{ groups['controllers'].index(inventory_hostname) }}"
+  become: "{{ controller.dir.become }}"
+
+- name: copy certificates
+  when: controller.protocol == 'https'
+  copy:
+    src: "{{ openwhisk_home }}/ansible/roles/controller/files/{{ item }}"
+    mode: 0666
+    dest: "{{ controller.confdir }}/controller{{ groups['controllers'].index(inventory_hostname) }}"
+  with_items:
+  - "{{ controller.ssl.cert }}"
+  - "{{ controller.ssl.key }}"
+  become: "{{ controller.dir.become }}"
+
 - name: check, that required databases exist
   include: "{{ openwhisk_home }}/ansible/tasks/db/checkDb.yml"
   vars:
@@ -154,11 +173,17 @@
 
       "CONTROLLER_LOCALBOOKKEEPING": "{{ controller.localBookkeeping }}"
       "AKKA_CLUSTER_SEED_NODES": "{{seed_nodes_list | join(' ') }}"
-
       "METRICS_KAMON": "{{ metrics.kamon.enabled }}"
       "METRICS_KAMON_TAGS": "{{ metrics.kamon.tags }}"
       "METRICS_LOG": "{{ metrics.log.enabled }}"
-
+      "CONFIG_whisk_controller_protocol": "{{ controller.protocol }}"
+      "CONFIG_whisk_controller_https_keystorePath": "{{ controller.ssl.keystore.path }}"
+      "CONFIG_whisk_controller_https_keystorePassword": "{{ controller.ssl.keystore.password }}"
+      "CONFIG_whisk_controller_https_keystoreFlavor": "{{ controller.ssl.storeFlavor }}"
+      "CONFIG_whisk_controller_https_truststorePath": "{{ controller.ssl.truststore.path }}"
+      "CONFIG_whisk_controller_https_truststorePassword": "{{ controller.ssl.truststore.password }}"
+      "CONFIG_whisk_controller_https_truststoreFlavor": "{{ controller.ssl.storeFlavor }}"
+      "CONFIG_whisk_controller_https_clientAuth": "{{ controller.ssl.clientAuth }}"
       "CONFIG_whisk_loadbalancer_invokerBusyThreshold": "{{ invoker.busyThreshold }}"
       "CONFIG_whisk_loadbalancer_blackboxFraction": "{{ controller.blackboxFraction }}"
 
@@ -183,7 +208,10 @@
 
 - name: wait until the Controller in this host is up and running
   uri:
-    url: "http://{{ ansible_host }}:{{ controller.basePort + (controller_index | int) }}/ping"
+    url: "{{ controller.protocol }}://{{ ansible_host }}:{{ controller.basePort + groups['controllers'].index(inventory_hostname) }}/ping"
+    validate_certs: no
+    client_key: "{{ controller.confdir }}/controller{{ groups['controllers'].index(inventory_hostname) }}/{{ controller.ssl.key }}"
+    client_cert: "{{ controller.confdir }}/controller{{ groups['controllers'].index(inventory_hostname) }}/{{ controller.ssl.cert }}"
   register: result
   until: result.status == 200
   retries: 12

--- a/ansible/roles/nginx/tasks/deploy.yml
+++ b/ansible/roles/nginx/tasks/deploy.yml
@@ -27,6 +27,15 @@
     dest: "{{ nginx.confdir }}"
   when: nginx.ssl.password_enabled == true
 
+- name: copy controller cert for authentication
+  copy:
+    src: "{{ openwhisk_home }}/ansible/roles/controller/files/{{ item }}"
+    dest: "{{ nginx.confdir }}"
+  with_items:
+        - "{{ controller.ssl.cert }}"
+        - "{{ controller.ssl.key }}"
+  when: "{{ controller.protocol == 'https' }}"
+
 - name: ensure nginx log directory is created with permissions
   file:
     path: "{{ whisk_logs_dir }}/nginx"

--- a/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/ansible/roles/nginx/templates/nginx.conf.j2
@@ -23,6 +23,14 @@ http {
     proxy_http_version 1.1;
     proxy_set_header Connection "";
 
+{% if controller.protocol == 'https' %}
+    proxy_ssl_session_reuse on;
+    proxy_ssl_name {{ controller.ssl.cn }};
+    proxy_ssl_protocols TLSv1.1 TLSv1.2;
+    proxy_ssl_certificate /etc/nginx/{{ controller.ssl.cert }};
+    proxy_ssl_certificate_key /etc/nginx/{{ controller.ssl.key }};
+{% endif %}
+
     upstream controllers {
         # fail_timeout: period of time the server will be considered unavailable
         # Mark the controller as unavailable for at least 60 seconds, to not get any requests during restart.
@@ -80,7 +88,7 @@ http {
             if ($namespace) {
               rewrite    /(.*) /api/v1/web/${namespace}/$1 break;
             }
-            proxy_pass http://controllers;
+            proxy_pass {{ controller.protocol }}://controllers;
             proxy_read_timeout 75s; # 70+5 additional seconds to allow controller to terminate request
         }
 
@@ -89,7 +97,7 @@ http {
             if ($namespace) {
               rewrite    ^ /api/v1/web/${namespace}/public/index.html break;
             }
-            proxy_pass http://controllers;
+            proxy_pass {{ controller.protocol }}://controllers;
             proxy_read_timeout 75s; # 70+5 additional seconds to allow controller to terminate request
         }
 

--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -48,3 +48,15 @@
   - name: generate kafka certificates
     local_action: shell "{{ playbook_dir }}/files/genssl.sh" "openwhisk-kafka" "server_with_JKS_keystore" "{{ playbook_dir }}/roles/kafka/files" openwhisk "generateKey" "kafka-"
     when: kafka_protocol_for_setup == 'SSL'
+
+  - name: ensure controller files directory exists
+    file:
+      path: "{{ playbook_dir }}/roles/controller/files/"
+      state: directory
+      mode: 0777
+    become: "{{ logs.dir.become }}"
+    when: controllerProtocolForSetup == 'https'
+
+  - name: generate controller certificates
+    when: controllerProtocolForSetup == 'https'
+    local_action: shell "{{ playbook_dir }}/files/genssl.sh" "openwhisk-controllers" "server" "{{ playbook_dir }}/roles/controller/files" {{ controllerKeystorePassword }} "generateKey" {{ controllerKeyPrefix }}

--- a/ansible/templates/whisk.properties.j2
+++ b/ansible/templates/whisk.properties.j2
@@ -56,6 +56,7 @@ invoker.hosts.basePort={{ invoker.port }}
 controller.hosts={{ groups["controllers"] | map('extract', hostvars, 'ansible_host') | list | join(",") }}
 controller.host.basePort={{ controller.basePort }}
 controller.instances={{ controller.instances }}
+controller.protocol={{ controller.protocol }}
 
 invoker.container.network=bridge
 invoker.container.policy={{ invoker_container_policy_name | default()}}

--- a/common/scala/src/main/scala/whisk/common/Https.scala
+++ b/common/scala/src/main/scala/whisk/common/Https.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.common
+
+import java.io.{FileInputStream, InputStream}
+import java.security.{KeyStore, SecureRandom}
+import javax.net.ssl.{KeyManagerFactory, SSLContext, TrustManagerFactory}
+
+import akka.http.scaladsl.ConnectionContext
+import akka.stream.TLSClientAuth
+import com.typesafe.sslconfig.akka.AkkaSSLConfig
+import whisk.core.WhiskConfig
+import pureconfig._
+
+object Https {
+  case class HttpsConfig(keystorePassword: String,
+                         keystoreFlavor: String,
+                         keystorePath: String,
+                         truststorePath: String,
+                         truststorePassword: String,
+                         truststoreFlavor: String,
+                         clientAuth: String)
+  private val httpsConfig = loadConfigOrThrow[HttpsConfig]("whisk.controller.https")
+
+  def getCertStore(password: Array[Char], flavor: String, path: String): KeyStore = {
+    val certStorePassword: Array[Char] = password
+    val cs: KeyStore = KeyStore.getInstance(flavor)
+    val certStore: InputStream = new FileInputStream(path)
+    cs.load(certStore, certStorePassword)
+    cs
+  }
+
+  def connectionContext(config: WhiskConfig, sslConfig: Option[AkkaSSLConfig] = None) = {
+
+    val keyFactoryType = "SunX509"
+    val clientAuth = {
+      if (httpsConfig.clientAuth.toBoolean)
+        Some(TLSClientAuth.need)
+      else
+        Some(TLSClientAuth.none)
+    }
+
+// configure keystore
+    val keystorePassword = httpsConfig.keystorePassword.toCharArray
+    val ks: KeyStore = getCertStore(keystorePassword, httpsConfig.keystoreFlavor, httpsConfig.keystorePath)
+    val keyManagerFactory: KeyManagerFactory = KeyManagerFactory.getInstance(keyFactoryType)
+    keyManagerFactory.init(ks, keystorePassword)
+
+// configure truststore
+    val truststorePassword = httpsConfig.truststorePassword.toCharArray
+    val ts: KeyStore = getCertStore(truststorePassword, httpsConfig.truststoreFlavor, httpsConfig.keystorePath)
+    val trustManagerFactory: TrustManagerFactory = TrustManagerFactory.getInstance(keyFactoryType)
+    trustManagerFactory.init(ts)
+
+    val sslContext: SSLContext = SSLContext.getInstance("TLS")
+    sslContext.init(keyManagerFactory.getKeyManagers, trustManagerFactory.getTrustManagers, new SecureRandom)
+
+    ConnectionContext.https(sslContext, sslConfig, clientAuth = clientAuth)
+  }
+}

--- a/core/controller/src/main/resources/application.conf
+++ b/core/controller/src/main/resources/application.conf
@@ -7,6 +7,9 @@ whisk {
     invoker-busy-threshold: 4
     blackbox-fraction: 10%
   }
+  controller {
+    protocol: http
+  }
 }
 
 # http://doc.akka.io/docs/akka-http/current/scala/http/configuration.html

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -49,6 +49,7 @@ import whisk.http.BasicRasService
 import whisk.spi.SpiLoader
 import whisk.core.containerpool.logging.LogStoreProvider
 import akka.event.Logging.InfoLevel
+import pureconfig.loadConfigOrThrow
 
 /**
  * The Controller is the service that provides the REST API for OpenWhisk.
@@ -159,6 +160,8 @@ class Controller(val instance: InstanceId,
  */
 object Controller {
 
+  protected val protocol = loadConfigOrThrow[String]("whisk.controller.protocol")
+
   // requiredProperties is a Map whose keys define properties that must be bound to
   // a value, and whose values are default values.   A null value in the Map means there is
   // no default value specified, so it must appear in the properties file
@@ -233,7 +236,10 @@ object Controller {
           actorSystem,
           ActorMaterializer.create(actorSystem),
           logger)
-        BasicHttpService.startService(controller.route, port)(actorSystem, controller.materializer)
+        if (Controller.protocol == "https")
+          BasicHttpService.startHttpsService(controller.route, port, config)(actorSystem, controller.materializer)
+        else
+          BasicHttpService.startHttpService(controller.route, port)(actorSystem, controller.materializer)
 
       case Failure(t) =>
         abort(s"Invalid runtimes manifest: $t")

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -189,6 +189,8 @@ object Invoker {
     })
 
     val port = config.servicePort.toInt
-    BasicHttpService.startService(new InvokerServer().route, port)(actorSystem, ActorMaterializer.create(actorSystem))
+    BasicHttpService.startHttpService(new InvokerServer().route, port)(
+      actorSystem,
+      ActorMaterializer.create(actorSystem))
   }
 }

--- a/tests/src/test/resources/application.conf.j2
+++ b/tests/src/test/resources/application.conf.j2
@@ -45,4 +45,17 @@ whisk {
           WhiskActivation = {{ db.whisk.activations }}
         }
     }
+
+    controller {
+      protocol = {{ controller.protocol }}
+      https {
+        keystore-flavor = "{{ controller.ssl.storeFlavor }}"
+        keystore-path = "{{ openwhisk_home }}/ansible/roles/controller/files/{{ controllerKeystoreName }}"
+        keystore-password = "{{ controller.ssl.keystore.password }}"
+        truststore-flavor = "{{ controller.ssl.storeFlavor }}"
+        truststore-path = "{{ openwhisk_home }}/ansible/roles/controller/files/{{ controllerKeystoreName }}"
+        truststore-password = "{{ controller.ssl.keystore.password }}"
+        client-auth = "{{ controller.ssl.clientAuth }}"
+      }
+    }
 }

--- a/tests/src/test/scala/common/rest/WskRest.scala
+++ b/tests/src/test/scala/common/rest/WskRest.scala
@@ -94,7 +94,7 @@ class AcceptAllHostNameVerifier extends HostnameVerifier {
 
 object SSL {
 
-  val httpsConfig = loadConfigOrThrow[HttpsConfig]("whisk.controller.https")
+  lazy val httpsConfig = loadConfigOrThrow[HttpsConfig]("whisk.controller.https")
 
   def keyManagers(clientAuth: Boolean) = {
     if (clientAuth)

--- a/tests/src/test/scala/common/rest/WskRest.scala
+++ b/tests/src/test/scala/common/rest/WskRest.scala
@@ -17,7 +17,7 @@
 
 package common.rest
 
-import java.io.File
+import java.io.{File, FileInputStream}
 import java.time.Instant
 import java.util.Base64
 import java.security.cert.X509Certificate
@@ -78,17 +78,42 @@ import common.WskActorSystem
 import common.WskProps
 import whisk.core.entity.ByteSize
 import whisk.utils.retry
-import javax.net.ssl.{HostnameVerifier, KeyManager, SSLContext, SSLSession, X509TrustManager}
+import javax.net.ssl._
 
 import com.typesafe.sslconfig.akka.AkkaSSLConfig
 import java.nio.charset.StandardCharsets
+import java.security.KeyStore
+
+import akka.actor.ActorSystem
+import pureconfig.loadConfigOrThrow
+import whisk.common.Https.HttpsConfig
 
 class AcceptAllHostNameVerifier extends HostnameVerifier {
   override def verify(s: String, sslSession: SSLSession): Boolean = true
 }
 
 object SSL {
-  lazy val nonValidatingContext: SSLContext = {
+
+  val httpsConfig = loadConfigOrThrow[HttpsConfig]("whisk.controller.https")
+
+  def keyManagers(clientAuth: Boolean) = {
+    if (clientAuth)
+      keyManagersForClientAuth
+    else
+      Array[KeyManager]()
+  }
+
+  def keyManagersForClientAuth: Array[KeyManager] = {
+    val keyFactoryType = "SunX509"
+    val keystorePassword = httpsConfig.keystorePassword.toCharArray
+    val ks: KeyStore = KeyStore.getInstance(httpsConfig.keystoreFlavor)
+    ks.load(new FileInputStream(httpsConfig.keystorePath), httpsConfig.keystorePassword.toCharArray)
+    val keyManagerFactory: KeyManagerFactory = KeyManagerFactory.getInstance(keyFactoryType)
+    keyManagerFactory.init(ks, keystorePassword)
+    keyManagerFactory.getKeyManagers
+  }
+
+  def nonValidatingContext(clientAuth: Boolean = false): SSLContext = {
     class IgnoreX509TrustManager extends X509TrustManager {
       def checkClientTrusted(chain: Array[X509Certificate], authType: String) = ()
       def checkServerTrusted(chain: Array[X509Certificate], authType: String) = ()
@@ -96,8 +121,34 @@ object SSL {
     }
 
     val context = SSLContext.getInstance("TLS")
-    context.init(Array[KeyManager](), Array(new IgnoreX509TrustManager), null)
+
+    context.init(keyManagers(clientAuth), Array(new IgnoreX509TrustManager), null)
     context
+  }
+
+  def httpsConnectionContext(implicit system: ActorSystem) = {
+    val sslConfig = AkkaSSLConfig().mapSettings { s =>
+      s.withHostnameVerifierClass(classOf[AcceptAllHostNameVerifier].asInstanceOf[Class[HostnameVerifier]])
+    }
+    new HttpsConnectionContext(SSL.nonValidatingContext(httpsConfig.clientAuth.toBoolean), Some(sslConfig))
+  }
+}
+
+object HttpConnection {
+
+  /**
+   * Returns either the https context that is tailored for self-signed certificates on the controller, or
+   * a default connection context used in Http.SingleRequest
+   * @param protocol protocol used to communicate with controller API
+   * @param system actor system
+   * @return https connection context
+   */
+  def getContext(protocol: String)(implicit system: ActorSystem) = {
+    if (protocol == "https")
+      SSL.httpsConnectionContext
+    else
+//    supports http
+      Http().defaultClientHttpsContext
   }
 }
 
@@ -1170,6 +1221,7 @@ class RunWskRestCmd() extends FlatSpec with RunWskCmd with Matchers with ScalaFu
 
   implicit val config = PatienceConfig(100 seconds, 15 milliseconds)
   implicit val materializer = ActorMaterializer()
+  val protocol = loadConfigOrThrow[String]("whisk.controller.protocol")
   val idleTimeout = 90 seconds
   val queueSize = 10
   val maxOpenRequest = 1024
@@ -1180,7 +1232,7 @@ class RunWskRestCmd() extends FlatSpec with RunWskCmd with Matchers with ScalaFu
     s.withHostnameVerifierClass(classOf[AcceptAllHostNameVerifier].asInstanceOf[Class[HostnameVerifier]])
   }
 
-  val connectionContext = new HttpsConnectionContext(SSL.nonValidatingContext, Some(sslConfig))
+  val connectionContext = new HttpsConnectionContext(SSL.nonValidatingContext(), Some(sslConfig))
 
   def isStatusCodeExpected(expectedExitCode: Int, statusCode: Int): Boolean = {
     if ((expectedExitCode != DONTCARE_EXIT) && (expectedExitCode != ANY_ERROR_EXIT))

--- a/tests/src/test/scala/services/HeadersTests.scala
+++ b/tests/src/test/scala/services/HeadersTests.scala
@@ -21,20 +21,17 @@ import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 import scala.language.postfixOps
 import scala.collection.immutable.Seq
-
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.time.Span.convertDurationToSpan
-
 import common.TestUtils
 import common.WhiskProperties
-import common.rest.WskRest
+import common.rest.{HttpConnection, WskRest}
 import common.WskProps
 import common.WskTestHelpers
-
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.model.Uri.Path
 import akka.http.scaladsl.model.headers.BasicHttpCredentials
@@ -52,8 +49,8 @@ import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.model.HttpMethod
 import akka.http.scaladsl.model.HttpHeader
 import akka.stream.ActorMaterializer
-
 import common.WskActorSystem
+import pureconfig.loadConfigOrThrow
 
 @RunWith(classOf[JUnitRunner])
 class HeadersTests extends FlatSpec with Matchers with ScalaFutures with WskActorSystem with WskTestHelpers {
@@ -62,12 +59,14 @@ class HeadersTests extends FlatSpec with Matchers with ScalaFutures with WskActo
 
   implicit val materializer = ActorMaterializer()
 
+  val controllerProtocol = loadConfigOrThrow[String]("whisk.controller.protocol")
+  println(loadConfigOrThrow[String]("whisk"))
   val whiskAuth = WhiskProperties.getBasicAuth
   val creds = BasicHttpCredentials(whiskAuth.fst, whiskAuth.snd)
   val allMethods = Some(Set(DELETE.name, GET.name, POST.name, PUT.name))
   val allowOrigin = `Access-Control-Allow-Origin`.*
   val allowHeaders = `Access-Control-Allow-Headers`("Authorization", "Content-Type")
-  val url = Uri(s"http://${WhiskProperties.getBaseControllerAddress()}")
+  val url = Uri(s"$controllerProtocol://${WhiskProperties.getBaseControllerAddress()}")
 
   def request(method: HttpMethod, uri: Uri, headers: Option[Seq[HttpHeader]] = None): Future[HttpResponse] = {
     val httpRequest = headers match {
@@ -75,7 +74,8 @@ class HeadersTests extends FlatSpec with Matchers with ScalaFutures with WskActo
       case None          => HttpRequest(method, uri)
     }
 
-    Http().singleRequest(httpRequest)
+    val connectionContext = HttpConnection.getContext(controllerProtocol)
+    Http().singleRequest(httpRequest, connectionContext = connectionContext)
   }
 
   implicit val config = PatienceConfig(10 seconds, 0 milliseconds)

--- a/tools/travis/setup.sh
+++ b/tools/travis/setup.sh
@@ -32,4 +32,4 @@ docker info
 pip install --user couchdb
 
 # Ansible
-pip install --user ansible==2.3.0.0
+pip install --user ansible==2.4.2.0


### PR DESCRIPTION
This PR will enable SSL between nginx and controllers. A couple of things that must be considered: 
* certs for local and docker-machine environments are self-signed
* certs are regenerated during OW deployment
* the default protocol will be https

@mhenke1 