### PR TITLE
implement suspend/resume for KubernetesContainer

### DIFF
--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -15,6 +15,7 @@ whisk {
   }
 
   kubernetes {
+    namespace: openwhisk
     # Timeouts for k8s commands. Set to "Inf" to disable timeout.
     timeouts {
       run: 1 minute

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -14,16 +14,18 @@ whisk {
     unpause: 10 seconds
   }
 
-  # Timeouts for k8s commands. Set to "Inf" to disable timeout.
   kubernetes {
+    # Timeouts for k8s commands. Set to "Inf" to disable timeout.
     timeouts {
       run: 1 minute
       rm: 1 minute
       inspect: 1 minute
       logs: 1 minute
     }
-    invoker-agent: false
-    invoker-agent-port: 3233
+    invoker-agent {
+      enabled: false
+      port: 3233
+    }
   }
 
   # Timeouts for runc commands. Set to "Inf" to disable timeout.
@@ -39,5 +41,4 @@ whisk {
     extra-args: {}
 
   }
-
 }

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -15,11 +15,15 @@ whisk {
   }
 
   # Timeouts for k8s commands. Set to "Inf" to disable timeout.
-  kubernetes.timeouts {
-    run: 1 minute
-    rm: 1 minute
-    inspect: 1 minute
-    logs: 1 minute
+  kubernetes {
+    timeouts {
+      run: 1 minute
+      rm: 1 minute
+      inspect: 1 minute
+      logs: 1 minute
+    }
+    invoker-agent: false
+    invoker-agent-port: 3233
   }
 
   # Timeouts for runc commands. Set to "Inf" to disable timeout.
@@ -35,4 +39,5 @@ whisk {
     extra-args: {}
 
   }
+
 }

--- a/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesClient.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesClient.scala
@@ -80,7 +80,9 @@ case class KubernetesInvokerAgentConfig(enabled: Boolean, port: Int)
 /**
  * General configuration for kubernetes client
  */
-case class KubernetesClientConfig(timeouts: KubernetesClientTimeoutConfig, invokerAgent: KubernetesInvokerAgentConfig)
+case class KubernetesClientConfig(namespace: String,
+                                  timeouts: KubernetesClientTimeoutConfig,
+                                  invokerAgent: KubernetesInvokerAgentConfig)
 
 /**
  * Serves as interface to the kubectl CLI tool.
@@ -149,12 +151,12 @@ class KubernetesClient(
       .endSpec()
       .build()
 
-    kubeRestClient.pods.inNamespace("openwhisk").create(pod)
+    kubeRestClient.pods.inNamespace(config.namespace).create(pod)
 
     Future {
       blocking {
         val createdPod = kubeRestClient.pods
-          .inNamespace("openwhisk")
+          .inNamespace(config.namespace)
           .withName(name)
           .waitUntilReady(config.timeouts.run.length, config.timeouts.run.unit)
         toContainer(createdPod)
@@ -175,7 +177,7 @@ class KubernetesClient(
       Future {
         blocking {
           kubeRestClient
-            .inNamespace("openwhisk")
+            .inNamespace(config.namespace)
             .pods()
             .withLabel(key, value)
             .list()

--- a/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesClient.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesClient.scala
@@ -238,6 +238,8 @@ class KubernetesClient(
     val id = ContainerId(pod.getMetadata.getName)
     val addr = ContainerAddress(pod.getStatus.getPodIP)
     val workerIP = pod.getStatus.getHostIP
+    // Extract the native (docker or containerd) containerId for the container
+    // By convention, kubernetes adds a docker:// prefix when using docker as the low-level container engine
     val nativeContainerId = pod.getStatus.getContainerStatuses.get(0).getContainerID.stripPrefix("docker://")
     implicit val kubernetes = this
     new KubernetesContainer(id, addr, workerIP, nativeContainerId)

--- a/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesClient.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesClient.scala
@@ -121,8 +121,8 @@ class KubernetesClient(
   def run(name: String,
           image: String,
           memory: ByteSize = 256.MB,
-          environment: Map[String, String] = Map(),
-          labels: Map[String, String] = Map())(implicit transid: TransactionId): Future[KubernetesContainer] = {
+          environment: Map[String, String] = Map.empty,
+          labels: Map[String, String] = Map.empty)(implicit transid: TransactionId): Future[KubernetesContainer] = {
 
     val envVars = environment.map {
       case (key, value) => new EnvVarBuilder().withName(key).withValue(value).build()
@@ -289,8 +289,8 @@ trait KubernetesApi {
   def run(name: String,
           image: String,
           memory: ByteSize,
-          environment: Map[String, String] = Map(),
-          labels: Map[String, String] = Map())(implicit transid: TransactionId): Future[KubernetesContainer]
+          environment: Map[String, String] = Map.empty,
+          labels: Map[String, String] = Map.empty)(implicit transid: TransactionId): Future[KubernetesContainer]
 
   def rm(container: KubernetesContainer)(implicit transid: TransactionId): Future[Unit]
 

--- a/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesContainer.scala
@@ -105,10 +105,7 @@ class KubernetesContainer(protected[core] val id: ContainerId,
 
   override def destroy()(implicit transid: TransactionId): Future[Unit] = {
     super.destroy()
-    // Attempting to remove a pod with a suspended container leaves the pod stuck in "Terminating" state.
-    resume()
-      .recover { case _ => () } // Ignore errors; it is possible the container was not actually suspended.
-      .map(_ => kubernetes.rm(this))
+    kubernetes.rm(this)
   }
 
   private val stringSentinel = DockerContainer.ActivationSentinel.utf8String

--- a/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesContainer.scala
@@ -57,10 +57,10 @@ object KubernetesContainer {
              image: String,
              userProvidedImage: Boolean = false,
              memory: ByteSize = 256.MB,
-             environment: Map[String, String] = Map(),
-             labels: Map[String, String] = Map())(implicit kubernetes: KubernetesApi,
-                                                  ec: ExecutionContext,
-                                                  log: Logging): Future[KubernetesContainer] = {
+             environment: Map[String, String] = Map.empty,
+             labels: Map[String, String] = Map.empty)(implicit kubernetes: KubernetesApi,
+                                                      ec: ExecutionContext,
+                                                      log: Logging): Future[KubernetesContainer] = {
     implicit val tid = transid
 
     val podName = name.replace("_", "-").replaceAll("[()]", "").toLowerCase()

--- a/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesContainerFactory.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesContainerFactory.scala
@@ -46,7 +46,7 @@ class KubernetesContainerFactory(label: String, config: WhiskConfig)(implicit ac
 
   override def cleanup() = {
     logging.info(this, "Cleaning up function runtimes")
-    val cleaning = kubernetes.rm("invoker", label)(TransactionId.invokerNanny)
+    val cleaning = kubernetes.rm("invoker", label, true)(TransactionId.invokerNanny)
     Await.ready(cleaning, 30.seconds)
   }
 

--- a/tests/src/test/scala/whisk/core/containerpool/kubernetes/test/KubernetesClientTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/kubernetes/test/KubernetesClientTests.scala
@@ -253,8 +253,8 @@ object KubernetesClientTests {
     def run(name: String,
             image: String,
             memory: ByteSize = 256.MB,
-            env: Map[String, String] = Map(),
-            labels: Map[String, String] = Map())(implicit transid: TransactionId): Future[KubernetesContainer] = {
+            env: Map[String, String] = Map.empty,
+            labels: Map[String, String] = Map.empty)(implicit transid: TransactionId): Future[KubernetesContainer] = {
       runs += ((name, image, env, labels))
       implicit val kubernetes = this
       val containerId = ContainerId("id")

--- a/tests/src/test/scala/whisk/core/containerpool/kubernetes/test/KubernetesContainerTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/kubernetes/test/KubernetesContainerTests.scala
@@ -167,8 +167,8 @@ class KubernetesContainerTests
         name: String,
         image: String,
         memory: ByteSize = 256.MB,
-        env: Map[String, String] = Map(),
-        labels: Map[String, String] = Map())(implicit transid: TransactionId): Future[KubernetesContainer] = {
+        env: Map[String, String] = Map.empty,
+        labels: Map[String, String] = Map.empty)(implicit transid: TransactionId): Future[KubernetesContainer] = {
         runs += ((name, image, env, labels))
         Future.failed(ProcessRunningException(1, "", ""))
       }

--- a/tests/src/test/scala/whisk/core/containerpool/kubernetes/test/KubernetesContainerTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/kubernetes/test/KubernetesContainerTests.scala
@@ -189,9 +189,7 @@ class KubernetesContainerTests
     implicit val kubernetes = stub[KubernetesApi]
 
     val id = ContainerId("id")
-    val container = new KubernetesContainer(id, ContainerAddress("ip"), "127.0.0.1", "docker://foo") {
-      override def resume()(implicit transid: TransactionId): Future[Unit] = Future.successful(())
-    }
+    val container = new KubernetesContainer(id, ContainerAddress("ip"), "127.0.0.1", "docker://foo")
 
     container.destroy()
 


### PR DESCRIPTION
We can implement suspend and resume for KubernetesContainerPool by delegating the operations to an invoker-agent that runs as a DaemonSet on every invoker node.  The invoker-agent interacts with the local docker/containerd engine to pause/unpause containers as directed by the invoker.

This PR contains the OpenWhisk core changes to implement this design.  It assumes an invoker-agent as implemented in https://github.com/apache/incubator-openwhisk-deploy-kube/pull/155.  The main changes in this PR are:
1.  Add configuration for the invoker-agent to application.conf (default to disabled).
2. Implement suspend/resume by delegating to the invoker-agent
3. Change the implementation of container creation to use the kubeRestClient to create the containers instead of using the kubectl command line.  As part of creation we now extract and save the workerNode IP information in the KubernetesContainer to cache the information needed to communicate with the invoker-agent.
4. Update test cases for changes in the KubernetesClient API.

If you look into the invoker-agent code in openwhisk-deploy-kube code, you will see that it also support log consolidation.   I plan to submit a separate PR for the openwhisk core side of the logging changes (because it also includes a modest refactor to the logging implementation that should be reviewed separately from the Kubernetes-centric changes in this PR).
 
