### PR TITLE
Disallow create and update of package with reserved names.

### DIFF
--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -109,9 +109,7 @@ object Messages {
   val bindingCannotReferenceBinding = "Cannot bind to another package binding."
   val requestedBindingIsNotValid = "Cannot bind to a resource that is not a package."
   val notAllowedOnBinding = "Operation not permitted on package binding."
-  def packageNameIsReserved(name: String) = {
-    s"Package name '$name' is reserved."
-  }
+  def packageNameIsReserved(name: String) = s"Package name '$name' is reserved."
 
   /** Error messages for sequence activations. */
   def sequenceRetrieveActivationTimeout(id: ActivationId) =


### PR DESCRIPTION
Fixes #2964.

Disable update on package with a reserved name. A `get` and `delete` of the package is still allowed. Packages that preexist with a reserved name will continue to work: can add actions to them, or invoke actions in them. But the package itself can't be updated.

