### PR TITLE
Avoid packaging log4j dependencies in invoker

### DIFF
--- a/core/invoker/build.gradle
+++ b/core/invoker/build.gradle
@@ -15,7 +15,11 @@ dependencies {
     compile project(':common:scala')
 
     compile 'org.apache.curator:curator-recipes:4.0.0', { exclude group: 'org.apache.zookeeper', module:'zookeeper' }
-    compile 'org.apache.zookeeper:zookeeper:3.4.11'
+    compile ('org.apache.zookeeper:zookeeper:3.4.11') {
+        exclude group: 'org.slf4j'
+        exclude group: 'log4j'
+        exclude group: 'jline'
+    }
 }
 
 tasks.withType(ScalaCompile) {


### PR DESCRIPTION
Currently invoker module pulls in log4j jars via transitive dependency on zookeeper

```
$./gradlew :core:invoker:dependencies
+--- org.apache.zookeeper:zookeeper:3.4.11
|    +--- org.slf4j:slf4j-api:1.6.1 -> 1.7.25
|    +--- org.slf4j:slf4j-log4j12:1.6.1
|    |    +--- org.slf4j:slf4j-api:1.6.1 -> 1.7.25
|    |    \--- log4j:log4j:1.2.16
|    +--- log4j:log4j:1.2.16
|    +--- jline:jline:0.9.94
|    |    \--- junit:junit:3.8.1
|    +--- org.apache.yetus:audience-annotations:0.5.0
|    \--- io.netty:netty:3.10.5.Final
```

This causes following warning logs in invoker logs and test runs

```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/invoker/lib/logback-classic-1.2.3.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/invoker/lib/slf4j-log4j12-1.6.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [ch.qos.logback.classic.util.ContextSelectorStaticBinder]
```

With this PR we exclude following transitive dependencies

* log4j and slf4j - Prevents pulling of log4j related jars in invoker distribution
* jline - This is required only for CLI which also pull in junit!. For 3.5.0 version these have been made optional ([ZOOKEEPER-1655][1])

With these exclusion invoker.tar size reduces from 46.4M to 45.7M and also the slf4j warnings are not seen. This would also ensure that logging backend is deterministic and not [dependent on runtime][1]

> The way SLF4J picks a binding is determined by the JVM and for all practical purposes should be considered random. As of version 1.6.6, SLF4J will name the framework/implementation class it is actually bound to.

[1]: https://issues.apache.org/jira/browse/ZOOKEEPER-1655
[2]: https://www.slf4j.org/codes.html#multiple_bindings