### PR TITLE
Use case class instead of self-rolled class for InvokerHealth

### DIFF
--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancer.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancer.scala
@@ -33,12 +33,7 @@ import whisk.spi.Spi
  * @param id a unique instance identifier for the invoker
  * @param status it status (healthy, unhealthy, offline)
  */
-class InvokerHealth(val id: InstanceId, val status: InvokerState) {
-  override def equals(obj: scala.Any): Boolean = obj match {
-    case that: InvokerHealth => that.id == this.id && that.status == this.status
-    case _                   => false
-  }
-}
+case class InvokerHealth(id: InstanceId, status: InvokerState)
 
 trait LoadBalancer {
 


### PR DESCRIPTION
`case class` give us the wanted equality by default without the added boilerplate.