### PR TITLE
Allow wskadmin user block/unblock to accept a list of subject to block

### DIFF
--- a/tests/src/test/scala/whisk/core/admin/WskAdminTests.scala
+++ b/tests/src/test/scala/whisk/core/admin/WskAdminTests.scala
@@ -151,6 +151,32 @@ class WskAdminTests extends TestHelpers with Matchers {
     }
   }
 
+  it should "block and unblock should accept more than a single subject" in {
+    val wskadmin = new RunWskAdminCmd {}
+    val subject1 = Subject().asString
+    val subject2 = Subject().asString
+    try {
+      wskadmin.cli(Seq("user", "create", subject1))
+      wskadmin.cli(Seq("user", "create", subject2))
+
+      // empty subjects are expected to be ignored
+      wskadmin.cli(Seq("user", "block", subject1, subject2, "", " ")).stdout shouldBe {
+        s"""|"$subject1" blocked successfully
+            |"$subject2" blocked successfully
+            |""".stripMargin
+      }
+
+      wskadmin.cli(Seq("user", "unblock", subject1, subject2, "", " ")).stdout shouldBe {
+        s"""|"$subject1" unblocked successfully
+            |"$subject2" unblocked successfully
+            |""".stripMargin
+      }
+    } finally {
+      wskadmin.cli(Seq("user", "delete", subject1)).stdout should include("Subject deleted")
+      wskadmin.cli(Seq("user", "delete", subject2)).stdout should include("Subject deleted")
+    }
+  }
+
   it should "not allow edits on a blocked subject" in {
     val wskadmin = new RunWskAdminCmd {}
     val subject = Subject().asString

--- a/tools/admin/wskadmin
+++ b/tools/admin/wskadmin
@@ -111,8 +111,8 @@ def parseArgs():
     subcmd = subparser.add_parser('block', help='block one or more users')
     subcmd.add_argument('subject', help='comma separated list of users to block')
 
-    subcmd = subparser.add_parser('unblock', help='unblock a user')
-    subcmd.add_argument('subject', help='the user to unblock')
+    subcmd = subparser.add_parser('unblock', help='unblock one or more users')
+    subcmd.add_argument('subject', help='comma separated list of users to unblock')
 
     subcmd = subparser.add_parser('list', help='list authorization keys associated with a namespace')
     subcmd.add_argument('namespace', help='the namespace to lookup')
@@ -307,6 +307,7 @@ def listUserCmd(args, props):
             return 0
         else:
             print('no identities found for namespace "%s"' % args.namespace)
+            return 0
     else:
         print('Failed to get namespace key (%s)' % res.read().strip())
         return 1
@@ -467,34 +468,44 @@ def whoisUserCmd(args, props):
     return 1
 
 def blockUserCmd(args, props):
-    (doc, res) = getDocumentFromDb(props, args.subject, args.verbose)
+    failed = 0
+    for subject in args.subject.split(","):
+        subject = subject.strip()
+        if len(subject) > 0:
+            (doc, res) = getDocumentFromDb(props, subject, args.verbose)
 
-    if doc is not None:
-        doc['blocked'] = True
-        insertRes = insertIntoDatabase(props, doc, args.verbose)
-        if insertRes.status in [201, 202]:
-            print('"%s" blocked successfully' % args.subject)
-        else:
-            print('Failed to block subject (%s)' % res.read().strip())
-            return 1
-    else:
-        print('Failed to get subject (%s)' % res.read().strip())
-        return 1
+            if doc is not None:
+                doc['blocked'] = True
+                insertRes = insertIntoDatabase(props, doc, args.verbose)
+                if insertRes.status in [201, 202]:
+                    print('"%s" blocked successfully' % subject)
+                else:
+                    print('Failed to block "%s" (%s)' % (subject, res.read().strip()))
+                    failed += 1
+            else:
+                print('Failed to block "%s" (%s)' % (subject, res.read().strip()))
+                failed += 1
+    return failed
 
 def unblockUserCmd(args, props):
-    (doc, res) = getDocumentFromDb(props, args.subject, args.verbose)
+    failed = 0
+    for subject in args.subject.split(","):
+        subject = subject.strip()
+        if len(subject) > 0:
+            (doc, res) = getDocumentFromDb(props, subject, args.verbose)
 
-    if doc is not None:
-        doc['blocked'] = False
-        insertRes = insertIntoDatabase(props, doc, args.verbose)
-        if insertRes.status in [201, 202]:
-            print('"%s" unblocked successfully' % args.subject)
-        else:
-            print('Failed to unblock subject (%s)' % res.read().strip())
-            return 1
-    else:
-        print('Failed to get subject (%s)' % res.read().strip())
-        return 1
+            if doc is not None:
+                doc['blocked'] = False
+                insertRes = insertIntoDatabase(props, doc, args.verbose)
+                if insertRes.status in [201, 202]:
+                    print('"%s" unblocked successfully' % subject)
+                else:
+                    print('Failed to unblock "%s" (%s)' % (subject, res.read().strip()))
+                    failed += 1
+            else:
+                print('Failed to unblock "%s" (%s)' % (subject, res.read().strip()))
+                failed += 1
+    return failed
 
 def setLimitsCmd(args, props):
     argsDict = vars(args)

--- a/tools/admin/wskadmin
+++ b/tools/admin/wskadmin
@@ -108,8 +108,8 @@ def parseArgs():
     subcmd = subparser.add_parser('whois', help='identify user from an authorization key')
     subcmd.add_argument('authkey', help='the credentials to look up')
 
-    subcmd = subparser.add_parser('block', help='block a user')
-    subcmd.add_argument('subject', help='the user to block')
+    subcmd = subparser.add_parser('block', help='block one or more users')
+    subcmd.add_argument('subject', help='comma separated list of users to block')
 
     subcmd = subparser.add_parser('unblock', help='unblock a user')
     subcmd.add_argument('subject', help='the user to unblock')
@@ -231,7 +231,7 @@ def createUserCmd(args, props):
         uid = str(uuid.uuid4())
         key = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(64))
 
