### PR TITLE
Fix "No such file or directory" problem when cleaning "veth*.ifstate"…

### DIFF
--- a/ansible/roles/invoker/tasks/clean.yml
+++ b/ansible/roles/invoker/tasks/clean.yml
@@ -48,4 +48,5 @@
     EXCLUDE_REGEX=$(if [ -z ${ACTIVE_VETH_IFACES} ]; then echo 'No active veth interfaces found' >&2; else printf '( -not -regex  /run/network/ifstate\.(%s) ) -and ' ${ACTIVE_VETH_IFACES}; fi)
     find /run/network -regextype posix-egrep ${EXCLUDE_REGEX} -name 'ifstate.veth*' -and -mmin +60 -delete
   become: True
+  ignore_errors: True
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '14.04'


### PR DESCRIPTION
… files

See #3081 for a discussion.

Let Ansible ignore errors from the `find` command because there is no option to let the `find` commmand ignore errors from the `-delete` action.

Root cause of the problem must be a race condition where files that have been identified during the `Find` phase have been removed before these files are processed in the `Action` phase.