### PR TITLE
No automatic topic creation in Kafka

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -96,7 +96,6 @@ kafka:
     port: 8093
   heap: "{{ kafka_heap | default('1g') }}"
   replicationFactor: "{{ kafka_replicationFactor | default((groups['kafkas']|length)|int) }}"
-  autoCreateTopics: "{{ kafka_autoCreateTopics | default('false') }}"
 
 kafka_connect_string: "{% set ret = [] %}\
                        {% for host in groups['kafkas'] %}\

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -96,6 +96,7 @@ kafka:
     port: 8093
   heap: "{{ kafka_heap | default('1g') }}"
   replicationFactor: "{{ kafka_replicationFactor | default((groups['kafkas']|length)|int) }}"
+  autoCreateTopics: "{{ kafka_autoCreateTopics | default('false') }}"
 
 kafka_connect_string: "{% set ret = [] %}\
                        {% for host in groups['kafkas'] %}\

--- a/ansible/roles/kafka/tasks/deploy.yml
+++ b/ansible/roles/kafka/tasks/deploy.yml
@@ -23,7 +23,7 @@
       "KAFKA_HEAP_OPTS": "-Xmx{{ kafka.heap }} -Xms{{ kafka.heap }}"
       "KAFKA_ZOOKEEPER_CONNECT": "{{ zookeeper_connect_string }}"
       "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR": "{{ kafka.replicationFactor }}"
-      "KAFKA_AUTO_CREATE_TOPICS_ENABLE": "{{ kafka.autoCreateTopics }}"
+      "KAFKA_AUTO_CREATE_TOPICS_ENABLE": "false"
     ports:
       - "{{ kafka.port + groups['kafkas'].index(inventory_hostname) }}:9092"
 

--- a/ansible/roles/kafka/tasks/deploy.yml
+++ b/ansible/roles/kafka/tasks/deploy.yml
@@ -23,6 +23,7 @@
       "KAFKA_HEAP_OPTS": "-Xmx{{ kafka.heap }} -Xms{{ kafka.heap }}"
       "KAFKA_ZOOKEEPER_CONNECT": "{{ zookeeper_connect_string }}"
       "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR": "{{ kafka.replicationFactor }}"
+      "KAFKA_AUTO_CREATE_TOPICS_ENABLE": "{{ kafka.autoCreateTopics }}"
     ports:
       - "{{ kafka.port + groups['kafkas'].index(inventory_hostname) }}:9092"
 

--- a/tests/src/test/resources/application.conf
+++ b/tests/src/test/resources/application.conf
@@ -8,3 +8,17 @@ whisk.spi {
 akka.http.client.idle-timeout = 90 s
 akka.http.host-connection-pool.idle-timeout = 90 s
 akka.http.host-connection-pool.client.idle-timeout = 90 s
+
+whisk {
+    # kafka related configuration
+    kafka {
+        replication-factor = 1
+        topics {
+            KafkaConnectorTestTopic {
+                segment-bytes   =  536870912
+                retention-bytes = 1073741824
+                retention-ms    = 3600000
+            }
+        }
+    }
+}

--- a/tests/src/test/scala/services/KafkaConnectorTests.scala
+++ b/tests/src/test/scala/services/KafkaConnectorTests.scala
@@ -50,7 +50,7 @@ class KafkaConnectorTests extends FlatSpec with Matchers with WskActorSystem wit
 
   val groupid = "kafkatest"
   val topic = "KafkaConnectorTestTopic"
-  assert(KafkaMessagingProvider.ensureTopic(config, topic, topic))
+  assert(KafkaMessagingProvider.ensureTopic(config, topic, topic), s"Creation of topic ${topic} failed")
   val sessionTimeout = 10 seconds
   val maxPollInterval = 10 seconds
   val producer = new KafkaProducerConnector(config.kafkaHosts, ec)

--- a/tests/src/test/scala/services/KafkaConnectorTests.scala
+++ b/tests/src/test/scala/services/KafkaConnectorTests.scala
@@ -140,7 +140,7 @@ class KafkaConnectorTests extends FlatSpec with Matchers with WskActorSystem wit
         val prevCount = startLog.r.findAllMatchIn(commandComponent(kafkaHost, "logs", s"kafka$i").stdout).length
 
         commandComponent(kafkaHost, "stop", s"kafka$i")
-        var received = sendAndReceiveMessage(message, 30 seconds, 30 seconds)
+        var received = sendAndReceiveMessage(message, 60 seconds, 60 seconds)
         received.size should be(1)
         consumer.commit()
 
@@ -151,7 +151,7 @@ class KafkaConnectorTests extends FlatSpec with Matchers with WskActorSystem wit
             .length shouldBe prevCount + 1
         }, 20, Some(1.second)) // wait until kafka is up
 
