### PR TITLE
Add binary, image, and main properties to WhiskActionMetaData

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Exec.scala
@@ -95,8 +95,21 @@ sealed abstract class CodeExec[+T <% SizeConversion] extends Exec {
 
 sealed abstract class ExecMetaData extends ExecMetaDataBase {
 
+  /** An entrypoint (typically name of 'main' function). 'None' means a default value will be used. */
+  val entryPoint: Option[String]
+
+  /** The runtime image (either built-in or a public image). */
+  val image: ImageName
+
   /** Indicates if a container image is required from the registry to execute the action. */
   val pull: Boolean
+
+  /**
+   * Indicates whether the code is stored in a text-readable or binary format.
+   * The binary bit may be read from the database but currently it is always computed
+   * when the "code" is moved to an attachment this may get changed to avoid recomputing
+   * the binary property.
+   */
   val binary: Boolean
 
   override def size = 0.B
@@ -115,9 +128,12 @@ protected[core] case class CodeExecAsString(manifest: RuntimeManifest,
   override def codeAsJson = JsString(code)
 }
 
-protected[core] case class CodeExecMetaDataAsString(manifest: RuntimeManifest, override val binary: Boolean = false)
+protected[core] case class CodeExecMetaDataAsString(manifest: RuntimeManifest,
+                                                    override val binary: Boolean = false,
+                                                    override val entryPoint: Option[String])
     extends ExecMetaData {
   override val kind = manifest.kind
+  override val image = manifest.image
   override val deprecated = manifest.deprecated.getOrElse(false)
   override val pull = false
 }
@@ -146,9 +162,12 @@ protected[core] case class CodeExecAsAttachment(manifest: RuntimeManifest,
   }
 }
 
-protected[core] case class CodeExecMetaDataAsAttachment(manifest: RuntimeManifest, override val binary: Boolean = false)
+protected[core] case class CodeExecMetaDataAsAttachment(manifest: RuntimeManifest,
+                                                        override val binary: Boolean = false,
+                                                        override val entryPoint: Option[String])
     extends ExecMetaData {
   override val kind = manifest.kind
+  override val image = manifest.image
   override val deprecated = manifest.deprecated.getOrElse(false)
   override val pull = false
 }
@@ -171,7 +190,10 @@ protected[core] case class BlackBoxExec(override val image: ImageName,
   override def size = super.size + image.publicImageName.sizeInBytes
 }
 
-protected[core] case class BlackBoxExecMetaData(val native: Boolean, override val binary: Boolean = false)
+protected[core] case class BlackBoxExecMetaData(override val image: ImageName,
+                                                override val entryPoint: Option[String],
+                                                val native: Boolean,
+                                                override val binary: Boolean = false)
     extends ExecMetaData {
   override val kind = ExecMetaDataBase.BLACKBOX
   override val deprecated = false
@@ -339,20 +361,23 @@ protected[core] object ExecMetaDataBase extends ArgNormalizer[ExecMetaDataBase] 
     override def write(e: ExecMetaDataBase) = e match {
       case c: CodeExecMetaDataAsString =>
         val base = Map("kind" -> JsString(c.kind), "binary" -> JsBoolean(c.binary))
-        JsObject(base)
+        val main = c.entryPoint.map("main" -> JsString(_))
+        JsObject(base ++ main)
 
       case a: CodeExecMetaDataAsAttachment =>
         val base =
           Map("kind" -> JsString(a.kind), "binary" -> JsBoolean(a.binary))
-        JsObject(base)
+        val main = a.entryPoint.map("main" -> JsString(_))
+        JsObject(base ++ main)
 
       case s @ SequenceExecMetaData(comp) =>
         JsObject("kind" -> JsString(s.kind), "components" -> comp.map(_.qualifiedNameWithLeadingSlash).toJson)
 
       case b: BlackBoxExecMetaData =>
         val base =
-          Map("kind" -> JsString(b.kind), "binary" -> JsBoolean(b.binary))
-        JsObject(base)
+          Map("kind" -> JsString(b.kind), "image" -> JsString(b.image.publicImageName), "binary" -> JsBoolean(b.binary))
+        val main = b.entryPoint.map("main" -> JsString(_))
+        JsObject(base ++ main)
     }
 
     override def read(v: JsValue) = {
@@ -372,9 +397,8 @@ protected[core] object ExecMetaDataBase extends ArgNormalizer[ExecMetaDataBase] 
         case None => None
       }
 
-      val binary: Boolean = obj.fields.get("binary") match {
+      lazy val binary: Boolean = obj.fields.get("binary") match {
         case Some(JsBoolean(b)) => b
-        case None               => false
         case _                  => throw new DeserializationException("'binary' must be a boolean defined in 'exec'")
       }
 
@@ -395,7 +419,7 @@ protected[core] object ExecMetaDataBase extends ArgNormalizer[ExecMetaDataBase] 
                 s"'image' must be a string defined in 'exec' for '${Exec.BLACKBOX}' actions")
           }
           val native = execManifests.skipDockerPull(image)
-          BlackBoxExecMetaData(native, binary)
+          BlackBoxExecMetaData(image, optMainField, native, binary)
 
         case _ =>
           // map "default" virtual runtime versions to the currently blessed actual runtime version
@@ -406,10 +430,16 @@ protected[core] object ExecMetaDataBase extends ArgNormalizer[ExecMetaDataBase] 
 
           manifest.attached
             .map { a =>
-              CodeExecMetaDataAsAttachment(manifest, binary)
+              val main = optMainField.orElse {
+                if (manifest.requireMain.exists(identity)) {
+                  throw new DeserializationException(s"'main' must be a string defined in 'exec' for '$kind' actions")
+                } else None
+              }
+
+              CodeExecMetaDataAsAttachment(manifest, binary, main)
             }
             .getOrElse {
-              CodeExecMetaDataAsString(manifest, binary)
+              CodeExecMetaDataAsString(manifest, binary, optMainField)
             }
       }
     }

