### PR TITLE
add remote_redirect mode for openwhisk_cli installation

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -295,11 +295,14 @@ catalog_repos:
 openwhisk_cli_tag: "{{ lookup('ini', 'git_tag section=openwhisk-cli file={{ openwhisk_home }}/ansible/files/package-versions.ini') }}"
 
 # The openwhisk_cli is used to determine how to install the OpenWhisk CLI. The
-# installation_mode can be specified into two modes: remote and local.
+# installation_mode can be specified into three modes: remote_redirect, remote and local.
+# The mode remote_redirect means to not install the available binaries
+# into the nginx container but to rely on a redirect to an external location.
 # The mode remote means to download the available binaries from the releases page
 # of the official openwhisk cli repository. The mode local means to build the binaries
 # locally in a directory and get them from the local directory. The default value
-# for openwhisk is local.
+# for openwhisk is remote_redirect.
+# NOTE: the remote and local modes are likely to be removed at some future time.
 #
 # The name specifies the package name of the binaries in remote mode.
 #
@@ -310,13 +313,17 @@ openwhisk_cli_tag: "{{ lookup('ini', 'git_tag section=openwhisk-cli file={{ open
 #
 
 openwhisk_cli:
-  installation_mode: "{{ cli_installation_mode | default('remote') }}"
+  installation_mode: "{{ cli_installation_mode | default('remote_redirect') }}"
   local:
     location: "{{ openwhisk_cli_home }}/bin"
   remote:
     name: OpenWhisk_CLI
     dest_name: OpenWhisk_CLI
     location: "https://github.com/apache/incubator-openwhisk-cli/releases/download/{{ openwhisk_cli_tag }}"
+  remote_redirect:
+    package_name: OpenWhisk_CLI
+    location_browse: "https://github.com/apache/incubator-openwhisk-cli/releases/{{ openwhisk_cli_tag }}"
+    location_download: "https://github.com/apache/incubator-openwhisk-cli/releases/download/{{ openwhisk_cli_tag }}"
 
 # The list of operating systems for which openwhisk cli binaries are downloaded,
 # if the installation_mode is remote.

--- a/ansible/roles/cli/tasks/deploy.yml
+++ b/ansible/roles/cli/tasks/deploy.yml
@@ -1,14 +1,15 @@
 ---
 # Tasks for handling CLI customization and publishing
 
+- set_fact:
+    cli_installation_mode="{{ openwhisk_cli.installation_mode }}"
+
 - name: "ensure nginx directory for cli exists"
   file:
     path: "{{ cli.nginxdir  }}"
     state: directory
   become: "{{ cli.dir.become }}"
-
-- set_fact:
-    cli_installation_mode="{{ openwhisk_cli.installation_mode }}"
+  when: cli_installation_mode != "remote_redirect"
 
 - include: docker_login.yml
 
@@ -26,3 +27,7 @@
   when: cli_installation_mode == "local"
 
 - include: download_cli.yml
+  when: cli_installation_mode != "remote_redirect"
+
+- include: download_remote_redirect_cli.yml
+  when: cli_installation_mode == "remote_redirect"

