### PR TITLE
Turn off Kafka auto-commits.

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -66,8 +66,7 @@ whisk {
         consumer {
             session-timeout-ms = 30000
             heartbeat-interval-ms = 10000
-            enable-auto-commit = true
-            auto-commit-interval-ms = 10000
+            enable-auto-commit = false
             auto-offset-reset = earliest
             max-poll-interval = 360000
             // This value controls the server-side wait time which affects polling latency.


### PR DESCRIPTION
We commit manually everywhere in our code. Some tests also rely on the manual commits to be the only ones around. We should be able to turn this off safely. If not we have a bug.