--- a/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
@@ -373,7 +373,8 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     put(entityStore, component)
     val components = Vector(s"/$namespace/${component.name}").map(stringToFullyQualifiedName(_))
     val seqAction = WhiskAction(namespace, aname(), sequence(components), seqParameters(components))
-    val seqActionContent = JsObject("exec" -> JsObject("kind" -> "sequence".toJson, "components" -> JsArray(s"/$namespace/${component.name}".toJson)))
+    val seqActionContent = JsObject(
+      "exec" -> JsObject("kind" -> "sequence".toJson, "components" -> JsArray(s"/$namespace/${component.name}".toJson)))
     val seqActionExpectedWhiskAction = WhiskAction(
       seqAction.namespace,
       seqAction.name,
@@ -678,7 +679,8 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
   }
 
   private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
-  private def seqParameters(seq: Vector[FullyQualifiedEntityName]) = Parameters("_actions", seq.map("/" + _.asString).toJson)
+  private def seqParameters(seq: Vector[FullyQualifiedEntityName]) =
+    Parameters("_actions", seq.map("/" + _.asString).toJson)
 
   // this test is sneaky; the installation of the sequence is done directly in the db
   // and api checks are skipped

--- a/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
@@ -26,7 +26,6 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
 import akka.http.scaladsl.model.StatusCodes._
-
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport.sprayJsonMarshaller
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport.sprayJsonUnmarshaller
 import akka.http.scaladsl.server.Route
@@ -374,8 +373,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     put(entityStore, component)
     val components = Vector(s"/$namespace/${component.name}").map(stringToFullyQualifiedName(_))
     val seqAction = WhiskAction(namespace, aname(), sequence(components), seqParameters(components))
-    val seqActionContent = JsObject(
-      "exec" -> JsObject("kind" -> "sequence".toJson, "components" -> JsArray(s"/$namespace/${component.name}".toJson)))
+    val seqActionContent = JsObject("exec" -> JsObject("kind" -> "sequence".toJson, "components" -> JsArray(s"/$namespace/${component.name}".toJson)))
     val seqActionExpectedWhiskAction = WhiskAction(
       seqAction.namespace,
       seqAction.name,
@@ -680,8 +678,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
   }
 
   private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
-  private def seqParameters(seq: Vector[FullyQualifiedEntityName]) =
-    Parameters("_actions", seq.map("/" + _.asString).toJson)
+  private def seqParameters(seq: Vector[FullyQualifiedEntityName]) = Parameters("_actions", seq.map("/" + _.asString).toJson)
 
   // this test is sneaky; the installation of the sequence is done directly in the db
   // and api checks are skipped

--- a/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
@@ -169,6 +169,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
       status should be(OK)
       val response = responseAs[JsObject]
       response.fields("exec").asJsObject.fields should not(contain key "code")
+      response.fields("exec").asJsObject.fields should contain key "binary"
       responseAs[WhiskActionMetaData] shouldBe a[WhiskActionMetaData]
     }
 

--- a/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
@@ -169,204 +169,51 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
       "code" -> "RHViZWU=",
       "image" -> "bb",
       "main" -> "bbMain")).toJson.asJsObject
-    val bbAction1ExpectedWhiskAction = WhiskAction(
-      bbAction1.namespace,
-      bbAction1.name,
-      bbAction1.exec,
-      bbAction1.parameters,
-      bbAction1.limits,
-      bbAction1.version,
-      bbAction1.publish,
-      bbAction1.annotations ++ Parameters(WhiskAction.execFieldName, Exec.BLACKBOX))
-    val bbAction1ExpectedWhiskActionMetaData = WhiskActionMetaData(
-      bbAction1.namespace,
-      bbAction1.name,
-      blackBoxMetaData("bb", Some("bbMain"), true),
-      bbAction1.parameters,
-      bbAction1.limits,
-      bbAction1.version,
-      bbAction1.publish,
-      bbAction1.annotations ++ Parameters(WhiskActionMetaData.execFieldName, Exec.BLACKBOX))
+    val bbAction1Exec = blackBoxMetaData("bb", Some("bbMain"), true)
 
     // BlackBox: binary: false, main: bbMain
     val bbAction2 = WhiskAction(namespace, aname(), bb("bb", "", Some("bbMain")))
     val bbAction2Content =
       Map("exec" -> Map("kind" -> Exec.BLACKBOX, "code" -> "", "image" -> "bb", "main" -> "bbMain")).toJson.asJsObject
