### PR TITLE
adding namePrefix config to ContainerArgsConfig

### DIFF
--- a/common/scala/src/main/scala/whisk/core/containerpool/ContainerFactory.scala
+++ b/common/scala/src/main/scala/whisk/core/containerpool/ContainerFactory.scala
@@ -29,8 +29,7 @@ import whisk.spi.Spi
 
 case class ContainerArgsConfig(network: String,
                                dnsServers: Seq[String] = Seq(),
-                               extraArgs: Map[String, Set[String]] = Map(),
-                               namePrefix: String)
+                               extraArgs: Map[String, Set[String]] = Map())
 
 /**
  * An abstraction for Container creation
@@ -49,6 +48,15 @@ trait ContainerFactory {
 
   /** cleanup any remaining Containers; should block until complete; should ONLY be run at startup/shutdown */
   def cleanup(): Unit
+}
+
+object ContainerFactory {
+
+  /** include the instance name, if specified and strip invalid chars before attempting to use them in the container name */
+  def containerNamePrefix(instanceId: InstanceId): String =
+    s"wsk${instanceId.name.getOrElse("")}${instanceId.toInt}"
+      .replaceAll("[^a-zA-Z0-9_\\.\\-]", "") // based on https://github.com/moby/moby/issues/3138 and https://github.com/moby/moby/blob/master/daemon/names/names.go
+
 }
 
 /**

--- a/common/scala/src/main/scala/whisk/core/containerpool/ContainerFactory.scala
+++ b/common/scala/src/main/scala/whisk/core/containerpool/ContainerFactory.scala
@@ -29,7 +29,8 @@ import whisk.spi.Spi
 
 case class ContainerArgsConfig(network: String,
                                dnsServers: Seq[String] = Seq(),
-                               extraArgs: Map[String, Set[String]] = Map())
+                               extraArgs: Map[String, Set[String]] = Map(),
+                               namePrefix: String)
 
 /**
  * An abstraction for Container creation

--- a/common/scala/src/main/scala/whisk/core/entity/InstanceId.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/InstanceId.scala
@@ -19,10 +19,10 @@ package whisk.core.entity
 
 import spray.json.DefaultJsonProtocol
 
-case class InstanceId(val instance: Int) {
+case class InstanceId(val instance: Int, name: Option[String] = None) {
   def toInt: Int = instance
 }
 
 object InstanceId extends DefaultJsonProtocol {
-  implicit val serdes = jsonFormat1(InstanceId.apply)
+  implicit val serdes = jsonFormat2(InstanceId.apply)
 }

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -24,8 +24,7 @@ whisk {
   container-factory.container-args {
     network: bridge
     dns-servers: []
-    extra-args: {},
-    name-prefix: "wsk" #prefix for action container names created by invoker (name will also include the instanceid etc)
+    extra-args: {}
 
   }
 }

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -24,7 +24,8 @@ whisk {
   container-factory.container-args {
     network: bridge
     dns-servers: []
-    extra-args: {}
+    extra-args: {},
+    name-prefix: "wsk" #prefix for action container names created by invoker (name will also include the instanceid etc)
 
   }
 }

--- a/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
@@ -18,7 +18,6 @@
 package whisk.core.containerpool
 
 import java.time.Instant
-
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Success
@@ -28,9 +27,11 @@ import akka.actor.Props
 import akka.actor.Stash
 import akka.actor.Status.{Failure => FailureMessage}
 import akka.pattern.pipe
+import pureconfig._
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import whisk.common.{AkkaLogging, Counter, LoggingMarkers, TransactionId}
+import whisk.core.ConfigKeys
 import whisk.core.connector.ActivationMessage
 import whisk.core.containerpool.logging.LogCollectingException
 import whisk.core.entity._
@@ -97,7 +98,8 @@ class ContainerProxy(
   collectLogs: (TransactionId, Identity, WhiskActivation, Container, ExecutableWhiskAction) => Future[ActivationLogs],
   instance: InstanceId,
   unusedTimeout: FiniteDuration,
-  pauseGrace: FiniteDuration)
+  pauseGrace: FiniteDuration,
+  containerArgsConfig: ContainerArgsConfig)
     extends FSM[ContainerState, ContainerData]
     with Stash {
   implicit val ec = context.system.dispatcher
@@ -111,7 +113,7 @@ class ContainerProxy(
     case Event(job: Start, _) =>
       factory(
         TransactionId.invokerWarmup,
-        ContainerProxy.containerName(instance, "prewarm", job.exec.kind),
+        ContainerProxy.containerName(instance, "prewarm", job.exec.kind, containerArgsConfig),
         job.exec.image,
         job.exec.pull,
         job.memoryLimit)
@@ -127,7 +129,7 @@ class ContainerProxy(
       // create a new container
       val container = factory(
         job.msg.transid,
-        ContainerProxy.containerName(instance, job.msg.user.namespace.name, job.action.name.name),
+        ContainerProxy.containerName(instance, job.msg.user.namespace.name, job.action.name.name, containerArgsConfig),
         job.action.exec.image,
         job.action.exec.pull,
         job.action.limits.memory.megabytes.MB)
@@ -414,8 +416,10 @@ object ContainerProxy {
     collectLogs: (TransactionId, Identity, WhiskActivation, Container, ExecutableWhiskAction) => Future[ActivationLogs],
     instance: InstanceId,
     unusedTimeout: FiniteDuration = 10.minutes,
-    pauseGrace: FiniteDuration = 50.milliseconds) =
-    Props(new ContainerProxy(factory, ack, store, collectLogs, instance, unusedTimeout, pauseGrace))
+    pauseGrace: FiniteDuration = 50.milliseconds,
+    containerArgsConfig: ContainerArgsConfig = loadConfigOrThrow[ContainerArgsConfig](ConfigKeys.containerArgs)) =
+    Props(
+      new ContainerProxy(factory, ack, store, collectLogs, instance, unusedTimeout, pauseGrace, containerArgsConfig))
 
   // Needs to be thread-safe as it's used by multiple proxies concurrently.
   private val containerCount = new Counter
@@ -427,8 +431,9 @@ object ContainerProxy {
    * @param suffix the container name's suffix
    * @return a unique container name
    */
