### PR TITLE
Self-generate random strings without going through a UUID.

### DIFF
--- a/common/scala/src/main/scala/whisk/common/RandomString.scala
+++ b/common/scala/src/main/scala/whisk/common/RandomString.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.common
+
+import java.security.SecureRandom
+
+import org.apache.commons.codec.binary.Hex
+
+object RandomString {
+  private val generator = new ThreadLocal[SecureRandom] {
+    override def initialValue() = new SecureRandom()
+  }
+
+  val lowercase: IndexedSeq[Char] = 'a' to 'z'
+  val uppercase: IndexedSeq[Char] = 'A' to 'Z'
+  val digits: IndexedSeq[Char] = '0' to '9'
+  val alphanumeric: IndexedSeq[Char] = lowercase ++ uppercase ++ digits
+
+  /**
+   * Generates a random string of hexadecimal characters and the given length.
+   *
+   * Vastly optimized for raw speed over the other generate methods. For that optimization, the length of the string
+   * needs to be divisible by 2 (4 bits make one hex character and a byte consists of 8 bits). If the number is not
+   * divisible by two, the outcome string will be one character shorter than expected.
+   *
+   * @param length length of the string to generate
+   * @return a random string
+   */
+  def generateHexadecimal(length: Int): String = {
+    val bytes = Array.ofDim[Byte](length / 2)
+    generator.get().nextBytes(bytes)
+    Hex.encodeHexString(bytes)
+  }
+
+  /**
+   * Generates a random string of the given character range and the given length.
+   *
+   * @param characters the characters to build the target string of
+   * @param length length of the target string
+   * @return a random string
+   */
+  def generate(characters: IndexedSeq[Char])(length: Int): String = {
+    val random = generator.get()
+    Stream.continually(characters(random.nextInt(characters.length))).take(length).mkString
+  }
+}

--- a/common/scala/src/main/scala/whisk/core/entity/ActivationId.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ActivationId.scala
@@ -19,8 +19,8 @@ package whisk.core.entity
 
 import spray.json.DefaultJsonProtocol.StringJsonFormat
 import spray.json._
+import whisk.common.RandomString
 import whisk.http.Messages
-
 import whisk.core.entity.size._
 
 import scala.util.{Failure, Success, Try}
@@ -74,7 +74,7 @@ protected[core] object ActivationId {
    *
    * @return new ActivationId
    */
-  protected[core] def generate(): ActivationId = new ActivationId(UUIDs.randomUUID().toString.filterNot(_ == '-'))
+  protected[core] def generate(): ActivationId = new ActivationId(RandomString.generateHexadecimal(32))
 
   protected[core] implicit val serdes: RootJsonFormat[ActivationId] = new RootJsonFormat[ActivationId] {
     def write(d: ActivationId) = JsString(d.toString)

--- a/common/scala/src/main/scala/whisk/core/entity/Secret.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Secret.scala
@@ -19,6 +19,7 @@ package whisk.core.entity
 
 import spray.json._
 import spray.json.DefaultJsonProtocol._
+import whisk.common.RandomString
 
 /**
  * Secret, a cryptographic string such as a key used for authentication.
@@ -57,19 +58,11 @@ protected[core] object Secret {
     new Secret(str)
   }
 
-  /**
-   * Creates a new random secret.
-   *
-   * @return Secret
-   */
-  protected[core] def apply(): Secret = {
-    Secret(rand.alphanumeric.take(MIN_LENGTH).mkString)
-  }
+  /** Creates a new random secret. */
+  protected[core] def apply(): Secret = Secret(RandomString.generate(RandomString.alphanumeric)(MIN_LENGTH))
 
   implicit val serdes: RootJsonFormat[Secret] = new RootJsonFormat[Secret] {
     def write(s: Secret): JsValue = s.toJson
     def read(value: JsValue): Secret = Secret(value.convertTo[String])
   }
-
-  private val rand = new scala.util.Random(new java.security.SecureRandom())
 }


### PR DESCRIPTION
## Description

ActivationIDs are generated via UUID.randomUUID() today. Looking through the code of that you'll notice that it only generates a random hexadecimal String, delimited with dashes. We then proceed to cut out the dashes to end up at our ActivationId format.

We can straight up jump to generate the String ourselves. This even has the added benefit of adding more entropy to that String, because the UUID contains some bytes to determine its version (which are fixed bytes).


## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#3395)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [X] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] "Bug fix" (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [X] ~~I added tests to cover my changes.~~ (Not necessary as caught by existing tests)
- [X] ~~My changes require further changes to the documentation.~~
- [X] I updated the documentation where necessary.

