### PR TITLE
Normalize a missing body for raw actions to JsString.empty.

### DIFF
--- a/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
@@ -129,11 +129,11 @@ private case class Context(propertyMap: WebApiDirectives,
     // if the body is a json object, merge with query parameters
     // otherwise, this is an opaque body that will be nested under
     // __ow_body in the parameters sent to the action as an argument
-    val bodyParams = body match {
+    val bodyParams: Map[String, JsValue] = body match {
       case Some(JsObject(fields)) if !boxQueryAndBody => fields
       case Some(v)                                    => Map(propertyMap.body -> v)
       case None if !boxQueryAndBody                   => Map.empty
-      case _                                          => Map(propertyMap.body -> JsObject())
+      case _                                          => Map(propertyMap.body -> JsString.empty)
     }
 
     // precedence order is: query params -> body (last wins)

--- a/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
@@ -1536,7 +1536,7 @@ trait WebActionsApiBaseTests extends ControllerTestCommon with BeforeAndAfterEac
           "action" -> "raw_export_c".toJson,
           "content" -> metaPayload(
             Post.method.name.toLowerCase,
-            Map(webApiDirectives.body -> JsObject(), webApiDirectives.query -> queryString.toJson).toJson.asJsObject,
+            Map(webApiDirectives.body -> "".toJson, webApiDirectives.query -> queryString.toJson).toJson.asJsObject,
             creds,
             pkgName = "proxy"))
       }
@@ -1586,6 +1586,24 @@ trait WebActionsApiBaseTests extends ControllerTestCommon with BeforeAndAfterEac
               pkgName = "proxy",
               headers = List(`Content-Type`(ContentTypes.`application/json`))))
         }
+      }
+    }
+
+    it should s"invoke raw action ensuring body and query arguments are empty strings when not specified in request (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+
+      Post(s"$testRoutePath/$systemId/proxy/raw_export_c.json") ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        invocationsAllowed += 1
+        val response = responseAs[JsObject]
+        response shouldBe JsObject(
+          "pkg" -> s"$systemId/proxy".toJson,
+          "action" -> "raw_export_c".toJson,
+          "content" -> metaPayload(
+            Post.method.name.toLowerCase,
+            Map(webApiDirectives.body -> "".toJson, webApiDirectives.query -> "".toJson).toJson.asJsObject,
+            creds,
+            pkgName = "proxy"))
       }
     }
 


### PR DESCRIPTION
Proposed fix for https://github.com/apache/incubator-openwhisk/issues/3321.

I partially confirmed the reported issue. The code and previous test confirms a missing body is an instance of JsObject, not JsArray. I'm not sure yet where the JsArray comes from; it may be PHP actions specific. A node test shows the type is not an array.

@akrabat FYI for node and python below.

<img width="1011" alt="screen shot 2018-02-21 at 10 27 59 am" src="https://user-images.githubusercontent.com/4959922/36498020-f2bb39a8-16f1-11e8-90a8-5436c954a41b.png">

<img width="1134" alt="screen shot 2018-02-21 at 10 34 55 am" src="https://user-images.githubusercontent.com/4959922/36498356-e87ecdfa-16f2-11e8-89b9-bdb0f0cf50eb.png">
