### PR TITLE
Use timestamps in Java error and heap filenames

### DIFF
--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -40,7 +40,7 @@
     restart_policy: "{{ docker.restart.policy }}"
     hostname: "controller{{ groups['controllers'].index(inventory_hostname) }}"
     env:
-      "JAVA_OPTS": "-Xmx{{ controller.heap }} -XX:+CrashOnOutOfMemoryError -XX:+UseGCOverheadLimit -XX:ErrorFile=/logs/java_error.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/logs"
+      "JAVA_OPTS": "-Xmx{{ controller.heap }} -XX:+CrashOnOutOfMemoryError -XX:+UseGCOverheadLimit -XX:ErrorFile=/logs/java_error_{{ ansible_date_time.iso8601_basic_short }}.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/logs/java_heap_{{ ansible_date_time.iso8601_basic_short }}.hprof"
       "CONTROLLER_OPTS": "{{ controller.arguments }}"
       "CONTROLLER_INSTANCES": "{{ controller.instances }}"
 


### PR DESCRIPTION
Tag the Java error log and heap dump with the execution timestamps. Currently the mentioned files will not be overwritten if they already exist. This prevents us from gather error information. Adding timestamps to the filenames ensure the files will be created when errors occur.
  

Example filenames:
```
java_error_20171231T032056.log
java_heap_20171231T032056.hprof
```