### PR TITLE
Disable createKeystore if test execution is disabled

### DIFF
--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -85,8 +85,14 @@ task createKeystore(dependsOn: deleteKeystore) {
     doLast {
         Properties props = new Properties()
         props.load(new FileInputStream(file('../whisk.properties')))
+        keystorePath.parentFile.mkdirs()
         def cmd = ['keytool', '-import', '-alias', 'Whisk', '-noprompt', '-trustcacerts', '-file', file(props['whisk.ssl.cert']), '-keystore', keystorePath, '-storepass', 'openwhisk']
         cmd.execute().waitForProcessOutput(System.out, System.err)
     }
 }
-compileTestScala.finalizedBy createKeystore
+
+afterEvaluate {
+    tasks.withType(Test) {
+        dependsOn createKeystore
+    }
+}


### PR DESCRIPTION
Currently the `createKeystore` in tests is linked with `compileTestScala`. This poses problem in cases where the build is triggered with test execution disabled.

```
* What went wrong:
Execution failed for task ':tests:createKeystore'.
> java.io.FileNotFoundException: /path/to/openwhisk/whisk.properties (No such file or directory)
```
This would be the case for example where core is build just to install the test artifacts to Maven repository and where whisk.properties is yet not generated. (see apache/incubator-openwhisk-runtime-docker#17)

This PR disables this task if `test` is disabled