### PR TITLE
Replace asString and asBool with generic method.

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/Parameter.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Parameter.scala
@@ -96,34 +96,11 @@ protected[core] class Parameters protected[entity] (private val params: Map[Para
     Some { (toJsObject.fields ++ args.fields).toJson.asJsObject }
   }
 
-  /**
-   * Retrieves parameter by name if it exists.
-   */
-  protected[core] def get(p: String): Option[JsValue] = {
-    params.get(new ParameterName(p)).map(_.value)
-  }
+  /** Retrieves parameter by name if it exists. */
+  protected[core] def get(p: String): Option[JsValue] = params.get(new ParameterName(p)).map(_.value)
 
-  /**
-   * Retrieves parameter by name if it exist. If value of parameter
-   * is a boolean, return its value else false.
-   */
-  protected[core] def asBool(p: String): Option[Boolean] = {
-    get(p) flatMap {
-      case JsBoolean(b) => Some(b)
-      case _            => None
-    }
-  }
-
-  /**
-   * Retrieves parameter by name if it exist. If value of parameter
-   * is a string, return its value else none.
-   */
-  protected[core] def asString(p: String): Option[String] = {
-    get(p) flatMap {
-      case JsString(s) => Some(s)
-      case _           => None
-    }
-  }
+  /** Retrieves parameter by name if it exists. Returns that parameter if it is deserializable to {@code T} */
+  protected[core] def getAs[T: JsonReader](p: String): Option[T] = get(p).flatMap(js => Try(js.convertTo[T]).toOption)
 }
 
 /**

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -78,7 +78,7 @@ abstract class WhiskActionLike(override val name: EntityName) extends WhiskEntit
 
   /** @return true iff action has appropriate annotation. */
   def hasFinalParamsAnnotation = {
-    annotations.asBool(WhiskAction.finalParamsAnnotationName) getOrElse false
+    annotations.getAs[Boolean](WhiskAction.finalParamsAnnotationName) getOrElse false
   }
 
   /** @return a Set of immutable parameternames */

--- a/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
@@ -483,7 +483,7 @@ trait WhiskWebActionsApi extends Directives with ValidateRequestSize with PostAc
               provide(fullyQualifiedActionName(actionName)) { fullActionName =>
                 onComplete(verifyWebAction(fullActionName, onBehalfOf.isDefined)) {
                   case Success((actionOwnerIdentity, action)) =>
-                    if (!action.annotations.asBool("web-custom-options").exists(identity)) {
+                    if (!action.annotations.getAs[Boolean]("web-custom-options").exists(identity)) {
                       respondWithHeaders(defaultCorsResponse(context.headers)) {
                         if (context.method == OPTIONS) {
                           complete(OK, HttpEntity.Empty)
@@ -559,7 +559,7 @@ trait WhiskWebActionsApi extends Directives with ValidateRequestSize with PostAc
       processRequest(actionOwnerIdentity, action, extension, onBehalfOf, context.withBody(body), isRawHttpAction)
     }
 
-    provide(action.annotations.asBool("raw-http").exists(identity)) { isRawHttpAction =>
+    provide(action.annotations.getAs[Boolean]("raw-http").exists(identity)) { isRawHttpAction =>
       httpEntity match {
         case Empty =>
           process(None, isRawHttpAction)
@@ -720,8 +720,8 @@ trait WhiskWebActionsApi extends Directives with ValidateRequestSize with PostAc
   private def confirmExportedAction(actionLookup: Future[WhiskActionMetaData], authenticated: Boolean)(
     implicit transid: TransactionId): Future[WhiskActionMetaData] = {
     actionLookup flatMap { action =>
-      val requiresAuthenticatedUser = action.annotations.asBool("require-whisk-auth").exists(identity)
-      val isExported = action.annotations.asBool("web-export").exists(identity)
+      val requiresAuthenticatedUser = action.annotations.getAs[Boolean]("require-whisk-auth").exists(identity)
+      val isExported = action.annotations.getAs[Boolean]("web-export").exists(identity)
 
       if ((isExported && requiresAuthenticatedUser && authenticated) ||
           (isExported && !requiresAuthenticatedUser)) {


### PR DESCRIPTION
Mainly aims to reduce boilerplate in code which tries to extract non-primitive data from parameters/annotations. Any supported json-format (for example case classes) can be loaded safely from parameters.