### PR TITLE
Extract message from callback and add it to pretty printed text.

### DIFF
--- a/ansible/callbacks/logformatter.py
+++ b/ansible/callbacks/logformatter.py
@@ -20,6 +20,7 @@
 from __future__ import (absolute_import, division, print_function)
 import os
 import sys
+import textwrap
 from ansible.plugins.callback import CallbackBase
 __metaclass__ = type
 
@@ -35,14 +36,18 @@ class CallbackModule(CallbackBase):
         """Emit colorized output based upon data contents."""
         if type(data) == dict:
             cmd = data['cmd'] if 'cmd' in data else None
+            msg = data['msg'] if 'msg' in data else None
             stdout = data['stdout'] if 'stdout' in data else None
             stderr = data['stderr'] if 'stderr' in data else None
             reason = data['reason'] if 'reason' in data else None
 
+            print()
             if cmd:
-                print(hilite('[%s]\n> %s' % (category, cmd), category))
+                print(hilite('[%s]\n> %s' % (category, cmd), category, wrap = False))
             if reason:
                 print(hilite(reason, category))
+            if msg:
+                print(hilite(msg, category))
             if stdout:
                 print(hilite(stdout, category))
             if stderr:
@@ -64,7 +69,7 @@ class CallbackModule(CallbackBase):
         self.emit(host, 'FAILED', res)
 
 
-def hilite(msg, status):
+def hilite(msg, status, wrap = True):
     """Highlight message."""
     def supports_color():
         if ((sys.platform != 'win32' or 'ANSICON' in os.environ) and
@@ -81,6 +86,7 @@ def hilite(msg, status):
         else:
             # bold
             attr.append('1')
-        return '\x1b[%sm%s\x1b[0m' % (';'.join(attr), msg)
+        text = '\x1b[%sm%s\x1b[0m' % (';'.join(attr), msg)
     else:
-        return msg
+        text = msg
+    return textwrap.fill(text, 80) if wrap else text


### PR DESCRIPTION
Here is a sample output:

```
TASK [cli : download cli (linux) amd64 to Nginx directory] *****************************************************************************************************************************************************************
Sunday 25 February 2018  10:38:38 -0500 (0:00:00.228)       0:00:08.284 ******* 
fatal: [172.17.0.1]: FAILED! => {"changed": false, "failed": true, "msg": "Failed to validate the SSL certificate for github.com:443. Make sure your managed systems have a valid CA certificate installed. You can use validate_certs=False if you do not need to confirm the servers identity but this is unsafe and not recommended. Paths checked for this platform: /etc/ssl/certs, /etc/ansible, /usr/local/etc/openssl. The exception msg was: [SSL: TLSV1_ALERT_PROTOCOL_VERSION] tlsv1 alert protocol version (_ssl.c:590)."}

Failed to validate the SSL certificate for github.com:443. Make sure your
managed systems have a valid CA certificate installed. You can use
validate_certs=False if you do not need to confirm the servers identity but this
is unsafe and not recommended. Paths checked for this platform: /etc/ssl/certs,
/etc/ansible, /usr/local/etc/openssl. The exception msg was: [SSL:
TLSV1_ALERT_PROTOCOL_VERSION] tlsv1 alert protocol version (_ssl.c:590).

```

The last paragraph is a result of this PR and I think easier to read.