### PR TITLE
Stop-start invoker and retry more to ease testing

### DIFF
--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -129,6 +129,12 @@
   set_fact:
     invoker_args: "{{ invoker.arguments }} {{ invoker.jmxremote.jvmArgs }}"
 
+- name: stop and remove the invoke container if it's currently running
+  docker_container:
+      name: invoker{{ groups['invokers'].index(inventory_hostname) }}
+      state: absent
+      force_kill: yes
+
 - name: start invoker using docker cli
   shell: >
         docker run -d
@@ -207,5 +213,5 @@
     url: "http://{{ ansible_host }}:{{ invoker.port + groups['invokers'].index(inventory_hostname) }}/ping"
   register: result
   until: result.status == 200
-  retries: 12
+  retries: 15
   delay: 5


### PR DESCRIPTION
When running repeated test cycles, it becomes necessary to 'docker rm -f invoker0' before rerunning the openwhisk.yml playbook.  This adds a step to ensure prior iterations are stopped before starting the new invoker.

Y'alls call whether you want to do it -- running 'mode=clean' before rerunning tests is another option; however for basic build testing it's nice to have the behavior of the playbook essentially the same for each run.  I won't take a 'no' personally (for this one...)

Yes, I've looked at:

https://github.com/apache/incubator-openwhisk/issues/1633
https://github.com/ansible/ansible-modules-core/issues/5054
https://github.com/ansible/ansible/issues/20648

BTW, both the ansible issues are closed without resolution; I can't divine the state of userns support.

-J