### PR TITLE
optional bypass of whisk.properties when setting GW_ values

### DIFF
--- a/ansible/roles/routemgmt/files/installRouteMgmt.sh
+++ b/ansible/roles/routemgmt/files/installRouteMgmt.sh
@@ -22,9 +22,15 @@ NAMESPACE="$3"
 WSK_CLI="$4"
 
 WHISKPROPS_FILE="$OPENWHISK_HOME/whisk.properties"
-GW_USER=`fgrep apigw.auth.user= $WHISKPROPS_FILE | cut -d'=' -f2`
-GW_PWD=`fgrep apigw.auth.pwd= $WHISKPROPS_FILE | cut -d'=' -f2-`
-GW_HOST_V2=`fgrep apigw.host.v2= $WHISKPROPS_FILE | cut -d'=' -f2`
+if [ -z "$GW_USER" ]; then
+   GW_USER=`fgrep apigw.auth.user= $WHISKPROPS_FILE | cut -d'=' -f2`
+fi
+if [ -z "$GW_PWD" ]; then
+    GW_PWD=`fgrep apigw.auth.pwd= $WHISKPROPS_FILE | cut -d'=' -f2-`
+fi
+if [ -z "$GW_HOST_V2" ]; then
+    GW_HOST_V2=`fgrep apigw.host.v2= $WHISKPROPS_FILE | cut -d'=' -f2`
+fi
 
 # If the auth key file exists, read the key in the file. Otherwise, take the
 # first argument as the key itself.


### PR DESCRIPTION
If GW_USER, GW_PWD, or GW_HOST_V2 are already set in the environment
when running installRouteMgmt.sh then use the value from the
environment bypassing the values in whisk.properties.
This is useful for downstream deployments such as kube to avoid
the need to generate a whisk.properties just to run this script.