### PR TITLE
Support CLI for s390x linux

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -179,7 +179,7 @@ nginx:
   confdir: "{{ config_root_dir }}/nginx"
   dir:
     become: "{{ nginx_dir_become | default(false) }}"
-  version: 1.11
+  version: "{{ nginx_version | default(1.11) }}"
   port:
     http: 80
     api: 443
@@ -321,18 +321,16 @@ openwhisk_cli:
     dest_name: OpenWhisk_CLI
     location: "https://github.com/apache/incubator-openwhisk-cli/releases/download/{{ openwhisk_cli_tag }}"
 
-# The list of operating systems for which openwhisk cli binaries are downloaded,
+# The list of operating systems and architectures for which openwhisk cli binaries are downloaded,
 # if the installation_mode is remote.
-cli_os:
-  - linux
-  - mac
-  - windows
-
-# The list of architectures for which openwhisk cli binaries are downloaded,
-# if the installation_mode is remote.
-cli_arch:
-  - amd64
-  - 386
+cli_os_arch:
+  - [ "linux", "amd64" ]
+  - [ "linux", "386" ]
+  - [ "linux", "s390x" ]
+  - [ "mac", "amd64" ]
+  - [ "mac", "386" ]
+  - [ "windows", "amd64" ]
+  - [ "windows", "386" ]
 
 # Controls access to log directories
 logs:

