### PR TITLE
Add type property to entity documents - Take 2

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -88,6 +88,8 @@ abstract class WhiskActionLike(override val name: EntityName) extends WhiskEntit
       parameters.definedParameters
     } else Set.empty[String]
 
+  def entityType = "action"
+
   def toJson =
     JsObject(
       "namespace" -> namespace.toJson,

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -72,7 +72,7 @@ case class WhiskActionPut(exec: Option[Exec] = None,
   }
 }
 
-abstract class WhiskActionLike(override val name: EntityName) extends WhiskEntity(name) {
+abstract class WhiskActionLike(override val name: EntityName) extends WhiskEntity(name, "action") {
   def exec: Exec
   def parameters: Parameters
   def limits: ActionLimits
@@ -87,8 +87,6 @@ abstract class WhiskActionLike(override val name: EntityName) extends WhiskEntit
     if (hasFinalParamsAnnotation) {
       parameters.definedParameters
     } else Set.empty[String]
-
-  def entityType = "action"
 
   def toJson =
     JsObject(

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
@@ -68,14 +68,12 @@ case class WhiskActivation(namespace: EntityPath,
                            publish: Boolean = false,
                            annotations: Parameters = Parameters(),
                            duration: Option[Long] = None)
-    extends WhiskEntity(EntityName(activationId.asString)) {
+    extends WhiskEntity(EntityName(activationId.asString), "activation") {
 
   require(cause != null, "cause undefined")
   require(start != null, "start undefined")
   require(end != null, "end undefined")
   require(response != null, "response undefined")
-
-  def entityType = "activation"
 
   def toJson = WhiskActivation.serdes.write(this).asJsObject
 

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
@@ -75,6 +75,8 @@ case class WhiskActivation(namespace: EntityPath,
   require(end != null, "end undefined")
   require(response != null, "response undefined")
 
+  def entityType = "activation"
+
   def toJson = WhiskActivation.serdes.write(this).asJsObject
 
   /** This the activation summary as computed by the database view. Strictly used for testing. */

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskEntity.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskEntity.scala
@@ -60,11 +60,17 @@ abstract class WhiskEntity protected[entity] (en: EntityName) extends WhiskDocum
   /** The primary key for the entity in the datastore */
   override final def docid = fullyQualifiedName(false).toDocId
 
+  /** Type of entity */
+  def entityType: String
+
   /**
    * Returns a JSON object with the fields specific to this abstract class.
    */
   protected def entityDocumentRecord: JsObject =
-    JsObject("name" -> JsString(name.toString), "updated" -> JsNumber(updated.toEpochMilli()))
+    JsObject(
+      "name" -> JsString(name.toString),
+      "updated" -> JsNumber(updated.toEpochMilli()),
+      "type" -> JsString(entityType))
 
   override def toDocumentRecord: JsObject = {
     val extraFields = entityDocumentRecord.fields

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskEntity.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskEntity.scala
@@ -41,7 +41,7 @@ import whisk.http.Messages
  * @throws IllegalArgumentException if any argument is undefined
  */
 @throws[IllegalArgumentException]
-abstract class WhiskEntity protected[entity] (en: EntityName) extends WhiskDocument {
+abstract class WhiskEntity protected[entity] (en: EntityName, val entityType: String) extends WhiskDocument {
 
   val namespace: EntityPath
   val name = en
@@ -60,9 +60,6 @@ abstract class WhiskEntity protected[entity] (en: EntityName) extends WhiskDocum
   /** The primary key for the entity in the datastore */
   override final def docid = fullyQualifiedName(false).toDocId
 
-  /** Type of entity */
-  def entityType: String
-
   /**
    * Returns a JSON object with the fields specific to this abstract class.
    */
@@ -70,7 +67,7 @@ abstract class WhiskEntity protected[entity] (en: EntityName) extends WhiskDocum
     JsObject(
       "name" -> JsString(name.toString),
       "updated" -> JsNumber(updated.toEpochMilli()),
-      "type" -> JsString(entityType))
+      "entityType" -> JsString(entityType))
 
   override def toDocumentRecord: JsObject = {
     val extraFields = entityDocumentRecord.fields

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
@@ -75,6 +75,8 @@ case class WhiskPackage(namespace: EntityPath,
 
   require(binding != null || (binding map { _ != null } getOrElse true), "binding undefined")
 
+  def entityType = "package"
+
   /**
    * Merges parameters into existing set of parameters for package.
    * Existing parameters supersede those in p.

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
@@ -71,11 +71,9 @@ case class WhiskPackage(namespace: EntityPath,
                         version: SemVer = SemVer(),
                         publish: Boolean = false,
                         annotations: Parameters = Parameters())
-    extends WhiskEntity(name) {
+    extends WhiskEntity(name, "package") {
 
   require(binding != null || (binding map { _ != null } getOrElse true), "binding undefined")
-
-  def entityType = "package"
 
   /**
    * Merges parameters into existing set of parameters for package.

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskRule.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskRule.scala
@@ -76,9 +76,7 @@ case class WhiskRule(namespace: EntityPath,
                      version: SemVer = SemVer(),
                      publish: Boolean = false,
                      annotations: Parameters = Parameters())
-    extends WhiskEntity(name) {
-
-  def entityType = "rule"
+    extends WhiskEntity(name, "rule") {
 
   def withStatus(s: Status) = WhiskRuleResponse(namespace, name, s, trigger, action, version, publish, annotations)
 

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskRule.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskRule.scala
@@ -78,6 +78,8 @@ case class WhiskRule(namespace: EntityPath,
                      annotations: Parameters = Parameters())
     extends WhiskEntity(name) {
 
+  def entityType = "rule"
+
   def withStatus(s: Status) = WhiskRuleResponse(namespace, name, s, trigger, action, version, publish, annotations)
 
   def toJson = WhiskRule.serdes.write(this).asJsObject

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskTrigger.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskTrigger.scala
@@ -67,11 +67,9 @@ case class WhiskTrigger(namespace: EntityPath,
                         publish: Boolean = false,
                         annotations: Parameters = Parameters(),
                         rules: Option[Map[FullyQualifiedEntityName, ReducedRule]] = None)
-    extends WhiskEntity(name) {
+    extends WhiskEntity(name, "trigger") {
 
   require(limits != null, "limits undefined")
-
-  def entityType = "trigger"
 
   def toJson = WhiskTrigger.serdes.write(this).asJsObject
 

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskTrigger.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskTrigger.scala
@@ -71,6 +71,8 @@ case class WhiskTrigger(namespace: EntityPath,
 
   require(limits != null, "limits undefined")
 
+  def entityType = "trigger"
+
   def toJson = WhiskTrigger.serdes.write(this).asJsObject
 
   def withoutRules = copy(rules = None).revision[WhiskTrigger](rev)

--- a/tests/src/test/scala/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ControllerTestCommon.scala
@@ -165,9 +165,7 @@ protected trait ControllerTestCommon
                                  version: SemVer = SemVer(),
                                  publish: Boolean = false,
                                  annotations: Parameters = Parameters())
-      extends WhiskEntity(name) {
-
-    override def entityType = "badEntity"
+      extends WhiskEntity(name, "badEntity") {
 
     override def toJson = BadEntity.serdes.write(this).asJsObject
   }

--- a/tests/src/test/scala/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ControllerTestCommon.scala
@@ -166,6 +166,9 @@ protected trait ControllerTestCommon
                                  publish: Boolean = false,
                                  annotations: Parameters = Parameters())
       extends WhiskEntity(name) {
+
+    override def entityType = "badEntity"
+
     override def toJson = BadEntity.serdes.write(this).asJsObject
   }
 

--- a/tests/src/test/scala/whisk/core/entity/test/MigrationEntities.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/MigrationEntities.scala
@@ -37,9 +37,7 @@ case class OldWhiskRule(namespace: EntityPath,
                         version: SemVer = SemVer(),
                         publish: Boolean = false,
                         annotations: Parameters = Parameters())
-    extends WhiskEntity(name) {
-
-  def entityType = "rule"
+    extends WhiskEntity(name, "rule") {
 
   def toJson = OldWhiskRule.serdes.write(this).asJsObject
 
@@ -74,9 +72,7 @@ case class OldWhiskTrigger(namespace: EntityPath,
                            version: SemVer = SemVer(),
                            publish: Boolean = false,
                            annotations: Parameters = Parameters())
-    extends WhiskEntity(name) {
-
-  def entityType = "trigger"
+    extends WhiskEntity(name, "trigger") {
 
   def toJson = OldWhiskTrigger.serdes.write(this).asJsObject
 

--- a/tests/src/test/scala/whisk/core/entity/test/MigrationEntities.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/MigrationEntities.scala
@@ -39,6 +39,8 @@ case class OldWhiskRule(namespace: EntityPath,
                         annotations: Parameters = Parameters())
     extends WhiskEntity(name) {
 
+  def entityType = "rule"
+
   def toJson = OldWhiskRule.serdes.write(this).asJsObject
 
   def toWhiskRule = {
@@ -73,6 +75,8 @@ case class OldWhiskTrigger(namespace: EntityPath,
                            publish: Boolean = false,
                            annotations: Parameters = Parameters())
     extends WhiskEntity(name) {
+
+  def entityType = "trigger"
 
   def toJson = OldWhiskTrigger.serdes.write(this).asJsObject
 

--- a/tests/src/test/scala/whisk/core/entity/test/WhiskEntityTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/WhiskEntityTests.scala
@@ -141,7 +141,7 @@ class WhiskEntityTests extends FlatSpec with ExecHelpers with Matchers {
 
   behavior of "WhiskEntity"
 
-  it should "define type property" in {
+  it should "define the entityType property in its json representation" in {
     def assertType(d: WhiskEntity, entityType: String) = {
       d.toDocumentRecord.fields("entityType") shouldBe JsString(entityType)
     }

--- a/tests/src/test/scala/whisk/core/entity/test/WhiskEntityTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/WhiskEntityTests.scala
@@ -143,7 +143,7 @@ class WhiskEntityTests extends FlatSpec with ExecHelpers with Matchers {
 
   it should "define type property" in {
     def assertType(d: WhiskEntity, entityType: String) = {
-      d.toDocumentRecord.fields("type") shouldBe JsString(entityType)
+      d.toDocumentRecord.fields("entityType") shouldBe JsString(entityType)
     }
 
     val action = WhiskAction(namespace, name, jsDefault("code"), Parameters())

--- a/tests/src/test/scala/whisk/core/entity/test/WhiskEntityTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/WhiskEntityTests.scala
@@ -33,10 +33,14 @@ import whisk.core.entity.WhiskActivation
 import whisk.core.entity.Subject
 import whisk.core.entity.ActivationId
 import java.time.Instant
+
+import spray.json.JsString
 import whisk.core.entity.ActivationLogs
 import whisk.core.entity.WhiskTrigger
 import whisk.core.entity.ReducedRule
 import whisk.core.entity.Status
+import whisk.core.entity.WhiskEntity
+import whisk.core.entity.WhiskRule
 
 @RunWith(classOf[JUnitRunner])
 class WhiskEntityTests extends FlatSpec with ExecHelpers with Matchers {
@@ -133,5 +137,29 @@ class WhiskEntityTests extends FlatSpec with ExecHelpers with Matchers {
     val rulesRemoved = ruleAdded.withoutRules
     rulesRemoved.rules shouldBe None
     rulesRemoved.rev shouldBe trigger.rev
+  }
+
+  behavior of "WhiskEntity"
+
+  it should "define type property" in {
+    def assertType(d: WhiskEntity, entityType: String) = {
+      d.toDocumentRecord.fields("type") shouldBe JsString(entityType)
+    }
+
+    val action = WhiskAction(namespace, name, jsDefault("code"), Parameters())
+    assertType(action, "action")
+
+    val activation = WhiskActivation(namespace, name, Subject(), ActivationId(), Instant.now(), Instant.now())
+    assertType(activation, "activation")
+
+    val whiskPackage = WhiskPackage(namespace, name)
+    assertType(whiskPackage, "package")
+
+    val rule =
+      WhiskRule(namespace, name, FullyQualifiedEntityName(namespace, name), FullyQualifiedEntityName(namespace, name))
+    assertType(rule, "rule")
+
+    val trigger = WhiskTrigger(namespace, name)
+    assertType(trigger, "trigger")
   }
 }


### PR DESCRIPTION
Adds a `type` property to the document json based on `entityType` method

This PR is second attempt for #3161. See the issue for more details. It adds a type property based onexplicitly defined `entityType` method value
  