### PR TITLE
Make package test resilient against eventual consistency.

### DIFF
--- a/tests/src/test/scala/whisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/PackagesApiTests.scala
@@ -335,10 +335,13 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
       aname(),
       jsDefault("??"),
       annotations = Parameters(Parameters.Feed, "true"))
+
     put(entityStore, provider)
     put(entityStore, reference)
     put(entityStore, action)
     put(entityStore, feed)
+
+    waitOnView(entityStore, WhiskAction, provider.fullPath, 2)
 
     // it should "reject get package reference from other subject" in {
     val auser = WhiskAuthHelpers.newIdentity()
@@ -349,7 +352,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     Get(s"$collectionPath/${reference.name}") ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[WhiskPackageWithActions]
-      response should be(reference withActions (List(action, feed)))
+      response should be(reference withActions List(action, feed))
     }
   }
 


### PR DESCRIPTION
When getting a package including actions a view is invoked. We need to wait on that view to make the test resilient against intermittent failures.