### PR TITLE
Add implicit ClassTag for entity type

### DIFF
--- a/common/scala/src/main/scala/whisk/core/database/ArtifactStoreProvider.scala
+++ b/common/scala/src/main/scala/whisk/core/database/ArtifactStoreProvider.scala
@@ -25,13 +25,15 @@ import whisk.core.WhiskConfig
 import whisk.spi.Spi
 import whisk.core.entity.DocumentReader
 
+import scala.reflect.ClassTag
+
 /**
  * An Spi for providing ArtifactStore implementations
  */
 trait ArtifactStoreProvider extends Spi {
-  def makeStore[D <: DocumentSerializer](config: WhiskConfig,
-                                         name: WhiskConfig => String,
-                                         useBatching: Boolean = false)(
+  def makeStore[D <: DocumentSerializer: ClassTag](config: WhiskConfig,
+                                                   name: WhiskConfig => String,
+                                                   useBatching: Boolean = false)(
     implicit jsonFormat: RootJsonFormat[D],
     docReader: DocumentReader,
     actorSystem: ActorSystem,

--- a/common/scala/src/main/scala/whisk/core/database/CouchDbStoreProvider.scala
+++ b/common/scala/src/main/scala/whisk/core/database/CouchDbStoreProvider.scala
@@ -24,9 +24,13 @@ import whisk.common.Logging
 import whisk.core.WhiskConfig
 import whisk.core.entity.DocumentReader
 
+import scala.reflect.ClassTag
+
 object CouchDbStoreProvider extends ArtifactStoreProvider {
 
-  def makeStore[D <: DocumentSerializer](config: WhiskConfig, name: WhiskConfig => String, useBatching: Boolean)(
+  def makeStore[D <: DocumentSerializer: ClassTag](config: WhiskConfig,
+                                                   name: WhiskConfig => String,
+                                                   useBatching: Boolean)(
     implicit jsonFormat: RootJsonFormat[D],
     docReader: DocumentReader,
     actorSystem: ActorSystem,

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
@@ -49,6 +49,8 @@ import whisk.core.database.StaleParameter
 import whisk.spi.SpiLoader
 import pureconfig._
 
+import scala.reflect.classTag
+
 package object types {
   type AuthStore = ArtifactStore[WhiskAuth]
   type EntityStore = ArtifactStore[WhiskEntity]
@@ -123,6 +125,7 @@ object WhiskEntityStore {
     SpiLoader
       .get[ArtifactStoreProvider]
       .makeStore[WhiskEntity](config, _.dbWhisk)(
+        classTag[WhiskEntity],
         WhiskEntityJsonFormat,
         WhiskDocumentReader,
         system,

--- a/tests/src/test/scala/whisk/core/controller/test/ActivationsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActivationsApiTests.scala
@@ -35,6 +35,8 @@ import whisk.core.entity.size._
 import whisk.http.{ErrorResponse, Messages}
 import whisk.spi.SpiLoader
 
+import scala.reflect.classTag
+
 /**
  * Tests Activations API.
  *
@@ -525,6 +527,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     val activationStore = SpiLoader
       .get[ArtifactStoreProvider]
       .makeStore[WhiskEntity](whiskConfig, _.dbActivations)(
+        classTag[WhiskEntity],
         WhiskEntityJsonFormat,
         WhiskDocumentReader,
         system,


### PR DESCRIPTION
For implementing custom `ArtifactStore` and computing views on client side for databases other than CouchDB the `ArtifactStore` would need access to the entity type. 

The logic in custom ArtifactStoreProvider would be similar to one present [here][1] just that this PR uses `ClassTag` instead of `Manifest` as [Manifest are now deprecated post Scala 2.10][2]

To enable that `ArtifactStoreProvider` should have an implicit parameter for `ClassTag`

[1]: https://github.com/apache/incubator-openwhisk/commit/9be13e2c6d581f42b60351f05a11e4aa71ca31d9#diff-9399daa47aa3257bb6bcb49425f4389dR110
[2]: https://docs.scala-lang.org/overviews/reflection/typetags-manifests.html#typetags-and-manifests