### PR TITLE
Make payload limit configurable.

### DIFF
--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -122,6 +122,8 @@
       "CONFIG_whisk_memory_max": "{{ limit_action_memory_max | default() }}"
       "CONFIG_whisk_memory_std": "{{ limit_action_memory_std | default() }}"
 
+      "CONFIG_whisk_activation_payload_max": "{{ limit_activation_payload | default() }}"
+
       "RUNTIMES_MANIFEST": "{{ runtimesManifest | to_json }}"
       "CONTROLLER_LOCALBOOKKEEPING": "{{ controller.localBookkeeping }}"
       "AKKA_CLUSTER_SEED_NODES": "{{seed_nodes_list | join(' ') }}"

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -187,6 +187,7 @@
         -e CONFIG_whisk_memory_min='{{ limit_action_memory_min | default() }}'
         -e CONFIG_whisk_memory_max='{{ limit_action_memory_max | default() }}'
         -e CONFIG_whisk_memory_std='{{ limit_action_memory_std | default() }}'
+        -e CONFIG_whisk_activation_payload_max='{{ limit_activation_payload | default() }}'
         -v /sys/fs/cgroup:/sys/fs/cgroup
         -v /run/runc:/run/runc
         -v {{ whisk_logs_dir }}/invoker{{ groups['invokers'].index(inventory_hostname) }}:/logs

--- a/ansible/roles/kafka/tasks/deploy.yml
+++ b/ansible/roles/kafka/tasks/deploy.yml
@@ -23,6 +23,7 @@
       "KAFKA_HEAP_OPTS": "-Xmx{{ kafka.heap }} -Xms{{ kafka.heap }}"
       "KAFKA_ZOOKEEPER_CONNECT": "{{ zookeeper_connect_string }}"
       "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR": "{{ kafka.replicationFactor }}"
+      "KAFKA_AUTO_CREATE_TOPICS_ENABLE": "false"
     ports:
       - "{{ kafka.port + groups['kafkas'].index(inventory_hostname) }}:9092"
 

--- a/ansible/roles/kafka/tasks/deploy.yml
+++ b/ansible/roles/kafka/tasks/deploy.yml
@@ -23,7 +23,6 @@
       "KAFKA_HEAP_OPTS": "-Xmx{{ kafka.heap }} -Xms{{ kafka.heap }}"
       "KAFKA_ZOOKEEPER_CONNECT": "{{ zookeeper_connect_string }}"
       "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR": "{{ kafka.replicationFactor }}"
