### PR TITLE
Cli ansible fix

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -1,7 +1,7 @@
 mode: deploy
 prompt_user: true
-openwhisk_home: "{{ lookup('env', 'OPENWHISK_HOME')|default(playbook_dir + '/..', true) }}"
-openwhisk_cli_home: "{{ lookup('env', 'OPENWHISK_CLI') | default(openwhisk_home, true) }}"
+openwhisk_home: "{{ lookup('env', 'OPENWHISK_HOME') | default(playbook_dir + '/..', true) }}"
+openwhisk_cli_home: "{{ lookup('env', 'OPENWHISK_CLI') | default(openwhisk_home ~ '/../incubator-openwhisk-cli', true) }}"
 exclude_logs_from: []
 
 # This whisk_api_localhost_name_default is used to configure nginx to permit vanity URLs for web actions
@@ -269,12 +269,11 @@ openwhisk_cli_tag: "{{ lookup('ini', 'git_tag section=openwhisk-cli file={{ open
 #
 # The location specifies the official website where Openwhisk CLI is hosted in
 # remote mode or location to save the binaries of the OpenWhisk CLI in local mode.
-#
 
 openwhisk_cli:
-  installation_mode: "{{ cli_installation_mode | default('remote') }}"
+  installation_mode: "{{ cli_installation_mode | default(lookup('env', 'OPENWHISK_CLI_MODE')) | default('remote') }}"
   local:
-    location: "{{ openwhisk_cli_home }}/bin"
+    location: "{{ openwhisk_cli_home }}/build"
   remote:
     name: OpenWhisk_CLI
     dest_name: OpenWhisk_CLI

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -271,7 +271,7 @@ openwhisk_cli_tag: "{{ lookup('ini', 'git_tag section=openwhisk-cli file={{ open
 # remote mode or location to save the binaries of the OpenWhisk CLI in local mode.
 
 openwhisk_cli:
-  installation_mode: "{{ cli_installation_mode | default(lookup('env', 'OPENWHISK_CLI_MODE')) | default('remote') }}"
+  installation_mode: "{{ cli_installation_mode | default(lookup('env', 'OPENWHISK_CLI_MODE')) | default('remote', true) }}"
   local:
     location: "{{ openwhisk_cli_home }}/build"
   remote:

--- a/ansible/roles/cli/tasks/copy_local_openwhisk_cli.yml
+++ b/ansible/roles/cli/tasks/copy_local_openwhisk_cli.yml
@@ -2,16 +2,35 @@
 
 # Copy the cli binaries to Nginx directory
 
-- local_action: stat path={{ openwhisk_cli.local.location }}/{{ item }}
+- name: "construct local file from which to source"
+  set_fact:
+    source_file: "{{ openwhisk_cli.local.location }}/\
+      {{ item | join('-') | replace('mac','darwin') }}/\
+      {{ (item[0] == 'windows') | ternary ('wsk.exe', 'wsk') }}"
+    target_dir: "{{ cli.nginxdir }}/{{ item[0] }}/{{ item[1] }}"
+    system_match: "{{ ( \
+        (ansible_system == 'Linux' and item[0] == 'linux') \
+        or (ansible_system == 'Darwin' and item[0] == 'mac') \
+        or (ansible_system == 'Windows' and item[0] == 'windows') \
+        ) }}"
+    arch_match: "{{ ( ((ansible_machine=='x86_64')|ternary('amd64', ansible_machine)) == item[1] ) }}"
+
+- local_action: stat path={{ source_file }}
   register: binary_path
 
 - name: "ensure Nginx cli directory is writable"
   file:
-    path: "{{ cli.nginxdir }}"
+    path: "{{ target_dir }}"
     state: directory
     mode: 0777
   become: "{{ cli.dir.become }}"
 
 - name: "copy the local binaries from a local directory to Nginx directory"
-  copy: src={{ openwhisk_cli.local.location }}/{{ item }} dest={{ cli.nginxdir }}/
+  copy:
+    src: "{{ source_file }}"
+    dest: "{{ target_dir }}/"
   when: binary_path.stat.exists
