### PR TITLE
Rework rule tests to not rely on views anymore.

### DIFF
--- a/tests/src/test/scala/system/basic/WskRuleTests.scala
+++ b/tests/src/test/scala/system/basic/WskRuleTests.scala
@@ -25,6 +25,7 @@ import common.TestUtils.RunResult
 import common.BaseWsk
 import common.WskProps
 import common.WskTestHelpers
+import common.RuleActivationResult
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import java.time.Instant
@@ -129,18 +130,15 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
 
     withActivation(wsk.activation, run) { triggerActivation =>
       triggerActivation.cause shouldBe None
-      triggerActivation.logs.get.size shouldBe (1)
-      val logs = triggerActivation.logs.get.mkString(" ")
-      logs should include(""""statusCode":0""")
-      logs should include(""""activationId":""")
-      logs should include(""""success":true""")
+      triggerActivation.logs.get should have size 1
 
-      withActivationsFromEntity(
-        wsk.activation,
-        actionName,
-        since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) { activationList =>
-        activationList.head.response.result shouldBe Some(testResult)
-        activationList.head.cause shouldBe None
+      val ruleActivation = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult]).head
+      ruleActivation.success shouldBe true
+      ruleActivation.statusCode shouldBe 0
+
+      withActivation(wsk.activation, ruleActivation.activationId) { actionActivation =>
+        actionActivation.response.result shouldBe Some(testResult)
+        actionActivation.cause shouldBe None
       }
     }
   }
@@ -164,17 +162,12 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
 
     withActivation(wsk.activation, run) { triggerActivation =>
       triggerActivation.cause shouldBe None
-      triggerActivation.logs.get.size shouldBe (1)
-      val logs = triggerActivation.logs.get.mkString(" ")
-      logs should include(""""statusCode":0""")
-      logs should include(""""activationId":""")
-      logs should include(""""success":true""")
+      val ruleActivation = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult]).head
+      ruleActivation.success shouldBe true
+      ruleActivation.statusCode shouldBe 0
 
-      withActivationsFromEntity(
-        wsk.activation,
-        pkgActionName,
-        since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
-        _.head.response.result shouldBe Some(testResult)
+      withActivation(wsk.activation, ruleActivation.activationId) { actionActivation =>
+        actionActivation.response.result shouldBe Some(testResult)
       }
     }
   }
@@ -202,17 +195,13 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
 
     withActivation(wsk.activation, run) { triggerActivation =>
       triggerActivation.cause shouldBe None
-      triggerActivation.logs.get.size shouldBe (1)
-      val logs = triggerActivation.logs.get.mkString(" ")
-      logs should include(""""statusCode":0""")
-      logs should include(""""activationId":""")
-      logs should include(""""success":true""")
+      val ruleActivation = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult]).head
+      ruleActivation.success shouldBe true
+      ruleActivation.statusCode shouldBe 0
 
-      withActivationsFromEntity(
-        wsk.activation,
-        pkgActionName,
-        since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
-        _.head.response.result shouldBe Some(testResult)
+      withActivation(wsk.activation, ruleActivation.activationId) { actionActivation =>
+        actionActivation.response.result shouldBe Some(testResult)
+        actionActivation.cause shouldBe None
       }
     }
   }
@@ -229,24 +218,16 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
       assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
         action.create(name, Some(defaultAction))
       }
