### PR TITLE
Remove obsolete code to remove old config directory of nginx.

### DIFF
--- a/ansible/roles/nginx/tasks/clean.yml
+++ b/ansible/roles/nginx/tasks/clean.yml
@@ -14,15 +14,6 @@
     state: absent
   become: "{{ nginx.dir.become }}"
 
-# As I changed the location of the log directory, this task will still remove the old config directory
-# This step will be removed soon again.
-- name: remove old config directory
-  file:
-    path: "{{ nginx.confdir | regex_replace('wskconf/nginx$', 'nginx') }}"
-    state: absent
-  become: "{{ nginx.dir.become }}"
-  when: nginx.confdir | match(".*/wskconf/nginx")
-
 - name: remove nginx log directory
   file:
     path: "{{ whisk_logs_dir }}/nginx"


### PR DESCRIPTION
Some weeks ago, I moved all config files to `wskconf`. To delete config files in the old directory, I added the code, that I remove again in this PR.