### PR TITLE
Remove restriction on updating a trigger with a new feed.

### DIFF
--- a/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
@@ -245,15 +245,7 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
       content.publish getOrElse trigger.publish,
       content.annotations getOrElse trigger.annotations,
       trigger.rules).revision[WhiskTrigger](trigger.docinfo.rev)
-
-    // feed must be specified in create, and cannot be added as a trigger update
-    content.annotations flatMap { _.get(Parameters.Feed) } map { _ =>
-      Future failed {
-        RejectRequest(BadRequest, "A trigger feed is only permitted when the trigger is created")
-      }
-    } getOrElse {
-      Future successful newTrigger
-    }
+    Future.successful(newTrigger)
   }
 
   /**

--- a/tests/src/test/scala/whisk/core/controller/test/TriggersApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/TriggersApiTests.scala
@@ -303,7 +303,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
     val content = WhiskTriggerPut(annotations = Some(trigger.annotations))
     put(entityStore, trigger)
     Put(s"$collectionPath/${trigger.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-      status should be(BadRequest)
+      deleteTrigger(trigger.docid)
+      status should be(OK)
     }
   }
 
@@ -313,7 +314,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
     val content = WhiskTriggerPut(annotations = Some(Parameters(Parameters.Feed, "xyz")))
     put(entityStore, trigger)
     Put(s"$collectionPath/${trigger.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-      status should be(BadRequest)
+      deleteTrigger(trigger.docid)
+      status should be(OK)
     }
   }
 


### PR DESCRIPTION
Feedback solicited.

Since a feed is already handled entirely on the client side today, should we just remove the restriction on the backend entirely?

Note the existing code is buggy - you can update an existing trigger with an attached feed, and de-associate it from the feed by specifying a new annotation. Further, if there's no feed attached, why prohibit an update that attaches a feed?

So either we should tighten the backend check, or remove it entirely, since clients like the CLI currently handle feed differently and route some API calls directly to the feed vs the controller. See https://github.com/apache/incubator-openwhisk-cli/issues/225 for example.

Closes https://github.com/apache/incubator-openwhisk/issues/3297
