### PR TITLE
singleton to hold PureConfig keys

### DIFF
--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaMessagingProvider.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaMessagingProvider.scala
@@ -30,6 +30,7 @@ import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.common.errors.TopicExistsException
 
 import whisk.common.Logging
+import whisk.core.PureConfigKeys
 import whisk.core.WhiskConfig
 import whisk.core.connector.MessageConsumer
 import whisk.core.connector.MessageProducer
@@ -60,8 +61,8 @@ object KafkaMessagingProvider extends MessagingProvider {
     new KafkaProducerConnector(config.kafkaHosts, ec)
 
   def ensureTopic(config: WhiskConfig, topic: String, topicConfig: String)(implicit logging: Logging): Boolean = {
-    val kc = loadConfigOrThrow[KafkaConfig]("whisk.kafka")
-    val tc = loadConfigOrThrow[TopicConfig](s"whisk.kafka.topics.$topicConfig")
+    val kc = loadConfigOrThrow[KafkaConfig](PureConfigKeys.whiskKafka)
+    val tc = loadConfigOrThrow[TopicConfig](PureConfigKeys.whiskKafkaTopics + s".$topicConfig")
     val props = new Properties
     props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, config.kafkaHosts)
     val client = AdminClient.create(props)

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -236,3 +236,12 @@ object WhiskConfig {
   val controllerLocalBookkeeping = "controller.localBookkeeping"
   val controllerHighAvailability = "controller.ha"
 }
+
+object PureConfigKeys {
+  val whiskLoadbalancer = "whisk.loadbalancer"
+
+  val whiskKafka = "whisk.kafka"
+  val whiskKafkaTopics = "whisk.kafka.topics"
+
+  val whiskDB = "whisk.db"
+}

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
@@ -25,6 +25,7 @@ import scala.util.Try
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import whisk.common.TransactionId
+import whisk.core.PureConfigKeys
 import whisk.core.database.ArtifactStore
 import whisk.core.database.DocumentFactory
 import whisk.core.database.StaleParameter
@@ -147,7 +148,7 @@ object WhiskActivation
 
   override val collectionName = "activations"
 
-  private val dbConfig = loadConfigOrThrow[DBConfig]("whisk.db")
+  private val dbConfig = loadConfigOrThrow[DBConfig](PureConfigKeys.whiskDB)
   private val mainDdoc = dbConfig.activationsDdoc
   private val filtersDdoc = dbConfig.activationsFilterDdoc
 

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
@@ -29,6 +29,7 @@ import spray.json.JsString
 import spray.json.RootJsonFormat
 import whisk.common.Logging
 import whisk.common.TransactionId
+import whisk.core.PureConfigKeys
 import whisk.core.WhiskConfig
 import whisk.core.WhiskConfig.dbActivations
 import whisk.core.WhiskConfig.dbAuths
@@ -192,7 +193,7 @@ object WhiskEntityQueries {
   val TOP = "\ufff0"
 
   /** The design document to use for queries. */
-  val designDoc = loadConfigOrThrow[DBConfig]("whisk.db").actionsDdoc
+  val designDoc = loadConfigOrThrow[DBConfig](PureConfigKeys.whiskDB).actionsDdoc
 
   /** The view name for the collection, within the design document. */
   def view(ddoc: String = designDoc, collection: String) = new View(ddoc, collection)

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -37,6 +37,7 @@ import akka.pattern.ask
 import whisk.common.Logging
 import whisk.common.LoggingMarkers
 import whisk.common.TransactionId
+import whisk.core.PureConfigKeys
 import whisk.core.WhiskConfig
 import whisk.core.WhiskConfig._
 import whisk.core.connector.{ActivationMessage, CompletionMessage}
@@ -90,7 +91,7 @@ class LoadBalancerService(config: WhiskConfig, instance: InstanceId, entityStore
   logging: Logging)
     extends LoadBalancer {
 
-  private val lbConfig = loadConfigOrThrow[LoadbalancerConfig]("whisk.loadbalancer")
+  private val lbConfig = loadConfigOrThrow[LoadbalancerConfig](PureConfigKeys.whiskLoadbalancer)
 
   /** The execution context for futures */
   implicit val executionContext: ExecutionContext = actorSystem.dispatcher


### PR DESCRIPTION
As suggested by @rabbah in review of another PR, introduce
a singleton to hold the various String keys used to load
config data via PureConfig to make it easier to find all
uses of a particular piece of configuration data.