-    val bbAction2ExpectedWhiskAction = WhiskAction(
-      bbAction2.namespace,
-      bbAction2.name,
-      bbAction2.exec,
-      bbAction2.parameters,
-      bbAction2.limits,
-      bbAction2.version,
-      bbAction2.publish,
-      bbAction2.annotations ++ Parameters(WhiskAction.execFieldName, Exec.BLACKBOX))
-    val bbAction2ExpectedWhiskActionMetaData = WhiskActionMetaData(
-      bbAction2.namespace,
-      bbAction2.name,
-      blackBoxMetaData("bb", Some("bbMain"), false),
-      bbAction2.parameters,
-      bbAction2.limits,
-      bbAction2.version,
-      bbAction2.publish,
-      bbAction2.annotations ++ Parameters(WhiskActionMetaData.execFieldName, Exec.BLACKBOX))
+    val bbAction2Exec = blackBoxMetaData("bb", Some("bbMain"), false)
 
     // BlackBox: binary: true, no main
     val bbAction3 = WhiskAction(namespace, aname(), bb("bb", "RHViZWU="))
     val bbAction3Content =
       Map("exec" -> Map("kind" -> Exec.BLACKBOX, "code" -> "RHViZWU=", "image" -> "bb")).toJson.asJsObject
-    val bbAction3ExpectedWhiskAction = WhiskAction(
-      bbAction3.namespace,
-      bbAction3.name,
-      bbAction3.exec,
-      bbAction3.parameters,
-      bbAction3.limits,
-      bbAction3.version,
-      bbAction3.publish,
-      bbAction3.annotations ++ Parameters(WhiskAction.execFieldName, Exec.BLACKBOX))
-    val bbAction3ExpectedWhiskActionMetaData = WhiskActionMetaData(
-      bbAction3.namespace,
-      bbAction3.name,
-      blackBoxMetaData("bb", None, true),
-      bbAction3.parameters,
-      bbAction3.limits,
-      bbAction3.version,
-      bbAction3.publish,
-      bbAction3.annotations ++ Parameters(WhiskActionMetaData.execFieldName, Exec.BLACKBOX))
+    val bbAction3Exec = blackBoxMetaData("bb", None, true)
 
     // BlackBox: binary: false, no main
     val bbAction4 = WhiskAction(namespace, aname(), bb("bb", ""))
     val bbAction4Content = Map("exec" -> Map("kind" -> Exec.BLACKBOX, "code" -> "", "image" -> "bb")).toJson.asJsObject
-    val bbAction4ExpectedWhiskAction = WhiskAction(
-      bbAction4.namespace,
-      bbAction4.name,
-      bbAction4.exec,
-      bbAction4.parameters,
-      bbAction4.limits,
-      bbAction4.version,
-      bbAction4.publish,
-      bbAction4.annotations ++ Parameters(WhiskAction.execFieldName, Exec.BLACKBOX))
-    val bbAction4ExpectedWhiskActionMetaData = WhiskActionMetaData(
-      bbAction4.namespace,
-      bbAction4.name,
-      blackBoxMetaData("bb", None, false),
-      bbAction4.parameters,
-      bbAction4.limits,
-      bbAction4.version,
-      bbAction4.publish,
-      bbAction4.annotations ++ Parameters(WhiskActionMetaData.execFieldName, Exec.BLACKBOX))
+    val bbAction4Exec = blackBoxMetaData("bb", None, false)
 
     // Attachment: binary: true, main: javaMain
     val javaAction1 = WhiskAction(namespace, aname(), javaDefault("RHViZWU=", Some("javaMain")))
     val javaAction1Content =
       Map("exec" -> Map("kind" -> JAVA_DEFAULT, "code" -> "RHViZWU=", "main" -> "javaMain")).toJson.asJsObject
-    val javaAction1ExpectedWhiskAction = WhiskAction(
-      javaAction1.namespace,
-      javaAction1.name,
-      javaAction1.exec,
-      javaAction1.parameters,
-      javaAction1.limits,
-      javaAction1.version,
-      javaAction1.publish,
-      javaAction1.annotations ++ Parameters(WhiskAction.execFieldName, JAVA_DEFAULT))
-    val javaAction1ExpectedWhiskActionMetaData = WhiskActionMetaData(
-      javaAction1.namespace,
-      javaAction1.name,
-      javaMetaData(Some("javaMain"), true),
-      javaAction1.parameters,
-      javaAction1.limits,
-      javaAction1.version,
-      javaAction1.publish,
-      javaAction1.annotations ++ Parameters(WhiskActionMetaData.execFieldName, JAVA_DEFAULT))
+    val javaAction1Exec = javaMetaData(Some("javaMain"), true)
 
     // String: binary: true, main: jsMain
     val jsAction1 = WhiskAction(namespace, aname(), jsDefault("RHViZWU=", Some("jsMain")))
     val jsAction1Content =
       Map("exec" -> Map("kind" -> NODEJS6, "code" -> "RHViZWU=", "main" -> "jsMain")).toJson.asJsObject
-    val jsAction1ExpectedWhiskAction = WhiskAction(
-      jsAction1.namespace,
-      jsAction1.name,
-      jsAction1.exec,
-      jsAction1.parameters,
-      jsAction1.limits,
-      jsAction1.version,
-      jsAction1.publish,
-      jsAction1.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6))
-    val jsAction1ExpectedWhiskActionMetaData = WhiskActionMetaData(
-      jsAction1.namespace,
-      jsAction1.name,
-      js6MetaData(Some("jsMain"), true),
-      jsAction1.parameters,
-      jsAction1.limits,
-      jsAction1.version,
-      jsAction1.publish,
-      jsAction1.annotations ++ Parameters(WhiskActionMetaData.execFieldName, NODEJS6))
+    val jsAction1Exec = js6MetaData(Some("jsMain"), true)
 
     // String: binary: false, main: jsMain
     val jsAction2 = WhiskAction(namespace, aname(), jsDefault("", Some("jsMain")))
     val jsAction2Content = Map("exec" -> Map("kind" -> NODEJS6, "code" -> "", "main" -> "jsMain")).toJson.asJsObject
