### PR TITLE
fix PrimitiveActions drag of WhiskActivations

### DIFF
--- a/common/scala/src/main/scala/whisk/utils/ExecutionContextFactory.scala
+++ b/common/scala/src/main/scala/whisk/utils/ExecutionContextFactory.scala
@@ -24,11 +24,28 @@ import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
+import scala.util.control.NonFatal
 
 import akka.actor.ActorSystem
-import akka.pattern.{after => expire}
+import akka.actor.Cancellable
+import akka.actor.Scheduler
 
 object ExecutionContextFactory {
+
+  private type CancellableFuture[T] = (Cancellable, Future[T])
+  private type MCF[T] = Either[Future[T], CancellableFuture[T]] // maybe cancellable future
+
+  // akka.pattern.after has a memory drag issue: it opaquely
+  // schedules an actor which consequently results in drag for the
+  // timeout duration
+  def expire[T](duration: FiniteDuration, using: Scheduler)(value: ⇒ Future[T])(implicit ec: ExecutionContext): MCF[T] =
+    if (duration.isFinite() && duration.length < 1) {
+      try Left(value) catch { case NonFatal(t) ⇒ Left(Future.failed(t)) }
+    } else {
+      val p = Promise[T]()
+      val cancellable = using.scheduleOnce(duration) { p completeWith { try value catch { case NonFatal(t) ⇒ Future.failed(t) } } }
+      Right((cancellable, p.future))
+    }
 
   // Future.firstCompletedOf has a memory drag bug
   // https://stackoverflow.com/questions/36420697/about-future-firstcompletedof-and-garbage-collect-mechanism
@@ -45,16 +62,39 @@ object ExecutionContextFactory {
     p.future
   }
 
+  def cancelAll[T](futures: TraversableOnce[MCF[T]]) = {
+    futures foreach { _ match {
+      case Right((cancellable, _)) => cancellable.cancel()
+      case _ => ()
+    } }
+  }
+
+  def firstCompletedOf2[T](futures: TraversableOnce[MCF[T]])(implicit executor: ExecutionContext): Future[T] = {
+    val p = Promise[T]()
+    val pref = new java.util.concurrent.atomic.AtomicReference(p)
+    val completeFirst: Try[T] => Unit = { result: Try[T] =>
+      val promise = pref.getAndSet(null)
+      if (promise != null) {
+        promise.tryComplete(result)
+      }
+    }
+    futures foreach { _ match {
+      case Left(future) => future onComplete completeFirst; cancelAll(futures)
+      case Right((_, future)) => future onComplete completeFirst; cancelAll(futures)
+    } }
+    p.future
+  }
+
   implicit class FutureExtensions[T](f: Future[T]) {
     def withTimeout(timeout: FiniteDuration, msg: => Throwable)(implicit system: ActorSystem): Future[T] = {
       implicit val ec = system.dispatcher
-      firstCompletedOf(Seq(f, expire(timeout, system.scheduler)(Future.failed(msg))))
+      firstCompletedOf2(Seq(Left(f), expire(timeout, system.scheduler)(Future.failed(msg))))
     }
 
     def withAlternativeAfterTimeout(timeout: FiniteDuration, alt: => Future[T])(
       implicit system: ActorSystem): Future[T] = {
       implicit val ec = system.dispatcher
-      firstCompletedOf(Seq(f, expire(timeout, system.scheduler)(alt)))
+      firstCompletedOf2(Seq(Left(f), expire(timeout, system.scheduler)(alt)))
     }
   }
 

--- a/common/scala/src/main/scala/whisk/utils/ExecutionContextFactory.scala
+++ b/common/scala/src/main/scala/whisk/utils/ExecutionContextFactory.scala
@@ -41,7 +41,8 @@ object ExecutionContextFactory {
    * timeout duration
    *
    */
-  def expire[T](duration: FiniteDuration, using: Scheduler)(value: ⇒ Future[T])(implicit ec: ExecutionContext): CancellableFuture[T] = {
+  def expire[T](duration: FiniteDuration, using: Scheduler)(value: ⇒ Future[T])(
+    implicit ec: ExecutionContext): CancellableFuture[T] = {
     val p = Promise[T]()
     val cancellable = using.scheduleOnce(duration) {
       p completeWith {
@@ -57,7 +58,8 @@ object ExecutionContextFactory {
    * finishes first, we will cancel f2
    *
    */
-  def firstCompletedOf2[T](f1: Future[T], f2: CancellableFuture[T])(implicit executor: ExecutionContext, logging: Logging): Future[T] = {
+  def firstCompletedOf2[T](f1: Future[T], f2: CancellableFuture[T])(implicit executor: ExecutionContext,
+                                                                    logging: Logging): Future[T] = {
     val p = Promise[T]()
 
     f1 onComplete { result =>
@@ -70,13 +72,14 @@ object ExecutionContextFactory {
   }
 
   implicit class FutureExtensions[T](f: Future[T]) {
-    def withTimeout(timeout: FiniteDuration, msg: => Throwable)(implicit system: ActorSystem, logging: Logging): Future[T] = {
+    def withTimeout(timeout: FiniteDuration, msg: => Throwable)(implicit system: ActorSystem,
+                                                                logging: Logging): Future[T] = {
       implicit val ec = system.dispatcher
       firstCompletedOf2(f, expire(timeout, system.scheduler)(Future.failed(msg)))
     }
 
-    def withAlternativeAfterTimeout(timeout: FiniteDuration, alt: => Future[T])(
-      implicit system: ActorSystem, logging: Logging): Future[T] = {
+    def withAlternativeAfterTimeout(timeout: FiniteDuration, alt: => Future[T])(implicit system: ActorSystem,
+                                                                                logging: Logging): Future[T] = {
       implicit val ec = system.dispatcher
       firstCompletedOf2(f, expire(timeout, system.scheduler)(alt))
     }

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerData.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerData.scala
@@ -19,11 +19,14 @@ package whisk.core.loadBalancer
 
 import whisk.core.entity.{ActivationId, InstanceId, UUID, WhiskActivation}
 
+import akka.actor.Cancellable
 import scala.concurrent.{Future, Promise}
 
+// please note: timeoutHandler.cancel must be called on all non-timeout paths, e.g. Success
 case class ActivationEntry(id: ActivationId,
                            namespaceId: UUID,
                            invokerName: InstanceId,
+                           timeoutHandler: Cancellable,
                            promise: Promise[Either[ActivationId, WhiskActivation]])
 trait LoadBalancerData {
 

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -154,6 +154,7 @@ class LoadBalancerService(config: WhiskConfig, instance: InstanceId, entityStore
         // the load balancer's activation map. Inform the invoker pool supervisor of the user action completion.
         invokerPool ! InvocationFinishedMessage(invoker, isSuccess)
         if (!forced) {
+          entry.timeoutHandler.cancel()
           entry.promise.trySuccess(response)
         } else {
           entry.promise.tryFailure(new Throwable("no active ack received"))
@@ -188,11 +189,12 @@ class LoadBalancerService(config: WhiskConfig, instance: InstanceId, entityStore
     // in case of missing synchronization between n controllers in HA configuration the invoker queue can be overloaded
     // n-1 times and the maximal time for answering with active ack can be n times the action time (plus some overhead)
     loadBalancerData.putActivation(activationId, {
-      actorSystem.scheduler.scheduleOnce(timeout) {
+      val timeoutHandler = actorSystem.scheduler.scheduleOnce(timeout) {
         processCompletion(Left(activationId), transid, forced = true, invoker = invokerName)
       }
 
-      ActivationEntry(activationId, namespaceId, invokerName, Promise[Either[ActivationId, WhiskActivation]]())
+      // please note: timeoutHandler.cancel must be called on all non-timeout paths, e.g. Success
+      ActivationEntry(activationId, namespaceId, invokerName, timeoutHandler, Promise[Either[ActivationId, WhiskActivation]]())
     })
   }
 

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -188,14 +188,20 @@ class LoadBalancerService(config: WhiskConfig, instance: InstanceId, entityStore
     // in this case, if the activation handler is still registered, remove it and update the books.
     // in case of missing synchronization between n controllers in HA configuration the invoker queue can be overloaded
     // n-1 times and the maximal time for answering with active ack can be n times the action time (plus some overhead)
-    loadBalancerData.putActivation(activationId, {
-      val timeoutHandler = actorSystem.scheduler.scheduleOnce(timeout) {
-        processCompletion(Left(activationId), transid, forced = true, invoker = invokerName)
-      }
+    loadBalancerData.putActivation(
+      activationId, {
+        val timeoutHandler = actorSystem.scheduler.scheduleOnce(timeout) {
+          processCompletion(Left(activationId), transid, forced = true, invoker = invokerName)
+        }
 
-      // please note: timeoutHandler.cancel must be called on all non-timeout paths, e.g. Success
-      ActivationEntry(activationId, namespaceId, invokerName, timeoutHandler, Promise[Either[ActivationId, WhiskActivation]]())
-    })
+        // please note: timeoutHandler.cancel must be called on all non-timeout paths, e.g. Success
+        ActivationEntry(
+          activationId,
+          namespaceId,
+          invokerName,
+          timeoutHandler,
+          Promise[Either[ActivationId, WhiskActivation]]())
+      })
   }
 
   /**

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/LoadBalancerDataTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/LoadBalancerDataTests.scala
@@ -31,9 +31,17 @@ import scala.concurrent.duration._
 
 class LoadBalancerDataTests extends FlatSpec with Matchers with StreamLogging {
 
+  // ActivationEntry requires a cancellable, which represents the timeoutHandler
+  class FakeCancellable(var cancelled: Boolean = false) extends akka.actor.Cancellable {
+    def cancel() = { cancelled = true }
+    def isCancelled() = cancelled
+  }
+
   val activationIdPromise = Promise[Either[ActivationId, WhiskActivation]]()
-  val firstEntry: ActivationEntry = ActivationEntry(ActivationId(), UUID(), InstanceId(0), activationIdPromise)
-  val secondEntry: ActivationEntry = ActivationEntry(ActivationId(), UUID(), InstanceId(1), activationIdPromise)
+  val firstEntry: ActivationEntry =
+    ActivationEntry(ActivationId(), UUID(), InstanceId(0), new FakeCancellable(), activationIdPromise)
+  val secondEntry: ActivationEntry =
+    ActivationEntry(ActivationId(), UUID(), InstanceId(1), new FakeCancellable(), activationIdPromise)
 
   val port = 2552
   val host = "127.0.0.1"
@@ -149,7 +157,7 @@ class LoadBalancerDataTests extends FlatSpec with Matchers with StreamLogging {
 
   it should "respond with different values accordingly" in {
 
-    val entry = ActivationEntry(ActivationId(), UUID(), InstanceId(1), activationIdPromise)
+    val entry = ActivationEntry(ActivationId(), UUID(), InstanceId(1), new FakeCancellable(), activationIdPromise)
     val entrySameInvokerAndNamespace = entry.copy(id = ActivationId())
     val entrySameInvoker = entry.copy(id = ActivationId(), namespaceId = UUID())
 

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/LoadBalancerDataTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/LoadBalancerDataTests.scala
@@ -18,6 +18,7 @@
 package whisk.core.loadBalancer.test
 
 import akka.actor.ActorSystem
+import akka.actor.Cancellable
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import common.StreamLogging
 import org.scalatest.{FlatSpec, Matchers}
@@ -30,18 +31,16 @@ import whisk.core.entity.InstanceId
 import scala.concurrent.duration._
 
 class LoadBalancerDataTests extends FlatSpec with Matchers with StreamLogging {
-
-  // ActivationEntry requires a cancellable, which represents the timeoutHandler
-  class FakeCancellable(var cancelled: Boolean = false) extends akka.actor.Cancellable {
-    def cancel() = { cancelled = true }
-    def isCancelled() = cancelled
+  final val emptyCancellable: Cancellable = new Cancellable {
+    def isCancelled = false
+    def cancel() = true
   }
 
   val activationIdPromise = Promise[Either[ActivationId, WhiskActivation]]()
   val firstEntry: ActivationEntry =
-    ActivationEntry(ActivationId(), UUID(), InstanceId(0), new FakeCancellable(), activationIdPromise)
+    ActivationEntry(ActivationId(), UUID(), InstanceId(0), emptyCancellable, activationIdPromise)
   val secondEntry: ActivationEntry =
-    ActivationEntry(ActivationId(), UUID(), InstanceId(1), new FakeCancellable(), activationIdPromise)
+    ActivationEntry(ActivationId(), UUID(), InstanceId(1), emptyCancellable, activationIdPromise)
 
   val port = 2552
   val host = "127.0.0.1"
@@ -157,7 +156,7 @@ class LoadBalancerDataTests extends FlatSpec with Matchers with StreamLogging {
 
   it should "respond with different values accordingly" in {
 
-    val entry = ActivationEntry(ActivationId(), UUID(), InstanceId(1), new FakeCancellable(), activationIdPromise)
+    val entry = ActivationEntry(ActivationId(), UUID(), InstanceId(1), emptyCancellable, activationIdPromise)
     val entrySameInvokerAndNamespace = entry.copy(id = ActivationId())
     val entrySameInvoker = entry.copy(id = ActivationId(), namespaceId = UUID())
 


### PR DESCRIPTION
the akka `after` implementation creates an actor, but opaquely. thus, we have no opportunity to cancel any timeout futures. this PR adjust the `after` impl to expose and utilize the Cancellables

the consequence of this drag is that WhiskActivations, and a bunch of related artifacts, hang around until various timeouts expire.

this is a descendent of #3118 
the relevant change for this PR is in ExecutionContextFactory.scala, i.e. https://github.com/apache/incubator-openwhisk/pull/3127/files#diff-37b2c2f6b7bfbdbd928baaa6696ba64d