### PR TITLE
Make action-time-limit's system bounds configurable.

### DIFF
--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -140,6 +140,10 @@
       "CONFIG_whisk_memory_max": "{{ limit_action_memory_max | default() }}"
       "CONFIG_whisk_memory_std": "{{ limit_action_memory_std | default() }}"
 
+      "CONFIG_whisk_timeLimit_min": "{{ limit_action_time_min | default() }}"
+      "CONFIG_whisk_timeLimit_max": "{{ limit_action_time_max | default() }}"
+      "CONFIG_whisk_timeLimit_std": "{{ limit_action_time_std | default() }}"
+
       "CONFIG_whisk_activation_payload_max": "{{ limit_activation_payload | default() }}"
 
       "RUNTIMES_MANIFEST": "{{ runtimesManifest | to_json }}"

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -203,6 +203,9 @@
         -e CONFIG_whisk_memory_min='{{ limit_action_memory_min | default() }}'
         -e CONFIG_whisk_memory_max='{{ limit_action_memory_max | default() }}'
         -e CONFIG_whisk_memory_std='{{ limit_action_memory_std | default() }}'
+        -e CONFIG_whisk_timeLimit_min='{{ limit_action_time_min | default() }}'
+        -e CONFIG_whisk_timeLimit_max='{{ limit_action_time_max | default() }}'
+        -e CONFIG_whisk_timeLimit_std='{{ limit_action_time_std | default() }}'
         -e CONFIG_whisk_activation_payload_max='{{ limit_activation_payload | default() }}'
         -v /sys/fs/cgroup:/sys/fs/cgroup
         -v /run/runc:/run/runc

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -125,6 +125,13 @@ whisk {
         }
     }
 
+    # action timelimit configuration
+    time-limit {
+        min = 100 ms
+        max = 5 m
+        std = 1 m
+    }
+
     # action memory configuration
     memory {
         min = 128 m

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -242,6 +242,7 @@ object ConfigKeys {
   val kafkaTopics = s"$kafka.topics"
 
   val memory = "whisk.memory"
+  val timeLimit = "whisk.time-limit"
   val activation = "whisk.activation"
   val activationPayload = s"$activation.payload"
 

--- a/common/scala/src/main/scala/whisk/core/entity/TimeLimit.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/TimeLimit.scala
@@ -17,19 +17,17 @@
 
 package whisk.core.entity
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.duration.DurationInt
-import scala.concurrent.duration.FiniteDuration
-import scala.concurrent.duration.MILLISECONDS
-import scala.language.postfixOps
+import pureconfig._
+
+import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
-
 import spray.json.JsNumber
 import spray.json.JsValue
 import spray.json.RootJsonFormat
 import spray.json.deserializationError
+import whisk.core.ConfigKeys
 
 /**
  * TimeLimit encapsulates a duration for an action. The duration must be within a
@@ -46,10 +44,14 @@ protected[entity] class TimeLimit private (val duration: FiniteDuration) extends
   override def toString = duration.toString
 }
 
+case class TimeLimitConfig(max: FiniteDuration, min: FiniteDuration, std: FiniteDuration)
+
 protected[core] object TimeLimit extends ArgNormalizer[TimeLimit] {
-  protected[core] val MIN_DURATION = 100 milliseconds
-  protected[core] val MAX_DURATION = 5 minutes
-  protected[core] val STD_DURATION = 1 minute
+  private val config = loadConfigOrThrow[TimeLimitConfig](ConfigKeys.timeLimit)
+
+  protected[core] val MIN_DURATION: FiniteDuration = config.min
+  protected[core] val MAX_DURATION: FiniteDuration = config.max
+  protected[core] val STD_DURATION: FiniteDuration = config.std
 
   /** Gets TimeLimit with default duration */
   protected[core] def apply(): TimeLimit = TimeLimit(STD_DURATION)


### PR DESCRIPTION
In the same vain the memory limits are settable, this should be decidable per deployment.