### PR TITLE
reduce fillInStackTrace expenses due to ArgNormalizer

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/DocInfo.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/DocInfo.scala
@@ -37,7 +37,7 @@ import whisk.core.entity.ArgNormalizer.trim
  *
  * @param id the document id, required not null
  */
-protected[core] class DocId private (val id: String) extends AnyVal {
+protected[core] class DocId(val id: String) extends AnyVal {
   def asString = id // to make explicit that this is a string conversion
   protected[core] def asDocInfo = DocInfo(this)
   protected[core] def asDocInfo(rev: DocRevision) = DocInfo(this, rev)

--- a/common/scala/src/main/scala/whisk/core/entity/FullyQualifiedEntityName.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/FullyQualifiedEntityName.scala
@@ -48,7 +48,7 @@ protected[core] case class FullyQualifiedEntityName(path: EntityPath, name: Enti
    */
   def add(n: EntityName) = FullyQualifiedEntityName(path.addPath(name), n)
 
-  def toDocId = DocId(qualifiedName)
+  def toDocId = new DocId(qualifiedName)
   def namespace: EntityName = path.root
   def qualifiedNameWithLeadingSlash: String = EntityPath.PATHSEP + qualifiedName
   def asString = path.addPath(name) + version.map("@" + _.toString).getOrElse("")

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
@@ -159,7 +159,7 @@ protected[actions] trait PrimitiveActions {
     // 2. failing active ack (due to active ack timeout), fall over to db polling
     // 3. timeout on db polling => converts activation to non-blocking (returns activation id only)
     // 4. internal error message
-    val docid = DocId(WhiskEntity.qualifiedName(user.namespace.toPath, activationId))
+    val docid = new DocId(WhiskEntity.qualifiedName(user.namespace.toPath, activationId))
     val (promise, finisher) = ActivationFinisher.props({ () =>
       WhiskActivation.get(activationStore, docid)
     })


### PR DESCRIPTION
ArgNormalizer uses a try/catch pattern when parsing entity names. in two common cases, the arg to be normalized is known to be a string. we can fast-path this case. i called this `DocId.direct()`

the expense of this can be witnessed from call stack samples: you will see `fillInStackTrace` due to exceptions being thrown by spray's json parser.

preliminary experiments show that this results in more stable performance, i.e. with improvements principally to p99 latency numbers.

```
           p25   p50   p75    p90    p99     max
master     20ms  23ms  28ms   40ms   270ms  1.7s
this PR    18ms  21ms  26ms   35ms   85ms   1.4s
```

test protocol: using wrk -t8 -c800; wipe.yml, then warmup 60s, then timed run 120s
endpoint: blocking invokes of echo action
deployment: environments/local, local couchdb, 44-way with 48GB memory; 12 invokers
load driver: 16-way located in the same rack

PG2/2715  🔵 