### PR TITLE
Script to generate IntelliJ Run Configuration for Controller and Invoker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ ansible/roles/controller/files/*.p12
 !tests/dat/actions/python_virtualenv_dir.zip
 !tests/dat/actions/python_virtualenv_name.zip
 !tests/dat/actions/zippedaction.zip
+
+# dev
+intellij-run-config.groovy

--- a/tools/dev/README.md
+++ b/tools/dev/README.md
@@ -59,3 +59,71 @@ Sample output
     Processing whisks_design_document_for_activations_db_filters_v2.1.0.json
             - whisks-filters.v2.1.0-activations.js
     Generated view json files in /path/too/tools/build/views
+
+## IntelliJ Run Config Generator
+
+This script enables creation of [Intellij Launch Configuration][1] in _<openwhisk home>/.idea/runConfigurations_ 
+with name controller0 and invoker0. For this to work your Intellij project should be [directory based][3]. If your 
+project is file based (uses ipr files) then you can convert it to directory based via _File -> Save as Directory-Based Format_
+
+### Usage
+
+First setup OpenWhisk so that Controller and Invoker containers are up and running. Then run the script
+
+    ./gradlew -p tools/dev intellij
+    
+It would inspect the running docker containers and then generate the launch configs with name 'controller0' 
+and 'invoker0'
+
+Key points to note
+
+1. Uses ~/tmp/openwhisk/controller (or invoker) as working directory
+2. Changes the PORT to linked one. So controller gets started at 10001 only just like container
+
+Now the docker container can be stopped and application can be launched from within the IDE
+
+**Note** - Currently only controller can be run from IDE. Invoker posses some [problems][2]
+
+### Configuration
+
+The script allows some local customization of the launch configuration. This can be done by creating a [config][4] file
+`intellij-run-config.groovy` in project root directory. Below is an example of _<openwhisk home>/intellij-run-config.groovy_ 
+file to customize the logging and db port used for CouchDB
+
+```groovy
+//Configures the settings for controller application
+controller {
+    //Base directory used for controller process
+    workingDir = "/path/to/controller"
+    //System properties to be set
+    props = [
+            'logback.configurationFile':'/path/to/custom/logback.xml'
+    ]
+    //Environment variables to be set
+    env = [
+            'DB_PORT' : '5989'
+    ]
+}
+
+invoker {
+    workingDir = "/path/to/invoker"
+    props = [
+            'logback.configurationFile':'/path/to/custom/logback.xml'
+    ]
+    env = [
+            'DB_PORT' : '5989'
+    ]
+}
+
+```
+
+The config allows following properties
+
+* `workingDir` - Base directory used for controller or invoker process
+* `props` - Map of system properties which should be passed to the application
+* `env` - Map of environment variables which should be set for application process
+
+[1]: https://www.jetbrains.com/help/idea/run-debug-configurations-dialog.html#run_config_common_options
+[2]: https://github.com/apache/incubator-openwhisk/issues/3195
+[3]: https://www.jetbrains.com/help/idea/configuring-projects.html#project-formats
+[4]: http://docs.groovy-lang.org/2.4.2/html/gapi/groovy/util/ConfigSlurper.html

--- a/tools/dev/README.md
+++ b/tools/dev/README.md
@@ -64,31 +64,31 @@ Sample output
 
 This script enables creation of [Intellij Launch Configuration][1] in _<openwhisk home>/.idea/runConfigurations_ 
 with name controller0 and invoker0. For this to work your Intellij project should be [directory based][3]. If your 
-project is file based (uses ipr files) then you can convert it to directory based via _File -> Save as Directory-Based Format_
+project is file based (uses ipr files) then you can convert it to directory based via _File -> Save as Directory-Based Format_. These run configurations can then be invoked from _Run -> Edit Configurations -> Application_
 
 ### Usage
 
-First setup OpenWhisk so that Controller and Invoker containers are up and running. Then run the script
+First setup OpenWhisk so that Controller and Invoker containers are up and running. Then run the script:
 
     ./gradlew -p tools/dev intellij
     
 It would inspect the running docker containers and then generate the launch configs with name 'controller0' 
-and 'invoker0'
+and 'invoker0'.
 
-Key points to note
+Key points to note:
 
-1. Uses ~/tmp/openwhisk/controller (or invoker) as working directory
-2. Changes the PORT to linked one. So controller gets started at 10001 only just like container
+1. Uses ~/tmp/openwhisk/controller (or invoker) as working directory.
+2. Changes the PORT to linked one. So controller gets started at 10001 only just like as its done in container.
 
-Now the docker container can be stopped and application can be launched from within the IDE
+Now the docker container can be stopped and application can be launched from within the IDE.
 
-**Note** - Currently only controller can be run from IDE. Invoker posses some [problems][2]
+**Note** - Currently only the controller can be run from IDE. Invoker posses some [problems][2].
 
 ### Configuration
 
 The script allows some local customization of the launch configuration. This can be done by creating a [config][4] file
 `intellij-run-config.groovy` in project root directory. Below is an example of _<openwhisk home>/intellij-run-config.groovy_ 
-file to customize the logging and db port used for CouchDB
+file to customize the logging and db port used for CouchDB.
 
 ```groovy
 //Configures the settings for controller application
@@ -117,11 +117,11 @@ invoker {
 
 ```
 
-The config allows following properties
+The config allows following properties:
 
-* `workingDir` - Base directory used for controller or invoker process
-* `props` - Map of system properties which should be passed to the application
-* `env` - Map of environment variables which should be set for application process
+* `workingDir` - Base directory used for controller or invoker process.
+* `props` - Map of system properties which should be passed to the application.
+* `env` - Map of environment variables which should be set for application process.
 
 [1]: https://www.jetbrains.com/help/idea/run-debug-configurations-dialog.html#run_config_common_options
 [2]: https://github.com/apache/incubator-openwhisk/issues/3195

--- a/tools/dev/README.md
+++ b/tools/dev/README.md
@@ -101,7 +101,8 @@ controller {
     ]
     //Environment variables to be set
     env = [
-            'DB_PORT' : '5989'
+            'DB_PORT' : '5989',
+            'CONFIG_whisk_controller_protocol' : 'http'
     ]
 }
 

--- a/tools/dev/build.gradle
+++ b/tools/dev/build.gradle
@@ -12,3 +12,10 @@ task couchdbViews(type: JavaExec) {
     args owHome.absolutePath
     classpath = sourceSets.main.runtimeClasspath
 }
+
+task intellij(type: JavaExec) {
+    description 'Generates Intellij run config for Controller and Invoker'
+    main = 'intellijRunConfig'
+    args owHome.absolutePath
+    classpath = sourceSets.main.runtimeClasspath
+}

--- a/tools/dev/build.gradle
+++ b/tools/dev/build.gradle
@@ -1,9 +1,13 @@
 apply plugin: 'groovy'
 
+repositories {
+    mavenCentral()
+}
+
 def owHome = project.projectDir.parentFile.parentFile
 
 dependencies {
-    compile localGroovy()
+    compile "org.codehaus.groovy:groovy-all:2.4.14"
 }
 
 task couchdbViews(type: JavaExec) {

--- a/tools/dev/src/main/groovy/intellijRunConfig.groovy
+++ b/tools/dev/src/main/groovy/intellijRunConfig.groovy
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import groovy.json.JsonSlurper
+import groovy.text.SimpleTemplateEngine
+
+assert args : "Expecting the OpenWhisk home directory to passed"
+owHome = args[0]
+
+//Launch config template
+def configTemplate = '''<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="${name}" type="Application" factoryName="Application">
+    <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
+    <option name="MAIN_CLASS_NAME" value="$main" />
+    <option name="VM_PARAMETERS" value="$sysProps" />
+    <option name="PROGRAM_PARAMETERS" value="0" />
+    <option name="WORKING_DIRECTORY" value="$workingDir" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+    <option name="ALTERNATIVE_JRE_PATH" />
+    <option name="ENABLE_SWING_INSPECTOR" value="false" />
+    <option name="ENV_VARIABLES" />
+    <option name="PASS_PARENT_ENVS" value="true" />
+    <module name="${type}_main" />
+    <envs>
+      <% env.each { k,v -> %><env name="$k" value="$v" />
+      <% } %>
+    </envs>
+    <method />
+  </configuration>
+</component>
+'''
+
+def meta = [
+        controller : [main:"whisk.core.controller.Controller"],
+        invoker : [main:"whisk.core.invoker.Invoker"]
+]
+
+//Get names of all running containers
+def containerNames = 'docker ps --format {{.Names}}'.execute().text.split("\n")
+
+//Command for transformEnvironment script
+transformEnvScript = "/bin/bash $owHome/common/scala/transformEnvironment.sh"
+
+config = getConfig()
+
+containerNames.each{cn ->
+    //Inspect the specific container
+    def inspectResult = "docker inspect $cn".execute().text
+    def json = new JsonSlurper().parseText(inspectResult)
+
+    def imageName = json[0].'Config'.'Image'
+    if (imageName.contains("controller") || imageName.contains("invoker")){
+        String type = imageName.contains("controller") ? "controller" : "invoker"
+
+        def mappedPort = json.'NetworkSettings'.'Ports'.'8080/tcp'[0][0].'HostPort'
+
+        def env = json[0].'Config'.'Env'
+        def overrides = [
+                'PORT' : mappedPort,
+                'WHISK_LOGS_DIR' : "$owHome/core/$type/build/tmp"
+        ]
+        def envMap = getEnv(env, type, overrides)
+
+        //Prepare system properties
+        def sysProps = getSysProps(envMap,type)
+
+        def templateBinding = [
+                main: meta[type].main,
+                type:type,
+                name:cn,
+                env: encodeForXML(envMap),
+                sysProps : sysProps,
+                USER_HOME : '$USER_HOME$',
+                workingDir : getWorkDir(type)
+        ]
+
+        def engine = new SimpleTemplateEngine()
+        def template = engine.createTemplate(configTemplate).make(templateBinding)
+
+        def launchFile = new File("$owHome/.idea/runConfigurations/${cn}.xml")
+        launchFile.parentFile.mkdirs()
+        launchFile.text = template
+        println "Created ${launchFile.absolutePath}"
+    }
+}
+
+/**
+ * Reads config from intellij-run-config.groovy file
+ */
+def getConfig(){
+    def configFile = new File(owHome, 'intellij-run-config.groovy')
+    def config = configFile.exists() ? new ConfigSlurper().parse(configFile.text) : new ConfigObject()
+    if (configFile.exists()) {
+        println "Reading config from ${configFile.absolutePath}"
+    }
+    config
+}
+
+def getWorkDir(String type){
+    def dir = config[type].workingDir
+    if (dir){
+        File f = new File(dir)
+        if (!f.exists()) {
+            f.mkdirs()
+        }
+        dir
+    }else {
+        'file://$MODULE_DIR$'
+    }
+}
+
+def getSysProps(def envMap, String type){
+    def props = config[type].props
+    def sysProps = transformEnvScript.execute(getEnvAsList(envMap), new File(".")).text
+    sysProps += props.collect{k,v -> "-D$k='$v'"}.join(' ')
+    sysProps.replace('\'','')
+}
+
+/**
+ * Inspect command from docker returns the environment variables as list of string of form key=value
+ * This method converts it to map and add provided overrides with overrides from config
+ */
+def getEnv(def env, String type, Map overrides){
+    def ignoredKeys = ['PATH']
+    def overridesFromConfig = config[type].env
+    Map envMap = env.collectEntries {String e ->
+        def eqIndex = e.indexOf('=')
+        def k = e.substring(0, eqIndex)
+        def v = e.substring(eqIndex + 1)
+        [(k):v]
+    }
+
+    envMap.putAll(overrides)
+
+    //Config override come last
+    envMap.putAll(overridesFromConfig)
+
+    //Remove ignored keys like PATH which should be inherited
+    ignoredKeys.each {envMap.remove(it)}
+
+    //Returned sorted view of env
+    new TreeMap(envMap)
+}
+
+def getEnvAsList(Map envMap){
+    envMap.collect{k,v -> "$k=$v"}
+}
+
+def encodeForXML(Map map){
+    map.collectEntries {k,v -> [(k): v.replace('"', '&quot;')]}
+}


### PR DESCRIPTION
Script which generates the run configuration for Controller and Invoker to enable launching them from within IDE. This allows faster development and debugging as time spent in rebuilding and restarting docker containers can be avoided

The script can be run via below command (requires OpenWhisk running)

    ./gradlew -p tools/dev intellij

![intellij-run](https://user-images.githubusercontent.com/664531/36413929-5d81cd8a-1646-11e8-9c81-e8f877798491.png)

The script also supports customizing the generated config with local overrides via custom config file (see README.md for details)

For now using this script Controller can be launched from within the IDE. Invoker posses some [problem](apache/incubator-openwhisk#3195)
