### PR TITLE
Configure Gradle build scan plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,16 @@ buildscript {
     }
 }
 
+plugins {
+    id "com.gradle.build-scan" version "1.12.1"
+}
+
+buildScan {
+    termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
+    publishAlwaysIf(System.getenv('CI') != null)
+}
+
 subprojects {
     apply plugin: 'scalafmt'
     scalafmt.configFilePath = gradle.scalafmt.config

--- a/tools/build/README.md
+++ b/tools/build/README.md
@@ -68,6 +68,19 @@ The logs are saved to `./B-build.log` and can be reprocessed using `citool` with
 citool -i -b B cat -s -g "tid_124" whisk/logs N
 ```
 
+## Gradle Build Scan Integration
+
+OpenWhisk builds on CI setups have [Gradle Build Scan][1] integrated. Each build on travis pushes scan reports to
+[Gradle Scan Community Hosted Server][2]. To see the scan report you need to check the travis build logs for lines like
+below 
+
+```
+Publishing build scan...
+https://gradle.com/s/reldo4qqlg3ka
+```
+
+The url above is the scan report url and is unique per build
+
 ## Troubleshooting
 
 If you encounter an error `ImportError: No module named pkg_resources` while running `redo`, try the workaround below
@@ -76,3 +89,6 @@ or see [these instructions](https://pypi.python.org/pypi/setuptools/0.9.8#instal
 ```
 pip install --upgrade setuptools
 ```
+
+[1]: https://gradle.com/build-scans
+[2]: https://scans.gradle.com

--- a/tools/build/README.md
+++ b/tools/build/README.md
@@ -70,8 +70,8 @@ citool -i -b B cat -s -g "tid_124" whisk/logs N
 
 ## Gradle Build Scan Integration
 
-OpenWhisk builds on CI setups have [Gradle Build Scan][1] integrated. Each build on travis pushes scan reports to
-[Gradle Scan Community Hosted Server][2]. To see the scan report you need to check the travis build logs for lines like
+OpenWhisk builds on CI setups have [Gradle Build Scan](https://gradle.com/build-scans) integrated. Each build on travis pushes scan reports to
+[Gradle Scan Community Hosted Server](https://scans.gradle.com). To see the scan report you need to check the travis build logs for lines like
 below 
 
 ```
@@ -89,6 +89,3 @@ or see [these instructions](https://pypi.python.org/pypi/setuptools/0.9.8#instal
 ```
 pip install --upgrade setuptools
 ```
-
-[1]: https://gradle.com/build-scans
-[2]: https://scans.gradle.com


### PR DESCRIPTION
PR for #3312. With this the scan result would only be published on CI setups

However with this change now following warning is seen

```
WARNING: The build scan plugin was applied after other plugins.
The captured data is more comprehensive when the build scan plugin is applied first.

Please see https://gradle.com/scans/help/plugin-late-apply for how to resolve this problem.
```

From changes done in this PR its ensured that this plugin comes first but still the warning is seen. For now it appears a [bug in gradle](gradle/gradle#3341) which was fixed in 4.3 (we use 4.1). I tried with current 4.5 and warning disappears.

@markusthoemmes Not sure sure if changes here affect down stream projects (like the issue seen with coverage pr)

Apart from the noisy warning things work fine