### PR TITLE
Rework some tests.

### DIFF
--- a/tests/src/test/scala/common/Wsk.scala
+++ b/tests/src/test/scala/common/Wsk.scala
@@ -684,9 +684,8 @@ class WskActivation() extends RunWskCmd with HasActivation with WaitFor with Bas
       () => {
         val result =
           cli(wp.overrides ++ Seq(noun, "get", activationId, "--auth", wp.authKey), expectedExitCode = DONTCARE_EXIT)
-        if (result.exitCode == NOT_FOUND) {
-          null
-        } else if (result.exitCode == SUCCESS_EXIT) {
+        result.exitCode shouldNot be(NOT_FOUND)
+        if (result.exitCode == SUCCESS_EXIT) {
           Right(result.stdout)
         } else Left(s"$result")
       },

--- a/tests/src/test/scala/whisk/core/database/test/CleanUpActivationsTest.scala
+++ b/tests/src/test/scala/whisk/core/database/test/CleanUpActivationsTest.scala
@@ -20,25 +20,17 @@ package whisk.core.database.test
 import java.io.File
 import java.time.Instant
 
-import scala.concurrent.duration.DurationInt
-import scala.concurrent.duration.FiniteDuration
-import scala.language.implicitConversions
-
+import akka.http.scaladsl.model.StatusCodes
+import common._
 import org.junit.runner.RunWith
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
+import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.junit.JUnitRunner
-
-import akka.http.scaladsl.model.StatusCodes
-import common.StreamLogging
-import common.TestUtils
-import common.WaitFor
-import common.WhiskProperties
-import common.WskActorSystem
 import spray.json.DefaultJsonProtocol._
-import spray.json.JsObject
-import spray.json.pimpAny
+import spray.json._
+
+import scala.concurrent.duration._
+import scala.language.implicitConversions
 
 @RunWith(classOf[JUnitRunner])
 class CleanUpActivationsTest
@@ -46,7 +38,6 @@ class CleanUpActivationsTest
     with Matchers
     with ScalaFutures
     with WskActorSystem
-    with WaitFor
     with StreamLogging
     with DatabaseScriptTestUtils {
 


### PR DESCRIPTION
This PR reworks some of our tests.

The biggest change is at the method `waitfor`. It will no longer handle `false` as unsuccessful. Instead, the action will be executed again, if an exception is thrown.
With this change, it behaves like `retry`.

PG5#25 is running.