### PR TITLE
use /var/tmp on Ubuntu to prevent configuration files changing owner when rebooting

### DIFF
--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -1,6 +1,6 @@
 whisk_version_name: local
-config_root_dir: /tmp/wskconf
-whisk_logs_dir: /tmp/wsklogs
+config_root_dir: "{{ '/var/tmp' if ansible_distribution == 'Ubuntu' else '/tmp' }}/wskconf"
+whisk_logs_dir: "{{ '/var/tmp' if ansible_distribution == 'Ubuntu' else '/tmp' }}/wsklogs"
 docker_registry: ""
 docker_dns: ""
 bypass_pull_for_local_images: true


### PR DESCRIPTION
I think I figure out what goes wrong when you reboot the Vagrant machine.
Files in /tmp change owner, probably because of some startup initialization in Ubuntu.
Since it does not happen using for example /var/tmp my patch is simply to change directory for those files. However since it can break Mac deployment I added a test to do it only for Ubunt. 
With this patch you can do vagrant reload safely or not worry about shutting down the vm.
It may also close #32