### PR TITLE
Disable reduce limits on all nodes

### DIFF
--- a/ansible/roles/couchdb/tasks/deploy.yml
+++ b/ansible/roles/couchdb/tasks/deploy.yml
@@ -101,4 +101,3 @@
     user: "{{ db_username }}"
     password: "{{ db_password }}"
     force_basic_auth: yes
-  when: inventory_hostname == coordinator


### PR DESCRIPTION
This pr is to disable `reduce_limit` on all nodes.
Currently, it is only disabled in coordinator node.

I thought this configuration is cluster-wide, but it was not.
So it should be disabled on all nodes respectively.