-    val jsAction2ExpectedWhiskAction = WhiskAction(
-      jsAction2.namespace,
-      jsAction2.name,
-      jsAction2.exec,
-      jsAction2.parameters,
-      jsAction2.limits,
-      jsAction2.version,
-      jsAction2.publish,
-      jsAction2.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6))
-    val jsAction2ExpectedWhiskActionMetaData = WhiskActionMetaData(
-      jsAction2.namespace,
-      jsAction2.name,
-      js6MetaData(Some("jsMain"), false),
-      jsAction2.parameters,
-      jsAction2.limits,
-      jsAction2.version,
-      jsAction2.publish,
-      jsAction2.annotations ++ Parameters(WhiskActionMetaData.execFieldName, NODEJS6))
+    val jsAction2Exec = js6MetaData(Some("jsMain"), false)
 
     // String: binary: true, no main
     val jsAction3 = WhiskAction(namespace, aname(), jsDefault("RHViZWU="))
     val jsAction3Content = Map("exec" -> Map("kind" -> NODEJS6, "code" -> "RHViZWU=")).toJson.asJsObject
-    val jsAction3ExpectedWhiskAction = WhiskAction(
-      jsAction3.namespace,
-      jsAction3.name,
-      jsAction3.exec,
-      jsAction3.parameters,
-      jsAction3.limits,
-      jsAction3.version,
-      jsAction3.publish,
-      jsAction3.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6))
-    val jsAction3ExpectedWhiskActionMetaData = WhiskActionMetaData(
-      jsAction3.namespace,
-      jsAction3.name,
-      js6MetaData(None, true),
-      jsAction3.parameters,
-      jsAction3.limits,
-      jsAction3.version,
-      jsAction3.publish,
-      jsAction3.annotations ++ Parameters(WhiskActionMetaData.execFieldName, NODEJS6))
+    val jsAction3Exec = js6MetaData(None, true)
 
     // String: binary: false, no main
     val jsAction4 = WhiskAction(namespace, aname(), jsDefault(""))
     val jsAction4Content = Map("exec" -> Map("kind" -> NODEJS6, "code" -> "")).toJson.asJsObject
-    val jsAction4ExpectedWhiskAction = WhiskAction(
-      jsAction4.namespace,
-      jsAction4.name,
-      jsAction4.exec,
-      jsAction4.parameters,
-      jsAction4.limits,
-      jsAction4.version,
-      jsAction4.publish,
-      jsAction4.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6))
-    val jsAction4ExpectedWhiskActionMetaData = WhiskActionMetaData(
-      jsAction4.namespace,
-      jsAction4.name,
-      js6MetaData(None, false),
-      jsAction4.parameters,
-      jsAction4.limits,
-      jsAction4.version,
-      jsAction4.publish,
-      jsAction4.annotations ++ Parameters(WhiskActionMetaData.execFieldName, NODEJS6))
+    val jsAction4Exec = js6MetaData(None, false)
 
     // Sequence
     val component = WhiskAction(namespace, aname(), jsDefault("??"))
@@ -375,39 +222,42 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     val seqAction = WhiskAction(namespace, aname(), sequence(components), seqParameters(components))
     val seqActionContent = JsObject(
       "exec" -> JsObject("kind" -> "sequence".toJson, "components" -> JsArray(s"/$namespace/${component.name}".toJson)))
