### PR TITLE
Move log message into a closure to defer string interpolation.

### DIFF
--- a/common/scala/src/main/scala/whisk/common/TransactionId.scala
+++ b/common/scala/src/main/scala/whisk/common/TransactionId.scala
@@ -50,16 +50,16 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
    *
    * @param from Reference, where the method was called from.
    * @param marker A LogMarkerToken. They are defined in <code>LoggingMarkers</code>.
-   * @param message An additional message that is written into the log, together with the other information.
+   * @param message An additional message to be written into the log, together with the other information.
    * @param logLevel The Loglevel, the message should have. Default is <code>InfoLevel</code>.
    */
-  def mark(from: AnyRef, marker: LogMarkerToken, message: String = "", logLevel: LogLevel = DebugLevel)(
+  def mark(from: AnyRef, marker: LogMarkerToken, message: => String = "", logLevel: LogLevel = DebugLevel)(
     implicit logging: Logging) = {
 
     if (TransactionId.metricsLog) {
       // marker received with a debug level will be emitted on info level
       logging.emit(InfoLevel, this, from, createMessageWithMarker(message, LogMarker(marker, deltaToStart)))
-    } else if (message.nonEmpty) {
+    } else {
       logging.emit(logLevel, this, from, message)
     }
 
@@ -75,18 +75,18 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
    *
    * @param from Reference, where the method was called from.
    * @param marker A LogMarkerToken. They are defined in <code>LoggingMarkers</code>.
-   * @param message An additional message that is written into the log, together with the other information.
+   * @param message An additional message to be written into the log, together with the other information.
    * @param logLevel The Loglevel, the message should have. Default is <code>InfoLevel</code>.
    *
    * @return startMarker that has to be passed to the finished or failed method to calculate the time difference.
    */
-  def started(from: AnyRef, marker: LogMarkerToken, message: String = "", logLevel: LogLevel = DebugLevel)(
+  def started(from: AnyRef, marker: LogMarkerToken, message: => String = "", logLevel: LogLevel = DebugLevel)(
     implicit logging: Logging): StartMarker = {
 
     if (TransactionId.metricsLog) {
       // marker received with a debug level will be emitted on info level
       logging.emit(InfoLevel, this, from, createMessageWithMarker(message, LogMarker(marker, deltaToStart)))
-    } else if (message.nonEmpty) {
+    } else {
       logging.emit(logLevel, this, from, message)
     }
 
@@ -102,13 +102,13 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
    *
    * @param from Reference, where the method was called from.
    * @param startMarker <code>StartMarker</code> returned by a <code>starting</code> method.
-   * @param message An additional message that is written into the log, together with the other information.
+   * @param message An additional message to be written into the log, together with the other information.
    * @param logLevel The Loglevel, the message should have. Default is <code>InfoLevel</code>.
    * @param endTime Manually set the timestamp of the end. By default it is NOW.
    */
   def finished(from: AnyRef,
                startMarker: StartMarker,
-               message: String = "",
+               message: => String = "",
                logLevel: LogLevel = DebugLevel,
                endTime: Instant = Instant.now(Clock.systemUTC))(implicit logging: Logging) = {
 
@@ -122,7 +122,7 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
         this,
         from,
         createMessageWithMarker(message, LogMarker(endMarker, deltaToStart, Some(deltaToEnd))))
-    } else if (message.nonEmpty) {
+    } else {
       logging.emit(logLevel, this, from, message)
     }
 
@@ -136,10 +136,10 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
    *
    * @param from Reference, where the method was called from.
    * @param startMarker <code>StartMarker</code> returned by a <code>starting</code> method.
-   * @param message An additional message that is written into the log, together with the other information.
+   * @param message An additional message to be written into the log, together with the other information.
    * @param logLevel The <code>LogLevel</code> the message should have. Default is <code>WarningLevel</code>.
    */
-  def failed(from: AnyRef, startMarker: StartMarker, message: String = "", logLevel: LogLevel = WarningLevel)(
+  def failed(from: AnyRef, startMarker: StartMarker, message: => String = "", logLevel: LogLevel = WarningLevel)(
     implicit logging: Logging) = {
 
     val endMarker =
@@ -152,7 +152,7 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
         this,
         from,
         createMessageWithMarker(message, LogMarker(endMarker, deltaToStart, Some(deltaToEnd))))
-    } else if (message.nonEmpty) {
+    } else {
       logging.emit(logLevel, this, from, message)
     }
 


### PR DESCRIPTION
A lot of log messages are logged at debug level and use string interpolation. By moving the message into a closure, for debug level messages which are generally not logged, the interpolation is deferred and then eschewed.

Apply the same to other logging methods and transaction markers.