### PR TITLE
Handle trigger activations with inactive rules

### DIFF
--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -111,6 +111,11 @@ object Messages {
   val notAllowedOnBinding = "Operation not permitted on package binding."
   def packageNameIsReserved(name: String) = s"Package name '$name' is reserved."
 
+  /** Error messages for triggers */
+  def triggerWithInactiveRule(rule: String, action: String) = {
+    s"Rule ${rule} is inactive; action ${action} was not activated."
+  }
+
   /** Error messages for sequence activations. */
   def sequenceRetrieveActivationTimeout(id: ActivationId) =
     s"Timeout reached when retrieving activation $id for sequence component."

--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -113,7 +113,7 @@ object Messages {
 
   /** Error messages for triggers */
   def triggerWithInactiveRule(rule: String, action: String) = {
-    s"Rule ${rule} is inactive; action ${action} was not activated."
+    s"Rule '$rule' is inactive, action '$action' was not activated."
   }
 
   /** Error messages for sequence activations. */

--- a/core/controller/src/main/resources/apiv1swagger.json
+++ b/core/controller/src/main/resources/apiv1swagger.json
@@ -940,6 +940,9 @@
                             "$ref": "#/definitions/ItemId"
                         }
                     },
+                    "204": {
+                        "$ref": "#/responses/NoActiveRules"
+                    },
                     "401": {
                         "$ref": "#/responses/UnauthorizedRequest"
                     },
@@ -2109,6 +2112,9 @@
             "schema": {
                 "$ref": "#/definitions/ErrorMessage"
             }
+        },
+        "NoActiveRules": {
+            "description": "Trigger has no active rules"
         }
     }
 }

--- a/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
@@ -150,9 +150,9 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
             complete(Accepted, triggerActivationId.toJsObject)
           } else {
             logging
-              .info(
+              .debug(
                 this,
-                s"[POST] trigger without an active rule was activated; no trigger activation record created for $triggerActivationId")
+                s"[POST] trigger without an active rule was activated; no trigger activation record created for $entityName")
             complete(NoContent)
           }
       })

--- a/tests/src/test/scala/system/basic/WskBasicTests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicTests.scala
@@ -808,7 +808,7 @@ class WskBasicTests extends TestHelpers with WskTestHelpers {
           JsObject(
             "statusCode" -> JsNumber(1),
             "success" -> JsBoolean(false),
-            "error" -> JsString(s"Rule ${ns}/$ruleName2 is inactive; action ${ns}/$actionName2 was not activated"),
+            "error" -> JsString(s"Rule ${ns}/$ruleName2 is inactive; action ${ns}/$actionName2 was not activated."),
             "rule" -> JsString(ns + "/" + ruleName2),
             "action" -> JsString(ns + "/" + actionName2)))
         logs shouldBe expectedLogs

--- a/tests/src/test/scala/system/basic/WskBasicTests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicTests.scala
@@ -754,6 +754,67 @@ class WskBasicTests extends TestHelpers with WskTestHelpers {
       }
   }
 
