### PR TITLE
Ansible image name overrides and bump NGinx to 1.12

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -168,7 +168,7 @@ nginx:
   confdir: "{{ config_root_dir }}/nginx"
   dir:
     become: "{{ nginx_dir_become | default(false) }}"
-  version: "{{ nginx_version | default(1.11) }}"
+  version: "{{ nginx_version | default('1.13.9') }}"
   port:
     http: 80
     api: 443

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -168,7 +168,7 @@ nginx:
   confdir: "{{ config_root_dir }}/nginx"
   dir:
     become: "{{ nginx_dir_become | default(false) }}"
-  version: "{{ nginx_version | default('1.13.9') }}"
+  version: "{{ nginx_version | default('1.12') }}"
   port:
     http: 80
     api: 443

--- a/ansible/roles/apigateway/tasks/deploy.yml
+++ b/ansible/roles/apigateway/tasks/deploy.yml
@@ -1,17 +1,10 @@
 ---
 # This role will install apigateway
 
-- name: "pull the openwhisk/apigateway:{{ apigateway.version }} image"
-  shell: "docker pull openwhisk/apigateway:{{ apigateway.version }}"
-  when: apigateway_local_build is undefined
-  retries: "{{ docker.pull.retries }}"
-  delay: "{{ docker.pull.delay }}"
-
-#temporary pinned to image 0.7.0 until apigateway fixes regressions
 - name: (re)start apigateway
   docker_container:
     name: apigateway
-    image: openwhisk/apigateway:{{ apigateway.version }}
+    image: "{{ apigateway.docker_image | default('openwhisk/apigateway:' ~ apigateway.version) }}"
     state: started
     recreate: true
     restart_policy: "{{ docker.restart.policy }}"
@@ -24,6 +17,7 @@
     ports:
       - "{{ apigateway.port.mgmt }}:8080"
       - "{{ apigateway.port.api }}:9000"
+    pull: "{{ apigateway_local_build is undefined }}"
 
 - name: wait until the API Gateway in this host is up and running
   uri:

--- a/ansible/roles/apigateway/tasks/deploy.yml
+++ b/ansible/roles/apigateway/tasks/deploy.yml
@@ -18,6 +18,8 @@
       - "{{ apigateway.port.mgmt }}:8080"
       - "{{ apigateway.port.api }}:9000"
     pull: "{{ apigateway_local_build is undefined }}"
+  retries: "{{ docker.pull.retries }}"
+  delay: "{{ docker.pull.delay }}"
 
 - name: wait until the API Gateway in this host is up and running
   uri:

--- a/ansible/roles/couchdb/tasks/deploy.yml
+++ b/ansible/roles/couchdb/tasks/deploy.yml
@@ -21,10 +21,12 @@
     volume_dir: "{{ instance.volume.fsmount | default( '/mnt/' + group_names|first, true ) }}:/usr/local/var/lib/couchdb"
   when: (block_device is defined) and (block_device in disk_status.stdout)
 
-- name: "(re)start CouchDB"
+- name: "(re)start CouchDB from '{{ couchdb_image }} ' "
+  vars: 
+    couchdb_image: "{{ couchdb.docker_image | default('apache/couchdb:' ~ couchdb.version ) }}" 
   docker_container:
     name: couchdb
-    image: "{{ couchdb.docker_image | default('apache/couchdb:' ~ couchdb.version ) }}"
+    image: "{{ couchdb_image }}"
     state: started
     recreate: true
     restart_policy: "{{ docker.restart.policy }}"

--- a/ansible/roles/couchdb/tasks/deploy.yml
+++ b/ansible/roles/couchdb/tasks/deploy.yml
@@ -21,15 +21,10 @@
     volume_dir: "{{ instance.volume.fsmount | default( '/mnt/' + group_names|first, true ) }}:/usr/local/var/lib/couchdb"
   when: (block_device is defined) and (block_device in disk_status.stdout)
 
-- name: "pull the apache/couchdb:{{ couchdb.version }} image"
-  shell: "docker pull apache/couchdb:{{ couchdb.version }}"
-  retries: "{{ docker.pull.retries }}"
-  delay: "{{ docker.pull.delay }}"
-
-- name: (re)start CouchDB
+- name: "(re)start CouchDB"
   docker_container:
     name: couchdb
-    image: apache/couchdb:{{ couchdb.version }}
+    image: "{{ couchdb.docker_image | default('apache/couchdb:' ~ couchdb.version ) }}"
     state: started
     recreate: true
     restart_policy: "{{ docker.restart.policy }}"
@@ -42,6 +37,7 @@
       COUCHDB_USER: "{{ db_username }}"
       COUCHDB_PASSWORD: "{{ db_password }}"
       NODENAME: "{{ ansible_host }}"
