### PR TITLE
Run container pool logging tests

### DIFF
--- a/tests/src/test/scala/whisk/core/containerpool/logging/LogDriverLogStoreTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/logging/LogDriverLogStoreTests.scala
@@ -19,10 +19,13 @@ package whisk.core.containerpool.logging
 
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
+import org.junit.runner.RunWith
 import org.scalatest.FlatSpecLike
 import org.scalatest.Matchers
+import org.scalatest.junit.JUnitRunner
 import whisk.core.containerpool.ContainerArgsConfig
 
+@RunWith(classOf[JUnitRunner])
 class LogDriverLogStoreTests extends TestKit(ActorSystem("LogDriverLogStore")) with FlatSpecLike with Matchers {
 
   val testConfig = ContainerArgsConfig(

--- a/tests/src/test/scala/whisk/core/containerpool/logging/SplunkLogStoreTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/logging/SplunkLogStoreTests.scala
@@ -33,9 +33,11 @@ import akka.stream.scaladsl.Flow
 import akka.testkit.TestKit
 import common.StreamLogging
 import java.time.ZonedDateTime
+import org.junit.runner.RunWith
 import org.scalatest.Matchers
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.junit.JUnitRunner
 import scala.util.Failure
 import whisk.core.entity.ActivationLogs
 import org.scalatest.FlatSpecLike
@@ -61,6 +63,7 @@ import whisk.core.entity.TimeLimit
 import whisk.core.entity.WhiskActivation
 import whisk.core.entity.size._
 
+@RunWith(classOf[JUnitRunner])
 class SplunkLogStoreTests
     extends TestKit(ActorSystem("SplunkLogStore"))
     with FlatSpecLike

--- a/tests/src/test/scala/whisk/core/containerpool/logging/test/DockerToActivationFileLogStoreTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/logging/test/DockerToActivationFileLogStoreTests.scala
@@ -23,7 +23,9 @@ import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.testkit.TestProbe
 import akka.util.ByteString
 import common.{StreamLogging, WskActorSystem}
+import org.junit.runner.RunWith
 import org.scalatest.Matchers
+import org.scalatest.junit.JUnitRunner
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import whisk.common.TransactionId
@@ -34,6 +36,7 @@ import whisk.core.entity._
  * Includes the tests for the DockerToActivationLogStore since the behavior towards the activation storage should
  * remain exactly the same.
  */
+@RunWith(classOf[JUnitRunner])
 class DockerToActivationFileLogStoreTests
     extends DockerToActivationLogStoreTests
     with Matchers

--- a/tests/src/test/scala/whisk/core/containerpool/logging/test/DockerToActivationLogStoreTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/logging/test/DockerToActivationLogStoreTests.scala
@@ -18,7 +18,9 @@
 package whisk.core.containerpool.logging.test
 
 import common.{StreamLogging, WskActorSystem}
+import org.junit.runner.RunWith
 import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.junit.JUnitRunner
 import whisk.core.containerpool.logging.{DockerToActivationLogStoreProvider, LogCollectingException, LogLine}
 import whisk.core.entity.ExecManifest.{ImageName, RuntimeManifest}
 import whisk.core.entity._
@@ -34,6 +36,7 @@ import whisk.http.Messages
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
 
+@RunWith(classOf[JUnitRunner])
 class DockerToActivationLogStoreTests extends FlatSpec with Matchers with WskActorSystem with StreamLogging {
   def await[T](future: Future[T]) = Await.result(future, 1.minute)
 


### PR DESCRIPTION
The following test suites were not being run: SplunkLogStoreTests, LogDriverLogStoreTests, DockerToActivationLogStoreTests, DockerToActivationFileLogStoreTests.