### PR TITLE
Remove kafka related debug message

### DIFF
--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaProducerConnector.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaProducerConnector.scala
@@ -50,8 +50,6 @@ class KafkaProducerConnector(kafkahosts: String,
   override def send(topic: String, msg: Message, retry: Int = 2): Future[RecordMetadata] = {
     implicit val transid = msg.transid
     val record = new ProducerRecord[String, String](topic, "messages", msg.serialize)
-
-    logging.debug(this, s"sending to topic '$topic' msg '$msg'")
     val produced = Promise[RecordMetadata]()
 
     producer.send(record, new Callback {


### PR DESCRIPTION
With enhanced kafka message sizes this debug message writes an enormous amount of data.
Since enough information is printed out in error cases, we can simply remove it.