### PR TITLE
For MacOSX using docker-for-mac, do not use runc.

### DIFF
--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -5,6 +5,7 @@ whisk_logs_dir: "{{ openwhisk_tmp_dir }}/wsklogs"
 docker_registry: ""
 docker_dns: ""
 runtimes_bypass_pull_for_local_images: true
+invoker_use_runc: "{{ ansible_distribution != 'MacOSX' }}"
 
 db_prefix: whisk_local_
 


### PR DESCRIPTION
`runc` fails on docker-for-mac; use docker pause/resume instead.