### PR TITLE
Create '_users' database for singleton ephemeral couchdb v 2+

### DIFF
--- a/ansible/roles/couchdb/tasks/deploy.yml
+++ b/ansible/roles/couchdb/tasks/deploy.yml
@@ -51,6 +51,16 @@
   retries: 12
   delay: 5
 
+- name: create '_users' database for singleton mode
+  uri:
+    url: "{{ db_protocol }}://{{ ansible_host }}:{{ db_port }}/_users"
+    method: PUT
+    status_code: 201
+    user: "{{ db_username }}"
+    password: "{{ db_password }}"
+    force_basic_auth: yes
+  when: (couchdb.version|version_compare('2.0','>=')) and (db.instances|int == 1)
+
 - name: enable the cluster setup mode
   uri:
     url: "{{ db_protocol }}://{{ ansible_host }}:{{ db_port }}/_cluster_setup"


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

Add a step to the 'ansible/roles/couchdb/deploy.yml' playbook that will create a `_users` database when the couchdb is set up as a singleton instance and the version is 2.0+.  As of version 2.0, the `_users` database is no longer created automatically.  When it does not exist, an error messge is periodically emitted, which in turn creates noise in the log file.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [X] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

