### PR TITLE
Enhance the RestResult with more information to debug failing tests e…

### DIFF
--- a/tests/src/test/scala/common/rest/WskRest.scala
+++ b/tests/src/test/scala/common/rest/WskRest.scala
@@ -1531,6 +1531,12 @@ class RestResult(var statusCode: StatusCode, var respData: String = "", blocking
       respData,
       RestResult.convertHttpResponseToStderr(respData)) {
 
+  override def toString: String = {
+    super.toString + s"""statusCode: $statusCode
+       |respData: $respData
+       |blocking: $blocking""".stripMargin
+  }
+
   def respBody: JsObject = respData.parseJson.asJsObject
 
   def getField(key: String): String = {


### PR DESCRIPTION
…asier.

I had to debug a failing test case. But most information from the RestResult was hidden. Only the information of the parent (RunResult) was shown.