### PR TITLE
Remove unneeded code reference from WhiskActionMetaData test helper

### DIFF
--- a/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
@@ -190,7 +190,7 @@ trait WebActionsApiBaseTests extends ControllerTestCommon with BeforeAndAfterEac
         WhiskActionMetaData(
           actionName.path,
           actionName.name,
-          jsDefaultMetaData("??"),
+          js6MetaData(),
           defaultActionParameters,
           annotations = {
             if (actionName.name.asString.startsWith("export_")) {

--- a/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
@@ -68,13 +68,9 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
     js6(code, main)
   }
 
-  protected def js6MetaData(code: String, main: Option[String] = None) = {
+  protected def js6MetaData(main: Option[String] = None) = {
     CodeExecMetaDataAsString(
       RuntimeManifest(NODEJS6, imagename(NODEJS6), default = Some(true), deprecated = Some(false)))
-  }
-
-  protected def jsDefaultMetaData(code: String, main: Option[String] = None) = {
-    js6MetaData(code, main)
   }
 
   protected def javaDefault(code: String, main: Option[String] = None) = {


### PR DESCRIPTION
A code parameter is not needed for `js6MetaData()`.