-      assetHelper.withCleaner(wsk.rule, ruleName, false) { (rule, name) =>
+      assetHelper.withCleaner(wsk.rule, ruleName, confirmDelete = false) { (rule, name) =>
         rule.create(name, triggerName, actionName)
       }
 
       val first = wsk.trigger.fire(triggerName, Map("payload" -> "bogus".toJson))
       wsk.rule.delete(ruleName)
-      wsk.trigger.fire(triggerName, Map("payload" -> "bogus2".toJson))
+      val second = wsk.trigger.fire(triggerName, Map("payload" -> "bogus2".toJson))
 
-      withActivation(wsk.activation, first) { activation =>
-        // tries to find 2 activations for the action, should only find 1
-        val activations = wsk.activation.pollFor(
-          2,
-          Some(actionName),
-          since = Some(activation.start.minusMillis(activationTimeSkewFactorMs)),
-          retries = 30)
-
-        activations.length shouldBe 1
-      }
+      withActivation(wsk.activation, first)(activation => activation.logs.get should have size 1)
+    // there won't be an activation for the second fire since there is no rule
   }
 
   it should "enable and disable a rule and check action is activated only when rule is enabled" in withAssetCleaner(
@@ -259,18 +240,23 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
 
     val first = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
     wsk.rule.disable(ruleName)
-    wsk.trigger.fire(triggerName, Map("payload" -> s"$testString with added words".toJson))
+    val second = wsk.trigger.fire(triggerName, Map("payload" -> s"$testString with added words".toJson))
     wsk.rule.enable(ruleName)
-    wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
+    val third = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
 
     withActivation(wsk.activation, first) { triggerActivation =>
-      withActivationsFromEntity(
-        wsk.activation,
-        actionName,
-        N = 2,
-        since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) { activations =>
-        val results = activations.map(_.response.result)
-        results should contain theSameElementsAs Seq(Some(testResult), Some(testResult))
+      val ruleActivation = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult]).head
+      withActivation(wsk.activation, ruleActivation.activationId) { actionActivation =>
+        actionActivation.response.result shouldBe Some(testResult)
+      }
+    }
+
+    // second fire will not write an activation
+
+    withActivation(wsk.activation, third) { triggerActivation =>
+      val ruleActivation = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult]).head
+      withActivation(wsk.activation, ruleActivation.activationId) { actionActivation =>
+        actionActivation.response.result shouldBe Some(testResult)
       }
     }
   }
@@ -303,11 +289,9 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
 
       val first = wsk.trigger.fire(triggerName2, Map("payload" -> testString.toJson))
       withActivation(wsk.activation, first) { triggerActivation =>
-        withActivationsFromEntity(
-          wsk.activation,
-          actionName,
-          since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
-          _.head.response.result shouldBe Some(testResult)
+        val ruleActivation = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult]).head
+        withActivation(wsk.activation, ruleActivation.activationId) { actionActivation =>
+          actionActivation.response.result shouldBe Some(testResult)
         }
       }
   }
@@ -325,23 +309,16 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
         assetHelper)
 
       val testPayloads = Seq("got three words", "got four words, period")
+      val runs = testPayloads.map(payload => wsk.trigger.fire(triggerName1, Map("payload" -> payload.toJson)))
 
-      val run = wsk.trigger.fire(triggerName1, Map("payload" -> testPayloads(0).toJson))
-      wsk.trigger.fire(triggerName2, Map("payload" -> testPayloads(1).toJson))
-
-      withActivation(wsk.activation, run) { triggerActivation =>
-        withActivationsFromEntity(
-          wsk.activation,
-          actionName,
-          N = 2,
-          since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) { activations =>
-          val results = activations.map(_.response.result)
-          val expectedResults = testPayloads.map { payload =>
-            Some(JsObject("count" -> payload.split(" ").length.toJson))
+      runs.zip(testPayloads).foreach {
+        case (run, payload) =>
+          withActivation(wsk.activation, run) { triggerActivation =>
+            val ruleActivation = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult]).head
+            withActivation(wsk.activation, ruleActivation.activationId) { actionActivation =>
+              actionActivation.response.result shouldBe Some(JsObject("count" -> payload.split(" ").length.toJson))
+            }
           }
-
-          results should contain theSameElementsAs expectedResults
-        }
       }
   }
 
@@ -360,17 +337,17 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
       val run = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
 
       withActivation(wsk.activation, run) { triggerActivation =>
-        withActivationsFromEntity(
-          wsk.activation,
-          actionName1,
-          since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
-          _.head.response.result shouldBe Some(testResult)
+        val ruleActivations = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult])
+        ruleActivations should have size 2
+
+        val action1Result = ruleActivations.find(_.action.contains(actionName1)).get
+        val action2Result = ruleActivations.find(_.action.contains(actionName2)).get
+
+        withActivation(wsk.activation, action1Result.activationId) { actionActivation =>
+          actionActivation.response.result shouldBe Some(testResult)
         }
