### PR TITLE
Fix view mismatch in test

### DIFF
--- a/tests/src/test/scala/whisk/core/entity/test/ViewTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ViewTests.scala
@@ -392,7 +392,7 @@ class ViewTests
         end = now.plusSeconds(20)))
 
     entities foreach { put(activationStore, _) }
-    waitOnView(activationStore, namespace1.root, entities.length, WhiskActivation.view)
+    waitOnView(activationStore, namespace1.addPath(actionName), entities.length, WhiskActivation.filtersView)
 
     getActivationsInNamespaceByNameSortedByDate(
       activationStore,


### PR DESCRIPTION
- currently the ViewTests suite is using two similar views inside a single test.  sometimes the two views (whiskActivation.view, hiskActivation.filtersView) become out of in-sync (db delays) resulting in a test failure.  the fix is to consolidate the test to use just one view. 