### PR TITLE
Efficiently parse CompletionMessage.

### DIFF
--- a/common/scala/src/main/scala/whisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/whisk/core/connector/Message.scala
@@ -95,6 +95,20 @@ case class CompletionMessage(override val transid: TransactionId,
 }
 
 object CompletionMessage extends DefaultJsonProtocol {
+  implicit def eitherResponse =
+    new JsonFormat[Either[ActivationId, WhiskActivation]] {
+      def write(either: Either[ActivationId, WhiskActivation]) = either match {
+        case Right(a) => a.toJson
+        case Left(b)  => b.toJson
+      }
+
+      def read(value: JsValue) = value match {
+        case _: JsString => Left(value.convertTo[ActivationId])
+        case _: JsObject => Right(value.convertTo[WhiskActivation])
+        case _           => deserializationError("could not read CompletionMessage")
+      }
+    }
+
   def parse(msg: String): Try[CompletionMessage] = Try(serdes.read(msg.parseJson))
   private val serdes = jsonFormat3(CompletionMessage.apply)
 }

--- a/common/scala/src/main/scala/whisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/whisk/core/connector/Message.scala
@@ -103,6 +103,7 @@ object CompletionMessage extends DefaultJsonProtocol {
       }
 
       def read(value: JsValue) = value match {
+        // per the ActivationId's serializer, it is guaranteed to be a String even if it only consists of digits
         case _: JsString => Left(value.convertTo[ActivationId])
         case _: JsObject => Right(value.convertTo[WhiskActivation])
         case _           => deserializationError("could not read CompletionMessage")


### PR DESCRIPTION
The parsing of `Either` relies on parsing failures in its generalized form. In this specialized case we can circumenvent this and parse only once, without throwing any forced error messages.

Fixes #3228

@starpit Want to have a look? I took the liberty to open the PR.