### PR TITLE
Use environment level defined directory if inventory_dir is not defined

### DIFF
--- a/ansible/boot_instances_dist.yml
+++ b/ansible/boot_instances_dist.yml
@@ -52,18 +52,18 @@
 # - local_action: add_host ansible_ssh_host={{ item.server.private_v4 }} groupname={{name}}
 #   with_items: instance_info.results
 
-- shell: "grep -e {{name}} {{inventory_dir}}/hosts"
+- shell: "grep -e {{name}} {{hosts_dir}}/hosts"
   ignore_errors: True
   register: hosts_file
 
 # TODO, should render the hosts file from a template by using the add_host module commented below with a template
-- shell: "echo [{{name}}] >> {{inventory_dir}}/hosts"
+- shell: "echo [{{name}}] >> {{hosts_dir}}/hosts"
   when: "{{hosts_file.rc}} != 0"
 
-- lineinfile: insertafter="^{{name}}" line="{{item.server.networks.itervalues().next()[0]}} block_device={{item.server.volumes[0].device }}" dest="{{inventory_dir}}/hosts"
+- lineinfile: insertafter="^{{name}}" line="{{item.server.networks.itervalues().next()[0]}} block_device={{item.server.volumes[0].device }}" dest="{{hosts_dir}}/hosts"
   with_items: instance_info.results
   when: (volume_env and volume_env != "") or (volume_dict and volume_dict.size)
 
-- lineinfile: insertafter="^{{name}}" line="{{item.server.networks.itervalues().next()[0]}}" dest="{{inventory_dir}}/hosts"
+- lineinfile: insertafter="^{{name}}" line="{{item.server.networks.itervalues().next()[0]}}" dest="{{hosts_dir}}/hosts"
   with_items: instance_info.results
   when: (not volume_env or volume_env == "" ) and (not volume_dict or not volume_dict.size)

--- a/ansible/environments/distributed/group_vars/all
+++ b/ansible/environments/distributed/group_vars/all
@@ -14,6 +14,8 @@ registry_storage_dir: "/"
 docker_registry: "{{ groups['registry'] | first }}:5000/"
 docker_dns: ""
 
+env_hosts_dir: "{{ playbook_dir }}/environments/distributed"
+
 registry:
   version: 2.3.1
   port: 5000

--- a/ansible/environments/docker-machine/group_vars/all
+++ b/ansible/environments/docker-machine/group_vars/all
@@ -5,6 +5,8 @@ docker_registry: ""
 docker_dns: ""
 bypass_pull_for_local_images: true
 
+env_hosts_dir: "{{ playbook_dir }}/environments/docker-machine"
+
 # The whisk_api_localhost_name is used to configure nginx to permit vanity URLs for web actions.
 # It is also used for the SSL certificate generation. For a local deployment, this is typically
 # a hostname that is resolved on the client, via /etc/hosts for example.

--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -33,3 +33,5 @@ kafka_topics_health_retentionBytes: 104857600
 kafka_topics_health_retentionMS: 300000
 kafka_topics_invoker_retentionBytes: 104857600
 kafka_topics_invoker_retentionMS: 300000
+
+env_hosts_dir: "{{ playbook_dir }}/environments/local"

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -18,6 +18,8 @@ exclude_logs_from: []
 #   whisk_api_localhost_name_default (last)
 whisk_api_localhost_name_default: "localhost"
 
+hosts_dir: "{{ inventory_dir| default(env_hosts_dir) }}" 
+
 whisk:
   version:
     date: "{{ansible_date_time.iso8601}}"

--- a/ansible/provision_env_dist.yml
+++ b/ansible/provision_env_dist.yml
@@ -6,7 +6,7 @@
     - name: add header to hosts file
       copy:
         content: "; the first parameter in a host is the inventory_hostname\n\nansible ansible_connection=local\n"
-        dest: "{{inventory_dir}}/hosts"
+        dest: "{{hosts_dir}}/hosts"
 
     - name: Create instances
       include: boot_instances_dist.yml instance={{item}}

--- a/ansible/roles/cli/tasks/download_cli.yml
+++ b/ansible/roles/cli/tasks/download_cli.yml
@@ -10,7 +10,7 @@
     mode=0755
     validate_certs=False
     force=True
-  when: ('environments/docker-machine' not in inventory_dir) and (ansible_os_family != "Darwin")
+  when: ('environments/docker-machine' not in hosts_dir) and (ansible_os_family != "Darwin")
 
 - name: "download cli for mac (docker-machine or Docker for Mac) to openwhisk home at {{ openwhisk_home }}"
   local_action: >
@@ -20,4 +20,4 @@
     mode=0755
     validate_certs=False
     force=True
-  when: ('environments/docker-machine' in inventory_dir ) or (ansible_os_family == "Darwin")
+  when: ('environments/docker-machine' in hosts_dir ) or (ansible_os_family == "Darwin")

--- a/ansible/roles/couchdb/tasks/deploy.yml
+++ b/ansible/roles/couchdb/tasks/deploy.yml
@@ -6,7 +6,7 @@
     coordinator: "{{ groups['db'][0] }}"
 
 - name: check if db credentials are valid for CouchDB
-  fail: msg="The db provider in your {{ inventory_dir }}/group_vars/all is {{ db_provider }}, it has to be CouchDB, pls double check"
+  fail: msg="The db provider in your {{ hosts_dir }}/group_vars/all is {{ db_provider }}, it has to be CouchDB, pls double check"
   when: db_provider != "CouchDB"
 
 - name: check for persistent disk

--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -5,21 +5,21 @@
   tasks:
   - name: gen hosts if 'local' env is used
     local_action: template src="{{playbook_dir}}/environments/local/hosts.j2.ini" dest="{{ playbook_dir }}/environments/local/hosts"
-    when: "'environments/local' in inventory_dir"
+    when: "'environments/local' in hosts_dir"
 
   - name: find the ip of docker-machine
     local_action: shell "docker-machine" "ip" "{{docker_machine_name | default('whisk')}}"
     register: result
-    when: "'environments/docker-machine' in inventory_dir"
+    when: "'environments/docker-machine' in hosts_dir"
 
   - name: get the docker-machine ip
     set_fact:
       docker_machine_ip: "{{ result.stdout }}"
-    when: "'environments/docker-machine' in inventory_dir"
+    when: "'environments/docker-machine' in hosts_dir"
 
   - name: gen hosts for docker-machine 
     local_action: template src="{{playbook_dir}}/environments/docker-machine/hosts.j2.ini" dest="{{ playbook_dir }}/environments/docker-machine/hosts"
-    when: "'environments/docker-machine' in inventory_dir"
+    when: "'environments/docker-machine' in hosts_dir"
 
   - name: gen untrusted server certificate for host
     local_action: shell "{{ playbook_dir }}/roles/nginx/files/genssl.sh" "*.{{ whisk_api_localhost_name | default(whisk_api_host_name) | default(whisk_api_localhost_name_default) }}" "server"


### PR DESCRIPTION
Starting with Ansible 2.4 the `inventory_dir` variable is not available anymore
(see: https://docs.ansible.com/ansible/2.4/porting_guide_2.4.html#inventory)

This PR changes the Ansible scripts to use an variable defined on environment level instead 

This change is tested with Ansible 2.3 for backward compatibility