### PR TITLE
Fix the TLS issue with the CLI download  

### DIFF
--- a/ansible/roles/cli/tasks/deploy.yml
+++ b/ansible/roles/cli/tasks/deploy.yml
@@ -26,10 +26,13 @@
 #  straightforward.
 #
 - name: "Download release archive to build directory ..."
-  get_url:
-    url: "{{ openwhisk_cli.remote.location }}/{{ openwhisk_cli.archive_name}}-{{ openwhisk_cli_tag }}-all.tgz"
-    dest: "{{ openwhisk_build_dir }}/{{ openwhisk_cli.archive_name }}.tgz"
-    headers: "{{ openwhisk_cli.remote.headers | default('') }}"
+  local_action: >
+      shell curl -L "{{ openwhisk_cli.remote.location }}/{{ openwhisk_cli.archive_name}}-{{ openwhisk_cli_tag }}-all.tgz" \
+        -o "{{ openwhisk_build_dir }}/{{ openwhisk_cli.archive_name }}.tgz"
+#  get_url:
+#    url: "{{ openwhisk_cli.remote.location }}/{{ openwhisk_cli.archive_name}}-{{ openwhisk_cli_tag }}-all.tgz"
+#    dest: "{{ openwhisk_build_dir }}/{{ openwhisk_cli.archive_name }}.tgz"
+#    headers: "{{ openwhisk_cli.remote.headers | default('') }}"
   when: openwhisk_cli.installation_mode == "remote"
 
 - name: "... or Copy release archive to build directory"


### PR DESCRIPTION
Due to https://github.com/blog/2498-weak-cryptographic-standards-removal-notice ansible setup fails with:
```
Failed to validate the SSL certificate for github.com:443...The exception msg was: [SSL: TLSV1_ALERT_PROTOCOL_VERSION] tlsv1 alert protocol version
```
This PR provides a workaround for this problem by using `local_action` with `curl -o` to download the CLI.