-    (doc, res) = getSubjectFromDb(args, props)
+    (doc, res) = getDocumentFromDb(props, args.subject, args.verbose)
     if doc is None:
         doc = {
             '_id': subject,
@@ -268,7 +268,7 @@ def createUserCmd(args, props):
         return 1
 
 def getUserCmd(args, props):
-    (doc, res) = getSubjectFromDb(args, props)
+    (doc, res) = getDocumentFromDb(props, args.subject, args.verbose)
 
     if doc is not None:
         if args.all is True:
@@ -310,9 +310,6 @@ def listUserCmd(args, props):
     else:
         print('Failed to get namespace key (%s)' % res.read().strip())
         return 1
-
-def getSubjectFromDb(args, props):
-    return getDocumentFromDb(props, args.subject, args.verbose)
 
 def getDocumentFromDb(props, doc, verbose):
     protocol = props[DB_PROTOCOL]
@@ -389,7 +386,7 @@ def deleteUserCmd(args, props):
         print('Namespace must not be empty')
         return 2
 
-    (prev, res) = getSubjectFromDb(args, props)
+    (prev, res) = getDocumentFromDb(props, args.subject, args.verbose)
     if prev is None:
         print('Failed to delete subject (%s)' % res.read().strip())
         return 1
@@ -470,7 +467,7 @@ def whoisUserCmd(args, props):
     return 1
 
 def blockUserCmd(args, props):
-    (doc, res) = getSubjectFromDb(args, props)
+    (doc, res) = getDocumentFromDb(props, args.subject, args.verbose)
 
     if doc is not None:
         doc['blocked'] = True
@@ -485,7 +482,7 @@ def blockUserCmd(args, props):
         return 1
 
 def unblockUserCmd(args, props):
-    (doc, res) = getSubjectFromDb(args, props)
+    (doc, res) = getDocumentFromDb(props, args.subject, args.verbose)
 
     if doc is not None:
         doc['blocked'] = False

--- a/tools/admin/wskadmin
+++ b/tools/admin/wskadmin
@@ -109,10 +109,10 @@ def parseArgs():
     subcmd.add_argument('authkey', help='the credentials to look up')
 
     subcmd = subparser.add_parser('block', help='block one or more users')
-    subcmd.add_argument('subject', help='comma separated list of users to block')
+    subcmd.add_argument('subjects', nargs='+', help='one or more users to block')
 
     subcmd = subparser.add_parser('unblock', help='unblock one or more users')
-    subcmd.add_argument('subject', help='comma separated list of users to unblock')
+    subcmd.add_argument('subjects', nargs='+', help='one or more users to unblock')
 
     subcmd = subparser.add_parser('list', help='list authorization keys associated with a namespace')
     subcmd.add_argument('namespace', help='the namespace to lookup')
@@ -469,7 +469,7 @@ def whoisUserCmd(args, props):
 
 def blockUserCmd(args, props):
     failed = 0
-    for subject in args.subject.split(","):
+    for subject in args.subjects:
         subject = subject.strip()
         if len(subject) > 0:
             (doc, res) = getDocumentFromDb(props, subject, args.verbose)
@@ -489,7 +489,7 @@ def blockUserCmd(args, props):
 
 def unblockUserCmd(args, props):
     failed = 0
-    for subject in args.subject.split(","):
+    for subject in args.subjects:
         subject = subject.strip()
         if len(subject) > 0:
             (doc, res) = getDocumentFromDb(props, subject, args.verbose)


### PR DESCRIPTION
This patch allows wskadmin to block or unblock a list of subjects, separated by a comma (which is not a valid token for subject names). The first commit is a semantic preserving change. The second commit adds:

```
+    for subject in args.subject.split(","):
+        subject = subject.strip()
+        if len(subject) > 0:
```

around the existing code: https://github.com/apache/incubator-openwhisk/pull/3348/files?w=1