### PR TITLE
Add bash kind action

### DIFF
--- a/actionRuntimes/bashAction/Dockerfile
+++ b/actionRuntimes/bashAction/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.6.4-alpine3.6
+
+# Upgrade and install basic Python dependencies
+RUN rm -rf /var/cache/apk/* && \
+    rm -rf /tmp/*
+RUN apk update
+RUN apk add --no-cache bash \
+        git \
+        jq \
+ && apk add --no-cache --virtual .build-deps \
+        bzip2-dev \
+        gcc \
+        libc-dev \
+  && pip install --no-cache-dir gevent==1.1.2 flask==0.11.1 \
+  && apk del .build-deps
+
+ENV FLASK_PROXY_PORT 8080
+
+RUN mkdir -p /actionProxy
+ADD actionproxy.py /actionProxy/
+
+RUN mkdir -p /action
+ADD stub.sh /action/exec
+RUN chmod +x /action/exec
+
+CMD ["/bin/bash", "-c", "cd actionProxy && python -u actionproxy.py"]

--- a/actionRuntimes/bashAction/actionproxy.py
+++ b/actionRuntimes/bashAction/actionproxy.py
@@ -1,0 +1,298 @@
+"""Executable Python script for a proxy service to bashAction.
+
+Provides a proxy service (using Flask, a Python web microframework)
+that implements the required /init and /run routes to interact with
+the OpenWhisk invoker service.
+
+The implementation of these routes is encapsulated in a class named
+ActionRunner which provides a basic framework for receiving code
+from an invoker, preparing it for execution, and then running the
+code when required.
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
+
+import sys
+import os
+import json
+import subprocess
+import codecs
+import flask
+from gevent.wsgi import WSGIServer
+import zipfile
+import io
+import base64
+
+class ActionRunner:
+    """ActionRunner."""
+    LOG_SENTINEL = 'XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX'
+
+    # initializes the runner
+    # @param source the path where the source code will be located (if any)
+    # @param binary the path where the binary will be located (may be the
+    # same as source code path)
+    def __init__(self, source=None, binary=None):
+        defaultBinary = '/action/exec'
+        self.source = source if source else defaultBinary
+        self.binary = binary if binary else defaultBinary
+
+    def preinit(self):
+        return
+
+    # extracts from the JSON object message a 'code' property and
+    # writes it to the <source> path. The source code may have an
+    # an optional <epilogue>. The source code is subsequently built
+    # to produce the <binary> that is executed during <run>.
+    # @param message is a JSON object, should contain 'code'
+    # @return True iff binary exists and is executable
+    def init(self, message):
+        def prep():
+            self.preinit()
+            if 'code' in message and message['code'] is not None:
+                binary = message['binary'] if 'binary' in message else False
+                if not binary:
+                    return self.initCodeFromString(message)
+                else:
+                    return self.initCodeFromZip(message)
+            else:
+                return False
+
+        if prep():
+            try:
+                # write source epilogue if any
+                # the message is passed along as it may contain other
+                # fields relevant to a specific container.
+                if self.epilogue(message) is False:
+                    return False
+                # build the source
+                if self.build(message) is False:
+                    return False
+            except Exception:
+                return False
+        # verify the binary exists and is executable
+        return self.verify()
+
+    # optionally appends source to the loaded code during <init>
+    def epilogue(self, init_arguments):
+        return
+
+    # optionally builds the source code loaded during <init> into an executable
+    def build(self, init_arguments):
+        return
+
+    # @return True iff binary exists and is executable, False otherwise
+    def verify(self):
+        return (os.path.isfile(self.binary) and
+                os.access(self.binary, os.X_OK))
+
+    # constructs an environment for the action to run in
+    # @param message is a JSON object received from invoker (should
+    # contain 'value' and 'api_key' and other metadata)
+    # @return an environment dictionary for the action process
+    def env(self, message):
+        # make sure to include all the env vars passed in by the invoker
+        env = os.environ
+        for p in ['api_key', 'namespace', 'action_name', 'activation_id', 'deadline']:
+            if p in message:
+                env['__OW_%s' % p.upper()] = message[p]
+        return env
+
+    # parse json data and set environment value by JSON key recursively
+    # @param data is a JSON (python dictionary)
+    # @param envKey is environment variable's key, use for recursive action
+    # return None but this function set environment value in docker
+    def envParser(self, data, envKey):
+        if not isinstance(data, (dict, list)):
+            os.environ[envKey] = str(data)
+            return
+
+        count = 0
+        for keyOrElement in data:
+            if type(data) is dict:
+                tempKey = envKey + '_' + keyOrElement
+                self.envParser(data[str(keyOrElement)], tempKey)
+            elif type(data) is list:
+                tempKey = envKey + '_' + str(count)
+                self.envParser(data[count], tempKey)
+            count += 1
+
+    # runs the action, called iff self.verify() is True.
+    # @param args is a JSON object representing the input to the action
+    # @param env is the environment for the action to run in (defined edge
+    # host, auth key)
+    # return JSON object result of running the action or an error dictionary
+    # if action failed
+    def run(self, args, env):
+        def error(msg):
+            # fall through (exception and else case are handled the same way)
+            sys.stdout.write('%s\n' % msg)
+            return (502, {'error': 'The action did not return a dictionary.'})
+
+        try:
+            input = json.dumps(args)
+            self.envParser(args, "")
+
+            p = subprocess.Popen(
+                [self.binary, input],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env)
+        except Exception as e:
+            return error(e)
+
+        # run the process and wait until it completes.
+        # stdout/stderr will always be set because we passed PIPEs to Popen
+        (o, e) = p.communicate()
+
+        # stdout/stderr may be either text or bytes, depending on Python
+        # version, so if bytes, decode to text. Note that in Python 2
+        # a string will match both types; so also skip decoding in that case
+        if isinstance(o, bytes) and not isinstance(o, str):
+            o = o.decode('utf-8')
+        if isinstance(e, bytes) and not isinstance(e, str):
+            e = e.decode('utf-8')
+
+        # get the last line of stdout, even if empty
+        lastNewLine = o.rfind('\n', 0, len(o) - 1)
+        if lastNewLine != -1:
+            # this is the result string to JSON parse
+            lastLine = o[lastNewLine + 1:].strip()
+            # emit the rest as logs to stdout (including last new line)
+            sys.stdout.write(o[:lastNewLine + 1])
+        else:
+            # either o is empty or it is the result string
+            lastLine = o.strip()
+
+        if e:
+            sys.stderr.write(e)
+
+        try:
+            json_output = json.loads(lastLine)
+            if isinstance(json_output, dict):
+                return (200, json_output)
+
+            # return int as string
+            elif isinstance(json_output, int):
+                return (200, {'result': str(json_output)})
+            else:
+                return error(lastLine)
+        except Exception:
+            return (200, {'result': lastLine})
+
+    # initialize code from inlined string
+    def initCodeFromString(self, message):
+        with codecs.open(self.source, 'w', 'utf-8') as fp:
+            fp.write(message['code'])
+        return True
+
+    # initialize code from base64 encoded archive
+    def initCodeFromZip(self, message):
+        try:
+            bytes = base64.b64decode(message['code'])
+            bytes = io.BytesIO(bytes)
+            archive = zipfile.ZipFile(bytes)
+            archive.extractall(os.path.dirname(self.source))
+            archive.close()
+            return True
+        except Exception as e:
+            print('err', str(e))
+            return False
+
+
+proxy = flask.Flask(__name__)
+proxy.debug = False
+runner = None
+
+
+def setRunner(r):
+    global runner
+    runner = r
+
+
+@proxy.route('/init', methods=['POST'])
+def init():
+    message = flask.request.get_json(force=True, silent=True)
+    if message and not isinstance(message, dict):
+        flask.abort(404)
+    else:
+        value = message.get('value', {}) if message else {}
+
+    if not isinstance(value, dict):
+        flask.abort(404)
+
+    try:
+        status = runner.init(value)
+    except Exception as e:
+        status = False
+
+    if status is True:
+        return ('OK', 200)
+    else:
+        response = flask.jsonify({'error': 'The action failed to generate or locate a binary. See logs for details.'})
+        response.status_code = 502
+        return complete(response)
+
+
+@proxy.route('/run', methods=['POST'])
+def run():
+    def error():
+        response = flask.jsonify({'error': 'The action did not receive a dictionary as an argument.'})
+        response.status_code = 404
+        return complete(response)
+
+    message = flask.request.get_json(force=True, silent=True)
+    if message and not isinstance(message, dict):
+        return error()
+    else:
+        args = message.get('value', {}) if message else {}
+        if not isinstance(args, dict):
+            return error()
+
+    if runner.verify():
+        try:
+            code, result = runner.run(args, runner.env(message or {}))
+            response = flask.jsonify(result)
+            response.status_code = code
+        except Exception as e:
+            response = flask.jsonify({'error': 'Internal error. {}'.format(e)})
+            response.status_code = 500
+    else:
+        response = flask.jsonify({'error': 'The action failed to locate a binary. See logs for details.'})
+        response.status_code = 502
+    return complete(response)
+
+
+def complete(response):
+    # Add sentinel to stdout/stderr
+    sys.stdout.write('%s\n' % ActionRunner.LOG_SENTINEL)
+    sys.stdout.flush()
+    sys.stderr.write('%s\n' % ActionRunner.LOG_SENTINEL)
+    sys.stderr.flush()
+    return response
+
+
+def main():
+    port = int(os.getenv('FLASK_PROXY_PORT', 8080))
+    server = WSGIServer(('', port), proxy, log=None)
+    server.serve_forever()
+
+
+if __name__ == '__main__':
+    setRunner(ActionRunner())
+    main()

--- a/actionRuntimes/bashAction/build.gradle
+++ b/actionRuntimes/bashAction/build.gradle
@@ -1,0 +1,2 @@
+ext.dockerImageName = 'action-bash'
+apply from: '../../gradle/docker.gradle'

--- a/actionRuntimes/bashAction/stub.sh
+++ b/actionRuntimes/bashAction/stub.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "{\"error\":\"This is a stub action.\"}"

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -99,6 +99,13 @@ runtimesManifestDefault:
       deprecated: false
       image:
         name: "action-php-v7.1"
+    bash:
+    - kind: "bash"
+      default: true
+      deprecated: false
+      image:
+        name: "action-bash"
+
   blackboxes:
     - name: "dockerskeleton"
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,7 @@ include 'actionRuntimes:python2Action'
 include 'actionRuntimes:swift3.1.1Action'
 include 'actionRuntimes:javaAction'
 include 'actionRuntimes:php7.1Action'
+include 'actionRuntimes:bashAction'
 
 include 'sdk:docker'
 

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -45,6 +45,7 @@ test.dependsOn([
     ':actionRuntimes:python2Action:distDocker',
     ':actionRuntimes:javaAction:distDocker',
     ':actionRuntimes:swift3.1.1Action:distDocker',
+    ':actionRuntimes:bashAction:distDocker',
     ':sdk:docker:distDocker',
     ':tests:dat:blackbox:badaction:distDocker',
     ':tests:dat:blackbox:badproxy:distDocker'

--- a/tests/src/test/scala/actionContainers/BashActionContainerTests.scala
+++ b/tests/src/test/scala/actionContainers/BashActionContainerTests.scala
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package actionContainers
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import ActionContainer.withContainer
+
+import common.WskActorSystem
+import spray.json._
+
+@RunWith(classOf[JUnitRunner])
+class BashActionContainerTests extends BasicActionRunnerTests with WskActorSystem {
+  // note: "out" will not be empty as the PHP web server outputs a message when
+  // it starts up
+  val enforceEmptyOutputStream = false
+
+  lazy val bashContainerImageName = "action-bash"
+
+  override def withActionContainer(env: Map[String, String] = Map.empty)(code: ActionContainer => Unit) = {
+    withContainer(bashContainerImageName, env)(code)
+  }
+
+  def withBashContainer(code: ActionContainer => Unit) = withActionContainer()(code)
+
+  behavior of bashContainerImageName
+
+  testEcho(Seq {
+    (
+      "bash",
+      """
+        |#!/bin/bash
+        |echo 'hello stdout'
+        |echo 'hello stderr' 1>&2
+        |echo $1
+      """.stripMargin.trim)
+  })
+
+  testEnv(Seq {
+    (
+      "bash",
+      """
+        |#!/bin/bash
+        |echo "{ \
+        |\"api_host\": \"$__OW_API_HOST\", \"api_key\": \"$__OW_API_KEY\", \
+        |\"namespace\": \"$__OW_NAMESPACE\", \"action_name\": \"$__OW_ACTION_NAME\", \
+        |\"activation_id\": \"$__OW_ACTIVATION_ID\", \"deadline\": \"$__OW_DEADLINE\" }"
+      """.stripMargin.trim)
+  })
+
+  it should "access to string parameter using environment variable" in {
+    val (out, err) = withBashContainer { c =>
+      val args = JsObject("string" -> JsString("hello"))
+      val (initCode, _) = c.init(initPayload("""
+                                               |#!/bin/bash
+                                               |
+                                               |if [ $_string = "hello" ]
+                                               |then
+                                               |  echo match
+                                               |fi
+                                             """.stripMargin.trim))
+      initCode should be(200)
+      val (runCode, out) = c.run(runPayload(args))
+      runCode should be(200)
+      out should be(Some(JsObject("result" -> JsString("match"))))
+    }
+  }
+
+  it should "access to number parameter using environment variable" in {
+    val (out, err) = withBashContainer { c =>
+      val args = JsObject("number" -> JsNumber(93))
+      val (initCode, _) = c.init(initPayload("""
+                                               |#!/bin/bash
+                                               |
+                                               |if [ $_number = 93 ]
+                                               |then
+                                               |  echo match
+                                               |fi
+                                             """.stripMargin.trim))
+      initCode should be(200)
+      val (runCode, out) = c.run(runPayload(args))
+      runCode should be(200)
+      out should be(Some(JsObject("result" -> JsString("match"))))
+    }
+  }
+
+  it should "access to object using environment variable" in {
+    val (out, err) = withBashContainer { c =>
+      val args = JsObject("object" -> JsObject("a" -> JsString("A")))
+      val (initCode, _) = c.init(initPayload("""
+                                               |#!/bin/bash
+                                               |
+                                               |if [ $_object_a = "A" ]
+                                               |then
+                                               |  echo match
+                                               |fi
+                                             """.stripMargin.trim))
+      initCode should be(200)
+      val (runCode, out) = c.run(runPayload(args))
+      runCode should be(200)
+      out should be(Some(JsObject("result" -> JsString("match"))))
+    }
+  }
+
+  it should "access to elements of list using environment variable" in {
+    val (out, err) = withBashContainer { c =>
+      val args = JsObject("list" -> JsArray(JsString("match1"), JsString("match2"), JsString("match3")))
+      val (initCode, _) =
+        c.init(initPayload("""
+                                               |#!/bin/bash
+                                               |
+                                               |if [ $_list_0 = "match1" ] && [ $_list_1 = "match2" ] && [ $_list_2 = "match3" ]
+                                               |then
+                                               |  echo match
+                                               |fi
+                                             """.stripMargin.trim))
+      initCode should be(200)
+      val (runCode, out) = c.run(runPayload(args))
+      runCode should be(200)
+      out should be(Some(JsObject("result" -> JsString("match"))))
+    }
+  }
+
+  it should "support auto boxing" in {
+    val (out, err) = withBashContainer { c =>
+      val (initCode, _) = c.init(initPayload("""
+                                               |#!/bin/sh
+                                               |echo not a json object
+                                             """.stripMargin.trim))
+      initCode should be(200)
+      val (runCode, out) = c.run(JsObject())
+      runCode should be(200)
+      out should be(Some(JsObject("result" -> JsString("not a json object"))))
+    }
+  }
+
+  it should "support jq" in {
+    val (out, err) = withBashContainer { c =>
+      val args =
+        JsObject("a" -> JsString("A"), "b" -> JsNumber(123), "c" -> JsArray(JsNumber(1), JsNumber(2), JsNumber(3)))
+
+      val (initCode, _) = c.init(initPayload("""
+                                               |#!/bin/bash
+                                               |
+                                               |ARGS=$@
+                                               |A=`echo "$ARGS" | jq '."a"'`
+                                               |B=`echo "$ARGS" | jq '."b"'`
+                                               |C=`echo "$ARGS" | jq '."c"[0]'`
+                                               |RES=$(($B + $C))
+                                               |
+                                               |echo $RES
+                                               |
+                                             """.stripMargin.trim))
+      initCode should be(200)
+      val (runCode, out) = c.run(runPayload(args))
+      runCode should be(200)
+      out should be(Some(JsObject("result" -> JsString("124"))))
+    }
+  }
+
+  it should "support unicode characters" in {
+    val (out, err) = withBashContainer { c =>
+      val args = JsObject("winter" -> JsString("❄ ☃ ❄"))
+
+      val (initCode, _) = c.init(initPayload("""
+                                               |#!/bin/sh
+                                               |echo $_winter
+                                             """.stripMargin.trim))
+      initCode should be(200)
+      val (runCode, out) = c.run(runPayload(args))
+      runCode should be(200)
+      out should be(Some(JsObject("result" -> JsString("❄ ☃ ❄"))))
+    }
+  }
+
+  it should "run and return a only last line" in {
+    val (out, err) = withBashContainer { c =>
+      val (initCode, _) = c.init(initPayload("""
+                                               |#!/bin/sh
+                                               |echo This is not a last line
+                                               |echo This is a last line
+                                             """.stripMargin.trim))
+      initCode should be(200)
+      val (runCode, out) = c.run(JsObject())
+      runCode should be(200)
+      out should be(Some(JsObject("result" -> JsString("This is a last line"))))
+    }
+  }
+
+  it should "run and return a json object" in {
+    val (out, err) = withBashContainer { c =>
+      val (initCode, _) = c.init(initPayload("""
+                                               |#!/bin/sh
+                                               |echo "{ \"result\": \"This is a json object\" }"
+                                             """.stripMargin.trim))
+      initCode should be(200)
+      val (runCode, out) = c.run(JsObject())
+      runCode should be(200)
+      out should be(Some(JsObject("result" -> JsString("This is a json object"))))
+    }
+  }
+
+  it should "fail to run a bad script" in {
+    val (out, err) = withBashContainer { c =>
+      val (initCode, _) = c.init(initPayload(""))
+      initCode should be(200)
+      val (runCode, out) = c.run(JsNull)
+      runCode should be(502)
+      out should be(Some(JsObject("error" -> JsString("The action did not return a dictionary."))))
+    }
+
+    checkStreams(out, err, {
+      case (o, _) => o should include("error")
+    })
+  }
+}

--- a/tools/build/redo
+++ b/tools/build/redo
@@ -308,6 +308,11 @@ Components = [
                   yaml = False,
                   gradle = 'actionRuntimes:php7.1Action'),
 
+    makeComponent('action-bash',
+                  'build bash action container',
+                  yaml = False,
+                  gradle = 'actionRuntimes:bashAction'),
+
     makeComponent('dockersdk',
                   'build docker action SDK (to deploy, use edge component)',
                   yaml = False,


### PR DESCRIPTION
This is a new bash kind action. Related issue is #2927.

bash action runtime is based on `openwhisk/dockerskeleton` and action proxy is overrided for bash script. also added jq to handle json in bash script

## How to use
```
cat <<EOF > exec
#!/bin/bash
echo \$_test
EOF
```
It returns only the last line, supports auto boxing. (no need to make json object in script)

```
$ wsk -i action update test exec --kind bash
ok: updated action test
$ wsk -i action invoke hello -r -p test "Hello World!"
{
    "result": "Hello World!"
}
```
## Using parameters easily
The parameters are easy to use as environment variables in bash scripts. access parameters using environment variables is more intuitive and easier to use.

[sungjunyoung/openwhisk-bashAction](https://github.com/sungjunyoung/openwhisk-bashAction), This is the repository in which it is implemented


1. Object
```json
{
  "key":{
    "key1":"value1",
    "key2":"value2"
  }
}
```
```bash
#!/bin/bash
echo $_key_key1
echo $_key_key2
```
2. List
```
{
  "key":[
    {"first":"value1"},
    {"second":"value2"}
  ]
}
```
```bash
#!/bin/bash
echo $_key_0_first
echo $_key_1_second
```

3. also can be access theme using jq, jq is aleady installed.
```bash
#!/bin/bash
ARGS=$@
A=`echo "$ARGS" | jq '."a"'`
B=`echo "$ARGS" | jq '."b"'`
C=`echo "$ARGS" | jq '."c"[0]'`
RES=$(($B + $C))
```

## Testing
```
./gradlew tests:test --tests actionContainers.BashActionContainerTests
```

Closes https://github.com/apache/incubator-openwhisk/issues/2927