--- a/ansible/roles/cli/files/createContentJson.sh
+++ b/ansible/roles/cli/files/createContentJson.sh
@@ -35,35 +35,45 @@ get_binary_path() {
 create_cli_packages() {
   local dirIndex="{\"cli\":{"
 
-  for platform in $platforms; do
-    dirIndex="$dirIndex\"$platform\":{"
+  #  I'm making a nasty assumption here that it's sorted by platforms
+  old_platform=''  # Not really necessary, but here to be explicit & transparent
+  for platform_arch in $platforms; do
 
-    for arch in $archs; do
-      comp_name=$(get_compressed_name $platform $arch $zip_name)
-      comp_path=$(get_binary_path $comp_name $platform $arch)
+    IFS="," read platform arch <<<"${platform_arch}"
 
-      if [ $arch = $default_arch ]; then
-          dirIndex="$dirIndex\"default\":{\"path\":\"$comp_path\"},";
+    #  Control-break processing for platform changes
+    if [ "$platform" != "$old_platform" ]; then
+      if [ "$old_platform" != "" ]; then
+        dirIndex="${dirIndex%','}" # Remove trailing comma
+        dirIndex+="},"             # And replace with end-brace comma
       fi
+      dirIndex+="\"$platform\":{"
+    fi
+    old_platform=$platform
 
-      dirIndex="$dirIndex\"$arch\":{\"path\":\"$comp_path\"},";
-    done
+    comp_name=$(get_compressed_name $platform $arch $zip_name)
+    comp_path=$(get_binary_path $comp_name $platform $arch)
 
-    dirIndex="$(echo $dirIndex | rev | cut -c2- | rev)"
-    dirIndex="$dirIndex},";
+    if [ $arch = $default_arch ]; then
+      dirIndex+="\"default\":{\"path\":\"$comp_path\"},";
+    fi
+
+    dirIndex+="\"$arch\":{\"path\":\"$comp_path\"},";
   done
 
-  dirIndex="$(echo $dirIndex | rev | cut -c2- | rev)"
-  dirIndex="$dirIndex}}"
+  #dirIndex="$(echo $dirIndex | rev | cut -c2- | rev)"
+  dirIndex="${dirIndex%','}"   # Remove trailing comma
+  dirIndex+="}}}"              # And replace with end-braces
 
   mkdir -p "${PATH_CONTENT_JSON}"
   echo $dirIndex > "${PATH_CONTENT_JSON}/content.json"
 };
 
-archs="386 amd64";
 default_arch="amd64"
 
 PATH_CONTENT_JSON=$1
+# 'shellcheck' pointed out that BINARY_TAG is unused.  I'm leaving it for now
+# because the future of content.json is in flux.
 BINARY_TAG=$2
 platforms=$3
 zip_name=$4

--- a/ansible/roles/cli/tasks/cli_remote_mode.yml
+++ b/ansible/roles/cli/tasks/cli_remote_mode.yml
@@ -4,12 +4,11 @@
 
 - name: "download the binaries from the release page of OpenWhisk CLI"
   include: download_openwhisk_cli.yml
-  with_nested:
-    - "{{ cli_os }}"
-    - "{{ cli_arch }}"
+  with_items:
+    - "{{ cli_os_arch }}"
 
 - name: "generate content.json locally for Nginx CLI directory"
-  local_action: shell "./createContentJson.sh" "{{ config_root_dir }}" "{{ openwhisk_cli_tag }}" "{{ cli_os | join(" ") }}" "{{ openwhisk_cli.remote.dest_name }}" chdir="{{ openwhisk_home }}/ansible/roles/cli/files"
+  local_action: shell "./createContentJson.sh" "{{ config_root_dir }}" "{{ openwhisk_cli_tag }}" "{{ cli_os_arch | sort | map('join', ',') | join(' ') }}" "{{ openwhisk_cli.remote.dest_name }}" chdir="{{ openwhisk_home }}/ansible/roles/cli/files"
 
 - name: "ensure Nginx cli directory is writable"
   file:
@@ -17,7 +16,7 @@
     state: directory
     mode: 0777
   become: "{{ cli.dir.become }}"
-  
+
 - name: "copy the local content.json to the remote node"
   copy: src={{ config_root_dir }}/content.json dest={{ cli.nginxdir }}/
 

--- a/ansible/roles/cli/tasks/deploy.yml
+++ b/ansible/roles/cli/tasks/deploy.yml
@@ -19,10 +19,11 @@
 - name: "copy the binaries from a local directory to Nginx directory"
   include: copy_local_openwhisk_cli.yml
   when: cli_installation_mode == "local"
-  with_items: "{{ cli_os }}"
+  with_items: "{{ cli_os_arch | first | unique }}"
 
 - name: "copy the local content.json from a local directory to Nginx directory"
   copy: src={{ openwhisk_cli.local.location }}/content.json dest={{ cli.nginxdir }}/
   when: cli_installation_mode == "local"
 
 - include: download_cli.yml
+  when: cli_installation_mode == "remote"

--- a/ansible/roles/cli/tasks/download_cli.yml
+++ b/ansible/roles/cli/tasks/download_cli.yml
@@ -2,10 +2,19 @@
 
 # Download the cli to openwhisk_home
 
+- name: "Use ansible fact to determine wsk architecture"
+  set_fact:
+      cli_arch: "{{ ansible_machine }}"
+
+- name: "If architecture is x86_64, change it to amd64"
+  set_fact:
+      cli_arch: "amd64"
+  when: ansible_machine == "x86_64"
+
 - name: "download cli (linux) to openwhisk home at {{ openwhisk_home }}"
   local_action: >
     get_url
-    url="https://{{ groups['edge'] | first }}/cli/go/download/linux/amd64/wsk"
+    url="https://{{ groups['edge'] | first }}/cli/go/download/linux/{{ cli_arch }}/wsk"
     dest="{{ openwhisk_home }}/bin/wsk"
     mode=0755
     validate_certs=False
@@ -15,7 +24,7 @@
 - name: "download cli for mac (docker-machine or Docker for Mac) to openwhisk home at {{ openwhisk_home }}"
   local_action: >
     get_url
-    url="https://{{ groups['edge'] | first }}/cli/go/download/mac/amd64/wsk"
+    url="https://{{ groups['edge'] | first }}/cli/go/download/mac/{{ cli_arch }}/wsk"
     dest="{{ openwhisk_home }}/bin/wsk"
     mode=0755
     validate_certs=False

--- a/ansible/roles/cli/tasks/download_openwhisk_cli.yml
+++ b/ansible/roles/cli/tasks/download_openwhisk_cli.yml
@@ -17,12 +17,16 @@
   set_fact:
     source_name="{{ openwhisk_cli.remote.name }}-{{ openwhisk_cli_tag }}-{{ os }}-{{ arc }}.{{ suffix }}"
 
+- name: "set the destination file name locally (default)"
+  set_fact:
+    dest_name="{{ openwhisk_cli.remote.dest_name }}-{{ os }}-{{arc}}.{{ suffix }}"
+
 - name: "set the destination file name locally after download for 32 bit"
   set_fact:
     dest_name="{{ openwhisk_cli.remote.dest_name }}-{{ os }}-32bit.{{ suffix }}"
   when: arc == "386"
 
-- name: "set the destination file name locally after download for 64 bit"
+- name: "set the destination file name locally after download for amd64"
   set_fact:
     dest_name="{{ openwhisk_cli.remote.dest_name }}-{{ os }}.{{ suffix }}"
   when: arc == "amd64"
@@ -70,4 +74,3 @@
   args:
     chdir: "{{ cli.nginxdir }}/{{ os }}/{{ arc }}/"
   when: os == "linux"
-


### PR DESCRIPTION
Separated from #3133 .  

It was also necessary to fiddle with the CLI download capabilities, now that the CLI is being automatically compiled for s390x. The result is not quite as dynamic as one might wish, yet, but it appears to get the job done.

This change is likely temporary -- responsibility for determining CLI build architectures is being moved toward the CLI build process in a separate repository -- the hope is eventually the list of all possible architectures will disappear from here.