-      "KAFKA_AUTO_CREATE_TOPICS_ENABLE": "false"
     ports:
       - "{{ kafka.port + groups['kafkas'].index(inventory_hostname) }}:9092"
 

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -53,6 +53,12 @@ whisk {
     # kafka related configuration
     kafka {
         replication-factor = 1
+
+        producer {
+            acks = 1
+            max-request-size = ${whisk.activation.payload.max}
+        }
+
         topics {
             cache-invalidation {
                 segment-bytes   =  536870912

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -70,9 +70,10 @@ whisk {
                 retention-ms    = 3600000
             }
             invoker {
-                segment-bytes   =  536870912
-                retention-bytes = 1073741824
-                retention-ms    = 172800000
+                segment-bytes     =  536870912
+                retention-bytes   = 1073741824
+                retention-ms      =  172800000
+                max-message-bytes = ${whisk.activation.payload.max}
             }
         }
     }
@@ -86,6 +87,12 @@ whisk {
     transactions {
         stride = 1
         stride = ${?CONTROLLER_INSTANCES}
+    }
+
+    activation {
+        payload {
+            max = 5242880 // 5 m not possible because cross-referenced to kafka configurations
+        }
     }
 
     # action memory configuration

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -97,7 +97,7 @@ whisk {
 
     activation {
         payload {
-            max = 5242880 // 5 m not possible because cross-referenced to kafka configurations
+            max = 1048576 // 5 m not possible because cross-referenced to kafka configurations
         }
     }
 

--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaMessagingProvider.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaMessagingProvider.scala
@@ -40,15 +40,6 @@ import pureconfig._
 
 case class KafkaConfig(replicationFactor: Short)
 
-case class TopicConfig(segmentBytes: Long, retentionBytes: Long, retentionMs: Long) {
-  def toMap: Map[String, String] = {
-    Map(
-      "retention.bytes" -> retentionBytes.toString,
-      "retention.ms" -> retentionMs.toString,
-      "segment.bytes" -> segmentBytes.toString)
-  }
-}
-
 /**
  * A Kafka based implementation of MessagingProvider
  */
@@ -62,12 +53,15 @@ object KafkaMessagingProvider extends MessagingProvider {
 
   def ensureTopic(config: WhiskConfig, topic: String, topicConfig: String)(implicit logging: Logging): Boolean = {
     val kc = loadConfigOrThrow[KafkaConfig](ConfigKeys.kafka)
-    val tc = loadConfigOrThrow[TopicConfig](ConfigKeys.kafkaTopics + s".$topicConfig")
+    val tc = loadConfigOrThrow[Map[String, String]](ConfigKeys.kafkaTopics + s".$topicConfig").map {
+      // Per convention, kebab-cased keys are transformed to dot.seperated keys as used by Kafka
+      case (key, value) => key.replace("-", ".") -> value
+    }
     val props = new Properties
     props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, config.kafkaHosts)
     val client = AdminClient.create(props)
     val numPartitions = 1
-    val nt = new NewTopic(topic, numPartitions, kc.replicationFactor).configs(tc.toMap.asJava)
+    val nt = new NewTopic(topic, numPartitions, kc.replicationFactor).configs(tc.asJava)
     val results = client.createTopics(List(nt).asJava)
     try {
       results.values().get(topic).get()

--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaProducerConnector.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaProducerConnector.scala
@@ -87,6 +87,9 @@ class KafkaProducerConnector(kafkahosts: String,
     val props = new Properties
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkahosts)
     props.put(ProducerConfig.ACKS_CONFIG, 1.toString)
+    // Allow messages with up to 5 MiB size
+    // The target topic must support this message size as well because it's larger as the default
+    props.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, 5242880.toString)
     props
   }
 

--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaProducerConnector.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaProducerConnector.scala
@@ -36,6 +36,8 @@ import whisk.common.Logging
 import whisk.core.connector.Message
 import whisk.core.connector.MessageProducer
 import whisk.core.entity.UUIDs
+import pureconfig._
+import whisk.core.ConfigKeys
 
 class KafkaProducerConnector(kafkahosts: String,
                              implicit val executionContext: ExecutionContext,
@@ -86,10 +88,11 @@ class KafkaProducerConnector(kafkahosts: String,
   private def getProps: Properties = {
     val props = new Properties
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkahosts)
-    props.put(ProducerConfig.ACKS_CONFIG, 1.toString)
-    // Allow messages with up to 5 MiB size
-    // The target topic must support this message size as well because it's larger as the default
-    props.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, 5242880.toString)
+
+    // Load additional config from the config files and add them here.
+    val config =
+      KafkaConfiguration.configMapToKafkaConfig(loadConfigOrThrow[Map[String, String]](ConfigKeys.kafkaProducer))
+    config.foreach { case (key, value) => props.put(key, value) }
     props
   }
 

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -236,6 +236,8 @@ object ConfigKeys {
   val kafkaTopics = s"$kafka.topics"
 
   val memory = "whisk.memory"
+  val activation = "whisk.activation"
+  val activationPayload = s"$activation.payload"
 
   val db = "whisk.db"
 

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -233,6 +233,7 @@ object ConfigKeys {
   val loadbalancer = "whisk.loadbalancer"
 
   val kafka = "whisk.kafka"
+  val kafkaProducer = s"$kafka.producer"
   val kafkaTopics = s"$kafka.topics"
 
   val memory = "whisk.memory"

--- a/common/scala/src/main/scala/whisk/core/entity/ActivationEntityLimit.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ActivationEntityLimit.scala
@@ -17,7 +17,11 @@
 
 package whisk.core.entity
 
-import whisk.core.entity.size.SizeInt
+import pureconfig._
+import whisk.core.ConfigKeys
+import whisk.core.entity.size.SizeLong
+
+case class ActivationEntityLimitConf(max: ByteSize)
 
 /**
  * ActivationEntityLimit defines the limits on the input/output payloads for actions
@@ -25,5 +29,8 @@ import whisk.core.entity.size.SizeInt
  * parameters for triggers.
  */
 protected[core] object ActivationEntityLimit {
-  protected[core] val MAX_ACTIVATION_ENTITY_LIMIT = 1.MB
+  private implicit val pureconfigLongReader: ConfigReader[ByteSize] = ConfigReader[Long].map(_.bytes)
+  private val config = loadConfigOrThrow[ActivationEntityLimitConf](ConfigKeys.activationPayload)
+
+  protected[core] val MAX_ACTIVATION_ENTITY_LIMIT: ByteSize = config.max
 }

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
@@ -31,7 +31,7 @@ import whisk.common.Logging
 import whisk.common.TransactionId
 import whisk.core.containerpool._
 import whisk.core.entity.ActivationResponse.{ConnectionError, MemoryExhausted}
-import whisk.core.entity.ByteSize
+import whisk.core.entity.{ActivationEntityLimit, ByteSize}
 import whisk.core.entity.size._
 import akka.stream.scaladsl.{Framing, Source}
 import akka.stream.stage._
@@ -189,7 +189,7 @@ class DockerContainer(protected val id: ContainerId,
     implicit transid: TransactionId): Future[RunResult] = {
     val started = Instant.now()
     val http = httpConnection.getOrElse {
-      val conn = new HttpUtils(s"${addr.host}:${addr.port}", timeout, 1.MB)
+      val conn = new HttpUtils(s"${addr.host}:${addr.port}", timeout, ActivationEntityLimit.MAX_ACTIVATION_ENTITY_LIMIT)
       httpConnection = Some(conn)
       conn
     }

--- a/tests/src/test/scala/whisk/core/limits/ActionLimitsTests.scala
+++ b/tests/src/test/scala/whisk/core/limits/ActionLimitsTests.scala
@@ -118,6 +118,28 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers {
       }
   }
 
+  it should s"successfully invoke an action with a payload close to the limit" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val name = "TestActionCausingJustInBoundaryResult"
+      assetHelper.withCleaner(wsk.action, name) {
+        val actionName = TestUtils.getTestActionFilename("echo.js")
+        (action, _) =>
+          action.create(name, Some(actionName), timeout = Some(15.seconds))
+      }
+
+      val allowedSize = ActivationEntityLimit.MAX_ACTIVATION_ENTITY_LIMIT.toBytes
+
+      // Needs some bytes grace since activation message is not only the payload.
+      val args = Map("p" -> ("a" * (allowedSize - 700).toInt).toJson)
+      val rr = wsk.action.invoke(name, args, blocking = true, expectedExitCode = 0)
+      val activation = wsk.parseJsonString(rr.respData).convertTo[ActivationResult]
+
+      activation.response.success shouldBe true
+
+      // The payload is echoed and thus the backchannel supports the limit as well.
+      activation.response.result shouldBe Some(args.toJson)
+  }
+
   Seq(true, false).foreach { blocking =>
     it should s"succeed but truncate result, if result exceeds its limit (blocking: $blocking)" in withAssetCleaner(
       wskprops) { (wp, assetHelper) =>


### PR DESCRIPTION
The maximum payload allowed to flow through the system is hardcoded today. Several pieces (kafka for instance) need to be adjusted to allow a larger payload.

**Note:** After travis passes happily, the default can be reset to 1 MB to not change anything here.