### PR TITLE
Fix deployment of the CLI if edge is on a remote machine.

### DIFF
--- a/ansible/roles/cli/tasks/deploy.yml
+++ b/ansible/roles/cli/tasks/deploy.yml
@@ -10,33 +10,22 @@
     state: directory
   become: "{{ openwhisk_cli.nginxdir.become }}"
 
-- name: "Ensure OpenWhisk build directory exists (for temp archive work)"
+- name: "Ensure temporary directory exists"
   file:
-    path: "{{ openwhisk_build_dir }}/{{ openwhisk_cli.archive_name }}"
+    path: "{{ nginx.confdir }}/cli_temp/{{ openwhisk_cli.archive_name }}"
     state: directory
-    mode: 0777
 
-#
-#  Why are we unarchiving into the build directory instead of directly into
-#  the Nginx config directory?  Because the Nginx config directory is (by
-#  default) located in the /tmp/... directory tree, which has a sticky bit
-#  set.  Said sticky bit creates no end of troubles for tar, so we're going
-#  to just avoid it entirely, rather than muck about with who's got which tar
-#  with which right tar options installed where.  It makes for many more
-#  items in this ansible playbook than we'd hoped, but at least it's (fairly)
-#  straightforward.
-#
 - name: "Download release archive to build directory ..."
   get_url:
     url: "{{ openwhisk_cli.remote.location }}/{{ openwhisk_cli.archive_name}}-{{ openwhisk_cli_tag }}-all.tgz"
-    dest: "{{ openwhisk_build_dir }}/{{ openwhisk_cli.archive_name }}.tgz"
+    dest: "{{ nginx.confdir }}/cli_temp/{{ openwhisk_cli.archive_name }}.tgz"
     headers: "{{ openwhisk_cli.remote.headers | default('') }}"
   when: openwhisk_cli.installation_mode == "remote"
 
 - name: "... or Copy release archive to build directory"
   copy:
     src: "{{ openwhisk_cli_home }}/release/{{ openwhisk_cli.archive_name}}-{{ openwhisk_cli_tag }}-all.tgz"
-    dest: "{{ openwhisk_build_dir }}/{{ openwhisk_cli.archive_name }}.tgz"
+    dest: "{{ nginx.confdir }}/cli_temp/{{ openwhisk_cli.archive_name }}.tgz"
   when: openwhisk_cli.installation_mode == "local"
 
 #
@@ -45,23 +34,19 @@
 #
 - name: "Expand the archive into the build directory"
   shell: >
-    tar zxf /{{ openwhisk_build_dir }}/{{ openwhisk_cli.archive_name }}.tgz
-    -C {{ openwhisk_build_dir }}/{{ openwhisk_cli.archive_name }}/
+    tar zxf {{ nginx.confdir }}/cli_temp/{{ openwhisk_cli.archive_name }}.tgz
+    -C {{ nginx.confdir }}/cli_temp/{{ openwhisk_cli.archive_name }}/
 
+# Remote copy does not support recursive copy of directories. That's why I'm using the shell.
 - name: "Copy expanded archive to final configuration directory"
-  copy:
-    #  WARNING:  The trailing slash is significant, signalling to copy contents
-    src: "{{ openwhisk_build_dir }}/{{ openwhisk_cli.archive_name }}/"
-    dest: "{{ openwhisk_cli.nginxdir.name }}"
+  #  WARNING:  The trailing slash is significant, signalling to copy contents
+  shell: "cp -r {{ nginx.confdir }}/cli_temp/{{ openwhisk_cli.archive_name }}/ {{ openwhisk_cli.nginxdir.name }}"
 
-- name: "Delete archive from build directory"
+- name: "Delete temp directory"
   file:
-    path: "{{ item }}"
+    path: "{{ nginx.confdir }}/cli_temp"
     state: absent
     force: yes
-  with_items:
-      - "{{ openwhisk_build_dir }}/{{ openwhisk_cli.archive_name }}.tgz"
-      - "{{ openwhisk_build_dir }}/{{ openwhisk_cli.archive_name }}/"
 
 - name: "Generate a list of individual tarballs to expand"
   find:

--- a/ansible/roles/cli/tasks/deploy.yml
+++ b/ansible/roles/cli/tasks/deploy.yml
@@ -40,7 +40,7 @@
 # Remote copy does not support recursive copy of directories. That's why I'm using the shell.
 - name: "Copy expanded archive to final configuration directory"
   #  WARNING:  The trailing slash is significant, signalling to copy contents
-  shell: "cp -r {{ nginx.confdir }}/cli_temp/{{ openwhisk_cli.archive_name }}/ {{ openwhisk_cli.nginxdir.name }}"
+  shell: "cp -r {{ nginx.confdir }}/cli_temp/{{ openwhisk_cli.archive_name }}/* {{ openwhisk_cli.nginxdir.name }}"
 
 - name: "Delete temp directory"
   file:


### PR DESCRIPTION
This PR fixes the deployment of the CLI if the edge is not on the same machine like the ansible-host.

## Description
This PR fixes the deployment of the CLI if the edge is not on the same machine like the ansible-host.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [X] Deployment
- [X] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

