### PR TITLE
Use Docker ADD command to untar

### DIFF
--- a/core/controller/Dockerfile
+++ b/core/controller/Dockerfile
@@ -9,11 +9,10 @@ RUN curl -sSL -o swagger-ui-v3.6.0.tar.gz --no-verbose https://github.com/swagge
 
 #
 # Copy app jars
-COPY build/distributions/controller.tar /
-RUN tar xf controller.tar
+ADD build/distributions/controller.tar /
 
 COPY init.sh /
 RUN chmod +x init.sh
 
 EXPOSE 8080
-CMD ["init.sh", "0"]
+CMD ["./init.sh", "0"]

--- a/core/invoker/Dockerfile
+++ b/core/invoker/Dockerfile
@@ -19,12 +19,10 @@ RUN wget --no-verbose https://storage.googleapis.com/kubernetes-release/release/
 chmod +x kubectl && \
 mv kubectl /usr/bin/kubectl
 
-COPY build/distributions/invoker.tar ./
-RUN tar xf invoker.tar && \
-rm -f invoker.tar
+ADD build/distributions/invoker.tar ./
 
 COPY init.sh /
 RUN chmod +x init.sh
 
 EXPOSE 8080
-CMD ["init.sh", "0"]
+CMD ["./init.sh", "0"]


### PR DESCRIPTION
This PR has two changes

### Use ADD instead of COPY

Currently 
* controller - The tar file is copied but not removed thus increasing the size
* invoker - Copies the tar and then removes it after untarring it

Instead of doing this use ADD command which has an implicit support for untar. See [ADD vs COPY][1]

> Consequently, the best use for ADD is local tar file auto-extraction into the image, as in ADD rootfs.tar.xz /.

With this change size of controller images drops to 281MB from 361MB (~80MB reduction)

### Change in CMD

```diff
-CMD ["init.sh", "0"]
+CMD ["./init.sh", "0"]
``` 

When I am extending the controller image for building a custom image for embedding custom ArtifactStore

```
FROM whisk/controller

COPY build/docker /controller/
```

The startup failed with
```
docker: Error response from daemon: oci runtime error: container_linux.go:247: starting container process caused "exec: \"init.sh\": executable file not found in $PATH".
```

On checking the `env` it appears `PATH` does not contain root directory
```
$ docker run -it --entrypoint /bin/bash whisk/controller
bash-4.3# env
...
PATH=/usr/lib/jvm/java-8-oracle/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
BUILD=15
PWD=/
...
```

Changing the command to use explicit relative path as in `./init.sh` fixed the issue. Not sure why the issue does not appear in normal explicit run for base image. Possibly because the launch done in ansible scripts uses explicit path

```
command: /bin/sh -c "exec /init.sh {{ controller_index }} >> /logs/{{ controller_name }}_logs.log 2>&1"
```

[1]: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy
