### PR TITLE
Narrow exclude to run needed tests.

### DIFF
--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -27,7 +27,7 @@ task testLean(type: Test) {
     exclude '**/*ThrottleTests*'
     exclude '**/MaxActionDurationTests*'
     exclude '**/*ApiGwTests*'
-    exclude '**/*Cli*'
+    exclude '**/*WskCli*'
 }
 
 task testLeanCli(type: Test) {


### PR DESCRIPTION
Some of our important tests do **not** run today because the exclude of "*Cli*" also covers "Client" tests, which is not suspected.

For posterity, this impacts:

```
tests/src/test/scala/whisk/core/database/test/CouchDbRestClientTests.scala
tests/src/test/scala/whisk/core/database/test/ExtendedCouchDbRestClient.scala
tests/src/test/scala/whisk/core/containerpool/docker/test/DockerClientWithFileAccessTests.scala
tests/src/test/scala/whisk/core/containerpool/docker/test/RuncClientTests.scala
tests/src/test/scala/whisk/core/containerpool/docker/test/DockerClientTests.scala
tests/src/test/scala/whisk/core/containerpool/kubernetes/test/KubernetesClientTests.scala
```