### PR TITLE
Allow invoke helper to work with tgz files.

### DIFF
--- a/actionRuntimes/actionProxy/invoke.py
+++ b/actionRuntimes/actionProxy/invoke.py
@@ -69,7 +69,7 @@ def init(args):
     main = args[1] if len(args) == 2 else "main"
     args = args[0] if len(args) >= 1 else None
 
-    if args and args.endswith(".zip"):
+    if args and (args.endswith(".zip") or args.endswith("tgz")):
         with open(args, "rb") as fp:
             contents = fp.read().encode("base64")
         binary = True


### PR DESCRIPTION
A zip or tgz (more generally archive format) is specific to a runtime. Allow this script to work with zip or tgz files.

See https://github.com/apache/incubator-openwhisk-runtime-nodejs/pull/16 for example.