### PR TITLE
GET trigger now returns matched rules in JSON payload

### DIFF
--- a/core/controller/src/main/resources/apiv1swagger.json
+++ b/core/controller/src/main/resources/apiv1swagger.json
@@ -410,7 +410,6 @@
                         }
                     },
                     "202": {
-                        "description": "Activation request accepted",
                         "$ref": "#/responses/AcceptedActivation"
                     },
                     "401": {
@@ -1718,6 +1717,10 @@
                 },
                 "limits": {
                     "$ref": "#/definitions/TriggerLimits"
+                },
+                "rules": {
+                    "type": "object",
+                    "description": "rules associated with the trigger"
                 }
             }
         },

--- a/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
@@ -283,7 +283,7 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
    * @param status the status to include in the response
    */
   private def completeAsTriggerResponse(trigger: WhiskTrigger): RequestContext => Future[RouteResult] = {
-    complete(OK, trigger.withoutRules)
+    complete(OK, trigger)
   }
 
   /**

--- a/tests/src/test/scala/system/basic/WskBasicTests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicTests.scala
@@ -513,6 +513,12 @@ class WskBasicTests extends TestHelpers with WskTestHelpers {
     trigger.getFieldJsValue("publish") shouldBe JsBoolean(false)
     trigger.getField("version") shouldBe "0.0.2"
 
+    val expectedRules = JsObject(
+      ns + "/" + ruleName -> JsObject(
+        "action" -> JsObject("name" -> JsString(actionName), "path" -> JsString(ns)),
+        "status" -> JsString("active")))
+    trigger.getFieldJsValue("rules") shouldBe expectedRules
+
     val dynamicParams = Map("t" -> "T".toJson)
     val run = wsk.trigger.fire(triggerName, dynamicParams)
     withActivation(wsk.activation, run) { activation =>

--- a/tests/src/test/scala/whisk/core/controller/test/TriggersApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/TriggersApiTests.scala
@@ -132,14 +132,14 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
     Get(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[WhiskTrigger]
-      response should be(trigger.withoutRules)
+      response should be(trigger)
     }
 
     // it should "get trigger by name in explicit namespace owned by subject" in
     Get(s"/$namespace/${collection.path}/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[WhiskTrigger]
-      response should be(trigger.withoutRules)
+      response should be(trigger)
     }
 
     // it should "reject get trigger by name in explicit namespace not owned by subject" in
@@ -170,7 +170,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
     Delete(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[WhiskTrigger]
-      response should be(trigger.withoutRules)
+      response should be(trigger)
     }
   }
 


### PR DESCRIPTION
Augment existing GET trigger payload with a new field, `rules` that describes the trigger's matched rules and the rule status.

```
{
    "namespace": "guest",
    "name": "trig-with-inactive-rule",
    "version": "0.0.1",
    "limits": {},
    "publish": false,
    "rules": {
        "guest/inactiverule": {
            "action": {
                "name": "web-echo-env",
                "path": "guest"
            },
            "status": "inactive"
        }
    }
}
```

Fixes #3239