### PR TITLE
Bump swift test-timeout to 2 minutes.

### DIFF
--- a/tests/src/test/scala/whisk/core/cli/test/Swift311Tests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/Swift311Tests.scala
@@ -35,7 +35,7 @@ class Swift311Tests extends TestHelpers with WskTestHelpers with Matchers {
 
   implicit val wskprops = WskProps()
   val wsk = new WskRest
-  val activationPollDuration = 60 seconds
+  val activationPollDuration = 2.minutes
   val defaultJsAction = Some(TestUtils.getTestActionFilename("hello.js"))
 
   lazy val runtimeContainer = "swift:3.1.1"


### PR DESCRIPTION
- This test is prone to errors because compiling swift apparently is subject to a lot variance (seen up to 1 minute).
- Refactor of some test helpers.