-  def containerName(instance: InstanceId, prefix: String, suffix: String) =
-    s"wsk${instance.toInt}_${containerCount.next()}_${prefix}_${suffix}".replaceAll("[^a-zA-Z0-9_]", "")
+  def containerName(instance: InstanceId, prefix: String, suffix: String, containerArgsConfig: ContainerArgsConfig) =
+    s"${containerArgsConfig.namePrefix}${instance.toInt}_${containerCount.next()}_${prefix}_${suffix}"
+      .replaceAll("[^a-zA-Z0-9_]", "")
 
   /**
    * Creates a WhiskActivation ready to be sent via active ack.

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainerFactory.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainerFactory.scala
@@ -107,7 +107,7 @@ class DockerContainerFactory(config: WhiskConfig,
   private def removeAllActionContainers(): Unit = {
     implicit val transid = TransactionId.invoker
     val cleaning =
-      docker.ps(filters = Seq("name" -> s"${containerArgs.namePrefix}${instance.toInt}_"), all = true).flatMap {
+      docker.ps(filters = Seq("name" -> s"${ContainerFactory.containerNamePrefix(instance)}_"), all = true).flatMap {
         containers =>
           logging.info(this, s"removing ${containers.size} action containers.")
           val removals = containers.map { id =>

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainerFactory.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainerFactory.scala
@@ -106,24 +106,26 @@ class DockerContainerFactory(config: WhiskConfig,
   @throws(classOf[InterruptedException])
   private def removeAllActionContainers(): Unit = {
     implicit val transid = TransactionId.invoker
-    val cleaning = docker.ps(filters = Seq("name" -> s"wsk${instance.toInt}_"), all = true).flatMap { containers =>
-      logging.info(this, s"removing ${containers.size} action containers.")
-      val removals = containers.map { id =>
-        (if (config.invokerUseRunc) {
-           runc.resume(id)
-         } else {
-           docker.unpause(id)
-         })
-          .recoverWith {
-            // Ignore resume failures and try to remove anyway
-            case _ => Future.successful(())
+    val cleaning =
+      docker.ps(filters = Seq("name" -> s"${containerArgs.namePrefix}${instance.toInt}_"), all = true).flatMap {
+        containers =>
+          logging.info(this, s"removing ${containers.size} action containers.")
+          val removals = containers.map { id =>
+            (if (config.invokerUseRunc) {
+               runc.resume(id)
+             } else {
+               docker.unpause(id)
+             })
+              .recoverWith {
+                // Ignore resume failures and try to remove anyway
+                case _ => Future.successful(())
+              }
+              .flatMap { _ =>
+                docker.rm(id)
+              }
           }
-          .flatMap { _ =>
-            docker.rm(id)
-          }
+          Future.sequence(removals)
       }
-      Future.sequence(removals)
-    }
     Await.ready(cleaning, 30.seconds)
   }
 }

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -120,7 +120,7 @@ object Invoker {
     }
     val cmdLineArgs = parse(args.toList, CmdLineArgs())
     logger.info(this, "Command line arguments parsed to yield " + cmdLineArgs)
-
+    val invokerName = cmdLineArgs.name.orElse(Option(config.invokerName))
     val assignedInvokerId = cmdLineArgs.id
       .map { id =>
         logger.info(this, s"invokerReg: using proposedInvokerId ${id}")
@@ -130,8 +130,7 @@ object Invoker {
         if (config.zookeeperHosts.startsWith(":") || config.zookeeperHosts.endsWith(":")) {
           abort(s"Must provide valid zookeeper host and port to use dynamicId assignment (${config.zookeeperHosts})")
         }
-        val invokerName = cmdLineArgs.name.getOrElse(config.invokerName)
-        if (invokerName.trim.isEmpty) {
+        if (invokerName.isEmpty || invokerName.get.trim.isEmpty) {
           abort("Invoker name can't be empty to use dynamicId assignment.")
         }
 
@@ -177,7 +176,7 @@ object Invoker {
         assignedId
       }
 
-    val invokerInstance = InstanceId(assignedInvokerId)
+    val invokerInstance = InstanceId(assignedInvokerId, invokerName)
     val msgProvider = SpiLoader.get[MessagingProvider]
     if (!msgProvider.ensureTopic(config, topic = "invoker" + assignedInvokerId, topicConfig = "invoker")) {
       abort(s"failure during msgProvider.ensureTopic for topic invoker$assignedInvokerId")

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -120,7 +120,7 @@ object Invoker {
     }
     val cmdLineArgs = parse(args.toList, CmdLineArgs())
     logger.info(this, "Command line arguments parsed to yield " + cmdLineArgs)
-    val invokerName = cmdLineArgs.name.orElse(Option(config.invokerName))
+    val invokerName = cmdLineArgs.name.orElse(if (config.invokerName.trim.isEmpty) None else Some(config.invokerName))
     val assignedInvokerId = cmdLineArgs.id
       .map { id =>
         logger.info(this, s"invokerReg: using proposedInvokerId ${id}")

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
@@ -185,17 +185,24 @@ class ContainerProxyTests
     val container = new TestContainer
     val factory = createFactory(Future.successful(container))
     val store = createStore
-
+    val containerArgsConfig = ContainerArgsConfig("net1", Seq("dns1"), Map("env" -> Set("e1", "e2")), "testprefix")
     val machine =
       childActorOf(
-        ContainerProxy.props(factory, createAcker, store, createCollector(), InstanceId(0), pauseGrace = timeout))
+        ContainerProxy.props(
+          factory,
+          createAcker,
+          store,
+          createCollector(),
+          InstanceId(0),
+          pauseGrace = timeout,
+          containerArgsConfig = containerArgsConfig))
     registerCallback(machine)
     preWarm(machine)
 
     factory.calls should have size 1
     val (tid, name, _, _, memory) = factory.calls(0)
     tid shouldBe TransactionId.invokerWarmup
-    name should fullyMatch regex """wsk\d+_\d+_prewarm_actionKind"""
+    name should fullyMatch regex """testprefix\d+_\d+_prewarm_actionKind"""
     memory shouldBe memoryLimit
   }
 

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
@@ -185,24 +185,17 @@ class ContainerProxyTests
     val container = new TestContainer
     val factory = createFactory(Future.successful(container))
     val store = createStore
-    val containerArgsConfig = ContainerArgsConfig("net1", Seq("dns1"), Map("env" -> Set("e1", "e2")), "testprefix")
     val machine =
       childActorOf(
-        ContainerProxy.props(
-          factory,
-          createAcker,
-          store,
-          createCollector(),
-          InstanceId(0),
-          pauseGrace = timeout,
-          containerArgsConfig = containerArgsConfig))
+        ContainerProxy
+          .props(factory, createAcker, store, createCollector(), InstanceId(0, Some("myname")), pauseGrace = timeout))
     registerCallback(machine)
     preWarm(machine)
 
     factory.calls should have size 1
     val (tid, name, _, _, memory) = factory.calls(0)
     tid shouldBe TransactionId.invokerWarmup
-    name should fullyMatch regex """testprefix\d+_\d+_prewarm_actionKind"""
+    name should fullyMatch regex """wskmyname\d+_\d+_prewarm_actionKind"""
     memory shouldBe memoryLimit
   }
 


### PR DESCRIPTION
This is to enable a deployment case where we briefly want to allow an invoker to run local to another running invoker; To enable this, the "cleanup" should not kill the action containers created by the previously existing invoker. As long as each invoker has a different prefix, they won't destroy each other's containers at startup.