+    pull: "{{ couchdb.pull_couchdb | default(true) }}"
 
 - name: wait until CouchDB in this host is up and running
   uri:

--- a/ansible/roles/couchdb/tasks/deploy.yml
+++ b/ansible/roles/couchdb/tasks/deploy.yml
@@ -38,6 +38,8 @@
       COUCHDB_PASSWORD: "{{ db_password }}"
       NODENAME: "{{ ansible_host }}"
     pull: "{{ couchdb.pull_couchdb | default(true) }}"
+  retries: "{{ docker.pull.retries }}"
+  delay: "{{ docker.pull.delay }}"
 
 - name: wait until CouchDB in this host is up and running
   uri:

--- a/ansible/roles/kafka/tasks/deploy.yml
+++ b/ansible/roles/kafka/tasks/deploy.yml
@@ -79,6 +79,8 @@
     volumes:
       - "{{ config_root_dir }}/kafka/certs:/config"
     pull: true
+  retries: "{{ docker.pull.retries }}"
+  delay: "{{ docker.pull.delay }}"
 
 - name: wait until the kafka server started up
   shell: docker logs kafka{{ groups['kafkas'].index(inventory_hostname) }}

--- a/ansible/roles/kafka/tasks/deploy.yml
+++ b/ansible/roles/kafka/tasks/deploy.yml
@@ -1,11 +1,6 @@
 ---
 # This role will install Kafka with Zookeeper in group 'kafka' in the environment inventory
 
-- name: "pull the wurstmeister/kafka:{{ kafka.version }} image"
-  shell: "docker pull wurstmeister/kafka:{{ kafka.version }}"
-  retries: "{{ docker.pull.retries }}"
-  delay: "{{ docker.pull.delay }}"
-
 - name: "create kafka certificate directory"
   file:
     path: "{{ config_root_dir }}/kafka/certs"
@@ -35,6 +30,7 @@
       "KAFKA_ADVERTISED_PORT": "{{ kafka.advertisedPort + groups['kafkas'].index(inventory_hostname) }}"
       "KAFKA_PORT": "{{ kafka.advertisedPort + groups['kafkas'].index(inventory_hostname) }}"
       "KAFKA_ADVERTISED_HOST_NAME": "{{ ansible_host }}"
+
 - name: add kafka ssl env vars
   when: kafka.protocol == 'SSL'
   set_fact:
@@ -72,7 +68,7 @@
     zookeeper_idx: "{{ groups['kafkas'].index(inventory_hostname) % (groups['zookeepers'] | length) }}"
   docker_container:
     name: kafka{{ groups['kafkas'].index(inventory_hostname) }}
-    image: wurstmeister/kafka:{{ kafka.version }}
+    image: "{{ kafka.docker_image | default ('wurstmeister/kafka:' ~ kafka.version) }}"
     state: started
     recreate: true
     restart_policy: "{{ docker.restart.policy }}"
@@ -82,6 +78,7 @@
       - "{{ kafka.advertisedPort + groups['kafkas'].index(inventory_hostname) }}:{{ kafka.advertisedPort + groups['kafkas'].index(inventory_hostname) }}"
     volumes:
       - "{{ config_root_dir }}/kafka/certs:/config"
+    pull: true
 
 - name: wait until the kafka server started up
   shell: docker logs kafka{{ groups['kafkas'].index(inventory_hostname) }}

--- a/ansible/roles/kafka/tasks/deploy.yml
+++ b/ansible/roles/kafka/tasks/deploy.yml
@@ -63,12 +63,13 @@
   set_fact:
     kafka_env_vars: "{{ kafka_env_vars | combine(kafka_non_ssl_vars) }}"
 
-- name: (re)start kafka
+- name: "(re)start kafka using '{{ kafka_image }}' "
   vars:
     zookeeper_idx: "{{ groups['kafkas'].index(inventory_hostname) % (groups['zookeepers'] | length) }}"
+    kafka_image: "{{ kafka.docker_image | default ('wurstmeister/kafka:' ~ kafka.version) }}"
   docker_container:
     name: kafka{{ groups['kafkas'].index(inventory_hostname) }}
-    image: "{{ kafka.docker_image | default ('wurstmeister/kafka:' ~ kafka.version) }}"
+    image: "{{ kafka_image }}"
     state: started
     recreate: true
     restart_policy: "{{ docker.restart.policy }}"


### PR DESCRIPTION
This is an incremental implementation of #3133 to reduce risk and complexity as we implement multi-architecture OpenWhisk.  This PR includes these changes:

- Add the ability to override image names to the ansible playbooks -- in support of overrides of images for multi-platform deployments.
- Bump Nginx version to 1.12 -- latest stable version, available as a multi-platform manifest from DockerHub (current Nginx 1.11 is not).
- Move responsiblity for docker pull to the docker module, reducing ansible steps and complexity -- improved maintainability.