### PR TITLE
Delete task 'set the volume_dir' in role cli

### DIFF
--- a/ansible/roles/cli/tasks/download_openwhisk_cli.yml
+++ b/ansible/roles/cli/tasks/download_openwhisk_cli.yml
@@ -41,13 +41,6 @@
     headers=""
   when: openwhisk_cli.remote.headers is not defined
 
-- name: "set the volume_dir"
-  vars:
-    instance: "{{instances | selectattr('name', 'equalto', 'db') | list | first}}"
-  set_fact:
-    volume_dir: "{{ instance.volume.fsmount | default( '/mnt/' + group_names|first, true ) }}:/usr/local/var/lib/couchdb"
-  when: (block_device is defined) and (block_device in disk_status.stdout)
-
 - name: "ensure Nginx cli directory for ({{ os }}) {{ arc }} exists"
   file:
     path: "{{ cli.nginxdir }}/{{ os }}/{{ arc }}"


### PR DESCRIPTION
This task is unused and will cause an error: "'disk_status' not defined" while pass environment "block_device=xxx"