--- a/ansible/roles/cli/tasks/download_remote_redirect_cli.yml
+++ b/ansible/roles/cli/tasks/download_remote_redirect_cli.yml
@@ -1,0 +1,38 @@
+# Download the cli package from the remote_redirect location to openwhisk_home/bin and unarchive it.
+
+- name: "set the file name to download for linux"
+  set_fact:
+    cli_download_name={{ openwhisk_cli.remote_redirect.package_name }}-{{ openwhisk_cli_tag }}-linux-amd64.tgz
+  when: ('environments/docker-machine' not in inventory_dir) and (ansible_os_family != "Darwin")
+
+- name: "set the file name to download for mac"
+  set_fact:
+    cli_download_name={{ openwhisk_cli.remote_redirect.package_name }}-{{ openwhisk_cli_tag }}-mac-amd64.zip
+  when: ('environments/docker-machine' in inventory_dir ) or (ansible_os_family == "Darwin")
+
+
+- name: "set the http header for downloading the binary packages"
+  set_fact:
+    headers="{{ openwhisk_cli.remote_redirect.headers }}"
+  when: openwhisk_cli.remote_redirect.headers is defined
+
+- name: "set the http header for downloading the binary packages to empty"
+  set_fact:
+    headers=""
+  when: openwhisk_cli.remote_redirect.headers is not defined
+
+
+- name: "download cli package to openwhisk home at {{ openwhisk_home }}"
+  local_action: >
+    get_url
+    url="{{ openwhisk_cli.remote_redirect.location_download }}/{{ cli_download_name }}"
+    headers="{{ headers }}"
+    dest="{{ openwhisk_home }}/bin/{{ cli_download_name }}"
+    mode=0755
+
+- name: "unarchive cli {{ openwhisk_home }}/bin/wsk"
+  local_action: >
+    unarchive
+    src="{{ openwhisk_home }}/bin/{{ cli_download_name }}"
+    dest="{{ openwhisk_home }}/bin"
+    creates="{{ openwhisk_home }}/bin/wsk"

--- a/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/ansible/roles/nginx/templates/nginx.conf.j2
@@ -90,9 +90,25 @@ http {
             return 301 https://github.com/apache/incubator-openwhisk-client-swift/releases/download/0.2.3/starterapp-0.2.3.zip;
         }
 
+{% if openwhisk_cli.installation_mode == "remote_redirect" %}
+        # redirect requests for specific binaries to the matching one from the {{ openwhisk_cli_tag }} openwhisk-cli release.
+  {% for os in cli_os %}
+     {% for arch in cli_arch %}
+        location /cli/go/download/{{ os }}/{{ arch }} {
+            return 301 {{ openwhisk_cli.remote_redirect.location_download }}/{{ openwhisk_cli.remote_redirect.package_name }}-{{ openwhisk_cli_tag }}-{{ os }}-{{ arch }}{% if os == 'linux' %}.tgz{% else %}.zip{% endif %};
+        }
+    {% endfor %}
+  {% endfor %}
+
+        # redirect top-level cli downloads to the {{ openwhisk_cli_tag }} openwhisk-cli release.
+        location /cli/go/download {
+            return 301 {{ openwhisk_cli.remote_redirect.location_browse }};
+         }
+{% else %}
         location /cli/go/download {
             autoindex on;
             root /etc/nginx;
         }
+{% endif %}
     }
 }

--- a/ansible/templates/whisk.properties.j2
+++ b/ansible/templates/whisk.properties.j2
@@ -3,6 +3,7 @@ openwhisk.home={{ openwhisk_home }}
 python.27=python
 use.cli.download=false
 nginx.conf.dir={{ nginx.confdir }}
+nginx.cli.redirect={{ openwhisk_cli.installation_mode == "remote_redirect" }}
 testing.auth={{ openwhisk_home }}/ansible/files/auth.guest
 vcap.services.file=
 

--- a/tests/src/test/scala/common/WhiskProperties.java
+++ b/tests/src/test/scala/common/WhiskProperties.java
@@ -152,6 +152,10 @@ public class WhiskProperties {
         return whiskProperties.getProperty("use.cli.download").equals("true");
     }
 
+    public static boolean nginxCLIRedirect() {
+        return whiskProperties.getProperty("nginx.cli.redirect").equalsIgnoreCase("true");
+    }
+
     public static String[] getInvokerHosts() {
         // split of empty string is non-empty array
         String hosts = whiskProperties.getProperty("invoker.hosts");


### PR DESCRIPTION
Add a third remote_redirect option to the prior local and
remote options for cli installation.  In remote_redirect mode,
the CLI binaries are not installed into the edge server's
file system. All requests to download the CLI are instead
redirected to an external URL (for example to download
from the openwhisk-cli release page).  This follows the
pattern already set for the iOS starter app and blackbox SDK.

See discussion in issue #2152.