-        received = sendAndReceiveMessage(message, 30 seconds, 30 seconds)
+        received = sendAndReceiveMessage(message, 60 seconds, 60 seconds)
         received.size should be(1)
         consumer.commit()
       }

--- a/tests/src/test/scala/services/KafkaConnectorTests.scala
+++ b/tests/src/test/scala/services/KafkaConnectorTests.scala
@@ -148,8 +148,7 @@ class KafkaConnectorTests extends FlatSpec with Matchers with WskActorSystem wit
         val prevCount = startLog.r.findAllMatchIn(commandComponent(kafkaHost, "logs", s"kafka$i").stdout).length
 
         commandComponent(kafkaHost, "stop", s"kafka$i")
-        var received = sendAndReceiveMessage(message, 60 seconds, 60 seconds)
-        received.size should be(1)
+        sendAndReceiveMessage(message, 30 seconds, 30 seconds) should have size (1)
         consumer.commit()
 
         commandComponent(kafkaHost, "start", s"kafka$i")
@@ -159,8 +158,7 @@ class KafkaConnectorTests extends FlatSpec with Matchers with WskActorSystem wit
             .length shouldBe prevCount + 1
         }, 20, Some(1.second)) // wait until kafka is up
 
-        received = sendAndReceiveMessage(message, 60 seconds, 60 seconds)
-        received.size should be(1)
+        sendAndReceiveMessage(message, 30 seconds, 30 seconds) should have size (1)
         consumer.commit()
       }
     }

--- a/tests/src/test/scala/services/KafkaConnectorTests.scala
+++ b/tests/src/test/scala/services/KafkaConnectorTests.scala
@@ -34,6 +34,7 @@ import common.{StreamLogging, TestUtils, WhiskProperties, WskActorSystem}
 import whisk.common.TransactionId
 import whisk.connector.kafka.KafkaConsumerConnector
 import whisk.connector.kafka.KafkaProducerConnector
+import whisk.connector.kafka.KafkaMessagingProvider
 import whisk.core.WhiskConfig
 import whisk.core.connector.Message
 import whisk.utils.ExecutionContextFactory
@@ -48,7 +49,8 @@ class KafkaConnectorTests extends FlatSpec with Matchers with WskActorSystem wit
   assert(config.isValid)
 
   val groupid = "kafkatest"
-  val topic = "Dinosaurs"
+  val topic = "KafkaConnectorTestTopic"
+  assert(KafkaMessagingProvider.ensureTopic(config, topic, topic))
   val sessionTimeout = 10 seconds
   val maxPollInterval = 10 seconds
   val producer = new KafkaProducerConnector(config.kafkaHosts, ec)


### PR DESCRIPTION
So far, we had automatic topic creation - the broker would automatically create a topic if a producer sent a message to a topic or a consumer tried to receive messages from a topic. In that case, topic would be created automatically with default settings. These default settings are not always what we need. In the end, this is a race condition during deployment. If we manage to create a topic with desired settings before it gets auto-created with default settings, we are fine. Otherwise, we may see undesired effects.

This change disables automatic topic creation.