### PR TITLE
Set mode of wsk to executable

### DIFF
--- a/ansible/roles/cli/tasks/copy_local_openwhisk_cli.yml
+++ b/ansible/roles/cli/tasks/copy_local_openwhisk_cli.yml
@@ -32,5 +32,5 @@
   when: binary_path.stat.exists
 
 - name: "copy the local binary to the root bin directory when architectures match"
-  local_action: copy src={{ source_file }} dest={{ openwhisk_home }}/bin
+  local_action: copy src={{ source_file }} dest={{ openwhisk_home }}/bin mode=0755
   when: system_match and arch_match


### PR DESCRIPTION
The updates to the copy of the 'wsk' or 'wsk.exe' executable from the Nginx downloads to the $OPENWHISK_HOME/bin directory did not set the mode to executable for that binary.  This PR changes that behavior.

This is in support of #3329 