### PR TITLE
Avoid repeated throttle check for sequences

### DIFF
--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -395,7 +395,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
     exec match {
       case Some(seq: SequenceExec) =>
         logging.info(this, "checking if sequence components are accessible")
-        entitlementProvider.check(user, right, referencedEntities(seq))
+        entitlementProvider.check(user, right, referencedEntities(seq), noThrottle = true)
       case _ => Future.successful(true)
     }
   }
@@ -405,7 +405,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
     exec match {
       case Some(seq: SequenceExecMetaData) =>
         logging.info(this, "checking if sequence components are accessible")
-        entitlementProvider.check(user, right, referencedEntities(seq))
+        entitlementProvider.check(user, right, referencedEntities(seq), noThrottle = true)
       case _ => Future.successful(true)
     }
   }


### PR DESCRIPTION
Suggested fix for #3176.

The entitlement check for reference entities in sequences (https://github.com/apache/incubator-openwhisk/blob/master/core/controller/src/main/scala/whisk/core/controller/Actions.scala#L382-L401) include checks against throttles (https://github.com/apache/incubator-openwhisk/blob/master/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala#L221-L223) instead of simply checking for read/activate privileges. This result in the sequence being incorrectly accounted for twice (if non-empty).

This patch adds the ability to check privileges without impacting throttles and uses the new option for the checking referenced entities in sequences.

The added flexibility to the `Entitlement` `check` method is also necessary to correctly entitle action compositions in composer (https://github.com/tardieu/composer/tree/hybrid).