+
+- name: "copy the local binary to the root bin directory when architectures match"
+  local_action: copy src={{ source_file }} dest={{ openwhisk_home }}/bin
+  when: system_match and arch_match

--- a/ansible/roles/cli/tasks/deploy.yml
+++ b/ansible/roles/cli/tasks/deploy.yml
@@ -19,7 +19,8 @@
 - name: "copy the binaries from a local directory to Nginx directory"
   include: copy_local_openwhisk_cli.yml
   when: cli_installation_mode == "local"
-  with_items: "{{ cli_os_arch | first | unique }}"
+  with_items:
+    - "{{ cli_os_arch }}"
 
 - name: "copy the local content.json from a local directory to Nginx directory"
   copy: src={{ openwhisk_cli.local.location }}/content.json dest={{ cli.nginxdir }}/

--- a/tools/build/redo
+++ b/tools/build/redo
@@ -94,7 +94,7 @@ def getArgs():
     parser.add_argument('-n', '--just-print', help='prints the component configuration but does not run any targets', action='store_const', const=True, default=False, dest='skiprun')
     parser.add_argument('-c', '--list-components', help='list known component names and exit', action='store_const', const=True, default=False, dest='list')
     parser.add_argument('-a', '--additional-task-arguments', dest='extraArgs', action='append', help='pass additional arguments to underlying task command')
-    parser.add_argument('components', nargs = '*', help='component name(s) to run (in order specified if more than one)')
+    parser.add_argument('components', nargs = '+', help='component name(s) to run (in order specified if more than one)')
     parser.add_argument('--dir', help='whisk home directory')
 
     args = parser.parse_args()

--- a/tools/build/redo
+++ b/tools/build/redo
@@ -93,7 +93,8 @@ def getArgs():
     parser.add_argument('-g', '--gradle', help='use target using inferred gradle file if component is not one of known targets', action='store_const', const=True, default=False)
     parser.add_argument('-n', '--just-print', help='prints the component configuration but does not run any targets', action='store_const', const=True, default=False, dest='skiprun')
     parser.add_argument('-c', '--list-components', help='list known component names and exit', action='store_const', const=True, default=False, dest='list')
-    parser.add_argument('-a', '--additional-task-arguments', dest='extraArgs', action='append', help='pass additional arguments to underlying task command')
+    parser.add_argument('-a', '--additional-task-arguments', dest='extraArgs', action='append', help='pass additional arguments to gradle build')
+    parser.add_argument('-e', '--extra-ansible-vars', dest='extraAnsibleVars', action='append', help='pass extra vars to ansible-playbook')
     parser.add_argument('components', nargs = '+', help='component name(s) to run (in order specified if more than one)')
     parser.add_argument('--dir', help='whisk home directory')
 
@@ -144,7 +145,7 @@ class Playbook:
     def path(self, basedir):
         return basedir + '/' + self.dir
 
-    def execcmd(self, props, mode = False, extraArgs = ''):
+    def execcmd(self, props, mode = False, extraAnsibleVars = []):
         if self.dir and self.file and (mode is False or mode in self.modes):
             cmd = [ self.cmd ]
             if self.env:
@@ -152,8 +153,8 @@ class Playbook:
             cmd.append(self.file)
             if mode:
                 cmd.append('-e mode=%s' % mode)
-            if extraArgs is not '':
-                cmd.append(extraArgs)
+            if extraAnsibleVars:
+                cmd.append(' '.join(map(lambda x: "-e '" + str(x) + "'", extraAnsibleVars)))
             return ' '.join(cmd)
 
 class Gradle:
@@ -393,7 +394,7 @@ def doOne(component, args, props):
         run(cmd, basedir, args.skiprun)
 
     if args.teardown and playbook is not None:
