### PR TITLE
refactor KubernetesClient to separate invokerAgent; add forwarding LogStoreProvider

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesClientWithInvokerAgent.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesClientWithInvokerAgent.scala
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool.kubernetes
+
+import whisk.common.{Logging, TransactionId}
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.Uri.Path
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse, MessageEntity, Uri}
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.http.scaladsl.marshalling.Marshal
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import pureconfig.loadConfigOrThrow
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+import whisk.core.ConfigKeys
+import whisk.core.entity.ByteSize
+
+import collection.JavaConverters._
+import scala.concurrent.{blocking, ExecutionContext, Future}
+
+/**
+ * An extended kubernetes client that works in tandem with an invokerAgent DaemonSet with
+ * instances running on every worker node that runs user containers to provide
+ * suspend/resume capability and higher performance log processing.
+ */
+class KubernetesClientWithInvokerAgent(config: KubernetesClientConfig =
+                                         loadConfigOrThrow[KubernetesClientConfig](ConfigKeys.kubernetes))(
+  executionContext: ExecutionContext)(implicit log: Logging, as: ActorSystem)
+    extends KubernetesClient(config)(executionContext)
+    with KubernetesApiWithInvokerAgent {
+
+  override def rm(key: String, value: String, ensureUnpaused: Boolean = false)(
+    implicit transid: TransactionId): Future[Unit] = {
+    if (ensureUnpaused) {
+      // The caller can't guarantee that every container with the label key=value is already unpaused.
+      // Therefore we must enumerate them and ensure they are unpaused before we attempt to delete them.
+      Future {
+        blocking {
+          kubeRestClient
+            .inNamespace(kubeRestClient.getNamespace)
+            .pods()
+            .withLabel(key, value)
+            .list()
+            .getItems
+            .asScala
+            .map { pod =>
+              val container = toContainer(pod)
+              container
+                .resume()
+                .recover { case _ => () } // Ignore errors; it is possible the container was not actually suspended.
+                .map(_ => rm(container))
+            }
+        }
+      }.flatMap(futures =>
+        Future
+          .sequence(futures)
+          .map(_ => ()))
+    } else {
+      super.rm(key, value, ensureUnpaused)
+    }
+  }
+
+  override def suspend(container: KubernetesContainer)(implicit transid: TransactionId): Future[Unit] = {
+    agentCommand("suspend", container)
+      .map(_.discardEntityBytes())
+  }
+
+  override def resume(container: KubernetesContainer)(implicit transid: TransactionId): Future[Unit] = {
+    agentCommand("resume", container)
+      .map(_.discardEntityBytes())
+  }
+
+  override def forwardLogs(container: KubernetesContainer,
+                           lastOffset: Long,
+                           sizeLimit: ByteSize,
+                           sentinelledLogs: Boolean,
+                           additionalMetadata: Map[String, JsValue],
+                           augmentedActivation: JsObject)(implicit transid: TransactionId): Future[Long] = {
+    val serializedData = Map(
+      "lastOffset" -> JsNumber(lastOffset),
+      "sizeLimit" -> JsNumber(sizeLimit.toBytes),
+      "sentinelledLogs" -> JsBoolean(sentinelledLogs),
+      "encodedLogLineMetadata" -> JsString(fieldsString(additionalMetadata)),
+      "encodedActivation" -> JsString(augmentedActivation.compactPrint))
+
+    agentCommand("logs", container, Some(serializedData))
+      .flatMap(response => Unmarshal(response.entity).to[String].map(_.toLong))
+  }
+
+  override def agentCommand(command: String,
+                            container: KubernetesContainer,
+                            payload: Option[Map[String, JsValue]] = None): Future[HttpResponse] = {
+    val uri = Uri()
+      .withScheme("http")
+      .withHost(container.workerIP)
+      .withPort(config.invokerAgent.port)
+      .withPath(Path / command / container.nativeContainerId)
+
+    Marshal(payload).to[MessageEntity].flatMap { entity =>
+      Http().singleRequest(HttpRequest(uri = uri, entity = entity))
+    }
+  }
+
+  private def fieldsString(fields: Map[String, JsValue]) =
+    fields
+      .map {
+        case (key, value) => s""""$key":${value.compactPrint}"""
+      }
+      .mkString(",")
+}
+
+trait KubernetesApiWithInvokerAgent extends KubernetesApi {
+
+  /**
+   * Request the invokerAgent running on the container's worker node to execute the given command
+   * @param command The command verb to execute
+   * @param container The container to which the command should be applied
+   * @param payload The additional data needed to execute the command.
+   * @return The HTTPResponse from the remote agent.
+   */
+  def agentCommand(command: String,
+                   container: KubernetesContainer,
+                   payload: Option[Map[String, JsValue]] = None): Future[HttpResponse]
+
+  /**
+   * Forward a section the argument container's stdout/stderr output to an external logging service.
+   *
+   * @param container the container whose logs should be forwarded
+   * @param lastOffset the last offset previously read in the remote log file
+   * @param sizeLimit The maximum number of bytes of log that should be forwarded before truncation
+   * @param sentinelledLogs Should the log forwarder expect a sentinel line at the end of stdout/stderr streams?
+   * @param additionalMetadata Additional metadata that should be injected into every log line
+   * @param augmentedActivation Activation record to be appended to the forwarded log.
+   * @return the last offset read from the remote log file (to be used on next call to forwardLogs)
+   */
+  def forwardLogs(container: KubernetesContainer,
+                  lastOffset: Long,
+                  sizeLimit: ByteSize,
+                  sentinelledLogs: Boolean,
+                  additionalMetadata: Map[String, JsValue],
+                  augmentedActivation: JsObject)(implicit transid: TransactionId): Future[Long]
+}

