### PR TITLE
#3243 - Use gradle scoverage to collect test coverage stats

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "cz.alenkacz:gradle-scalafmt:${gradle.scalafmt.version}"
+        classpath 'org.scoverage:gradle-scoverage:2.1.0'
     }
 }
 

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'scala'
 apply plugin: 'eclipse'
 apply plugin: 'maven'
+apply plugin: 'org.scoverage'
 
 ext.dockerImageName = 'scala'
 apply from: '../../gradle/docker.gradle'
@@ -46,6 +47,7 @@ dependencies {
     compile 'io.kamon:kamon-statsd_2.11:0.6.7'
     //for mesos
     compile 'com.adobe.api.platform.runtime:mesos-actor:0.0.7'
+    scoverage gradle.scoverage.deps
 }
 
 tasks.withType(ScalaCompile) {

--- a/core/controller/build.gradle
+++ b/core/controller/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'scala'
 apply plugin: 'application'
 apply plugin: 'eclipse'
 apply plugin: 'maven'
+apply plugin: 'org.scoverage'
 
 ext.dockerImageName = 'controller'
 apply from: '../../gradle/docker.gradle'
@@ -19,6 +20,7 @@ dependencies {
     compile 'com.lightbend.akka.discovery:akka-discovery-kubernetes-api_2.11:0.11.0'
     compile 'com.lightbend.akka.discovery:akka-discovery-marathon-api_2.11:0.11.0'
     compile project(':common:scala')
+    scoverage gradle.scoverage.deps
 }
 
 tasks.withType(ScalaCompile) {

--- a/core/invoker/build.gradle
+++ b/core/invoker/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'scala'
 apply plugin: 'application'
 apply plugin: 'eclipse'
 apply plugin: 'maven'
+apply plugin: 'org.scoverage'
 
 ext.dockerImageName = 'invoker'
 apply from: '../../gradle/docker.gradle'
@@ -23,6 +24,7 @@ dependencies {
         exclude group: 'log4j'
         exclude group: 'jline'
     }
+    scoverage gradle.scoverage.deps
 }
 
 tasks.withType(ScalaCompile) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,3 +30,8 @@ gradle.ext.scalafmt = [
     version: '1.5.0',
     config: new File(rootProject.projectDir, '.scalafmt.conf')
 ]
+
+gradle.ext.scoverage = [
+        deps: ['org.scoverage:scalac-scoverage-plugin_2.11:1.3.1',
+               'org.scoverage:scalac-scoverage-runtime_2.11:1.3.1']
+]

--- a/settings.gradle
+++ b/settings.gradle
@@ -32,6 +32,8 @@ gradle.ext.scalafmt = [
 ]
 
 gradle.ext.scoverage = [
-        deps: ['org.scoverage:scalac-scoverage-plugin_2.11:1.3.1',
-               'org.scoverage:scalac-scoverage-runtime_2.11:1.3.1']
+    deps: [
+        'org.scoverage:scalac-scoverage-plugin_2.11:1.3.1',
+        'org.scoverage:scalac-scoverage-runtime_2.11:1.3.1'
+    ]
 ]

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -24,13 +24,13 @@ tasks.withType(Test) {
 }
 
 def leanExcludes = [
-        '**/*Swift*',
-        '**/*Python*',
-        '**/*Java*',
-        '**/*ThrottleTests*',
-        '**/MaxActionDurationTests*',
-        '**/*ApiGwRestBasicTests*',
-        '**/*WskCli*'
+    '**/*Swift*',
+    '**/*Python*',
+    '**/*Java*',
+    '**/*ThrottleTests*',
+    '**/MaxActionDurationTests*',
+    '**/*ApiGwRestBasicTests*',
+    '**/*WskCli*'
 ]
 
 task testLean(type: Test) {
@@ -106,7 +106,7 @@ afterEvaluate {
         exclude leanExcludes
     }
 
-    task testCoverage(type:Test){
+    task testCoverage(type:Test) {
         classpath = getScoverageClasspath(project)
     }
     tasks.withType(Test) {
@@ -118,11 +118,11 @@ afterEvaluate {
  * Task to generate coverage xml report. Requires the
  * tests to be executed prior to its invocation
  */
-task reportCoverage(type: ScoverageReport){
+task reportCoverage(type: ScoverageReport) {
     dependsOn([
-            ':common:scala:reportScoverage',
-            ':core:controller:reportScoverage',
-            ':core:invoker:reportScoverage'
+        ':common:scala:reportScoverage',
+        ':core:controller:reportScoverage',
+        ':core:invoker:reportScoverage'
     ])
 }
 
@@ -135,13 +135,13 @@ task aggregateCoverage(type: JavaExec, dependsOn: reportCoverage) {
     main = 'org.scoverage.AggregateReportApp'
     classpath = project.extensions.scoverage.pluginClasspath
     args = [
-            project.rootProject.projectDir, //Use the root project path so as to "see" all source paths
-            new File(project.buildDir, 'scoverage-aggregate'),
-            false, //Clean scoverage report post process
-            true,  //coverageOutputCobertura
-            true,  //coverageOutputXML
-            true,  //coverageOutputHTML
-            false  //coverageDebug
+        project.rootProject.projectDir, //Use the root project path so as to "see" all source paths
+        new File(project.buildDir, 'scoverage-aggregate'),
+        false, //Clean scoverage report post process
+        true,  //coverageOutputCobertura
+        true,  //coverageOutputXML
+        true,  //coverageOutputHTML
+        false  //coverageDebug
     ]
 }
 
@@ -149,11 +149,11 @@ task aggregateCoverage(type: JavaExec, dependsOn: reportCoverage) {
  * Prepares the classpath which refer to scoverage instrumented classes from
  * dependent projects "before" the non instrumented classes
  */
-def getScoverageClasspath(Project project){
+def getScoverageClasspath(Project project) {
     def projectNames = [
-            ':common:scala',
-            ':core:controller',
-            ':core:invoker'
+        ':common:scala',
+        ':core:controller',
+        ':core:invoker'
     ]
     def combinedClasspath = projectNames.inject(project.files([])){result, name ->
         result + project.project(name).sourceSets.scoverage.runtimeClasspath

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -30,7 +30,6 @@ def leanExcludes = [
         '**/*ThrottleTests*',
         '**/MaxActionDurationTests*',
         '**/*ApiGwRestBasicTests*',
-        '**/*Cli*',
         '**/*WskCli*'
 ]
 

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -103,8 +103,12 @@ task createKeystore(dependsOn: deleteKeystore) {
 
 afterEvaluate {
     task testCoverageLean(type:Test) {
-        classpath = getScoverageClasspath(project) + sourceSets.test.runtimeClasspath
+        classpath = getScoverageClasspath(project)
         exclude leanExcludes
+    }
+
+    task testCoverage(type:Test){
+        classpath = getScoverageClasspath(project)
     }
     tasks.withType(Test) {
         dependsOn createKeystore
@@ -127,7 +131,7 @@ task reportCoverage(type: ScoverageReport){
  * Aggregates the scoverage xml reports from various modules into a
  * single report
  */
-task aggregateCoverage(type: JavaExec) {
+task aggregateCoverage(type: JavaExec, dependsOn: reportCoverage) {
     //Taken from ScoverageAggregate
     main = 'org.scoverage.AggregateReportApp'
     classpath = project.extensions.scoverage.pluginClasspath
@@ -152,7 +156,9 @@ def getScoverageClasspath(Project project){
             ':core:controller',
             ':core:invoker'
     ]
-    projectNames.inject(project.files([])){result, name ->
+    def combinedClasspath = projectNames.inject(project.files([])){result, name ->
         result + project.project(name).sourceSets.scoverage.runtimeClasspath
     }
+
+    combinedClasspath + sourceSets.test.runtimeClasspath
 }

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -1,6 +1,9 @@
+import org.scoverage.ScoverageReport
+
 apply plugin: 'scala'
 apply plugin: 'eclipse'
 apply plugin: 'maven'
+apply plugin: 'org.scoverage'
 compileTestScala.options.encoding = 'UTF-8'
 
 repositories {
@@ -20,14 +23,19 @@ tasks.withType(Test) {
     outputs.upToDateWhen { false } // force tests to run every time
 }
 
+def leanExcludes = [
+        '**/*Swift*',
+        '**/*Python*',
+        '**/*Java*',
+        '**/*ThrottleTests*',
+        '**/MaxActionDurationTests*',
+        '**/*ApiGwRestBasicTests*',
+        '**/*Cli*',
+        '**/*WskCli*'
+]
+
 task testLean(type: Test) {
-    exclude '**/*Swift*'
-    exclude '**/*Python*'
-    exclude '**/*Java*'
-    exclude '**/*ThrottleTests*'
-    exclude '**/MaxActionDurationTests*'
-    exclude '**/*ApiGwRestBasicTests*'
-    exclude '**/*WskCli*'
+    exclude leanExcludes
 }
 
 task testLeanCli(type: Test) {
@@ -71,6 +79,8 @@ dependencies {
     compile project(':common:scala')
     compile project(':core:controller')
     compile project(':core:invoker')
+
+    scoverage gradle.scoverage.deps
 }
 
 tasks.withType(ScalaCompile) {
@@ -92,7 +102,57 @@ task createKeystore(dependsOn: deleteKeystore) {
 }
 
 afterEvaluate {
+    task testCoverageLean(type:Test) {
+        classpath = getScoverageClasspath(project) + sourceSets.test.runtimeClasspath
+        exclude leanExcludes
+    }
     tasks.withType(Test) {
         dependsOn createKeystore
+    }
+}
+
+/**
+ * Task to generate coverage xml report. Requires the
+ * tests to be executed prior to its invocation
+ */
+task reportCoverage(type: ScoverageReport){
+    dependsOn([
+            ':common:scala:reportScoverage',
+            ':core:controller:reportScoverage',
+            ':core:invoker:reportScoverage'
+    ])
+}
+
+/**
+ * Aggregates the scoverage xml reports from various modules into a
+ * single report
+ */
+task aggregateCoverage(type: JavaExec) {
+    //Taken from ScoverageAggregate
+    main = 'org.scoverage.AggregateReportApp'
+    classpath = project.extensions.scoverage.pluginClasspath
+    args = [
+            project.rootProject.projectDir, //Use the root project path so as to "see" all source paths
+            new File(project.buildDir, 'scoverage-aggregate'),
+            false, //Clean scoverage report post process
+            true,  //coverageOutputCobertura
+            true,  //coverageOutputXML
+            true,  //coverageOutputHTML
+            false  //coverageDebug
+    ]
+}
+
+/**
+ * Prepares the classpath which refer to scoverage instrumented classes from
+ * dependent projects "before" the non instrumented classes
+ */
+def getScoverageClasspath(Project project){
+    def projectNames = [
+            ':common:scala',
+            ':core:controller',
+            ':core:invoker'
+    ]
+    projectNames.inject(project.files([])){result, name ->
+        result + project.project(name).sourceSets.scoverage.runtimeClasspath
     }
 }

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -63,10 +63,12 @@ $ANSIBLE_CMD openwhisk.yml
 
 cd $ROOTDIR
 cat whisk.properties
-TERM=dumb ./gradlew :tests:testLean $GRADLE_PROJS_SKIP
+TERM=dumb ./gradlew tests:testCoverageLean :tests:reportCoverage
 
 cd $ROOTDIR/ansible
 $ANSIBLE_CMD logs.yml
 
 cd $ROOTDIR
 tools/build/checkLogs.py logs
+
+bash <(curl -s https://codecov.io/bash)

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -63,7 +63,7 @@ $ANSIBLE_CMD openwhisk.yml
 
 cd $ROOTDIR
 cat whisk.properties
-TERM=dumb ./gradlew tests:testCoverageLean :tests:reportCoverage
+TERM=dumb ./gradlew :tests:testCoverageLean :tests:reportCoverage
 
 cd $ROOTDIR/ansible
 $ANSIBLE_CMD logs.yml


### PR DESCRIPTION
Adds scoverage plugin to instrument and collect coverage data. Also configures a `aggregateCoverage` task to generate a combined report

This PR enables collections of coverage data for tests run in vm and do not hit controller or invoker dockers containers.

You can see the coverage stats at [codecov][1] for my fork. With just the lean set (used for travis ci) we get a coverage of ~ 72%. The build time for test phase increased by ~ 2 min (27m 17s to 29m 23s)

Codecov integration can be enabled with simple change in `build.sh` for travis.

```diff
diff --git a/tools/travis/build.sh b/tools/travis/build.sh
index 4870acb72a..fdd77b7c67 100755
--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -40,10 +40,12 @@ $ANSIBLE_CMD openwhisk.yml
 
 cd $ROOTDIR
 cat whisk.properties
-TERM=dumb ./gradlew :tests:testLean $GRADLE_PROJS_SKIP
+TERM=dumb ./gradlew tests:testCoverageLean $GRADLE_PROJS_SKIP :tests:reportCoverage
 
 cd $ROOTDIR/ansible
 $ANSIBLE_CMD logs.yml
 
 cd $ROOTDIR
 tools/build/checkLogs.py logs
+
+bash <(curl -s https://codecov.io/bash)
\ No newline at end of file
```

Once these changes are done (except build.sh) I can work on a separate PR for codecov integration

Collecting coverage stats for containers would need [more work](https://github.com/apache/incubator-openwhisk/issues/3243#issuecomment-363160950)

### Local Run

To see the report locally run following

    ./gradlew tests:testCoverageLean  tests:aggregateCoverage

This should generate reports in `tests/build/scoverage-aggregate`. To run specific tests

    ./gradlew tests:testCoverage --tests whisk.core.entity.test.*  tests:aggregateCoverage

[1]: https://codecov.io/gh/chetanmeh/incubator-openwhisk/branch/3243-coverage-ci