### PR TITLE
Add namespace-blacklist to invoker.

### DIFF
--- a/ansible/files/namespace_throttlings_design_document_for_subjects_db.json
+++ b/ansible/files/namespace_throttlings_design_document_for_subjects_db.json
@@ -2,7 +2,7 @@
   "_id": "_design/namespaceThrottlings",
   "views": {
     "blockedNamespaces": {
-      "map": "function (doc) {\n  if (doc._id.indexOf(\"/limits\") >= 0) {\n    if (doc.concurrentInvocations === 0 || doc.invocationsPerMinute === 0) {\n      var namespace = doc._id.replace(\"/limits\", \"\");\n      emit(namespace, 1);\n    }\n  }\n}",
+      "map": "function (doc) {\n  if (doc._id.indexOf(\"/limits\") >= 0) {\n    if (doc.concurrentInvocations === 0 || doc.invocationsPerMinute === 0) {\n      var namespace = doc._id.replace(\"/limits\", \"\");\n      emit(namespace, 1);\n    }\n  } else if (doc.subject && doc.namespaces && doc.blocked) {\n    doc.namespaces.forEach(function(namespace) {\n      emit(namespace.name, 1);\n    });\n  }\n}",
       "reduce": "_sum"
     }
   },

--- a/ansible/files/namespace_throttlings_design_document_for_subjects_db.json
+++ b/ansible/files/namespace_throttlings_design_document_for_subjects_db.json
@@ -1,0 +1,10 @@
+{
+  "_id": "_design/namespaceThrottlings",
+  "views": {
+    "blockedNamespaces": {
+      "map": "function (doc) {\n  if (doc._id.indexOf(\"/limits\") >= 0) {\n    if (doc.concurrentInvocations === 0 || doc.invocationsPerMinute === 0) {\n      var namespace = doc._id.replace(\"/limits\", \"\");\n      emit(namespace, 1);\n    }\n  }\n}",
+      "reduce": "_sum"
+    }
+  },
+  "language": "javascript"
+}

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -169,6 +169,7 @@
         -e DB_PASSWORD='{{ db_password }}'
         -e DB_WHISK_ACTIONS='{{ db.whisk.actions }}'
         -e DB_WHISK_ACTIVATIONS='{{ db.whisk.activations }}'
+        -e DB_WHISK_AUTHS='{{ db.whisk.auth }}'
         -e CONFIG_whisk_db_actionsDdoc='{{ db_whisk_actions_ddoc | default() }}'
         -e CONFIG_whisk_db_activationsDdoc='{{ db_whisk_activations_ddoc | default() }}'
         -e CONFIG_whisk_db_activationsFilterDdoc='{{ db_whisk_activations_filter_ddoc | default() }}'

--- a/ansible/tasks/initdb.yml
+++ b/ansible/tasks/initdb.yml
@@ -14,6 +14,7 @@
   with_items:
     - "{{ openwhisk_home }}/ansible/files/auth_index.json"
     - "{{ openwhisk_home }}/ansible/files/filter_design_document.json"