-    val seqActionExpectedWhiskAction = WhiskAction(
-      seqAction.namespace,
-      seqAction.name,
-      seqAction.exec,
-      seqAction.parameters,
-      seqAction.limits,
-      seqAction.version,
-      seqAction.publish,
-      seqAction.annotations ++ Parameters(WhiskAction.execFieldName, "sequence"))
-    val seqActionExpectedWhiskActionMetaData = WhiskActionMetaData(
-      seqAction.namespace,
-      seqAction.name,
-      sequenceMetaData(components),
-      seqAction.parameters,
-      seqAction.limits,
-      seqAction.version,
-      seqAction.publish,
-      seqAction.annotations ++ Parameters(WhiskActionMetaData.execFieldName, "sequence"))
+    val seqActionExec = sequenceMetaData(components)
 
     val actions = Seq(
-      (bbAction1, bbAction1Content, bbAction1ExpectedWhiskAction, bbAction1ExpectedWhiskActionMetaData),
-      (bbAction2, bbAction2Content, bbAction2ExpectedWhiskAction, bbAction2ExpectedWhiskActionMetaData),
-      (bbAction3, bbAction3Content, bbAction3ExpectedWhiskAction, bbAction3ExpectedWhiskActionMetaData),
-      (bbAction4, bbAction4Content, bbAction4ExpectedWhiskAction, bbAction4ExpectedWhiskActionMetaData),
-      (javaAction1, javaAction1Content, javaAction1ExpectedWhiskAction, javaAction1ExpectedWhiskActionMetaData),
-      (jsAction1, jsAction1Content, jsAction1ExpectedWhiskAction, jsAction1ExpectedWhiskActionMetaData),
-      (jsAction2, jsAction2Content, jsAction2ExpectedWhiskAction, jsAction2ExpectedWhiskActionMetaData),
-      (jsAction3, jsAction3Content, jsAction3ExpectedWhiskAction, jsAction3ExpectedWhiskActionMetaData),
-      (jsAction4, jsAction4Content, jsAction4ExpectedWhiskAction, jsAction4ExpectedWhiskActionMetaData),
-      (seqAction, seqActionContent, seqActionExpectedWhiskAction, seqActionExpectedWhiskActionMetaData))
+      (bbAction1, bbAction1Content, bbAction1Exec),
+      (bbAction2, bbAction2Content, bbAction2Exec),
+      (bbAction3, bbAction3Content, bbAction3Exec),
+      (bbAction4, bbAction4Content, bbAction4Exec),
+      (javaAction1, javaAction1Content, javaAction1Exec),
+      (jsAction1, jsAction1Content, jsAction1Exec),
+      (jsAction2, jsAction2Content, jsAction2Exec),
+      (jsAction3, jsAction3Content, jsAction3Exec),
+      (jsAction4, jsAction4Content, jsAction4Exec),
+      (seqAction, seqActionContent, seqActionExec))
 
     actions.foreach {
-      case (action, content, expectedWhiskAction, expectedWhiskActionMetaData) =>
+      case (action, content, exec) =>
+        val expectedWhiskAction = WhiskAction(
+          action.namespace,
+          action.name,
+          action.exec,
+          action.parameters,
+          action.limits,
+          action.version,
+          action.publish,
+          action.annotations ++ Parameters(WhiskAction.execFieldName, action.exec.kind))
+
+        val expectedWhiskActionMetaData = WhiskActionMetaData(
+          action.namespace,
+          action.name,
+          exec,
+          action.parameters,
+          action.limits,
+          action.version,
+          action.publish,
+          action.annotations ++ Parameters(WhiskActionMetaData.execFieldName, action.exec.kind))
+
         Put(s"$collectionPath/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
           status should be(OK)
           val response = responseAs[WhiskAction]

--- a/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
@@ -164,8 +164,11 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
 
     // BlackBox: binary: true, main: bbMain
     val bbAction1 = WhiskAction(namespace, aname(), bb("bb", "RHViZWU=", Some("bbMain")))
-    val bbAction1Content = Map(
-      "exec" -> Map("kind" -> "blackbox", "code" -> "RHViZWU=", "image" -> "bb", "main" -> "bbMain")).toJson.asJsObject
+    val bbAction1Content = Map("exec" -> Map(
+      "kind" -> Exec.BLACKBOX,
+      "code" -> "RHViZWU=",
+      "image" -> "bb",
+      "main" -> "bbMain")).toJson.asJsObject
     val bbAction1ExpectedWhiskAction = WhiskAction(
       bbAction1.namespace,
       bbAction1.name,
@@ -188,7 +191,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     // BlackBox: binary: false, main: bbMain
     val bbAction2 = WhiskAction(namespace, aname(), bb("bb", "", Some("bbMain")))
     val bbAction2Content =
-      Map("exec" -> Map("kind" -> "blackbox", "code" -> "", "image" -> "bb", "main" -> "bbMain")).toJson.asJsObject
+      Map("exec" -> Map("kind" -> Exec.BLACKBOX, "code" -> "", "image" -> "bb", "main" -> "bbMain")).toJson.asJsObject
     val bbAction2ExpectedWhiskAction = WhiskAction(
       bbAction2.namespace,
       bbAction2.name,
@@ -211,7 +214,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     // BlackBox: binary: true, no main
     val bbAction3 = WhiskAction(namespace, aname(), bb("bb", "RHViZWU="))
     val bbAction3Content =
-      Map("exec" -> Map("kind" -> "blackbox", "code" -> "RHViZWU=", "image" -> "bb")).toJson.asJsObject
+      Map("exec" -> Map("kind" -> Exec.BLACKBOX, "code" -> "RHViZWU=", "image" -> "bb")).toJson.asJsObject
     val bbAction3ExpectedWhiskAction = WhiskAction(
       bbAction3.namespace,
       bbAction3.name,
@@ -233,7 +236,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
 
     // BlackBox: binary: false, no main
     val bbAction4 = WhiskAction(namespace, aname(), bb("bb", ""))
-    val bbAction4Content = Map("exec" -> Map("kind" -> "blackbox", "code" -> "", "image" -> "bb")).toJson.asJsObject
+    val bbAction4Content = Map("exec" -> Map("kind" -> Exec.BLACKBOX, "code" -> "", "image" -> "bb")).toJson.asJsObject
     val bbAction4ExpectedWhiskAction = WhiskAction(
       bbAction4.namespace,
       bbAction4.name,
@@ -253,11 +256,128 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
       bbAction4.publish,
       bbAction4.annotations ++ Parameters(WhiskActionMetaData.execFieldName, Exec.BLACKBOX))
 
+    // Attachment: binary: true, main: javaMain
+    val javaAction1 = WhiskAction(namespace, aname(), javaDefault("RHViZWU=", Some("javaMain")))
+    val javaAction1Content =
+      Map("exec" -> Map("kind" -> JAVA_DEFAULT, "code" -> "RHViZWU=", "main" -> "javaMain")).toJson.asJsObject
+    val javaAction1ExpectedWhiskAction = WhiskAction(
+      javaAction1.namespace,
+      javaAction1.name,
+      javaAction1.exec,
+      javaAction1.parameters,
+      javaAction1.limits,
+      javaAction1.version,
+      javaAction1.publish,
+      javaAction1.annotations ++ Parameters(WhiskAction.execFieldName, JAVA_DEFAULT))
+    val javaAction1ExpectedWhiskActionMetaData = WhiskActionMetaData(
+      javaAction1.namespace,
+      javaAction1.name,
+      javaMetaData(Some("javaMain"), true),
+      javaAction1.parameters,
+      javaAction1.limits,
+      javaAction1.version,
+      javaAction1.publish,
+      javaAction1.annotations ++ Parameters(WhiskActionMetaData.execFieldName, JAVA_DEFAULT))
+
+    // String: binary: true, main: jsMain
+    val jsAction1 = WhiskAction(namespace, aname(), jsDefault("RHViZWU=", Some("jsMain")))
+    val jsAction1Content =
+      Map("exec" -> Map("kind" -> NODEJS6, "code" -> "RHViZWU=", "main" -> "jsMain")).toJson.asJsObject
+    val jsAction1ExpectedWhiskAction = WhiskAction(
+      jsAction1.namespace,
+      jsAction1.name,
+      jsAction1.exec,
+      jsAction1.parameters,
+      jsAction1.limits,
+      jsAction1.version,
+      jsAction1.publish,
+      jsAction1.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6))
+    val jsAction1ExpectedWhiskActionMetaData = WhiskActionMetaData(
+      jsAction1.namespace,
+      jsAction1.name,
+      js6MetaData(Some("jsMain"), true),
+      jsAction1.parameters,
+      jsAction1.limits,
+      jsAction1.version,
+      jsAction1.publish,
+      jsAction1.annotations ++ Parameters(WhiskActionMetaData.execFieldName, NODEJS6))
+
+    // String: binary: false, main: jsMain
+    val jsAction2 = WhiskAction(namespace, aname(), jsDefault("", Some("jsMain")))
+    val jsAction2Content = Map("exec" -> Map("kind" -> NODEJS6, "code" -> "", "main" -> "jsMain")).toJson.asJsObject
+    val jsAction2ExpectedWhiskAction = WhiskAction(
+      jsAction2.namespace,
+      jsAction2.name,
+      jsAction2.exec,
+      jsAction2.parameters,
+      jsAction2.limits,
+      jsAction2.version,
+      jsAction2.publish,
+      jsAction2.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6))
+    val jsAction2ExpectedWhiskActionMetaData = WhiskActionMetaData(
+      jsAction2.namespace,
+      jsAction2.name,
+      js6MetaData(Some("jsMain"), false),
+      jsAction2.parameters,
+      jsAction2.limits,
+      jsAction2.version,
+      jsAction2.publish,
+      jsAction2.annotations ++ Parameters(WhiskActionMetaData.execFieldName, NODEJS6))
+
+    // String: binary: true, no main
+    val jsAction3 = WhiskAction(namespace, aname(), jsDefault("RHViZWU="))
+    val jsAction3Content = Map("exec" -> Map("kind" -> NODEJS6, "code" -> "RHViZWU=")).toJson.asJsObject
+    val jsAction3ExpectedWhiskAction = WhiskAction(
+      jsAction3.namespace,
+      jsAction3.name,
+      jsAction3.exec,
+      jsAction3.parameters,
+      jsAction3.limits,
+      jsAction3.version,
+      jsAction3.publish,
+      jsAction3.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6))
+    val jsAction3ExpectedWhiskActionMetaData = WhiskActionMetaData(
+      jsAction3.namespace,
+      jsAction3.name,
+      js6MetaData(None, true),
+      jsAction3.parameters,
+      jsAction3.limits,
+      jsAction3.version,
+      jsAction3.publish,
+      jsAction3.annotations ++ Parameters(WhiskActionMetaData.execFieldName, NODEJS6))
+
+    // String: binary: false, no main
+    val jsAction4 = WhiskAction(namespace, aname(), jsDefault(""))
+    val jsAction4Content = Map("exec" -> Map("kind" -> NODEJS6, "code" -> "")).toJson.asJsObject
+    val jsAction4ExpectedWhiskAction = WhiskAction(
+      jsAction4.namespace,
+      jsAction4.name,
+      jsAction4.exec,
+      jsAction4.parameters,
+      jsAction4.limits,
+      jsAction4.version,
+      jsAction4.publish,
+      jsAction4.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6))
+    val jsAction4ExpectedWhiskActionMetaData = WhiskActionMetaData(
+      jsAction4.namespace,
+      jsAction4.name,
+      js6MetaData(None, false),
+      jsAction4.parameters,
+      jsAction4.limits,
+      jsAction4.version,
+      jsAction4.publish,
+      jsAction4.annotations ++ Parameters(WhiskActionMetaData.execFieldName, NODEJS6))
+
     val actions = Seq(
       (bbAction1, bbAction1Content, bbAction1ExpectedWhiskAction, bbAction1ExpectedWhiskActionMetaData),
       (bbAction2, bbAction2Content, bbAction2ExpectedWhiskAction, bbAction2ExpectedWhiskActionMetaData),
       (bbAction3, bbAction3Content, bbAction3ExpectedWhiskAction, bbAction3ExpectedWhiskActionMetaData),
-      (bbAction4, bbAction4Content, bbAction4ExpectedWhiskAction, bbAction4ExpectedWhiskActionMetaData))
+      (bbAction4, bbAction4Content, bbAction4ExpectedWhiskAction, bbAction4ExpectedWhiskActionMetaData),
+      (javaAction1, javaAction1Content, javaAction1ExpectedWhiskAction, javaAction1ExpectedWhiskActionMetaData),
+      (jsAction1, jsAction1Content, jsAction1ExpectedWhiskAction, jsAction1ExpectedWhiskActionMetaData),
+      (jsAction2, jsAction2Content, jsAction2ExpectedWhiskAction, jsAction2ExpectedWhiskActionMetaData),
+      (jsAction3, jsAction3Content, jsAction3ExpectedWhiskAction, jsAction3ExpectedWhiskActionMetaData),
+      (jsAction4, jsAction4Content, jsAction4ExpectedWhiskAction, jsAction4ExpectedWhiskActionMetaData))
 
     actions.foreach {
       case (action, content, expectedWhiskAction, expectedWhiskActionMetaData) =>

--- a/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
@@ -159,7 +159,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     }
   }
 
