### PR TITLE
Allow container tests to run without a proxy.

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -42,23 +42,6 @@ An expedient workaround is to add alias for `docker0` network to loopback interf
 sudo ifconfig lo0 alias 172.17.0.1/24
 ```
 
-##### Setup proxy container to run unit tests (optional)
-
-This step is only required to run tests with Docker for Mac.
-If you do not run tests locally, you can just skip this step.
-
-```
-docker run -d -p 3128:3128 style95/squid:3.5.26-p1
-```
-
-You need to configure gradle proxy settings.
-
-**~/.gradle/gradle.properties**
-```
-systemProp.http.proxyHost=localhost
-systemProp.http.proxyPort=3128
-```
-
 ### Using Ansible
 **Caveat:** All Ansible commands are meant to be executed from the `ansible` directory.
 This is important because that's where `ansible.cfg` is located which contains generic settings that are needed for the remaining steps.

--- a/tests/src/test/scala/actionContainers/DockerExampleContainerTests.scala
+++ b/tests/src/test/scala/actionContainers/DockerExampleContainerTests.scala
@@ -137,7 +137,7 @@ class DockerExampleContainerTests extends ActionProxyContainerTestUtils with Wsk
 
   it should "timeout bad proxy with exception" in {
     val (out, err) = withContainer("badproxy") { c =>
-      a[TimeoutException] should be thrownBy {
+      an[IllegalStateException] should be thrownBy {
         val (code, out) = c.init(JsObject())
         println(code, out)
       }


### PR DESCRIPTION
Running container unit tests on docker-for-mac does not work because the 172. network is not reachable. Instead detect "local" mode and use port forwarding instead.

@akrabat FYI.