### PR TITLE
Refine error message on failure to fetch action in invoker.

### DIFF
--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -187,6 +187,7 @@ object Messages {
 
   val actionRemovedWhileInvoking = "Action could not be found or may have been deleted."
   val actionMismatchWhileInvoking = "Action version is not compatible and cannot be invoked."
+  val actionFetchErrorWhileInvoking = "Action could not be fetched."
 }
 
 /** Replaces rejections with Json object containing cause and transaction id. */


### PR DESCRIPTION
Refine error message so that internal connection errors don't generate a misleading error response.