### PR TITLE
Download cli while cli_installation_mode=local too

### DIFF
--- a/ansible/roles/cli/tasks/deploy.yml
+++ b/ansible/roles/cli/tasks/deploy.yml
@@ -27,4 +27,3 @@
   when: cli_installation_mode == "local"
 
 - include: download_cli.yml
-  when: cli_installation_mode == "remote"


### PR DESCRIPTION
While using local mode to get cli, we'd better use ansible to auto detect
the os and arch of deploy machine and download the correct cli just like
remote mode.