### PR TITLE
Remove namespace configuration; use invoker's instead

### DIFF
--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -19,7 +19,6 @@ whisk {
   }
 
   kubernetes {
-    namespace: openwhisk
     # Timeouts for k8s commands. Set to "Inf" to disable timeout.
     timeouts {
       run: 1 minute


### PR DESCRIPTION
Making this configurable -- and defaulting to something that may not
be the ns in which the invoker is running -- is more trouble than it's
worth, I think.