### PR TITLE
Add dockerignore files to reduce size of build context

### DIFF
--- a/common/scala/.dockerignore
+++ b/common/scala/.dockerignore
@@ -1,0 +1,3 @@
+*
+!transformEnvironment.sh
+!build/distributions

--- a/core/controller/.dockerignore
+++ b/core/controller/.dockerignore
@@ -1,0 +1,3 @@
+*
+!init.sh
+!build/distributions

--- a/core/invoker/.dockerignore
+++ b/core/invoker/.dockerignore
@@ -1,0 +1,3 @@
+*
+!init.sh
+!build/distributions


### PR DESCRIPTION
Adds .dockerignore files to 3 docker images which also have scala code. This ensures that build context send to docker daemon only includes required files.

This is based on recommended docker best practice of [using a .dockerignore file][1]. 

Below are the size of build context send prior and post change
 
- common:scala

        Sending build context to Docker daemon  30.32MB //current
        Sending build context to Docker daemon  6.144kB  //post change
- :core:controller

        Sending build context to Docker daemon  65.54MB //current
        Sending build context to Docker daemon  48.74MB //post change
- :core:invoker

        Sending build context to Docker daemon  49.87MB //current
        Sending build context to Docker daemon  45.46MB //post change

This leads to decent saving for common for now. Going forward once Maven artifacts are also build (#3060) then it would ensure that build context does not increase
    
[1]: https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#use-a-dockerignore-file