### PR TITLE
Preserve rule status when rule is updated

### DIFF
--- a/core/controller/src/main/scala/whisk/core/controller/Rules.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Rules.scala
@@ -286,6 +286,7 @@ trait WhiskRulesApi extends WhiskCollectionAPI with ReferencedEntities {
     val oldTriggerName = rule.trigger
 
     getTrigger(oldTriggerName) flatMap { oldTriggerOpt =>
+      val status = getStatus(oldTriggerOpt, ruleName)
       val newTriggerEntity = content.trigger getOrElse rule.trigger
       val newTriggerName = newTriggerEntity
 
@@ -313,7 +314,7 @@ trait WhiskRulesApi extends WhiskCollectionAPI with ReferencedEntities {
             WhiskTrigger.put(entityStore, oldTrigger.removeRule(ruleName))
           }
 
-          val triggerLink = ReducedRule(actionName, Status.INACTIVE)
+          val triggerLink = ReducedRule(actionName, status)
           val update = WhiskTrigger.put(entityStore, newTrigger.addRule(ruleName, triggerLink))
           Future.sequence(Seq(deleteOldLink.getOrElse(Future.successful(true)), update)).map(_ => r)
       }

--- a/tests/src/test/scala/system/basic/WskRuleTests.scala
+++ b/tests/src/test/scala/system/basic/WskRuleTests.scala
@@ -106,7 +106,13 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
     statusPermutations.foreach {
       case (trigger, status) =>
         if (status == active) wsk.rule.enable(ruleName) else wsk.rule.disable(ruleName)
-        wsk.rule.create(ruleName, trigger, actionName, update = true)
+        wsk.rule
+          .create(ruleName, trigger, actionName, update = true)
+          .stdout
+          .parseJson
+          .asJsObject
+          .fields
+          .get("status") shouldBe (status)
         wsk.rule.get(ruleName).stdout.parseJson.asJsObject.fields.get("status") shouldBe (status)
     }
   }

--- a/tests/src/test/scala/system/basic/WskRuleTests.scala
+++ b/tests/src/test/scala/system/basic/WskRuleTests.scala
@@ -88,61 +88,27 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
 
   behavior of "Whisk rules"
 
-  it should "preserve rule status when the rule is updated" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "preserve rule status when a rule is updated" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
     val ruleName = withTimestamp("r1to1")
     val triggerName = withTimestamp("t1to1")
     val actionName = withTimestamp("a1 to 1")
     val triggerName2 = withTimestamp("t2to1")
     val active = Some("active".toJson)
     val inactive = Some("inactive".toJson)
+    val statusPermutations =
+      Seq((triggerName, active), (triggerName, inactive), (triggerName2, active), (triggerName2, inactive))
 
     ruleSetup(Seq((ruleName, triggerName, (actionName, actionName, defaultAction))), assetHelper)
     assetHelper.withCleaner(wsk.trigger, triggerName2) { (trigger, name) =>
       trigger.create(name)
     }
 