-  it should "get action using code query parameter" in {
+  def getExecPermutations() = {
     implicit val tid = transid()
 
     // BlackBox: binary: true, main: bbMain
@@ -169,51 +169,51 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
       "code" -> "RHViZWU=",
       "image" -> "bb",
       "main" -> "bbMain")).toJson.asJsObject
-    val bbAction1Exec = blackBoxMetaData("bb", Some("bbMain"), true)
+    val bbAction1ExecMetaData = blackBoxMetaData("bb", Some("bbMain"), true)
 
     // BlackBox: binary: false, main: bbMain
     val bbAction2 = WhiskAction(namespace, aname(), bb("bb", "", Some("bbMain")))
     val bbAction2Content =
       Map("exec" -> Map("kind" -> Exec.BLACKBOX, "code" -> "", "image" -> "bb", "main" -> "bbMain")).toJson.asJsObject
-    val bbAction2Exec = blackBoxMetaData("bb", Some("bbMain"), false)
+    val bbAction2ExecMetaData = blackBoxMetaData("bb", Some("bbMain"), false)
 
     // BlackBox: binary: true, no main
     val bbAction3 = WhiskAction(namespace, aname(), bb("bb", "RHViZWU="))
     val bbAction3Content =
       Map("exec" -> Map("kind" -> Exec.BLACKBOX, "code" -> "RHViZWU=", "image" -> "bb")).toJson.asJsObject
