### PR TITLE
Remove two log messages, tweak logging with metrics, add log message for conductors

### DIFF
--- a/common/scala/src/main/scala/whisk/common/TransactionId.scala
+++ b/common/scala/src/main/scala/whisk/common/TransactionId.scala
@@ -121,7 +121,9 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
         InfoLevel,
         this,
         from,
-        createMessageWithMarker(message, LogMarker(endMarker, deltaToStart, Some(deltaToEnd))))
+        createMessageWithMarker(
+          if (logLevel <= InfoLevel) message else "",
+          LogMarker(endMarker, deltaToStart, Some(deltaToEnd))))
     } else {
       logging.emit(logLevel, this, from, message)
     }

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
@@ -281,6 +281,8 @@ protected[actions] trait PrimitiveActions {
       accounting = accounting.getOrElse(CompositionAccounting()), // share accounting with caller
       logs = Buffer.empty)
 
+    logging.info(this, s"invoking composition $action topmost ${cause.isEmpty} activationid '${session.activationId}'")
+
     val response: Future[Either[ActivationId, WhiskActivation]] =
       invokeConductor(user, payload, session).map(response => Right(completeActivation(user, session, response)))
 
@@ -587,7 +589,7 @@ protected[actions] trait PrimitiveActions {
       case _ =>
         // active ack received but it does not carry the response,
         // no result available except by polling the db
-        logging.warn(this, "pre-emptively polling db because active ack is missing result")
+        logging.warn(this, "preemptively polling db because active ack is missing result")
         finisher ! Scheduler.WorkOnceNow
     }
 

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/ContainerPoolBalancer.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/ContainerPoolBalancer.scala
@@ -185,11 +185,7 @@ class ContainerPoolBalancer(config: WhiskConfig, controllerInstance: InstanceId)
 
     producer.send(topic, msg).andThen {
       case Success(status) =>
-        transid.finished(
-          this,
-          start,
-          s"posted to ${status.topic()}[${status.partition()}][${status.offset()}]",
-          logLevel = InfoLevel)
+        transid.finished(this, start, s"posted to ${status.topic()}[${status.partition()}][${status.offset()}]")
       case Failure(e) => transid.failed(this, start, s"error on posting to topic $topic")
     }
   }


### PR DESCRIPTION
When logging only a metric, skip the message unless the log level is enabled.
Lowered log level on two messages.
Add log message for compositions.

@vvraskin can you review?
pg3/1873 🏃 