+  it should "create and fire a trigger having an active rule and an inactive rule" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val ruleName1 = withTimestamp("r1toa1")
+      val ruleName2 = withTimestamp("r2toa2")
+      val triggerName = withTimestamp("t1tor1r2")
+      val actionName1 = withTimestamp("a1")
+      val actionName2 = withTimestamp("a2")
+      val ns = wsk.namespace.whois()
+
+      assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
+        trigger.create(triggerName)
+        trigger.create(triggerName, update = true)
+      }
+
+      assetHelper.withCleaner(wsk.action, actionName1) { (action, name) =>
+        action.create(name, defaultAction)
+      }
+      assetHelper.withCleaner(wsk.action, actionName2) { (action, name) =>
+        action.create(name, defaultAction)
+      }
+
+      assetHelper.withCleaner(wsk.rule, ruleName1) { (rule, name) =>
+        rule.create(name, trigger = triggerName, action = actionName1)
+      }
+      assetHelper.withCleaner(wsk.rule, ruleName2) { (rule, name) =>
+        rule.create(name, trigger = triggerName, action = actionName2)
+        rule.disable(ruleName2)
+      }
+
+      val run = wsk.trigger.fire(triggerName)
+      withActivation(wsk.activation, run) { activation =>
+        activation.duration shouldBe 0L // shouldn't exist but CLI generates it
+        activation.end shouldBe Instant.EPOCH // shouldn't exist but CLI generates it
+        activation.logs shouldBe defined
+        activation.logs.get.size shouldBe 2
+
+        val logEntry1 = activation.logs.get(0).parseJson.asJsObject
+        val logEntry2 = activation.logs.get(1).parseJson.asJsObject
+        val logs = JsArray(logEntry1, logEntry2)
+        val ruleActivationId: String = if (logEntry1.getFields("activationId").size == 1) {
+          logEntry1.getFields("activationId")(0).convertTo[String]
+        } else {
+          logEntry2.getFields("activationId")(0).convertTo[String]
+        }
+        val expectedLogs = JsArray(
+          JsObject(
+            "statusCode" -> JsNumber(0),
+            "activationId" -> JsString(ruleActivationId),
+            "success" -> JsBoolean(true),
+            "rule" -> JsString(ns + "/" + ruleName1),
+            "action" -> JsString(ns + "/" + actionName1)),
+          JsObject(
+            "statusCode" -> JsNumber(1),
+            "success" -> JsBoolean(false),
+            "error" -> JsString(s"Rule ${ns}/$ruleName2 is inactive; action ${ns}/$actionName2 was not activated"),
+            "rule" -> JsString(ns + "/" + ruleName2),
+            "action" -> JsString(ns + "/" + actionName2)))
+        logs shouldBe expectedLogs
+      }
+  }
+
   behavior of "Wsk Rule REST"
 
   it should "create rule, get rule, update rule and list rule" in withAssetCleaner(wskprops) { (wp, assetHelper) =>

--- a/tests/src/test/scala/system/basic/WskBasicTests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicTests.scala
@@ -39,6 +39,7 @@ import common.WskProps
 import common.WskTestHelpers
 import spray.json._
 import spray.json.DefaultJsonProtocol._
+import whisk.http.Messages
 
 @RunWith(classOf[JUnitRunner])
 class WskBasicTests extends TestHelpers with WskTestHelpers {
@@ -808,7 +809,7 @@ class WskBasicTests extends TestHelpers with WskTestHelpers {
           JsObject(
             "statusCode" -> JsNumber(1),
             "success" -> JsBoolean(false),
-            "error" -> JsString(s"Rule ${ns}/$ruleName2 is inactive; action ${ns}/$actionName2 was not activated."),
+            "error" -> JsString(Messages.triggerWithInactiveRule(s"$ns/$ruleName2", s"$ns/$actionName2")),
             "rule" -> JsString(ns + "/" + ruleName2),
             "action" -> JsString(ns + "/" + actionName2)))
         logs shouldBe expectedLogs

--- a/tests/src/test/scala/whisk/core/controller/test/TriggersApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/TriggersApiTests.scala
@@ -366,6 +366,15 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
     }
   }
 
+  it should "not fire a trigger without a rule" in {
+    implicit val tid = transid()
+    val trigger = WhiskTrigger(namespace, aname())
+    put(entityStore, trigger)
+    Post(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
+      status shouldBe NoContent
+    }
+  }
+
   //// invalid resource
   it should "reject invalid resource" in {
     implicit val tid = transid()


### PR DESCRIPTION
- log trigger activation entry for disabled rules (but at least one active rule is needed to create a trigger activation record)
- if trigger has no associated active rule(s); return a 204.  also no trigger activation record is created

Closes #3304.