### PR TITLE
Making prewarm kind (and count) configurable

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -36,6 +36,11 @@ whisk:
 #
 runtimesManifest: "{{ runtimes_manifest | default(lookup('file', '{{ openwhisk_home }}/ansible/files/runtimes.json') | from_json) }}"
 
+##
+# Prewarm configuration
+prewarmKind: "{{prewarm_kind | default('nodejs:6')}}"
+prewarmCount: "{{prewarm_count | default('2')}}"
+
 limits:
   invocationsPerMinute: "{{ limit_invocations_per_minute | default(60) }}"
   concurrentInvocations: "{{ limit_invocations_concurrent | default(30) }}"

--- a/ansible/templates/whisk.properties.j2
+++ b/ansible/templates/whisk.properties.j2
@@ -35,6 +35,9 @@ whisk.api.vanity.subdomain.parts=1
 
 runtimes.manifest={{ runtimesManifest | to_json }}
 
+prewarm.kind={{ prewarmKind | default('nodejs:6') }}
+prewarm.count={{ prewarmCount | default('2') }}
+
 limits.actions.invokes.perMinute={{ limits.invocationsPerMinute }}
 limits.actions.invokes.concurrent={{ limits.concurrentInvocations }}
 limits.actions.invokes.concurrentInSystem={{ limits.concurrentInvocationsSystem }}

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -90,6 +90,9 @@ class WhiskConfig(requiredProperties: Map[String, String],
   val mainDockerEndpoint = this(WhiskConfig.mainDockerEndpoint)
 
   val runtimesManifest = this(WhiskConfig.runtimesManifest)
+  val prewarmKind = this(WhiskConfig.prewarmKind)
+  val prewarmCount = this(WhiskConfig.prewarmCount)
+
   val actionInvokePerMinuteLimit = this(WhiskConfig.actionInvokePerMinuteLimit)
   val actionInvokeConcurrentLimit = this(WhiskConfig.actionInvokeConcurrentLimit)
   val triggerFirePerMinuteLimit = this(WhiskConfig.triggerFirePerMinuteLimit)
@@ -218,6 +221,8 @@ object WhiskConfig {
   val zookeeperHosts = Map(zookeeperHostList -> null)
 
   val runtimesManifest = "runtimes.manifest"
+  val prewarmKind = "prewarm.kind"
+  val prewarmCount = "prewarm.count"
 
   val actionSequenceMaxLimit = "limits.actions.sequence.maxLength"
   val actionInvokePerMinuteLimit = "limits.actions.invokes.perMinute"

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -67,7 +67,8 @@ object Invoker {
       invokerNumCore -> "4",
       invokerCoreShare -> "2",
       invokerUseRunc -> "true") ++
-      Map(invokerName -> "")
+      Map(invokerName -> "") ++
+      Map(prewarmKind -> "nodejs:6", prewarmCount -> "2")
 
   def main(args: Array[String]): Unit = {
     Kamon.start()

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
@@ -141,7 +141,8 @@ class InvokerReactive(config: WhiskConfig, instance: InstanceId, producer: Messa
   val childFactory = (f: ActorRefFactory) =>
     f.actorOf(ContainerProxy.props(containerFactory.createContainer, ack, store, logsProvider.collectLogs, instance))
 
-  val prewarmKind = "nodejs:6"
+  val prewarmKind = config.prewarmKind
+  val prewarmCount = config.prewarmCount.toInt
   val prewarmExec = ExecManifest.runtimesManifest
     .resolveDefaultRuntime(prewarmKind)
     .map { manifest =>
@@ -155,7 +156,7 @@ class InvokerReactive(config: WhiskConfig, instance: InstanceId, producer: Messa
       maximumContainers,
       maximumContainers,
       activationFeed,
-      Some(PrewarmingConfig(2, prewarmExec, 256.MB))))
+      Some(PrewarmingConfig(prewarmCount, prewarmExec, 256.MB))))
 
   /** Is called when an ActivationMessage is read from Kafka */
   def processActivationMessage(bytes: Array[Byte]): Future[Unit] = {


### PR DESCRIPTION
This is to make configurable the prewarm kind (ex:nodejs:6) and prewarm count (number of containers the invoker prewarms) which is hardcoded to 2 right now.