-    val bbAction3Exec = blackBoxMetaData("bb", None, true)
+    val bbAction3ExecMetaData = blackBoxMetaData("bb", None, true)
 
     // BlackBox: binary: false, no main
     val bbAction4 = WhiskAction(namespace, aname(), bb("bb", ""))
     val bbAction4Content = Map("exec" -> Map("kind" -> Exec.BLACKBOX, "code" -> "", "image" -> "bb")).toJson.asJsObject
-    val bbAction4Exec = blackBoxMetaData("bb", None, false)
+    val bbAction4ExecMetaData = blackBoxMetaData("bb", None, false)
 
     // Attachment: binary: true, main: javaMain
     val javaAction1 = WhiskAction(namespace, aname(), javaDefault("RHViZWU=", Some("javaMain")))
     val javaAction1Content =
       Map("exec" -> Map("kind" -> JAVA_DEFAULT, "code" -> "RHViZWU=", "main" -> "javaMain")).toJson.asJsObject
-    val javaAction1Exec = javaMetaData(Some("javaMain"), true)
+    val javaAction1ExecMetaData = javaMetaData(Some("javaMain"), true)
 
     // String: binary: true, main: jsMain
     val jsAction1 = WhiskAction(namespace, aname(), jsDefault("RHViZWU=", Some("jsMain")))
     val jsAction1Content =
       Map("exec" -> Map("kind" -> NODEJS6, "code" -> "RHViZWU=", "main" -> "jsMain")).toJson.asJsObject
-    val jsAction1Exec = js6MetaData(Some("jsMain"), true)
+    val jsAction1ExecMetaData = js6MetaData(Some("jsMain"), true)
 
     // String: binary: false, main: jsMain
     val jsAction2 = WhiskAction(namespace, aname(), jsDefault("", Some("jsMain")))
     val jsAction2Content = Map("exec" -> Map("kind" -> NODEJS6, "code" -> "", "main" -> "jsMain")).toJson.asJsObject
-    val jsAction2Exec = js6MetaData(Some("jsMain"), false)
+    val jsAction2ExecMetaData = js6MetaData(Some("jsMain"), false)
 
     // String: binary: true, no main
     val jsAction3 = WhiskAction(namespace, aname(), jsDefault("RHViZWU="))
     val jsAction3Content = Map("exec" -> Map("kind" -> NODEJS6, "code" -> "RHViZWU=")).toJson.asJsObject
-    val jsAction3Exec = js6MetaData(None, true)
+    val jsAction3ExecMetaData = js6MetaData(None, true)
 
     // String: binary: false, no main
     val jsAction4 = WhiskAction(namespace, aname(), jsDefault(""))
     val jsAction4Content = Map("exec" -> Map("kind" -> NODEJS6, "code" -> "")).toJson.asJsObject
-    val jsAction4Exec = js6MetaData(None, false)
+    val jsAction4ExecMetaData = js6MetaData(None, false)
 
     // Sequence
     val component = WhiskAction(namespace, aname(), jsDefault("??"))
@@ -222,22 +222,26 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     val seqAction = WhiskAction(namespace, aname(), sequence(components), seqParameters(components))
     val seqActionContent = JsObject(
       "exec" -> JsObject("kind" -> "sequence".toJson, "components" -> JsArray(s"/$namespace/${component.name}".toJson)))
-    val seqActionExec = sequenceMetaData(components)
+    val seqActionExecMetaData = sequenceMetaData(components)
 
