### PR TITLE
Update akka-http to 10.0.11

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -18,8 +18,8 @@ dependencies {
     compile 'com.typesafe.akka:akka-stream_2.11:2.5.6'
     compile 'com.typesafe.akka:akka-slf4j_2.11:2.5.6'
 
-    compile 'com.typesafe.akka:akka-http-core_2.11:10.0.10'
-    compile 'com.typesafe.akka:akka-http-spray-json_2.11:10.0.10'
+    compile "com.typesafe.akka:akka-http-core_2.11:${gradle.akkahttp.version}"
+    compile "com.typesafe.akka:akka-http-spray-json_2.11:${gradle.akkahttp.version}"
 
     compile 'ch.qos.logback:logback-classic:1.2.3'
     compile 'org.slf4j:jcl-over-slf4j:1.7.25'

--- a/common/scala/src/main/scala/whisk/core/entity/ArgNormalizer.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ArgNormalizer.scala
@@ -18,8 +18,8 @@
 package whisk.core.entity
 
 import spray.json.RootJsonFormat
-import spray.json.pimpString
 import spray.json.JsString
+import spray.json._
 import scala.util.Try
 
 protected[entity] trait ArgNormalizer[T] {

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,5 +30,5 @@ gradle.ext.scalafmt = [
 ]
 
 gradle.ext.akkahttp = [
-        version: '10.0.11'
+    version: '10.0.11'
 ]

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,3 +28,7 @@ gradle.ext.scalafmt = [
     version: '1.5.0',
     config: new File(rootProject.projectDir, '.scalafmt.conf')
 ]
+
+gradle.ext.akkahttp = [
+        version: '10.0.11'
+]

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     compile 'com.google.code.gson:gson:2.3.1'
     compile 'org.scalamock:scalamock-scalatest-support_2.11:3.4.2'
     compile 'com.typesafe.akka:akka-testkit_2.11:2.4.16'
-    compile 'com.typesafe.akka:akka-http-testkit_2.11:10.0.10'
+    compile "com.typesafe.akka:akka-http-testkit_2.11:${gradle.akkahttp.version}"
     compile 'com.github.java-json-tools:json-schema-validator:2.2.8';
 
     compile project(':common:scala')

--- a/tests/src/test/scala/common/BaseWsk.scala
+++ b/tests/src/test/scala/common/BaseWsk.scala
@@ -31,7 +31,7 @@ import org.scalatest.Matchers
 import TestUtils._
 import spray.json.JsObject
 import spray.json.JsValue
-import spray.json.pimpString
+import spray.json._
 import whisk.core.entity.ByteSize
 
 case class WskProps(

--- a/tests/src/test/scala/common/rest/WskRest.scala
+++ b/tests/src/test/scala/common/rest/WskRest.scala
@@ -72,7 +72,6 @@ import spray.json._
 import spray.json.DefaultJsonProtocol._
 import spray.json.JsObject
 import spray.json.JsValue
-import spray.json.pimpString
 
 import common._
 import common.BaseDeleteFromCollection

--- a/tests/src/test/scala/system/basic/WskActionTests.scala
+++ b/tests/src/test/scala/system/basic/WskActionTests.scala
@@ -31,7 +31,6 @@ import common.WskTestHelpers
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import spray.json.JsObject
-import spray.json.pimpAny
 
 @RunWith(classOf[JUnitRunner])
 abstract class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers {

--- a/tests/src/test/scala/system/basic/WskBasicSwift3Tests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicSwift3Tests.scala
@@ -26,7 +26,7 @@ import common.TestUtils
 import common.BaseWsk
 import common.WskProps
 import common.WskTestHelpers
-import spray.json.pimpString
+import spray.json._
 import spray.json.JsString
 import common.TestUtils.RunResult
 import spray.json.JsObject

--- a/tests/src/test/scala/system/basic/WskBasicTests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicTests.scala
@@ -34,7 +34,6 @@ import common.WskProps
 import common.WskTestHelpers
 import spray.json._
 import spray.json.DefaultJsonProtocol._
-import spray.json.pimpAny
 
 import whisk.http.Messages
 

--- a/tests/src/test/scala/system/basic/WskConsoleTests.scala
+++ b/tests/src/test/scala/system/basic/WskConsoleTests.scala
@@ -34,7 +34,7 @@ import common.WskProps
 import common.WskTestHelpers
 import spray.json.DefaultJsonProtocol.IntJsonFormat
 import spray.json.DefaultJsonProtocol.StringJsonFormat
-import spray.json.pimpAny
+import spray.json._
 
 /**
  * Tests of the text console

--- a/tests/src/test/scala/system/rest/ActionSchemaTests.scala
+++ b/tests/src/test/scala/system/rest/ActionSchemaTests.scala
@@ -34,7 +34,7 @@ import common.WskProps
 import common.WskTestHelpers
 import spray.json.JsArray
 import spray.json.JsObject
-import spray.json.pimpString
+import spray.json._
 
 /**
  * Basic tests of API calls for actions

--- a/tests/src/test/scala/system/rest/RestUtil.scala
+++ b/tests/src/test/scala/system/rest/RestUtil.scala
@@ -26,7 +26,7 @@ import com.jayway.restassured.config.SSLConfig
 import common.WhiskProperties
 import spray.json.JsObject
 import spray.json.JsValue
-import spray.json.pimpString
+import spray.json._
 
 /**
  * Utilities for REST tests

--- a/tests/src/test/scala/whisk/core/cli/test/Swift311Tests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/Swift311Tests.scala
@@ -28,7 +28,7 @@ import common.rest.WskRest
 import common.WskProps
 import common.WskTestHelpers
 import spray.json.DefaultJsonProtocol.StringJsonFormat
-import spray.json.pimpAny
+import spray.json._
 
 @RunWith(classOf[JUnitRunner])
 class Swift311Tests extends TestHelpers with WskTestHelpers with Matchers {

--- a/tests/src/test/scala/whisk/core/database/test/CleanUpActivationsTest.scala
+++ b/tests/src/test/scala/whisk/core/database/test/CleanUpActivationsTest.scala
@@ -38,7 +38,7 @@ import common.WhiskProperties
 import common.WskActorSystem
 import spray.json.DefaultJsonProtocol._
 import spray.json.JsObject
-import spray.json.pimpAny
+import spray.json._
 
 @RunWith(classOf[JUnitRunner])
 class CleanUpActivationsTest

--- a/tests/src/test/scala/whisk/core/entity/test/ActivationResponseTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ActivationResponseTests.scala
@@ -22,8 +22,7 @@ import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import org.scalatest.junit.JUnitRunner
-import spray.json.pimpAny
-import spray.json.pimpString
+import spray.json._
 import whisk.common.PrintStreamLogging
 import whisk.core.entity.ActivationResponse._
 import whisk.core.entity.size.SizeInt


### PR DESCRIPTION
A new version of akka-http was released on Dec 1st. This PR updates our akka-http dependancies to the latest version.

Also, the akka-http version has been moved to a central location in settings.gradle.

Blog: https://akka.io/blog/news/2017/12/01/akka-http-10.0.11-released

Release notes: https://doc.akka.io/docs/akka-http/current/scala/http/release-notes.html#10-0-11

Explanation behind spray.json import changes: https://github.com/spray/spray-json/releases