### PR TITLE
Switch snapshot version to 1.0.0-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ subprojects {
     scalafmt.configFilePath = gradle.scalafmt.config
 
     group 'org.apache.openwhisk'
-    version '0.0.1-SNAPSHOT'
+    version '1.0.0-SNAPSHOT'
 
     afterEvaluate {
         if (project.plugins.hasPlugin('application')


### PR DESCRIPTION
The releases can be still be done to lower version but post release the next snapshot version should always be 1.0.0-SNAPSHOT.

This allows other repositories which run tests against runtime based on current master to be pinned to 1.0.0-SNAPSHOT and would not require any change if release has been made from master result in increase of version number for released artifacts