### PR TITLE
Remove finely granulated metrics.

### DIFF
--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -242,8 +242,7 @@ object LoggingMarkers {
   // Check invoker healthy state from loadbalancer
   val LOADBALANCER_INVOKER_OFFLINE = LogMarkerToken(loadbalancer, "invokerOffline", count)
   val LOADBALANCER_INVOKER_UNHEALTHY = LogMarkerToken(loadbalancer, "invokerUnhealthy", count)
-  def LOADBALANCER_ACTIVATION_START(namespaceId: String) =
-    LogMarkerToken(loadbalancer, s"activations_$namespaceId", count)
+  val LOADBALANCER_ACTIVATION_START = LogMarkerToken(loadbalancer, "activations", count)
 
   // Time that is needed to execute the action
   val INVOKER_ACTIVATION_RUN = LogMarkerToken(invoker, "activationRun", start)
@@ -258,8 +257,8 @@ object LoggingMarkers {
   val INVOKER_ACTIVATION = LogMarkerToken(invoker, activation, start)
   def INVOKER_DOCKER_CMD(cmd: String) = LogMarkerToken(invoker, s"docker.$cmd", start)
   def INVOKER_RUNC_CMD(cmd: String) = LogMarkerToken(invoker, s"runc.$cmd", start)
-  def INVOKER_CONTAINER_START(actionName: String, namespaceName: String, containerState: String) =
-    LogMarkerToken(invoker, s"container_start_${containerState}_${namespaceName}_$actionName", count)
+  def INVOKER_CONTAINER_START(containerState: String) =
+    LogMarkerToken(invoker, s"container_start_${containerState}", count)
 
   /*
    * General markers

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/ContainerPoolBalancer.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/ContainerPoolBalancer.scala
@@ -175,7 +175,7 @@ class ContainerPoolBalancer(config: WhiskConfig, controllerInstance: InstanceId)
                                       invoker: InstanceId): Future[RecordMetadata] = {
     implicit val transid = msg.transid
 
-    MetricEmitter.emitCounterMetric(LoggingMarkers.LOADBALANCER_ACTIVATION_START(msg.user.uuid.asString))
+    MetricEmitter.emitCounterMetric(LoggingMarkers.LOADBALANCER_ACTIVATION_START)
     val topic = s"invoker${invoker.toInt}"
     val start = transid.started(
       this,

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
@@ -183,7 +183,7 @@ class ShardingContainerPoolBalancer(config: WhiskConfig, controllerInstance: Ins
 
     val topic = s"invoker${invoker.toInt}"
 
-    MetricEmitter.emitCounterMetric(LoggingMarkers.LOADBALANCER_ACTIVATION_START(msg.user.uuid.asString))
+    MetricEmitter.emitCounterMetric(LoggingMarkers.LOADBALANCER_ACTIVATION_START)
     val start = transid.started(
       this,
       LoggingMarkers.CONTROLLER_KAFKA,

--- a/core/invoker/src/main/scala/whisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/ContainerPool.scala
@@ -86,7 +86,7 @@ class ContainerPool(childFactory: ActorRefFactory => ActorRef,
 
     r.msg.transid.mark(
       this,
-      LoggingMarkers.INVOKER_CONTAINER_START(actionName, namespaceName, containerState),
+      LoggingMarkers.INVOKER_CONTAINER_START(containerState),
       s"containerStart containerState: $containerState action: $actionName namespace: $namespaceName activationId: $activationId",
       akka.event.Logging.InfoLevel)
   }


### PR DESCRIPTION
We introduced some very finely granulated metrics.
On using a commonly used monitoring backend, it can be easily overloaded with a huge amount of users and different actions on the OpenWhisk system.