### PR TITLE
Change recently added metric key name. (very simple change)

### DIFF
--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -243,7 +243,7 @@ object LoggingMarkers {
   val LOADBALANCER_INVOKER_OFFLINE = LogMarkerToken(loadbalancer, "invokerOffline", count)
   val LOADBALANCER_INVOKER_UNHEALTHY = LogMarkerToken(loadbalancer, "invokerUnhealthy", count)
   def LOADBALANCER_ACTIVATION_START(namespaceId: String) =
-    LogMarkerToken(loadbalancer, s"activations_$namespaceId", count)
+    LogMarkerToken(loadbalancer, s"activations.$namespaceId", count)
 
   // Time that is needed to execute the action
   val INVOKER_ACTIVATION_RUN = LogMarkerToken(invoker, "activationRun", start)
@@ -259,7 +259,7 @@ object LoggingMarkers {
   def INVOKER_DOCKER_CMD(cmd: String) = LogMarkerToken(invoker, s"docker.$cmd", start)
   def INVOKER_RUNC_CMD(cmd: String) = LogMarkerToken(invoker, s"runc.$cmd", start)
   def INVOKER_CONTAINER_START(actionName: String, namespaceName: String, containerState: String) =
-    LogMarkerToken(invoker, s"container_start_${containerState}_${namespaceName}_$actionName", count)
+    LogMarkerToken(invoker, s"containerStart.$containerState.$namespaceName.$actionName", count)
 
   /*
    * General markers


### PR DESCRIPTION
This PR is related to #2968(merged 2days ago) and thank you for your commit @mhenke1 

I think it is more common to use dotted notation format(.) for recording metric.

Most time series db like Graphite, OpenTSDB and InfluxDB normally use a dot-delimited notation. (e.g. `sys.cpu.user`, `invoker_docker.rm_start`)

Even in the openwhisk code, metric keys for recording docker cmd use dot delimiter.
```scala
def INVOKER_RUNC_CMD(cmd: String) = LogMarkerToken(invoker, s"runc.$cmd", start)
```

If you are using kamon-statsd with graphite, a query is a better way. 
For example, a query like `invoker_containerStart.prewarmed.*` will fill the variable with all possible values that exist in the wildcard position

### Before
```
invoker_container_start_prewarmed_guest_hello_count
```

> if action name is `foo_bar` and namespace is `baz_qux` then this marker will look ambiguous. `invoker_container_start_prewarmed_baz_qux_foo_bar_count`

### After
```
invoker_containerStart.prewarmed.guest.hello_count
```

> but in this case, dotted format is not ambiguous and can be seperated by dot(.) delimiter in Grafana, `invoker_containerStart.prewarmed.baz_qux.foo_bar_count`

> with grafana, It is possible to query using wildcard(*) easily `invoker_containerStart.prewarmed.*`

![image](https://user-images.githubusercontent.com/5635513/36058907-bef30446-0e6f-11e8-9568-a05f6290c818.png)


And I also changed naming convention, 
because most of the metric key names already used in the code is using camelcase like `activationRun`, `invokerOffline` and `blockingActivation`, 
