### PR TITLE
Pin docker engine version on ubuntu

### DIFF
--- a/tools/ubuntu-setup/docker.sh
+++ b/tools/ubuntu-setup/docker.sh
@@ -15,6 +15,7 @@ sudo apt-get -y install linux-image-extra-$(uname -r)
 
 # DOCKER
 sudo apt-get install -y --force-yes docker-engine=1.12.0-0~trusty
+sudo apt-mark hold docker-engine
 
 # enable (security - use 127.0.0.1)
 sudo -E bash -c 'echo '\''DOCKER_OPTS="-H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock --storage-driver=aufs"'\'' >> /etc/default/docker'


### PR DESCRIPTION
We require a specific docker engine version on ubuntu. We should pin the package so that it does not get automatically updated when running system-wide updates. 
