### PR TITLE
Sanitize error message returned by a failed container startup.

### DIFF
--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -187,6 +187,9 @@ object Messages {
   val actionRemovedWhileInvoking = "Action could not be found or may have been deleted."
   val actionMismatchWhileInvoking = "Action version is not compatible and cannot be invoked."
   val actionFetchErrorWhileInvoking = "Action could not be fetched."
+
+  /** Indicates that the container for the action could not be started. */
+  val resourceProvisionError = "Failed to provision resources to run the action."
 }
 
 /** Replaces rejections with Json object containing cause and transaction id. */

--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -188,6 +188,9 @@ object Messages {
   val actionMismatchWhileInvoking = "Action version is not compatible and cannot be invoked."
   val actionFetchErrorWhileInvoking = "Action could not be fetched."
 
+  /** Indicates that the image could not be pulled. */
+  def imagePullError(image: String) = s"Failed to pull container image '$image'."
+
   /** Indicates that the container for the action could not be started. */
   val resourceProvisionError = "Failed to provision resources to run the action."
 }

--- a/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
@@ -147,7 +147,7 @@ class ContainerProxy(
             // the failure is either the system fault, or for docker actions, the application/developer fault
             val response = t match {
               case WhiskContainerStartupError(_) => ActivationResponse.whiskError(Messages.resourceProvisionError)
-              case BlackboxStartupError(_)       => ActivationResponse.applicationError(Messages.resourceProvisionError)
+              case BlackboxStartupError(msg)     => ActivationResponse.applicationError(msg)
               case _                             => ActivationResponse.whiskError(Messages.resourceProvisionError)
             }
             // construct an appropriate activation and record it in the datastore,

--- a/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
@@ -146,9 +146,9 @@ class ContainerProxy(
             // the container did not come up cleanly, so disambiguate the failure mode and then cleanup
             // the failure is either the system fault, or for docker actions, the application/developer fault
             val response = t match {
-              case WhiskContainerStartupError(_) => ActivationResponse.whiskError(Messages.resourceProvisionError)
-              case BlackboxStartupError(msg)     => ActivationResponse.applicationError(msg)
-              case _                             => ActivationResponse.whiskError(Messages.resourceProvisionError)
+              case WhiskContainerStartupError(msg) => ActivationResponse.whiskError(msg)
+              case BlackboxStartupError(msg)       => ActivationResponse.applicationError(msg)
+              case _                               => ActivationResponse.whiskError(Messages.resourceProvisionError)
             }
             // construct an appropriate activation and record it in the datastore,
             // also update the feed and active ack; the container cleanup is queued

--- a/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
@@ -146,9 +146,9 @@ class ContainerProxy(
             // the container did not come up cleanly, so disambiguate the failure mode and then cleanup
             // the failure is either the system fault, or for docker actions, the application/developer fault
             val response = t match {
-              case WhiskContainerStartupError(msg) => ActivationResponse.whiskError(msg)
-              case BlackboxStartupError(msg)       => ActivationResponse.applicationError(msg)
-              case _                               => ActivationResponse.whiskError(t.getMessage)
+              case WhiskContainerStartupError(_) => ActivationResponse.whiskError(Messages.resourceProvisionError)
+              case BlackboxStartupError(_)       => ActivationResponse.applicationError(Messages.resourceProvisionError)
+              case _                             => ActivationResponse.whiskError(Messages.resourceProvisionError)
             }
             // construct an appropriate activation and record it in the datastore,
             // also update the feed and active ack; the container cleanup is queued

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
@@ -104,7 +104,7 @@ object DockerContainer {
       params
     val pulled = if (userProvidedImage) {
       docker.pull(image).recoverWith {
-        case _ => Future.failed(BlackboxStartupError(s"Failed to pull container image '${image}'."))
+        case _ => Future.failed(BlackboxStartupError(Messages.imagePullError(image)))
       }
     } else Future.successful(())
 
@@ -115,17 +115,16 @@ object DockerContainer {
           // Remove the broken container - but don't wait or check for the result.
           // If the removal fails, there is nothing we could do to recover from the recovery.
           docker.rm(brokenId)
-          Future.failed(
-            WhiskContainerStartupError(s"Failed to run container with image '${image}'. Removing broken container."))
+          Future.failed(WhiskContainerStartupError(Messages.resourceProvisionError))
         case _ =>
-          Future.failed(WhiskContainerStartupError(s"Failed to run container with image '${image}'."))
+          Future.failed(WhiskContainerStartupError(Messages.resourceProvisionError))
       }
       ip <- docker.inspectIPAddress(id, network).recoverWith {
         // remove the container immediately if inspect failed as
         // we cannot recover that case automatically
         case _ =>
           docker.rm(id)
-          Future.failed(WhiskContainerStartupError(s"Failed to obtain IP address of container '${id.asString}'."))
+          Future.failed(WhiskContainerStartupError(Messages.resourceProvisionError))
       }
     } yield new DockerContainer(id, ip, useRunc)
   }


### PR DESCRIPTION
The error message returned by a failing container startup contains internal information (like the internally configured images, various exception messages). Returning a sanitized string is better design in general here.

All error cases are logged fine for operators to find the root-cause of the failing run.