### PR TITLE
Sanitize test subjects before tests.

### DIFF
--- a/tests/src/test/scala/common/WskTestHelpers.scala
+++ b/tests/src/test/scala/common/WskTestHelpers.scala
@@ -31,6 +31,7 @@ import spray.json._
 import spray.json.DefaultJsonProtocol._
 
 import TestUtils.RunResult
+import TestUtils.SUCCESS_EXIT
 import TestUtils.CONFLICT
 import akka.http.scaladsl.model.StatusCodes
 
@@ -287,10 +288,10 @@ trait WskTestHelpers extends Matchers {
     WskProps(namespace = newUser, authKey = wskadmin.cli(Seq("user", "create", newUser)).stdout.trim)
   }
 
-  def disposeAdditionalTestSubject(subject: String): Unit = {
+  def disposeAdditionalTestSubject(subject: String, expectedExitCode: Int = SUCCESS_EXIT): Unit = {
     val wskadmin = new RunWskAdminCmd {}
     withClue(s"failed to delete temporary subject $subject") {
-      wskadmin.cli(Seq("user", "delete", subject)).stdout should include("Subject deleted")
+      wskadmin.cli(Seq("user", "delete", subject), expectedExitCode).stdout should include("Subject deleted")
     }
   }
 }

--- a/tests/src/test/scala/limits/ThrottleTests.scala
+++ b/tests/src/test/scala/limits/ThrottleTests.scala
@@ -303,15 +303,17 @@ class NamespaceSpecificThrottleTests
   val wskadmin = new RunWskAdminCmd {}
   val wsk = new WskRest
 
-  def sanitizeNamespaces(namespaces: Seq[String], expectedExitCode: Int = SUCCESS_EXIT) = {
+  def sanitizeNamespaces(namespaces: Seq[String], expectedExitCode: Int = SUCCESS_EXIT): Unit = {
+    var errors = 0
     namespaces.foreach { ns =>
       try {
         disposeAdditionalTestSubject(ns, expectedExitCode)
         withClue(s"failed to delete temporary limits for $ns") {
           wskadmin.cli(Seq("limits", "delete", ns), expectedExitCode)
         }
-      } catch { case _: Throwable => }
+      } catch { case _: Throwable => errors += 1 }
     }
+    if (expectedExitCode == SUCCESS_EXIT) assert(errors == 0)
   }
 
   sanitizeNamespaces(

--- a/tests/src/test/scala/limits/ThrottleTests.scala
+++ b/tests/src/test/scala/limits/ThrottleTests.scala
@@ -46,7 +46,7 @@ import whisk.http.Messages._
 import whisk.utils.ExecutionContextFactory
 import whisk.utils.retry
 
-import scala.util.{Failure, Success, Try}
+import scala.util.{Success, Try}
 
 protected[limits] trait LocalHelper {
   def prefix(msg: String) = msg.substring(0, msg.indexOf('('))


### PR DESCRIPTION
This test suite will fail if the subjects are not properly deleted in a previous run. Attempts to wipe the subjects before running the suite to compensate for past failures.

Closes https://github.com/apache/incubator-openwhisk/issues/3136.