### PR TITLE
Wait for logs based on intervals not based on total processing time.

### DIFF
--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
@@ -34,7 +34,6 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.FlatSpec
 import whisk.core.containerpool.logging.{DockerToActivationLogStore, LogLine}
-
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.Matchers
 import common.{StreamLogging, WskActorSystem}
@@ -49,7 +48,6 @@ import whisk.core.entity.ActivationResponse.ContainerResponse
 import whisk.core.entity.ActivationResponse.Timeout
 import whisk.core.entity.size._
 import whisk.http.Messages
-
 import whisk.core.entity.size._
 
 /**
@@ -583,8 +581,9 @@ class DockerContainerTests
 
     docker.rawContainerLogsInvocations should have size 1
 
-    processedLog should have size expectedLog.length
-    processedLog shouldBe expectedLog.map(_.toFormattedString)
+    processedLog should have size expectedLog.length + 1 //error log should be appended
+    processedLog.head shouldBe expectedLog.head.toFormattedString
+    processedLog(1) should include(Messages.logFailure)
   }
 
   it should "truncate logs and advance reading position to end of current read" in {


### PR DESCRIPTION
Writing a large chunk of logs can take quite some time to process. The standard timeout for this process is 2 seconds today. It is bounded, because an action developer might break the action proxy to make sentinels not appear at all which would cause us to infinitely wait on sentinels.

As we process logs after an activation has run though, we can safely rely on the time **between** two logs not exceeding a certain threshold. That way, the complete processing is not bounded by some arbitrary timeout (which can even be too short for large volumes) and is still tight enough to exit early if sentinels really are missing.

Furthermore, an error line is inserted if this timeout hits to inform the user that something might've gone wrong.