-    val actions = Seq(
-      (bbAction1, bbAction1Content, bbAction1Exec),
-      (bbAction2, bbAction2Content, bbAction2Exec),
-      (bbAction3, bbAction3Content, bbAction3Exec),
-      (bbAction4, bbAction4Content, bbAction4Exec),
-      (javaAction1, javaAction1Content, javaAction1Exec),
-      (jsAction1, jsAction1Content, jsAction1Exec),
-      (jsAction2, jsAction2Content, jsAction2Exec),
-      (jsAction3, jsAction3Content, jsAction3Exec),
-      (jsAction4, jsAction4Content, jsAction4Exec),
-      (seqAction, seqActionContent, seqActionExec))
+    Seq(
+      (bbAction1, bbAction1Content, bbAction1ExecMetaData),
+      (bbAction2, bbAction2Content, bbAction2ExecMetaData),
+      (bbAction3, bbAction3Content, bbAction3ExecMetaData),
+      (bbAction4, bbAction4Content, bbAction4ExecMetaData),
+      (javaAction1, javaAction1Content, javaAction1ExecMetaData),
+      (jsAction1, jsAction1Content, jsAction1ExecMetaData),
+      (jsAction2, jsAction2Content, jsAction2ExecMetaData),
+      (jsAction3, jsAction3Content, jsAction3ExecMetaData),
+      (jsAction4, jsAction4Content, jsAction4ExecMetaData),
+      (seqAction, seqActionContent, seqActionExecMetaData))
+  }
 
-    actions.foreach {
-      case (action, content, exec) =>
+  it should "get action using code query parameter" in {
+    implicit val tid = transid()
+
+    getExecPermutations.foreach {
+      case (action, content, execMetaData) =>
         val expectedWhiskAction = WhiskAction(
           action.namespace,
           action.name,
@@ -251,7 +255,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         val expectedWhiskActionMetaData = WhiskActionMetaData(
           action.namespace,
           action.name,
-          exec,
+          execMetaData,
           action.parameters,
           action.limits,
           action.version,

--- a/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
@@ -190,7 +190,7 @@ trait WebActionsApiBaseTests extends ControllerTestCommon with BeforeAndAfterEac
         WhiskActionMetaData(
           actionName.path,
           actionName.name,
-          js6MetaData(false),
+          js6MetaData(binary = false),
           defaultActionParameters,
           annotations = {
             if (actionName.name.asString.startsWith("export_")) {

--- a/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
@@ -190,7 +190,7 @@ trait WebActionsApiBaseTests extends ControllerTestCommon with BeforeAndAfterEac
         WhiskActionMetaData(
           actionName.path,
           actionName.name,
-          js6MetaData(),
+          js6MetaData(false),
           defaultActionParameters,
           annotations = {
             if (actionName.name.asString.startsWith("export_")) {

--- a/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
@@ -102,6 +102,8 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
 
   protected def sequence(components: Vector[FullyQualifiedEntityName]) = SequenceExec(components)
 
+  protected def sequenceMetaData(components: Vector[FullyQualifiedEntityName]) = SequenceExecMetaData(components)
+
   protected def bb(image: String) = BlackBoxExec(ExecManifest.ImageName(trim(image)), None, None, false)
 
   protected def bb(image: String, code: String, main: Option[String] = None) = {

--- a/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
@@ -68,7 +68,7 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
     js6(code, main)
   }
 
-  protected def js6MetaData(binary: Boolean, main: Option[String] = None) = {
+  protected def js6MetaData(main: Option[String] = None, binary: Boolean) = {
     CodeExecMetaDataAsString(
       RuntimeManifest(NODEJS6, imagename(NODEJS6), default = Some(true), deprecated = Some(false)),
       binary,
@@ -80,6 +80,12 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
     val manifest = ExecManifest.runtimesManifest.resolveDefaultRuntime(JAVA_DEFAULT).get
 
     CodeExecAsAttachment(manifest, attachment, main.map(_.trim))
+  }
+
+  protected def javaMetaData(main: Option[String] = None, binary: Boolean) = {
+    val manifest = ExecManifest.runtimesManifest.resolveDefaultRuntime(JAVA_DEFAULT).get
+
+    CodeExecMetaDataAsAttachment(manifest, binary, main.map(_.trim))
   }
 
   protected def swift(code: String, main: Option[String] = None) = {

--- a/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
@@ -68,9 +68,11 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
     js6(code, main)
   }
 
-  protected def js6MetaData(main: Option[String] = None) = {
+  protected def js6MetaData(binary: Boolean, main: Option[String] = None) = {
     CodeExecMetaDataAsString(
-      RuntimeManifest(NODEJS6, imagename(NODEJS6), default = Some(true), deprecated = Some(false)))
+      RuntimeManifest(NODEJS6, imagename(NODEJS6), default = Some(true), deprecated = Some(false)),
+      binary,
+      main.map(_.trim))
   }
 
   protected def javaDefault(code: String, main: Option[String] = None) = {
@@ -98,5 +100,9 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
 
   protected def bb(image: String, code: String, main: Option[String] = None) = {
     BlackBoxExec(ExecManifest.ImageName(trim(image)), Some(trim(code)).filter(_.nonEmpty), main, false)
+  }
+
+  protected def blackBoxMetaData(image: String, main: Option[String] = None, binary: Boolean) = {
+    BlackBoxExecMetaData(ExecManifest.ImageName(trim(image)), main, false, binary)
   }
 }


### PR DESCRIPTION
This PR adds a binary, image, and main properties to a WhiskActionMetaData.

Values that should be shown in WhiskActionMetaData:
- string exec
	- kind, binary, main

- attach exec
	- kind, binary, main

- blackbox exec
	- kind, image, binary, main

- sequence exec
	- kind, components