--- a/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesContainerFactory.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesContainerFactory.scala
@@ -18,6 +18,7 @@
 package whisk.core.containerpool.kubernetes
 
 import akka.actor.ActorSystem
+import pureconfig.loadConfigOrThrow
 
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
@@ -32,14 +33,23 @@ import whisk.core.containerpool.ContainerFactoryProvider
 import whisk.core.entity.ByteSize
 import whisk.core.entity.ExecManifest.ImageName
 import whisk.core.entity.InstanceId
-import whisk.core.WhiskConfig
+import whisk.core.{ConfigKeys, WhiskConfig}
 
 class KubernetesContainerFactory(label: String, config: WhiskConfig)(implicit actorSystem: ActorSystem,
                                                                      ec: ExecutionContext,
                                                                      logging: Logging)
     extends ContainerFactory {
 
-  implicit val kubernetes = new KubernetesClient()(ec)
+  implicit val kubernetes = initializeKubeClient()
+
+  private def initializeKubeClient(): KubernetesClient = {
+    val config = loadConfigOrThrow[KubernetesClientConfig](ConfigKeys.kubernetes)
+    if (config.invokerAgent.enabled) {
+      new KubernetesClientWithInvokerAgent(config)(ec)
+    } else {
+      new KubernetesClient(config)(ec)
+    }
+  }
 
   /** Perform cleanup on init */
   override def init(): Unit = cleanup()

--- a/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesInvokerAgentLogStore.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesInvokerAgentLogStore.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool.kubernetes
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+import whisk.common.TransactionId
+import whisk.core.containerpool.Container
+import whisk.core.containerpool.logging.{LogCollectingException, LogDriverLogStore, LogStore, LogStoreProvider}
+import whisk.core.entity.{ActivationLogs, ExecutableWhiskAction, Identity, WhiskActivation}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+ * A LogStore implementation for Kubernetes that delegates all log processing to a remote invokerAgent that
+ * runs on the worker node where the user container is executing.  The remote invokerAgent will read container logs,
+ * enrich them with the activation-specific metadata it is provided, and consolidate them into a remote
+ * combined log file that can be processed asynchronously by log forwarding services.
+ *
+ * Logs are never processed by the invoker itself and therefore are not stored in the activation record;
+ * collectLogs will return an empty ActivationLogs.
+ */
+class KubernetesInvokerAgentLogStore(system: ActorSystem) extends LogDriverLogStore(system) {
+  implicit val ec: ExecutionContext = system.dispatcher
+  implicit val mat: ActorMaterializer = ActorMaterializer()(system)
+
+  override def collectLogs(transid: TransactionId,
+                           user: Identity,
+                           activation: WhiskActivation,
+                           container: Container,
+                           action: ExecutableWhiskAction): Future[ActivationLogs] = {
+
+    val sizeLimit = action.limits.logs.asMegaBytes
+    val sentinelledLogs = action.exec.sentinelledLogs
+
+    // Add the userId field to every written record, so any background process can properly correlate.
+    val userIdField = Map("namespaceId" -> user.authkey.uuid.toJson)
+
+    val additionalMetadata = Map(
+      "activationId" -> activation.activationId.asString.toJson,
+      "action" -> action.fullyQualifiedName(false).asString.toJson) ++ userIdField
+
+    val augmentedActivation = JsObject(activation.toJson.fields ++ userIdField)
+
+    container match {
+      case kc: KubernetesContainer => {
+        kc.forwardLogs(sizeLimit, sentinelledLogs, additionalMetadata, augmentedActivation)(transid)
+          .map { _ =>
+            ActivationLogs()
+          }
+      }
+      case _ => Future.failed(LogCollectingException(ActivationLogs()))
+    }
+  }
+}
+
+object KubernetesInvokerAgentLogStoreProvider extends LogStoreProvider {
+  override def logStore(actorSystem: ActorSystem): LogStore = new KubernetesInvokerAgentLogStore(actorSystem)
+}


### PR DESCRIPTION
## Description
1. refactor KubernetesClient to move invokerAgent into a subclass to get a better separation of concerns. 
2. add an implementation of a forwarding LogStoreProvider for Kubernetes that uses the invokerAgent to remotely extract the user action logs and enrich them with additional per-activation metadata to prepare them for ingestion by a logging service. Logs are never processed by the invoker; all processing is remote.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [x] ~~My changes require further changes to the documentation.~~
- [x] ~~I updated the documentation where necessary.~~

