### PR TITLE
Remove expected duration from Swift test

### DIFF
--- a/tests/src/test/scala/whisk/core/cli/test/Swift311Tests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/Swift311Tests.scala
@@ -35,7 +35,6 @@ class Swift311Tests extends TestHelpers with WskTestHelpers with Matchers {
 
   implicit val wskprops = WskProps()
   val wsk = new WskRest
-  val expectedDuration = 45 seconds
   val activationPollDuration = 60 seconds
   val defaultJsAction = Some(TestUtils.getTestActionFilename("hello.js"))
 
@@ -52,7 +51,6 @@ class Swift311Tests extends TestHelpers with WskTestHelpers with Matchers {
       action.create(name, Some(TestUtils.getTestActionFilename("hello.swift")))
     }
 
-    val start = System.currentTimeMillis()
     withActivation(wsk.activation, wsk.action.invoke(name), totalWait = activationPollDuration) {
       _.response.result.get.toString should include("Hello stranger!")
     }
@@ -62,11 +60,6 @@ class Swift311Tests extends TestHelpers with WskTestHelpers with Matchers {
       wsk.action.invoke(name, Map("name" -> "Sir".toJson)),
       totalWait = activationPollDuration) {
       _.response.result.get.toString should include("Hello Sir!")
-    }
-
-    withClue("Test duration exceeds expectation (ms)") {
-      val duration = System.currentTimeMillis() - start
-      duration should be <= expectedDuration.toMillis
     }
   }
 


### PR DESCRIPTION
This test is prone to failure because of the expected test duration exceeds 45 seconds. The time limit instead should be based on the action's `timeout` property, which by default is 60 seconds. Also, don't count the time it takes to fetch the action's activation.

Test failure example:
`Test duration exceeds expectation (ms) 48629 was not less than or equal to 45000`