-        cmd = playbook.execcmd(props, 'clean', extraArgs = extraArgs)
+        cmd = playbook.execcmd(props, 'clean', extraAnsibleVars = args.extraAnsibleVars)
         run(cmd, playbook.path(basedir), args.skiprun)
 
     if args.deploy and playbook is not None:

--- a/tools/build/redo
+++ b/tools/build/redo
@@ -93,9 +93,8 @@ def getArgs():
     parser.add_argument('-g', '--gradle', help='use target using inferred gradle file if component is not one of known targets', action='store_const', const=True, default=False)
     parser.add_argument('-n', '--just-print', help='prints the component configuration but does not run any targets', action='store_const', const=True, default=False, dest='skiprun')
     parser.add_argument('-c', '--list-components', help='list known component names and exit', action='store_const', const=True, default=False, dest='list')
-    parser.add_argument('-a', '--additional-task-arguments', dest='extraArgs', action='append', help='pass additional arguments to gradle build')
-    parser.add_argument('-e', '--extra-ansible-vars', dest='extraAnsibleVars', action='append', help='pass extra vars to ansible-playbook')
-    parser.add_argument('components', nargs = '+', help='component name(s) to run (in order specified if more than one)')
+    parser.add_argument('-a', '--additional-task-arguments', dest='extraArgs', action='append', help='pass additional arguments to underlying task command')
+    parser.add_argument('components', nargs = '*', help='component name(s) to run (in order specified if more than one)')
     parser.add_argument('--dir', help='whisk home directory')
 
     args = parser.parse_args()
@@ -145,7 +144,7 @@ class Playbook:
     def path(self, basedir):
         return basedir + '/' + self.dir
 
-    def execcmd(self, props, mode = False, extraAnsibleVars = []):
+    def execcmd(self, props, mode = False, extraArgs = ''):
         if self.dir and self.file and (mode is False or mode in self.modes):
             cmd = [ self.cmd ]
             if self.env:
@@ -153,8 +152,8 @@ class Playbook:
             cmd.append(self.file)
             if mode:
                 cmd.append('-e mode=%s' % mode)
-            if extraAnsibleVars:
-                cmd.append(' '.join(map(lambda x: "-e '" + str(x) + "'", extraAnsibleVars)))
+            if extraArgs is not '':
+                cmd.append(extraArgs)
             return ' '.join(cmd)
 
 class Gradle:
@@ -394,11 +393,11 @@ def doOne(component, args, props):
         run(cmd, basedir, args.skiprun)
 
     if args.teardown and playbook is not None:
-        cmd = playbook.execcmd(props, 'clean', extraAnsibleVars = args.extraAnsibleVars)
+        cmd = playbook.execcmd(props, 'clean', extraArgs = extraArgs)
         run(cmd, playbook.path(basedir), args.skiprun)
 
     if args.deploy and playbook is not None:
-        cmd = playbook.execcmd(props, extraAnsibleVars = args.extraAnsibleVars)
+        cmd = playbook.execcmd(props, extraArgs = extraArgs)
         run(cmd, playbook.path(basedir), args.skiprun)
 
 if __name__ == '__main__':

--- a/tools/build/redo
+++ b/tools/build/redo
@@ -398,7 +398,7 @@ def doOne(component, args, props):
         run(cmd, playbook.path(basedir), args.skiprun)
 
     if args.deploy and playbook is not None:
-        cmd = playbook.execcmd(props, extraArgs = extraArgs)
+        cmd = playbook.execcmd(props, extraAnsibleVars = args.extraAnsibleVars)
         run(cmd, playbook.path(basedir), args.skiprun)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Changes to ansible build so that it will work appropriately for local CLI build.  Assumption is 'incubator-openwhisk-cli' is in the same directory as 'incubator-openwhisk'.  Also added environment variable `OPENWHISK_CLI_MODE` which will be checked if `cli_installation_mode` is not explicitly set for ansible.

Changes to travis will follow; keeping the two areas separate for now.

First of two fixes for #3329 

P.S.  Sorry about the extra commits.  I appear to have gotten sloppy with my branches -- please squash when merging.