### PR TITLE
Use cache invalidation policy based on access time

### DIFF
--- a/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
+++ b/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
@@ -442,7 +442,7 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
     Caffeine
       .newBuilder()
       .asInstanceOf[Caffeine[Any, Future[Entry]]]
-      .expireAfterWrite(5, TimeUnit.MINUTES)
+      .expireAfterAccess(5, TimeUnit.MINUTES)
       .softValues()
       .build()
       .asMap())

--- a/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
+++ b/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
@@ -91,12 +91,18 @@ private object MultipleReadersSingleWriterCache {
 
 trait CacheChangeNotification extends (CacheKey => Future[Unit])
 
+sealed trait EvictionPolicy
+
+case object AccessTime extends EvictionPolicy
+case object WriteTime extends EvictionPolicy
+
 trait MultipleReadersSingleWriterCache[W, Winfo] {
   import MultipleReadersSingleWriterCache._
   import MultipleReadersSingleWriterCache.State._
 
   /** Subclasses: Toggle this to enable/disable caching for your entity type. */
   protected val cacheEnabled = true
+  protected val evictionPolicy: EvictionPolicy = AccessTime
 
   private object Entry {
     def apply(transid: TransactionId, state: State, value: Option[Future[W]]): Entry = {
@@ -438,14 +444,27 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
   }
 
   /** This is the backing store. */
-  private val cache: ConcurrentMapBackedCache[Entry] = new ConcurrentMapBackedCache(
-    Caffeine
-      .newBuilder()
-      .asInstanceOf[Caffeine[Any, Future[Entry]]]
-      .expireAfterAccess(5, TimeUnit.MINUTES)
-      .softValues()
-      .build()
-      .asMap())
+  private lazy val cache: ConcurrentMapBackedCache[Entry] = evictionPolicy match {
+    case AccessTime =>
+      new ConcurrentMapBackedCache(
+        Caffeine
+          .newBuilder()
+          .asInstanceOf[Caffeine[Any, Future[Entry]]]
+          .expireAfterAccess(5, TimeUnit.MINUTES)
+          .softValues()
+          .build()
+          .asMap())
+
+    case _ =>
+      new ConcurrentMapBackedCache(
+        Caffeine
+          .newBuilder()
+          .asInstanceOf[Caffeine[Any, Future[Entry]]]
+          .expireAfterWrite(5, TimeUnit.MINUTES)
+          .softValues()
+          .build()
+          .asMap())
+  }
 }
 
 /**

--- a/common/scala/src/main/scala/whisk/core/entity/Identity.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Identity.scala
@@ -27,6 +27,7 @@ import whisk.common.TransactionId
 import whisk.core.database.MultipleReadersSingleWriterCache
 import whisk.core.database.NoDocumentException
 import whisk.core.database.StaleParameter
+import whisk.core.database.WriteTime
 import whisk.core.entitlement.Privilege
 
 case class UserLimits(invocationsPerMinute: Option[Int] = None,
@@ -50,6 +51,8 @@ object Identity extends MultipleReadersSingleWriterCache[Identity, DocInfo] with
   private val viewName = "subjects/identities"
 
   override val cacheEnabled = true
+  override val evictionPolicy = WriteTime
+
   implicit val serdes = jsonFormat5(Identity.apply)
 
   /**


### PR DESCRIPTION
Currently the cache uses an `expireAfterWrite` policy to invalidate entries. The current policy invalidates entities five minutes after entities are cached even if they are accessed within that time period. 

Using an `expireAfterAccess` policy with a time of five minutes will keep entities in the cache that are accessed within that timeframe. This prevents unnecessary database reads for entities that are used frequently.  

For documentation see: https://github.com/ben-manes/caffeine/wiki/Eviction.
  