### PR TITLE
Make parameters with defined values final 

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/Parameter.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Parameter.scala
@@ -41,10 +41,7 @@ protected[core] class Parameters protected[entity] (private val params: Map[Para
    */
   def size = {
     params
-      .map {
-        case (name, value) =>
-          name.size + value.size
-      }
+      .map { case (name, value) => name.size + value.size }
       .foldLeft(0 B)(_ + _)
   }
 
@@ -77,14 +74,14 @@ protected[core] class Parameters protected[entity] (private val params: Map[Para
     params.keySet filter (params(_).isDefined) map (_.name)
   }
 
-  protected[core] def toJsArray =
+  protected[core] def toJsArray = {
     JsArray(params map { p =>
       JsObject("key" -> p._1.name.toJson, "value" -> p._2.value.toJson)
     } toSeq: _*)
-  protected[core] def toJsObject =
-    JsObject(params map { p =>
-      (p._1.name -> p._2.value.toJson)
-    })
+  }
+
+  protected[core] def toJsObject = JsObject(params.map(p => (p._1.name -> p._2.value.toJson)))
+
   override def toString = toJsArray.compactPrint
 
   /**

--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -230,7 +230,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
                 // incoming parameters may not override final parameters (i.e., parameters with already defined values)
                 // on an action once its parameters are resolved across package and binding
                 val allowInvoke = payload
-                  .map(_.fields.keySet.intersect(actionWithMergedParams.immutableParameters).isEmpty)
+                  .map(_.fields.keySet.forall(key => !actionWithMergedParams.immutableParameters.contains(key)))
                   .getOrElse(true)
 
                 if (allowInvoke) {


### PR DESCRIPTION
Web actions can carry a final annotation which makes their parameters with predefined values immutable. This patch makes the same behavior applicable for a POST invoke as well.

The relevant change is the third commit. The first two, staged this way, introduce semantic preserving changes and a new test. Suggest https://github.com/apache/incubator-openwhisk/pull/3333/files?w=1