### PR TITLE
Fixed the curl command line to update the 'reduce_limit'

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -138,7 +138,7 @@ ansible-playbook -i environments/<environment> prereq.yml
 ### Deploying Using CouchDB
 - Make sure your `db_local.ini` file is set up for CouchDB. See [Setup](#setup)
 - If you deploy CouchDB manually (i.e., without using the deploy CouchDB playbook), you must set the `reduce_limit` property on views to `false`.
-This may be done via the REST API, as in: `curl -X PUT ${OW_DB_PROTOCOL}://${OW_DB_HOST}:${OW_DB_PORT}/_config/query_server_config/reduce_limit -d '"false"' -u ${OW_DB_USERNAME}:${OW_DB_PASSWORD}`.
+This may be done via the REST API, as in: `curl -X PUT ${OW_DB_PROTOCOL}://${OW_DB_HOST}:${OW_DB_PORT}/_node/{node-name}/_config/query_server_config/reduce_limit -d '"false"' -u ${OW_DB_USERNAME}:${OW_DB_PASSWORD}`.
 - Then execute
 
 ```

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -138,7 +138,7 @@ ansible-playbook -i environments/<environment> prereq.yml
 ### Deploying Using CouchDB
 - Make sure your `db_local.ini` file is set up for CouchDB. See [Setup](#setup)
 - If you deploy CouchDB manually (i.e., without using the deploy CouchDB playbook), you must set the `reduce_limit` property on views to `false`.
-This may be done via the REST API, as in: `curl -X PUT ${OW_DB_PROTOCOL}://${OW_DB_HOST}:${OW_DB_PORT}/_node/{node-name}/_config/query_server_config/reduce_limit -d '"false"' -u ${OW_DB_USERNAME}:${OW_DB_PASSWORD}`.
+This may be done via the REST API, as in: `curl -X PUT ${OW_DB_PROTOCOL}://${OW_DB_HOST}:${OW_DB_PORT}/_node/{node-name}/_config/query_server_config/reduce_limit -d '"false"' -u ${OW_DB_USERNAME}:${OW_DB_PASSWORD}`. '{node-name}' is depends on your environment, you can get it by `curl ${OW_DB_PROTOCOL}://${OW_DB_HOST}:${OW_DB_PORT}/_membership`.
 - Then execute
 
 ```


### PR DESCRIPTION
This patch fixed the curl command line to update the CouchDB
'reduce_limit' config parameter.
API path should have '/_node/{node-name}' in front of '/_config' [1].

 [1] http://docs.couchdb.org/en/2.1.1/http-api.html