### PR TITLE
Cleanup replication doc after testing replay of database.

### DIFF
--- a/tests/src/test/scala/whisk/core/database/test/ReplicatorTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/ReplicatorTests.scala
@@ -477,6 +477,7 @@ class ReplicatorTests
     compareDatabases(backupDbName, dbName, false)
 
     // Cleanup databases
+    removeReplicationDoc(replicationId)
     removeDatabase(backupDbName)
     removeDatabase(dbName)
   }


### PR DESCRIPTION
This test forgot to remove a replication document after the test.
This PR fixes this.