### PR TITLE
Add type property to entity documents 

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
@@ -70,6 +70,14 @@ protected[core] trait WhiskDocument extends DocumentSerializer with DocumentRevi
   protected[core] final def docinfo: DocInfo = DocInfo(docid, rev)
 
   /**
+   * Determines entity type based on entity class name
+   */
+  protected[core] def documentType: String = {
+    val typeName = this.getClass.getSimpleName.toLowerCase
+    if (typeName.startsWith("whisk")) typeName.substring(5) else typeName
+  }
+
+  /**
    * The representation as JSON, e.g. for REST calls. Does not include id/rev.
    */
   def toJson: JsObject
@@ -85,7 +93,8 @@ protected[core] trait WhiskDocument extends DocumentSerializer with DocumentRevi
     // Building up the fields.
     val base = this.toJson.fields
     val withId = base + ("_id" -> JsString(id))
-    val withRev = if (revOrNull == null) withId else { withId + ("_rev" -> JsString(revOrNull)) }
+    val withType = withId + ("type" -> JsString(documentType))
+    val withRev = if (revOrNull == null) withType else { withType + ("_rev" -> JsString(revOrNull))}
     JsObject(withRev)
   }
 }

--- a/tests/src/test/scala/whisk/core/entity/test/WhiskEntityTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/WhiskEntityTests.scala
@@ -21,6 +21,7 @@ import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import org.scalatest.junit.JUnitRunner
+import spray.json.JsString
 import whisk.core.entity.EntityPath
 import whisk.core.entity.EntityName
 import whisk.core.entity.WhiskAction
@@ -68,6 +69,13 @@ class WhiskEntityTests extends FlatSpec with ExecHelpers with Matchers {
     val resolved = action.resolve(EntityName(user))
     resolved.exec.asInstanceOf[SequenceExec].components.head shouldBe sequenceAction.copy(path = EntityPath(user))
     action.rev shouldBe resolved.rev
+  }
+
+  it should "define type property" in {
+    val exec = jsDefault("code")
+    val action = WhiskAction(namespace, name, exec, Parameters())
+    val js = action.toDocumentRecord
+    js.fields("type") shouldBe JsString("action")
   }
 
   behavior of "WhiskPackage"


### PR DESCRIPTION
Adds a `type` property derived from entity class name

This PR is first attempt for #3161. See the issue for more details. It adds a `type` property based on entity class

