### PR TITLE
Fixes to Vagrantfile

### DIFF
--- a/tools/vagrant/Vagrantfile
+++ b/tools/vagrant/Vagrantfile
@@ -33,7 +33,7 @@ Vagrant.configure('2') do |config|
   end
 
   # Shared root of repository; do not use symlinks
-  config.vm.synced_folder '../../', '/home/vagrant/openwhisk'
+  config.vm.synced_folder File.expand_path('..', File.expand_path('..', Dir.pwd)), '/home/vagrant/openwhisk'
 
   # Prevents "stdin: is not a tty" on Ubuntu (https://github.com/mitchellh/vagrant/issues/1673)
   config.vm.provision "fix-no-tty", type: "shell" do |s|

--- a/tools/vagrant/Vagrantfile
+++ b/tools/vagrant/Vagrantfile
@@ -159,7 +159,7 @@ $script_end = <<SCRIPT
   touch $HOME/.wskprops
   chown -R vagrant:vagrant $HOME
   # This allows user to see how to configure the wsk cli outside the VM
-  wsk property set --apihost ${WHISK_IP} --namespace guest --auth `cat ${ANSIBLE_HOME}/files/auth.guest`
+  wsk property set --apihost http://${WHISK_IP}:10001 --namespace guest --auth `cat ${ANSIBLE_HOME}/files/auth.guest`
   wsk action invoke /whisk.system/utils/echo -p message hello --result
   echo "`date`: build-deploy-end" >> /tmp/vagrant-times.txt
 SCRIPT

--- a/tools/vagrant/Vagrantfile
+++ b/tools/vagrant/Vagrantfile
@@ -159,7 +159,7 @@ $script_end = <<SCRIPT
   touch $HOME/.wskprops
   chown -R vagrant:vagrant $HOME
   # This allows user to see how to configure the wsk cli outside the VM
-  wsk property set --apihost http://${WHISK_IP}:10001 --namespace guest --auth `cat ${ANSIBLE_HOME}/files/auth.guest`
+  wsk property set --apihost ${WHISK_IP} --namespace guest --auth `cat ${ANSIBLE_HOME}/files/auth.guest`
   wsk action invoke /whisk.system/utils/echo -p message hello --result
   echo "`date`: build-deploy-end" >> /tmp/vagrant-times.txt
 SCRIPT


### PR DESCRIPTION
The Vagrantfile does not work in Windows because of the hardcoded slashed. I fixed this.
Also the wsk property configuration in the Vagrantfile does not reflect the current setup, so I changes to use http: and 10001.