### PR TITLE
 Support size-in-bytes readings per PureConfig.

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -11,7 +11,7 @@ repositories {
 dependencies {
     compile "org.scala-lang:scala-library:${gradle.scala.version}"
 
-    compile 'com.github.pureconfig:pureconfig_2.11:0.7.2'
+    compile 'com.github.pureconfig:pureconfig_2.11:0.9.0'
     compile 'io.spray:spray-json_2.11:1.3.3'
 
     compile 'com.typesafe.akka:akka-actor_2.11:2.5.6'

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -90,8 +90,8 @@ whisk {
 
     # action memory configuration
     memory {
-        min = "128M"
-        max = "512M"
-        std = "256M"
+        min = 128 m
+        max = 512 m
+        std = 256 m
     }
 }

--- a/common/scala/src/main/scala/whisk/core/entity/MemoryLimit.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/MemoryLimit.scala
@@ -22,15 +22,12 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
-import spray.json.JsNumber
-import spray.json.JsValue
-import spray.json.RootJsonFormat
-import spray.json.deserializationError
-import whisk.core.entity.size.SizeInt
+import spray.json._
+import whisk.core.entity.size._
 import whisk.core.ConfigKeys
 import pureconfig._
 
-case class MemoryLimitConfig(min: String, max: String, std: String)
+case class MemoryLimitConfig(min: ByteSize, max: ByteSize, std: ByteSize)
 
 /**
  * MemoryLimit encapsulates allowed memory for an action. The limit must be within a
@@ -42,14 +39,14 @@ case class MemoryLimitConfig(min: String, max: String, std: String)
  *
  * @param megabytes the memory limit in megabytes for the action
  */
-protected[entity] class MemoryLimit private (val megabytes: Int) extends AnyVal {}
+protected[entity] class MemoryLimit private (val megabytes: Int) extends AnyVal
 
 protected[core] object MemoryLimit extends ArgNormalizer[MemoryLimit] {
   private val memoryConfig = loadConfigOrThrow[MemoryLimitConfig](ConfigKeys.memory)
 
-  protected[core] val minMemory = ByteSize.fromString(memoryConfig.min)
-  protected[core] val maxMemory = ByteSize.fromString(memoryConfig.max)
-  protected[core] val stdMemory = ByteSize.fromString(memoryConfig.std)
+  protected[core] val minMemory: ByteSize = memoryConfig.min
+  protected[core] val maxMemory: ByteSize = memoryConfig.max
+  protected[core] val stdMemory: ByteSize = memoryConfig.std
 
   /** Gets MemoryLimit with default value */
   protected[core] def apply(): MemoryLimit = MemoryLimit(stdMemory)
@@ -65,7 +62,7 @@ protected[core] object MemoryLimit extends ArgNormalizer[MemoryLimit] {
   protected[core] def apply(megabytes: ByteSize): MemoryLimit = {
     require(megabytes >= minMemory, s"memory $megabytes below allowed threshold of $minMemory")
     require(megabytes <= maxMemory, s"memory $megabytes exceeds allowed threshold of $maxMemory")
-    new MemoryLimit(megabytes.toMB.toInt);
+    new MemoryLimit(megabytes.toMB.toInt)
   }
 
   override protected[core] implicit val serdes = new RootJsonFormat[MemoryLimit] {

--- a/common/scala/src/main/scala/whisk/core/entity/Size.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Size.scala
@@ -19,6 +19,9 @@ package whisk.core.entity
 
 import java.nio.charset.StandardCharsets
 
+import com.typesafe.config.ConfigValue
+import pureconfig._
+
 object SizeUnits extends Enumeration {
 
   sealed abstract class Unit() {
@@ -77,8 +80,8 @@ case class ByteSize(size: Long, unit: SizeUnits.Unit) extends Ordered[ByteSize] 
 
 object ByteSize {
   def fromString(sizeString: String): ByteSize = {
-    val unitprefix = sizeString.takeRight(1)
-    val size = sizeString.dropRight(1).toLong
+    val unitprefix = sizeString.takeRight(1).toUpperCase
+    val size = sizeString.dropRight(1).trim.toLong
 
     val unit = unitprefix match {
       case "B" => SizeUnits.BYTE
@@ -112,6 +115,10 @@ object size {
         ByteSize(0, unit)
       }
   }
+
+  // Creation of an intermediary Config object is necessary here, since "getBytes" is only part of that interface.
+  implicit val pureconfigReader =
+    ConfigReader[ConfigValue].map(v => ByteSize(v.atKey("key").getBytes("key"), SizeUnits.BYTE))
 }
 
 trait SizeConversion {


### PR DESCRIPTION
Some additions to @duynguyen's work (Thanks for doing this 🎉 )

TypesafeConfig supports size-in-bytes values (lightbend/config:HOCON.md@master#size-in-bytes-format). Instead of relying on our custom parsing code, this makes `ByteSize` compatible with the format specified by TypesafeConfig.

In addition it adds support for `ByteSize` to be directly deserialized by PureConfig, making for denser, more readable configuration parsing.