+    - "{{ openwhisk_home }}/ansible/files/namespace_throttlings_design_document_for_subjects_db.json"
 
 - name: create necessary "auth" keys
   include: db/recreateDoc.yml

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -256,6 +256,7 @@ object ConfigKeys {
   val runcTimeouts = s"$runc.timeouts"
   val containerFactory = "whisk.container-factory"
   val containerArgs = s"$containerFactory.container-args"
+  val blacklist = "whisk.blacklist"
 
   val kubernetes = "whisk.kubernetes"
   val kubernetesTimeouts = s"$kubernetes.timeouts"

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
@@ -155,7 +155,7 @@ object WhiskActivationStore {
  * @param ddoc the design document
  * @param view the view name within the design doc
  */
-protected[core] class View(ddoc: String, view: String) {
+protected[core] case class View(ddoc: String, view: String) {
 
   /** The name of the table to query. */
   val name = s"$ddoc/$view"

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -3,6 +3,10 @@ include "logging"
 include "akka-http-version"
 
 whisk {
+  blacklist {
+    poll-interval: 5 minutes
+  }
+
   # Timeouts for docker commands. Set to "Inf" to disable timeout.
   docker.timeouts {
     run: 1 minute
@@ -40,6 +44,5 @@ whisk {
     network: bridge
     dns-servers: []
     extra-args: {}
-
   }
 }

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -22,13 +22,10 @@ import scala.concurrent.duration._
 import scala.concurrent.Future
 import scala.util.Failure
 import scala.util.Try
-
 import kamon.Kamon
-
 import org.apache.curator.retry.RetryUntilElapsed
 import org.apache.curator.framework.CuratorFrameworkFactory
 import org.apache.curator.framework.recipes.shared.SharedCount
-
 import akka.Done
 import akka.actor.ActorSystem
 import akka.actor.CoordinatedShutdown
@@ -39,10 +36,7 @@ import whisk.core.WhiskConfig
 import whisk.core.WhiskConfig._
 import whisk.core.connector.MessagingProvider
 import whisk.core.connector.PingMessage
-import whisk.core.entity.ExecManifest
-import whisk.core.entity.InstanceId
-import whisk.core.entity.WhiskActivationStore
-import whisk.core.entity.WhiskEntityStore
+import whisk.core.entity._
 import whisk.http.BasicHttpService
 import whisk.spi.SpiLoader
 import whisk.utils.ExecutionContextFactory
@@ -60,6 +54,7 @@ object Invoker {
       ExecManifest.requiredProperties ++
       WhiskEntityStore.requiredProperties ++
       WhiskActivationStore.requiredProperties ++
+      WhiskAuthStore.requiredProperties ++
       kafkaHosts ++
       zookeeperHosts ++
       wskApiHost ++ Map(

--- a/core/invoker/src/main/scala/whisk/core/invoker/NamespaceBlacklist.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/NamespaceBlacklist.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.invoker
+
+import whisk.common.TransactionId
+import whisk.core.database.StaleParameter
+import whisk.core.entity.{Identity, View}
+import whisk.core.entity.types.AuthStore
+
+import scala.concurrent.{ExecutionContext, Future}
+import spray.json.DefaultJsonProtocol._
+
+/**
+ * The Namespace blacklist gets all namespaces that are throttled to 0 from the database.
+ * The caller is responsible for a periodically update of the blacklist with `refreshBlacklist`.
+ *
+ * @param authStore Subjects database with the limit-documents.
+ */
+class NamespaceBlacklist(authStore: AuthStore) {
+
+  private var blacklist: Set[String] = Set.empty
+
+  /**
+   * Check if the identity, who invoked the activation is in the blacklist.
+   *
+   * @param identity User who invoked the action.
+   * @return true or false, depending if the current identity is blocked.
+   */
+  def isBlacklisted(identity: Identity): Boolean = blacklist.contains(identity.namespace.name)
+
+  def refreshBlacklist()(implicit ec: ExecutionContext, tid: TransactionId): Future[Set[String]] = {
+    authStore
+      .query(
+        table = NamespaceBlacklist.view.name,
+        startKey = List.empty,
+        endKey = List.empty,
+        skip = 0,
+        limit = Int.MaxValue,
+        includeDocs = false,
+        descending = true,
+        reduce = false,
+        stale = StaleParameter.UpdateAfter)
+      .map(_.map(_.fields("key").convertTo[String]).toSet)
+      .map { newBlacklist =>
+        blacklist = newBlacklist
+        newBlacklist
+      }
+  }
+}
+
+object NamespaceBlacklist {
+  val view = View("namespaceThrottlings", "blockedNamespaces")
+}
+
+case class NamespaceBlacklistedException(ns: String) extends Exception(s"Namespace $ns was blocked in invoker.")

--- a/tests/src/test/scala/whisk/core/invoker/test/NamespaceBlacklistTests.scala
+++ b/tests/src/test/scala/whisk/core/invoker/test/NamespaceBlacklistTests.scala
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.invoker.test
+
+import akka.stream.ActorMaterializer
+import common.{StreamLogging, WhiskProperties, WskActorSystem}
+import org.junit.runner.RunWith
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{FlatSpec, Matchers}
+import spray.json._
+import whisk.common.TransactionId
+import whisk.core.WhiskConfig
+import whisk.core.database.CouchDbRestClient
+import whisk.core.database.test.{DbUtils, ExtendedCouchDbRestClient}
+import whisk.core.entity._
+import whisk.core.invoker.NamespaceBlacklist
+import spray.json.DefaultJsonProtocol._
+
+import scala.concurrent.duration._
+
+@RunWith(classOf[JUnitRunner])
+class NamespaceBlacklistTests
+    extends FlatSpec
+    with Matchers
+    with DbUtils
+    with ScalaFutures
+    with IntegrationPatience
+    with WskActorSystem
+    with StreamLogging {
+
+  behavior of "NamespaceBlacklist"
+
+  val config = new WhiskConfig(WhiskAuthStore.requiredProperties)
+
+  implicit val materializer = ActorMaterializer()
+  implicit val tid = TransactionId.testing
+
+  val authStore = WhiskAuthStore.datastore(config)
+  val subjectsDb = new ExtendedCouchDbRestClient(
+    WhiskProperties.getProperty(WhiskConfig.dbProtocol),
+    WhiskProperties.getProperty(WhiskConfig.dbHost),
+    WhiskProperties.getProperty(WhiskConfig.dbPort).toInt,
+    WhiskProperties.getProperty(WhiskConfig.dbUsername),
+    WhiskProperties.getProperty(WhiskConfig.dbPassword),
+    WhiskProperties.getProperty(WhiskConfig.dbAuths))
+
+  val identities = Seq(
+    Identity(Subject(), EntityName("testnamespace1"), AuthKey(), Set.empty, UserLimits(invocationsPerMinute = Some(0))),
+    Identity(
+      Subject(),
+      EntityName("testnamespace2"),
+      AuthKey(),
+      Set.empty,
+      UserLimits(concurrentInvocations = Some(0))),
+    Identity(
+      Subject(),
+      EntityName("testnamespace3"),
+      AuthKey(),
+      Set.empty,
+      UserLimits(invocationsPerMinute = Some(1), concurrentInvocations = Some(1))))
+
+  override def beforeAll() = {
+    identities.foreach { id =>
+      putLimitsForIdentity(subjectsDb, id)
+    }
+    // Wait on view
+    waitOnView(subjectsDb, NamespaceBlacklist.view.ddoc, NamespaceBlacklist.view.view, 2)(executionContext, 1.minute)
+  }
+
+  override def afterAll() = {
+    identities.foreach { id =>
+      deleteLimitDocForIdentity(subjectsDb, id)
+    }
+    super.afterAll()
+  }
+
+  def putLimitsForIdentity(db: CouchDbRestClient, identity: Identity) = {
+    db.putDoc(identity.namespace.name + "/limits", identity.limits.toJson.asJsObject).futureValue
+  }
+
+  def deleteLimitDocForIdentity(db: CouchDbRestClient, identity: Identity) = {
+    val doc = subjectsDb.getDoc(identity.namespace.name + "/limits").futureValue
+    doc shouldBe 'right
+    subjectsDb
+      .deleteDoc(doc.right.get.fields("_id").convertTo[String], doc.right.get.fields("_rev").convertTo[String])
+      .futureValue
+  }
+
+  it should "mark a namespace as blocked if limit is 0 in database" in {
+    val blacklist = new NamespaceBlacklist(authStore)
+
+    // Execute refresh
+    blacklist.refreshBlacklist().futureValue should have size 2
+
+    // execute isBlacklisted -> true
+    identities.map(blacklist.isBlacklisted) shouldBe Seq(true, true, false)
+  }
+}


### PR DESCRIPTION
This commit adds a check to the invoker, if the current namespace is allowed to execute actions.
This check is already done in the controller, but if the action is already in the queue and throttled afterwards, there is no chance to get this action out of the queue.
With this commit, the invoker checks as well if the action is allowed to be executed. If it is not, it will be refused immediately. This will clean up the queue very fast.