### PR TITLE
Remove redundant property from activation message.

### DIFF
--- a/common/scala/src/main/scala/whisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/whisk/core/connector/Message.scala
@@ -23,7 +23,6 @@ import spray.json._
 import whisk.common.TransactionId
 import whisk.core.entity.ActivationId
 import whisk.core.entity.DocRevision
-import whisk.core.entity.EntityPath
 import whisk.core.entity.FullyQualifiedEntityName
 import whisk.core.entity.Identity
 import whisk.core.entity.InstanceId
@@ -53,7 +52,6 @@ case class ActivationMessage(override val transid: TransactionId,
                              revision: DocRevision,
                              user: Identity,
                              activationId: ActivationId,
-                             activationNamespace: EntityPath,
                              rootControllerIndex: InstanceId,
                              blocking: Boolean,
                              content: Option[JsObject],
@@ -84,7 +82,7 @@ object ActivationMessage extends DefaultJsonProtocol {
   def parse(msg: String) = Try(serdes.read(msg.parseJson))
 
   private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
-  implicit val serdes = jsonFormat10(ActivationMessage.apply)
+  implicit val serdes = jsonFormat9(ActivationMessage.apply)
 }
 
 /**

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
@@ -105,7 +105,6 @@ protected[actions] trait PrimitiveActions {
       action.rev,
       user,
       activationIdFactory.make(), // activation id created here
-      activationNamespace = user.namespace.toPath,
       activeAckTopicIndex,
       waitForResponse.isDefined,
       args,

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
@@ -328,7 +328,6 @@ class InvokerActor(invokerInstance: InstanceId, controllerInstance: InstanceId) 
         user = InvokerPool.healthActionIdentity,
         // Create a new Activation ID for this activation
         activationId = new ActivationIdGenerator {}.make(),
-        activationNamespace = action.namespace,
         rootControllerIndex = controllerInstance,
         blocking = false,
         content = None)

--- a/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
@@ -455,7 +455,7 @@ object ContainerProxy {
 
     WhiskActivation(
       activationId = job.msg.activationId,
-      namespace = job.msg.activationNamespace,
+      namespace = job.msg.user.namespace.toPath,
       subject = job.msg.user.subject,
       cause = job.msg.cause,
       name = job.action.name,

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
@@ -210,7 +210,7 @@ class InvokerReactive(config: WhiskConfig, instance: InstanceId, producer: Messa
               } else None
               val activation = WhiskActivation(
                 activationId = msg.activationId,
-                namespace = msg.activationNamespace,
+                namespace = msg.user.namespace.toPath,
                 subject = msg.user.subject,
                 cause = msg.cause,
                 name = msg.action.name,

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerPoolTests.scala
@@ -77,7 +77,6 @@ class ContainerPoolTests
       action.rev,
       Identity(Subject(), invocationNamespace, AuthKey(), Set()),
       ActivationId(),
-      invocationNamespace.toPath,
       InstanceId(0),
       blocking = false,
       content = None)
@@ -90,6 +89,7 @@ class ContainerPoolTests
   val differentAction = action.copy(name = EntityName("actionName2"))
 
   val runMessage = createRunMessage(action, invocationNamespace)
+  val runMessageDifferentAction = createRunMessage(differentAction, invocationNamespace)
   val runMessageDifferentNamespace = createRunMessage(action, differentInvocationNamespace)
   val runMessageDifferentEverything = createRunMessage(differentAction, differentInvocationNamespace)
 

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
@@ -97,7 +97,6 @@ class ContainerProxyTests
     action.rev,
     Identity(Subject(), invocationNamespace, AuthKey(), Set()),
     ActivationId(),
-    invocationNamespace.toPath,
     InstanceId(0),
     blocking = false,
     content = None)

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/InvokerSupervisionTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/InvokerSupervisionTests.scala
@@ -198,7 +198,6 @@ class InvokerSupervisionTests
         AuthKey(UUID(), Secret()),
         Set[Privilege]()),
       activationId = new ActivationIdGenerator {}.make(),
-      activationNamespace = EntityPath("guest"),
       rootControllerIndex = InstanceId(0),
       blocking = false,
       content = None)


### PR DESCRIPTION
The property `activationNamespace` in an activation message is redundant with the `user` identity that is also part of the message. We don't need to pass in on the control plane as a result.