### PR TITLE
Fix intermitent test failures due to non-unique entity names

### DIFF
--- a/tests/src/test/scala/common/WskTestHelpers.scala
+++ b/tests/src/test/scala/common/WskTestHelpers.scala
@@ -293,4 +293,9 @@ trait WskTestHelpers extends Matchers {
       wskadmin.cli(Seq("user", "delete", subject)).stdout should include("Subject deleted")
     }
   }
+
+  /**
+   * Append the current timestamp in ms
+   */
+  def withTimestamp(text: String) = s"${text}-${System.currentTimeMillis}"
 }

--- a/tests/src/test/scala/system/basic/WskBasicTests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicTests.scala
@@ -48,11 +48,6 @@ class WskBasicTests extends TestHelpers with WskTestHelpers {
   val wsk: common.rest.WskRest = new WskRest
   val defaultAction: Some[String] = Some(TestUtils.getTestActionFilename("hello.js"))
 
-  /**
-   * Append the current timestamp in ms
-   */
-  def withTimestamp(text: String) = s"${text}-${System.currentTimeMillis}"
-
   behavior of "Wsk REST"
 
   it should "reject creating duplicate entity" in withAssetCleaner(wskprops) { (wp, assetHelper) =>

--- a/tests/src/test/scala/system/basic/WskConsoleTests.scala
+++ b/tests/src/test/scala/system/basic/WskConsoleTests.scala
@@ -46,11 +46,6 @@ abstract class WskConsoleTests extends TestHelpers with WskTestHelpers {
   val wsk: BaseWsk
   val guestNamespace = wskprops.namespace
 
-  /**
-   * Append the current timestamp in ms
-   */
-  def withTimestamp(text: String) = s"${text}-${System.currentTimeMillis}"
-
   behavior of "Wsk Activation Console"
 
   it should "show an activation log message for hello world" in withAssetCleaner(wskprops) { (wp, assetHelper) =>

--- a/tests/src/test/scala/system/basic/WskPackageTests.scala
+++ b/tests/src/test/scala/system/basic/WskPackageTests.scala
@@ -43,7 +43,7 @@ abstract class WskPackageTests extends TestHelpers with WskTestHelpers {
   behavior of "Wsk Package"
 
   it should "allow creation and deletion of a package" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "simplepackage"
+    val name = withTimestamp("simplepackage")
     assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
       pkg.create(name, Map())
     }
@@ -53,14 +53,14 @@ abstract class WskPackageTests extends TestHelpers with WskTestHelpers {
   val params2 = Map("p1" -> "v1".toJson, "p2" -> "v2".toJson, "p3" -> "v3".toJson)
 
   it should "allow creation of a package with parameters" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "simplepackagewithparams"
+    val name = withTimestamp("simplepackagewithparams")
     assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
       pkg.create(name, params1)
     }
   }
 
   it should "allow updating a package" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "simplepackagetoupdate"
+    val name = withTimestamp("simplepackagetoupdate")
     assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
       pkg.create(name, params1)
       pkg.create(name, params2, update = true)
@@ -68,8 +68,8 @@ abstract class WskPackageTests extends TestHelpers with WskTestHelpers {
   }
 
   it should "allow binding of a package" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "simplepackagetobind"
-    val bindName = "simplebind"
+    val name = withTimestamp("simplepackagetobind")
+    val bindName = withTimestamp("simplebind")
     assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
       pkg.create(name, params1)
     }
@@ -79,9 +79,9 @@ abstract class WskPackageTests extends TestHelpers with WskTestHelpers {
   }
 
   it should "perform package binds so parameters are inherited" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val packageName = "package1"
-    val bindName = "package2"
-    val actionName = "print"
+    val packageName = withTimestamp("package1")
+    val bindName = withTimestamp("package2")
+    val actionName = withTimestamp("print")
     val packageActionName = packageName + "/" + actionName
     val bindActionName = bindName + "/" + actionName
     val packageParams = Map("key1a" -> "value1a".toJson, "key1b" -> "value1b".toJson)

--- a/tests/src/test/scala/system/basic/WskRuleTests.scala
+++ b/tests/src/test/scala/system/basic/WskRuleTests.scala
@@ -76,11 +76,6 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
     }
   }
 
-  /**
-   * Append the current timestamp in ms
-   */
-  def withTimestamp(text: String) = s"$text-${System.currentTimeMillis}"
-
   behavior of "Whisk rules"
 
   it should "preserve rule status when a rule is updated" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
@@ -105,15 +100,10 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
         // Needs to be retried since the enable/disable causes a cache invalidation which needs to propagate first
         retry(
           {
-            wsk.rule
-              .create(ruleName, trigger, actionName, update = true)
-              .stdout
-              .parseJson
-              .asJsObject
-              .fields
-              .get("status") shouldBe status
-
-            wsk.rule.get(ruleName).stdout.parseJson.asJsObject.fields.get("status") shouldBe status
+            // CLI stdout must strip out the preamble text (i.e. "ok: got rule XXXXX") to get at the JSON
+            wsk.rule.create(ruleName, trigger, actionName, update = true)
+            val getStdout = wsk.rule.get(ruleName).stdout
+            getStdout.substring(getStdout.indexOf('{')).parseJson.asJsObject.fields.get("status") shouldBe status
           },
           10,
           Some(1.second))


### PR DESCRIPTION
- leverage the `withTimestamp` method in a few more tests
- move `withTimestamp` into common module and remove copies