-        withActivationsFromEntity(
-          wsk.activation,
-          actionName2,
-          since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) {
-          _.head.logs.get.mkString(" ") should include(s"hello, $testString")
+        withActivation(wsk.activation, action2Result.activationId) { actionActivation =>
+          actionActivation.logs.get.mkString(" ") should include(s"hello, $testString")
         }
       }
   }
@@ -391,35 +368,27 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
         assetHelper)
 
       val testPayloads = Seq("got three words", "got four words, period")
-      val run = wsk.trigger.fire(triggerName1, Map("payload" -> testPayloads(0).toJson))
-      wsk.trigger.fire(triggerName2, Map("payload" -> testPayloads(1).toJson))
+      val runs = Seq(triggerName1, triggerName2).zip(testPayloads).map {
+        case (trigger, payload) =>
+          payload -> wsk.trigger.fire(trigger, Map("payload" -> payload.toJson))
+      }
 
-      withActivation(wsk.activation, run) { triggerActivation =>
-        withActivationsFromEntity(
-          wsk.activation,
-          actionName1,
-          N = 2,
-          since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) { activations =>
-          val results = activations.map(_.response.result)
-          val expectedResults = testPayloads.map { payload =>
-            Some(JsObject("count" -> payload.split(" ").length.toJson))
+      runs.foreach {
+        case (payload, run) =>
+          withActivation(wsk.activation, run) { triggerActivation =>
+            val ruleActivations = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult])
+            ruleActivations should have size 2 // each trigger has 2 actions attached
+
+            val action1Result = ruleActivations.find(_.action.contains(actionName1)).get
+            val action2Result = ruleActivations.find(_.action.contains(actionName2)).get
+
+            withActivation(wsk.activation, action1Result.activationId) { actionActivation =>
+              actionActivation.response.result shouldBe Some(JsObject("count" -> payload.split(" ").length.toJson))
+            }
+            withActivation(wsk.activation, action2Result.activationId) { actionActivation =>
+              actionActivation.logs.get.mkString(" ") should include(s"hello, $payload")
+            }
           }
-
-          results should contain theSameElementsAs expectedResults
-        }
-        withActivationsFromEntity(
-          wsk.activation,
-          actionName2,
-          N = 2,
-          since = Some(triggerActivation.start.minusMillis(activationTimeSkewFactorMs))) { activations =>
-          // drops the leftmost 39 characters (timestamp + streamname)
-          val logs = activations.map(_.logs.get.map(_.drop(39))).flatten
-          val expectedLogs = testPayloads.map { payload =>
-            s"hello, $payload!"
-          }
-
-          logs should contain theSameElementsAs expectedLogs
-        }
       }
   }
 

--- a/tests/src/test/scala/system/basic/WskSequenceTests.scala
+++ b/tests/src/test/scala/system/basic/WskSequenceTests.scala
@@ -34,6 +34,7 @@ import common.TestUtils
 import common.TestUtils._
 import common.BaseWsk
 import common.WskProps
+import common.RuleActivationResult
 import common.WskTestHelpers
 
 import akka.http.scaladsl.testkit.ScalatestRouteTest
@@ -472,9 +473,10 @@ abstract class WskSequenceTests extends TestHelpers with ScalatestRouteTest with
    */
   private def checkEchoSeqRuleResult(triggerFireRun: RunResult, seqName: String, triggerPayload: JsObject) = {
     withActivation(wsk.activation, triggerFireRun) { triggerActivation =>
-      withActivationsFromEntity(wsk.activation, seqName, since = Some(triggerActivation.start)) { activationList =>
-        activationList.head.response.result shouldBe Some(triggerPayload)
-        activationList.head.cause shouldBe None
+      val ruleActivation = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult]).head
+      withActivation(wsk.activation, ruleActivation.activationId) { actionActivation =>
+        actionActivation.response.result shouldBe Some(triggerPayload)
+        actionActivation.cause shouldBe None
       }
     }
   }


### PR DESCRIPTION
Relying on views is brittle and will fail if the database is under high load. We don't need to rely on those anymore.