### PR TITLE
Remove usages of replace and replaceAll on the hotpath.

### DIFF
--- a/common/scala/src/main/scala/whisk/core/containerpool/ContainerFactory.scala
+++ b/common/scala/src/main/scala/whisk/core/containerpool/ContainerFactory.scala
@@ -52,11 +52,12 @@ trait ContainerFactory {
 
 object ContainerFactory {
 
+  /** based on https://github.com/moby/moby/issues/3138 and https://github.com/moby/moby/blob/master/daemon/names/names.go */
+  private def isAllowed(c: Char) = c.isLetterOrDigit || c == '_' || c == '.' || c == '-'
+
   /** include the instance name, if specified and strip invalid chars before attempting to use them in the container name */
   def containerNamePrefix(instanceId: InstanceId): String =
-    s"wsk${instanceId.name.getOrElse("")}${instanceId.toInt}"
-      .replaceAll("[^a-zA-Z0-9_\\.\\-]", "") // based on https://github.com/moby/moby/issues/3138 and https://github.com/moby/moby/blob/master/daemon/names/names.go
-
+    s"wsk${instanceId.name.getOrElse("")}${instanceId.toInt}".filter(isAllowed)
 }
 
 /**

--- a/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
@@ -427,9 +427,14 @@ object ContainerProxy {
    * @param suffix the container name's suffix
    * @return a unique container name
    */
-  def containerName(instance: InstanceId, prefix: String, suffix: String) =
-    s"${ContainerFactory.containerNamePrefix(instance)}_${containerCount.next()}_${prefix}_${suffix}"
-      .replaceAll("[^a-zA-Z0-9_]", "")
+  def containerName(instance: InstanceId, prefix: String, suffix: String): String = {
+    def isAllowed(c: Char): Boolean = c.isLetterOrDigit || c == '_'
+
+    val sanitizedPrefix = prefix.filter(isAllowed)
+    val sanitizedSuffix = suffix.filter(isAllowed)
+
+    s"${ContainerFactory.containerNamePrefix(instance)}_${containerCount.next()}_${sanitizedPrefix}_${sanitizedSuffix}"
+  }
 
   /**
    * Creates a WhiskActivation ready to be sent via active ack.


### PR DESCRIPTION
replace(String, String) and replaceAll(String, String) will compile regex patterns implicitly. This creates a lot of unnecessary garbage.