-    // Ensure status stays active when rule is updated with its current trigger
-    wsk.rule.create(ruleName, triggerName, actionName, update = true)
-    wsk.rule
-      .get(ruleName)
-      .stdout
-      .parseJson
-      .asJsObject
-      .fields
-      .get("status") shouldBe (active)
-
-    // Ensure status stays inactive when rule is updated with its current trigger
-    wsk.rule.disable(ruleName)
-    wsk.rule.create(ruleName, triggerName, actionName, update = true)
-    wsk.rule
-      .get(ruleName)
-      .stdout
-      .parseJson
-      .asJsObject
-      .fields
-      .get("status") shouldBe (inactive)
-
-    // Ensure status stays active when rule is updated with a new trigger
-    wsk.rule.enable(ruleName)
-    wsk.rule.create(ruleName, triggerName2, actionName, update = true)
-    wsk.rule
-      .get(ruleName)
-      .stdout
-      .parseJson
-      .asJsObject
-      .fields
-      .get("status") shouldBe (active)
-
-    // Ensure status stays inactive when rule is updated with a new trigger
-    wsk.rule.disable(ruleName)
-    wsk.rule.create(ruleName, triggerName, actionName, update = true)
-    wsk.rule
-      .get(ruleName)
-      .stdout
-      .parseJson
-      .asJsObject
-      .fields
-      .get("status") shouldBe (inactive)
+    statusPermutations.foreach {
+      case (trigger, status) =>
+        if (status == active) wsk.rule.enable(ruleName) else wsk.rule.disable(ruleName)
+        wsk.rule.create(ruleName, trigger, actionName, update = true)
+        wsk.rule.get(ruleName).stdout.parseJson.asJsObject.fields.get("status") shouldBe (status)
+    }
   }
 
   it should "invoke the action attached on trigger fire, creating an activation for each entity including the cause" in withAssetCleaner(

--- a/tests/src/test/scala/system/basic/WskRuleTests.scala
+++ b/tests/src/test/scala/system/basic/WskRuleTests.scala
@@ -93,11 +93,14 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
     val triggerName = withTimestamp("t1to1")
     val actionName = withTimestamp("a1 to 1")
     val triggerName2 = withTimestamp("t2to1")
-    val actionName2 = withTimestamp("a2 to 1")
 
     ruleSetup(Seq((ruleName, triggerName, (actionName, actionName, defaultAction))), assetHelper)
 
-    // Ensure status stays active when rule is updated with its current trigger and action
+    assetHelper.withCleaner(wsk.trigger, triggerName2) { (trigger, name) =>
+      trigger.create(name)
+    }
+
+    // Ensure status stays active when rule is updated with its current trigger
     wsk.rule
       .create(ruleName, triggerName, actionName, update = true)
       .stdout
@@ -108,7 +111,7 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
 
     wsk.rule.disable(ruleName)
 
-    // Ensure status stays inactive when rule is updated with its current trigger and action
+    // Ensure status stays inactive when rule is updated with its current trigger
     wsk.rule
         .create(ruleName, triggerName, actionName, update = true)
         .stdout
@@ -117,19 +120,11 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
         .fields
         .get("status") shouldBe (Some("inactive".toJson))
 
-    assetHelper.withCleaner(wsk.trigger, triggerName2) { (trigger, name) =>
-      trigger.create(name)
-    }
-
-    assetHelper.withCleaner(wsk.action, actionName2) { (action, name) =>
-      action.create(name, Some(defaultAction))
-    }
-
     wsk.rule.enable(ruleName)
 
-    // Ensure status stays active when rule is updated with a new trigger and action
+    // Ensure status stays active when rule is updated with a new trigger
     wsk.rule
-      .create(ruleName, triggerName2, actionName2, update = true)
+      .create(ruleName, triggerName2, actionName, update = true)
       .stdout
       .parseJson
       .asJsObject
@@ -138,7 +133,7 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
 
     wsk.rule.disable(ruleName)
 
-    // Ensure status stays inactive when rule is updated with a new trigger and action
+    // Ensure status stays inactive when rule is updated with a new trigger
     wsk.rule
         .create(ruleName, triggerName, actionName, update = true)
         .stdout

--- a/tests/src/test/scala/whisk/core/controller/test/RulesApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/RulesApiTests.scala
@@ -563,7 +563,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
         WhiskRuleResponse(
           namespace,
           rule.name,
-          Status.ACTIVE,
+          Status.INACTIVE,
           trigger.fullyQualifiedName(false),
           action.fullyQualifiedName(false),
           version = SemVer().upPatch))
@@ -594,7 +594,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
         WhiskRuleResponse(
           namespace,
           rule.name,
-          Status.ACTIVE,
+          Status.INACTIVE,
           trigger.fullyQualifiedName(false),
           action.fullyQualifiedName(false),
           version = SemVer().upPatch))
@@ -625,7 +625,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
         WhiskRuleResponse(
           namespace,
           rule.name,
-          Status.ACTIVE,
+          Status.INACTIVE,
           trigger.fullyQualifiedName(false),
           action.fullyQualifiedName(false),
           version = SemVer().upPatch))
@@ -656,7 +656,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
         WhiskRuleResponse(
           namespace,
           rule.name,
-          Status.ACTIVE,
+          Status.INACTIVE,
           trigger.fullyQualifiedName(false),
           action.fullyQualifiedName(false),
           version = SemVer().upPatch))
@@ -684,7 +684,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
         WhiskRuleResponse(
           namespace,
           rule.name,
-          Status.ACTIVE,
+          Status.INACTIVE,
           trigger.fullyQualifiedName(false),
           action.fullyQualifiedName(false),
           version = SemVer().upPatch))


### PR DESCRIPTION
Fixes two rule bugs:
1. Updating a rule with `wsk rule update` always returned a status of `active`.
2. After updating a rule with `wsk rule update` the status would be `inactive` when the rule is fetched with `wsk rule get`.

Closes https://github.com/apache/incubator-openwhisk/issues/1840