### PR TITLE
Make AuthKey parsing leaner.

### DIFF
--- a/tests/src/test/scala/whisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/SchemaTests.scala
@@ -56,7 +56,7 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with ExecHelpers with Mat
   }
 
   it should "reject malformed ids" in {
-    Seq(null, "", " ", ":", " : ", " :", ": ", "a:b").foreach { i =>
+    Seq("", " ", ":", " : ", " :", ": ", "a:b").foreach { i =>
       an[IllegalArgumentException] should be thrownBy AuthKey(i)
     }
   }


### PR DESCRIPTION
Like in the case of ActivationIds, for AuthKeys we do not care if the user really gives us a UUID. For the system internal it doesn't matter.