### PR TITLE
Removing unused param

### DIFF
--- a/ansible/tasks/installOpenwhiskCatalog.yml
+++ b/ansible/tasks/installOpenwhiskCatalog.yml
@@ -18,7 +18,6 @@
 
 - set_fact:
     skip_catalog_install="{{ item.value.skip | default(false) }}"
-    optional_package_skip="{{ item.value.optional_package_skip | default(true) }}"
 
 - set_fact:
     environment_catalog:


### PR DESCRIPTION
This parameter was originally used to optionally skip a package when there are two provided. We refactored this recently to instead use a better (more generic) solution of passing in environment variables for a catalog, which could be used for anything. PR #3144. This additional parameter can now be removed -- it's not set anywhere other than as a default value here, nor is it used anywhere.