### PR TITLE
support cleanup of cloudant/kafka trigger dbs

### DIFF
--- a/tests/src/test/scala/whisk/core/database/test/CleanUpWhisksDbSkriptTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/CleanUpWhisksDbSkriptTests.scala
@@ -293,9 +293,9 @@ class CleanUpWhisksDbSkriptTests
 
     // Create document/action with random namespace
     val documents = Map(
-      ":AHA04676_dev:vision-cloudant-trigger" -> JsObject("dbname" -> JsString("openwhisk-darkvision-dev")),
-      ":AHA04676_stage:vision-cloudant-trigger" -> JsObject("dbname" -> JsString("openwhisk-darkvision-stage")),
-      ":AHA04676_prod:vision-cloudant-trigger" -> JsObject("dbname" -> JsString("openwhisk-darkvision-prod")))
+      ":dev_cluster:vision-cloudant-trigger" -> JsObject("dbname" -> JsString("openwhisk-darkvision-dev")),
+      ":stage_cluster:vision-cloudant-trigger" -> JsObject("dbname" -> JsString("openwhisk-darkvision-stage")),
+      ":prod_cluster:vision-cloudant-trigger" -> JsObject("dbname" -> JsString("openwhisk-darkvision-prod")))
 
     documents.foreach {
       case (id, document) =>
@@ -366,15 +366,15 @@ class CleanUpWhisksDbSkriptTests
 
     // Create document/action with random namespace
     val documents = Map(
-      "/AJackson@uk.ibm.com_dev/badgers" -> JsObject(
+      "/User@ibm.com_dev/badgers" -> JsObject(
         "triggerURL" -> JsString(
-          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers")),
-      "/AJackson@uk.ibm.com_dev/badgers2" -> JsObject(
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/User%40ibm.com_dev/triggers/badgers")),
+      "/User@ibm.com_dev/badgers2" -> JsObject(
         "triggerURL" -> JsString(
-          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers2")),
-      "/AJackson@uk.ibm.com_dev/badgers3" -> JsObject(
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/User%40ibm.com_dev/triggers/badgers2")),
+      "/User@ibm.com_dev/badgers3" -> JsObject(
         "triggerURL" -> JsString(
-          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers3")))
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/User%40ibm.com_dev/triggers/badgers3")))
 
     documents.foreach {
       case (id, document) =>
@@ -451,15 +451,15 @@ class CleanUpWhisksDbSkriptTests
 
     // Create document/action with random namespace
     val documents = Map(
-      "02e116e9-b66f-4ed3-8159-a40048ae829b:XXX/swapna_gen4_org_dev/trigger_2bd1d70424a7b627ef18827fac212dae" -> JsObject(
+      "02e116e9-b66f-4ed3-8159-a40048ae829b:XXX/user_gen4_org_dev/trigger_2bd1d70424a7b627ef18827fac212dae" -> JsObject(
         "triggerURL" -> JsString(
-          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers")),
-      "02e116e9-b66f-4ed3-8159-a40048ae829b:XXX/swapna_gen4_org_stage/trigger_2bd1d70424a7b627ef18827fac212dae" -> JsObject(
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/user%40ibm.com_dev/triggers/badgers")),
+      "02e116e9-b66f-4ed3-8159-a40048ae829b:XXX/user_gen4_org_stage/trigger_2bd1d70424a7b627ef18827fac212dae" -> JsObject(
         "triggerURL" -> JsString(
-          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers2")),
-      "02e116e9-b66f-4ed3-8159-a40048ae829b:XXX/swapna_gen4_org_prod/trigger_2bd1d70424a7b627ef18827fac212dae" -> JsObject(
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/user%40ibm.com_dev/triggers/badgers2")),
+      "02e116e9-b66f-4ed3-8159-a40048ae829b:XXX/user_gen4_org_prod/trigger_2bd1d70424a7b627ef18827fac212dae" -> JsObject(
         "triggerURL" -> JsString(
-          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers3")))
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/user%40ibm.com_dev/triggers/badgers3")))
 
     documents.foreach {
       case (id, document) =>
@@ -496,13 +496,13 @@ class CleanUpWhisksDbSkriptTests
     val documents = Map(
       "02e116e9-b66f-4ed3-8159-a40048ae829b:XXX/whisk.system/trigger" -> JsObject(
         "triggerURL" -> JsString(
-          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers")),
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/user%40ibm.com_dev/triggers/badgers")),
       "02e116e9-b66f-4ed3-8159-a40048ae829b:XXX/whisk.system/trigger2" -> JsObject(
         "triggerURL" -> JsString(
-          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers")),
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/user%40ibm.com_dev/triggers/badgers")),
       "02e116e9-b66f-4ed3-8159-a40048ae829b:XXX/whisk.system/trigger3" -> JsObject(
         "triggerURL" -> JsString(
-          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers")))
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/user%40ibm.com_dev/triggers/badgers")))
 
     documents.foreach {
       case (id, document) =>

--- a/tests/src/test/scala/whisk/core/database/test/CleanUpWhisksDbSkriptTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/CleanUpWhisksDbSkriptTests.scala
@@ -366,15 +366,15 @@ class CleanUpWhisksDbSkriptTests
 
     // Create document/action with random namespace
     val documents = Map(
-      "/User@ibm.com_dev/badgers" -> JsObject(
+      "/User@com_dev/badgers" -> JsObject(
         "triggerURL" -> JsString(
-          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/User%40ibm.com_dev/triggers/badgers")),
-      "/User@ibm.com_dev/badgers2" -> JsObject(
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/User%40com_dev/triggers/badgers")),
+      "/User@com_dev/badgers2" -> JsObject(
         "triggerURL" -> JsString(
-          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/User%40ibm.com_dev/triggers/badgers2")),
-      "/User@ibm.com_dev/badgers3" -> JsObject(
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/User%40com_dev/triggers/badgers2")),
+      "/User@com_dev/badgers3" -> JsObject(
         "triggerURL" -> JsString(
-          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/User%40ibm.com_dev/triggers/badgers3")))
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/User%40com_dev/triggers/badgers3")))
 
     documents.foreach {
       case (id, document) =>
@@ -411,13 +411,13 @@ class CleanUpWhisksDbSkriptTests
     val documents = Map(
       "/whisk.system/badgers" -> JsObject(
         "triggerURL" -> JsString(
-          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers")),
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/User%40com_dev/triggers/badgers")),
       "/whisk.system/badgers2" -> JsObject(
         "triggerURL" -> JsString(
-          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers")),
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/User%40com_dev/triggers/badgers2")),
       "/whisk.system/badgers3" -> JsObject(
         "triggerURL" -> JsString(
-          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers")))
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/User%40com_dev/triggers/badgers3")))
 
     documents.foreach {
       case (id, document) =>
@@ -451,15 +451,15 @@ class CleanUpWhisksDbSkriptTests
 
     // Create document/action with random namespace
     val documents = Map(
-      "02e116e9-b66f-4ed3-8159-a40048ae829b:XXX/user_gen4_org_dev/trigger_2bd1d70424a7b627ef18827fac212dae" -> JsObject(
+      "id:XXX/user_gen4_org_dev/trigger_id" -> JsObject(
         "triggerURL" -> JsString(
-          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/user%40ibm.com_dev/triggers/badgers")),
-      "02e116e9-b66f-4ed3-8159-a40048ae829b:XXX/user_gen4_org_stage/trigger_2bd1d70424a7b627ef18827fac212dae" -> JsObject(
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/user%40com_dev/triggers/badgers")),
+      "id:XXX/user_gen4_org_stage/trigger_id" -> JsObject(
         "triggerURL" -> JsString(
-          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/user%40ibm.com_dev/triggers/badgers2")),
-      "02e116e9-b66f-4ed3-8159-a40048ae829b:XXX/user_gen4_org_prod/trigger_2bd1d70424a7b627ef18827fac212dae" -> JsObject(
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/user%40com_dev/triggers/badgers2")),
+      "id:XXX/user_gen4_org_prod/trigger_id" -> JsObject(
         "triggerURL" -> JsString(
-          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/user%40ibm.com_dev/triggers/badgers3")))
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/user%40com_dev/triggers/badgers3")))
 
     documents.foreach {
       case (id, document) =>
@@ -494,15 +494,15 @@ class CleanUpWhisksDbSkriptTests
 
     // Create document/action with whisk-system namespace
     val documents = Map(
-      "02e116e9-b66f-4ed3-8159-a40048ae829b:XXX/whisk.system/trigger" -> JsObject(
+      "id:XXX/whisk.system/trigger" -> JsObject(
         "triggerURL" -> JsString(
-          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/user%40ibm.com_dev/triggers/badgers")),
-      "02e116e9-b66f-4ed3-8159-a40048ae829b:XXX/whisk.system/trigger2" -> JsObject(
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/user%40com_dev/triggers/badgers")),
+      "id:XXX/whisk.system/trigger2" -> JsObject(
         "triggerURL" -> JsString(
-          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/user%40ibm.com_dev/triggers/badgers")),
-      "02e116e9-b66f-4ed3-8159-a40048ae829b:XXX/whisk.system/trigger3" -> JsObject(
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/user%40com_dev/triggers/badgers2")),
+      "id:XXX/whisk.system/trigger3" -> JsObject(
         "triggerURL" -> JsString(
-          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/user%40ibm.com_dev/triggers/badgers")))
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/user%40com_dev/triggers/badgers3")))
 
     documents.foreach {
       case (id, document) =>

--- a/tests/src/test/scala/whisk/core/database/test/CleanUpWhisksDbSkriptTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/CleanUpWhisksDbSkriptTests.scala
@@ -45,8 +45,8 @@ class CleanUpWhisksDbSkriptTests
   val dbConfig = loadConfigOrThrow[CouchDbConfig](ConfigKeys.couchdb)
   val authDBName = dbConfig.databaseFor[WhiskAuth]
 
-  def runScript(dbUrl: String, whisksDbName: String, subjectsDbName: String) = {
-    println(s"Running script: $dbUrl, $whisksDbName, $subjectsDbName")
+  def runScript(dbUrl: String, whisksDbName: String, subjectsDbName: String, whiskDbType: String) = {
+    println(s"Running script: $dbUrl, $whisksDbName, $subjectsDbName, $whiskDbType")
 
     val cmd =
       Seq(
@@ -58,26 +58,35 @@ class CleanUpWhisksDbSkriptTests
         whisksDbName,
         "--dbNameSubjects",
         subjectsDbName,
+        "--whiskDBType",
+        whiskDbType,
         "--days",
-        "1",
+        "7",
         "--docsPerRequest",
         "1")
 
     val rr = TestUtils.runCmd(0, new File("."), cmd: _*)
 
-    val Seq(marked, deleted, skipped, kept) =
-      Seq("marking: ", "deleting: ", "skipping: ", "keeping: ").map { linePrefix =>
+    rr.stdout.lines.foreach {
+      case (line) =>
+        println(s"line: $line")
+    }
+
+    val Seq(marking, marked, deleting, skipping, keeping, statistic) =
+      Seq("marking: ", "marked: ", "deleting: ", "skipping: ", "keeping: ", "statistic: ").map { linePrefix =>
         rr.stdout.lines.collect {
           case line if line.startsWith(linePrefix) => line.replace(linePrefix, "")
         }.toList
       }
 
-    println(s"marked:  $marked")
-    println(s"deleted: $deleted")
-    println(s"skipped: $skipped")
-    println(s"kept:    $kept")
+    println(s"marked for deletion: $marking")
+    println(s"already marked:      $marked")
+    println(s"deleted:             $deleting")
+    println(s"skipped:             $skipping")
+    println(s"kept:                $keeping")
+    println(s"statistic:           $statistic")
 
-    (marked, deleted, skipped, kept)
+    (marking, deleting, skipping, keeping)
   }
 
   behavior of "Cleanup whisksDb script"
@@ -99,7 +108,7 @@ class CleanUpWhisksDbSkriptTests
     }
 
     // execute script
-    val (marked, _, _, _) = runScript(dbUrl, dbName, authDBName)
+    val (marked, _, _, _) = runScript(dbUrl, dbName, authDBName, "whisks")
     println(s"marked: $marked")
 
     // Check, that script marked document to be deleted: output + document from DB
@@ -142,7 +151,7 @@ class CleanUpWhisksDbSkriptTests
     }
 
     // execute script
-    val (marked, deleted, _, _) = runScript(dbUrl, dbName, authDBName)
+    val (marked, deleted, _, _) = runScript(dbUrl, dbName, authDBName, "whisks")
     println(s"marked: $marked")
     println(s"deleted: $deleted")
 
@@ -178,13 +187,13 @@ class CleanUpWhisksDbSkriptTests
     }
 
     // execute script
-    val (_, _, _, kept) = runScript(dbUrl, dbName, authDBName)
+    val (_, _, _, kept) = runScript(dbUrl, dbName, authDBName, "whisks")
     println(s"kept: $kept")
 
     // Check, that script did not mark documents for deletion
     val ids = documents.keys
     println(s"ids: $ids")
-    kept should contain allElementsOf ids
+    kept should contain ("3 doc(s) for namespace whisk.system")
 
     val databaseResponse = client.getAllDocs(includeDocs = Some(true)).futureValue
     databaseResponse should be('right)
@@ -214,7 +223,7 @@ class CleanUpWhisksDbSkriptTests
     }
 
     // execute script
-    val (_, _, skipped, _) = runScript(dbUrl, dbName, authDBName)
+    val (_, _, skipped, _) = runScript(dbUrl, dbName, authDBName, "whisks")
     println(s"skipped: $skipped")
 
     // Check, that script skipped design documents
@@ -257,19 +266,165 @@ class CleanUpWhisksDbSkriptTests
     }
 
     // execute script
-    val (_, _, _, kept) = runScript(dbUrl, dbName, authDBName)
+    val (_, _, _, kept) = runScript(dbUrl, dbName, authDBName, "whisks")
     println(s"kept: $kept")
 
     // Check, that script kept documents in DB
     val ids = documents.keys
     println(s"ids: $ids")
-    kept should contain allElementsOf ids
+    kept should contain ("3 doc(s) for namespace whisk.system")
 
     val databaseResponse = client.getAllDocs(includeDocs = Some(true)).futureValue
     databaseResponse should be('right)
 
     val databaseDocuments = databaseResponse.right.get.fields("rows").convertTo[List[JsObject]]
 
+    val databaseDocumentIDs = databaseDocuments.map(_.fields("id").convertTo[String])
+    databaseDocumentIDs should contain allElementsOf ids
+
+    // Delete database
+    client.deleteDb().futureValue
+  }
+
+  it should "mark documents for deletion in cloudanttrigger if namespace does not exist" in {
+    // Create whisks db
+    val dbName = dbPrefix + "cleanup_cloudanttrigger_test_mark_for_deletion"
+    val client = createDatabase(dbName, None)
+
+    // Create document/action with random namespace
+    val documents = Map(
+      ":AHA04676_dev:vision-cloudant-trigger" -> JsObject("dbname" -> JsString("openwhisk-darkvision-dev")),
+      ":AHA04676_stage:vision-cloudant-trigger" -> JsObject("dbname" -> JsString("openwhisk-darkvision-stage")),
+      ":AHA04676_prod:vision-cloudant-trigger" -> JsObject("dbname" -> JsString("openwhisk-darkvision-prod")))
+
+    documents.foreach {
+      case (id, document) =>
+        client.putDoc(id, document).futureValue
+    }
+
+    // execute script
+    val (marked, _, _, _) = runScript(dbUrl, dbName, authDBName, "cloudanttrigger")
+    println(s"marked: $marked")
+
+    // Check, that script marked document to be deleted: output + document from DB
+    val ids = documents.keys
+    println(s"ids: $ids")
+    marked should contain allElementsOf ids
+
+    val databaseResponse = client.getAllDocs(includeDocs = Some(true)).futureValue
+    databaseResponse should be('right)
+    val databaseDocuments = databaseResponse.right.get.fields("rows").convertTo[List[JsObject]]
+
+    databaseDocuments.foreach { doc =>
+      doc.fields("doc").asJsObject.fields.keys should contain("markedForDeletion")
+    }
+
+    // Delete database
+    client.deleteDb().futureValue
+  }
+
+  it should "not mark documents for deletion in cloudanttrigger if namespace does exist" in {
+    // Create whisks db
+    val dbName = dbPrefix + "cleanup_cloudanttrigger_test_not_mark_for_deletion"
+    val client = createDatabase(dbName, None)
+
+    // Create document/action with whisk-system namespace
+    val documents = Map(
+      ":whisk.system:vision-cloudant-trigger" -> JsObject("dbname" -> JsString("openwhisk-darkvision-dev")),
+      ":whisk.system:vision-cloudant-trigger2" -> JsObject("dbname" -> JsString("openwhisk-darkvision-dev")),
+      ":whisk.system:vision-cloudant-trigger3" -> JsObject("dbname" -> JsString("openwhisk-darkvision-dev")))
+
+    documents.foreach {
+      case (id, document) =>
+        client.putDoc(id, document).futureValue
+    }
+
+    // execute script
+    val (_, _, _, kept) = runScript(dbUrl, dbName, authDBName, "cloudanttrigger")
+    println(s"kept: $kept")
+
+    // Check, that script did not mark documents for deletion
+    val ids = documents.keys
+    println(s"ids: $ids")
+    kept should contain ("3 doc(s) for namespace whisk.system")
+
+    val databaseResponse = client.getAllDocs(includeDocs = Some(true)).futureValue
+    databaseResponse should be('right)
+
+    val databaseDocuments = databaseResponse.right.get.fields("rows").convertTo[List[JsObject]]
+    val databaseDocumentIDs = databaseDocuments.map(_.fields("id").convertTo[String])
+    databaseDocumentIDs should contain allElementsOf ids
+
+    // Delete database
+    client.deleteDb().futureValue
+  }
+
+  it should "mark documents for deletion in kafkatrigger if namespace does not exist" in {
+    // Create whisks db
+    val dbName = dbPrefix + "cleanup_kafkatrigger_test_mark_for_deletion"
+    val client = createDatabase(dbName, None)
+
+    // Create document/action with random namespace
+    val documents = Map(
+      "/AJackson@uk.ibm.com_dev/badgers" -> JsObject("triggerURL" -> JsString("https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers")),
+      "/AJackson@uk.ibm.com_dev/badgers2" -> JsObject("triggerURL" -> JsString("https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers2")),
+      "/AJackson@uk.ibm.com_dev/badgers3" -> JsObject("triggerURL" -> JsString("https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers3")))
+
+    documents.foreach {
+      case (id, document) =>
+        client.putDoc(id, document).futureValue
+    }
+
+    // execute script
+    val (marked, _, _, _) = runScript(dbUrl, dbName, authDBName, "kafkatrigger")
+    println(s"marked: $marked")
+
+    // Check, that script marked document to be deleted: output + document from DB
+    val ids = documents.keys
+    println(s"ids: $ids")
+    marked should contain allElementsOf ids
+
+    val databaseResponse = client.getAllDocs(includeDocs = Some(true)).futureValue
+    databaseResponse should be('right)
+    val databaseDocuments = databaseResponse.right.get.fields("rows").convertTo[List[JsObject]]
+
+    databaseDocuments.foreach { doc =>
+      doc.fields("doc").asJsObject.fields.keys should contain("markedForDeletion")
+    }
+
+    // Delete database
+    client.deleteDb().futureValue
+  }
+
+  it should "not mark documents for deletion in kafkatrigger if namespace does exist" in {
+    // Create whisks db
+    val dbName = dbPrefix + "cleanup_kafkatrigger_test_not_mark_for_deletion"
+    val client = createDatabase(dbName, None)
+
+    // Create document/action with whisk-system namespace
+    val documents = Map(
+      "/whisk.system/badgers" -> JsObject("triggerURL" -> JsString("https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers")),
+      "/whisk.system/badgers2" -> JsObject("triggerURL" -> JsString("https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers")),
+      "/whisk.system/badgers3" -> JsObject("triggerURL" -> JsString("https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers")))
+
+    documents.foreach {
+      case (id, document) =>
+        client.putDoc(id, document).futureValue
+    }
+
+    // execute script
+    val (_, _, _, kept) = runScript(dbUrl, dbName, authDBName, "kafkatrigger")
+    println(s"kept: $kept")
+
+    // Check, that script did not mark documents for deletion
+    val ids = documents.keys
+    println(s"ids: $ids")
+    kept should contain ("3 doc(s) for namespace whisk.system")
+
+    val databaseResponse = client.getAllDocs(includeDocs = Some(true)).futureValue
+    databaseResponse should be('right)
+
+    val databaseDocuments = databaseResponse.right.get.fields("rows").convertTo[List[JsObject]]
     val databaseDocumentIDs = databaseDocuments.map(_.fields("id").convertTo[String])
     databaseDocumentIDs should contain allElementsOf ids
 

--- a/tests/src/test/scala/whisk/core/database/test/CleanUpWhisksDbSkriptTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/CleanUpWhisksDbSkriptTests.scala
@@ -193,7 +193,7 @@ class CleanUpWhisksDbSkriptTests
     // Check, that script did not mark documents for deletion
     val ids = documents.keys
     println(s"ids: $ids")
-    kept should contain ("3 doc(s) for namespace whisk.system")
+    kept should contain("3 doc(s) for namespace whisk.system")
 
     val databaseResponse = client.getAllDocs(includeDocs = Some(true)).futureValue
     databaseResponse should be('right)
@@ -272,7 +272,7 @@ class CleanUpWhisksDbSkriptTests
     // Check, that script kept documents in DB
     val ids = documents.keys
     println(s"ids: $ids")
-    kept should contain ("3 doc(s) for namespace whisk.system")
+    kept should contain("3 doc(s) for namespace whisk.system")
 
     val databaseResponse = client.getAllDocs(includeDocs = Some(true)).futureValue
     databaseResponse should be('right)
@@ -346,7 +346,7 @@ class CleanUpWhisksDbSkriptTests
     // Check, that script did not mark documents for deletion
     val ids = documents.keys
     println(s"ids: $ids")
-    kept should contain ("3 doc(s) for namespace whisk.system")
+    kept should contain("3 doc(s) for namespace whisk.system")
 
     val databaseResponse = client.getAllDocs(includeDocs = Some(true)).futureValue
     databaseResponse should be('right)
@@ -366,9 +366,15 @@ class CleanUpWhisksDbSkriptTests
 
     // Create document/action with random namespace
     val documents = Map(
-      "/AJackson@uk.ibm.com_dev/badgers" -> JsObject("triggerURL" -> JsString("https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers")),
-      "/AJackson@uk.ibm.com_dev/badgers2" -> JsObject("triggerURL" -> JsString("https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers2")),
-      "/AJackson@uk.ibm.com_dev/badgers3" -> JsObject("triggerURL" -> JsString("https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers3")))
+      "/AJackson@uk.ibm.com_dev/badgers" -> JsObject(
+        "triggerURL" -> JsString(
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers")),
+      "/AJackson@uk.ibm.com_dev/badgers2" -> JsObject(
+        "triggerURL" -> JsString(
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers2")),
+      "/AJackson@uk.ibm.com_dev/badgers3" -> JsObject(
+        "triggerURL" -> JsString(
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers3")))
 
     documents.foreach {
       case (id, document) =>
@@ -403,9 +409,15 @@ class CleanUpWhisksDbSkriptTests
 
     // Create document/action with whisk-system namespace
     val documents = Map(
-      "/whisk.system/badgers" -> JsObject("triggerURL" -> JsString("https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers")),
-      "/whisk.system/badgers2" -> JsObject("triggerURL" -> JsString("https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers")),
-      "/whisk.system/badgers3" -> JsObject("triggerURL" -> JsString("https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers")))
+      "/whisk.system/badgers" -> JsObject(
+        "triggerURL" -> JsString(
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers")),
+      "/whisk.system/badgers2" -> JsObject(
+        "triggerURL" -> JsString(
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers")),
+      "/whisk.system/badgers3" -> JsObject(
+        "triggerURL" -> JsString(
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers")))
 
     documents.foreach {
       case (id, document) =>
@@ -419,7 +431,92 @@ class CleanUpWhisksDbSkriptTests
     // Check, that script did not mark documents for deletion
     val ids = documents.keys
     println(s"ids: $ids")
-    kept should contain ("3 doc(s) for namespace whisk.system")
+    kept should contain("3 doc(s) for namespace whisk.system")
+
+    val databaseResponse = client.getAllDocs(includeDocs = Some(true)).futureValue
+    databaseResponse should be('right)
+
+    val databaseDocuments = databaseResponse.right.get.fields("rows").convertTo[List[JsObject]]
+    val databaseDocumentIDs = databaseDocuments.map(_.fields("id").convertTo[String])
+    databaseDocumentIDs should contain allElementsOf ids
+
+    // Delete database
+    client.deleteDb().futureValue
+  }
+
+  it should "mark documents for deletion in alarmservice if namespace does not exist" in {
+    // Create alarmservice db
+    val dbName = dbPrefix + "cleanup_alarmservice_test_mark_for_deletion"
+    val client = createDatabase(dbName, None)
+
+    // Create document/action with random namespace
+    val documents = Map(
+      "02e116e9-b66f-4ed3-8159-a40048ae829b:XXX/swapna_gen4_org_dev/trigger_2bd1d70424a7b627ef18827fac212dae" -> JsObject(
+        "triggerURL" -> JsString(
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers")),
+      "02e116e9-b66f-4ed3-8159-a40048ae829b:XXX/swapna_gen4_org_stage/trigger_2bd1d70424a7b627ef18827fac212dae" -> JsObject(
+        "triggerURL" -> JsString(
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers2")),
+      "02e116e9-b66f-4ed3-8159-a40048ae829b:XXX/swapna_gen4_org_prod/trigger_2bd1d70424a7b627ef18827fac212dae" -> JsObject(
+        "triggerURL" -> JsString(
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers3")))
+
+    documents.foreach {
+      case (id, document) =>
+        client.putDoc(id, document).futureValue
+    }
+
+    // execute script
+    val (marked, _, _, _) = runScript(dbUrl, dbName, authDBName, "alarmservice")
+    println(s"marked: $marked")
+
+    // Check, that script marked document to be deleted: output + document from DB
+    val ids = documents.keys
+    println(s"ids: $ids")
+    marked should contain allElementsOf ids
+
+    val databaseResponse = client.getAllDocs(includeDocs = Some(true)).futureValue
+    databaseResponse should be('right)
+    val databaseDocuments = databaseResponse.right.get.fields("rows").convertTo[List[JsObject]]
+
+    databaseDocuments.foreach { doc =>
+      doc.fields("doc").asJsObject.fields.keys should contain("markedForDeletion")
+    }
+
+    // Delete database
+    client.deleteDb().futureValue
+  }
+
+  it should "not mark documents for deletion in alarmservice if namespace does exist" in {
+    // Create alarmservice db
+    val dbName = dbPrefix + "cleanup_alarmservice_test_not_mark_for_deletion"
+    val client = createDatabase(dbName, None)
+
+    // Create document/action with whisk-system namespace
+    val documents = Map(
+      "02e116e9-b66f-4ed3-8159-a40048ae829b:XXX/whisk.system/trigger" -> JsObject(
+        "triggerURL" -> JsString(
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers")),
+      "02e116e9-b66f-4ed3-8159-a40048ae829b:XXX/whisk.system/trigger2" -> JsObject(
+        "triggerURL" -> JsString(
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers")),
+      "02e116e9-b66f-4ed3-8159-a40048ae829b:XXX/whisk.system/trigger3" -> JsObject(
+        "triggerURL" -> JsString(
+          "https://xxx:xxx@openwhisk.ng.bluemix.net/api/v1/namespaces/AJackson%40uk.ibm.com_dev/triggers/badgers")))
+
+    documents.foreach {
+      case (id, document) =>
+        client.putDoc(id, document).futureValue
+    }
+
+    // execute script
+    val (_, _, _, kept) = runScript(dbUrl, dbName, authDBName, "alarmservice")
+    println(s"kept: $kept")
+
+    // Check, that script did not mark documents for deletion
+    val ids = documents.keys
+    println(s"ids: $ids")
+    kept should contain("3 doc(s) for namespace whisk.system")
 
     val databaseResponse = client.getAllDocs(includeDocs = Some(true)).futureValue
     databaseResponse should be('right)

--- a/tests/src/test/scala/whisk/core/database/test/CleanUpWhisksDbSkriptTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/CleanUpWhisksDbSkriptTests.scala
@@ -67,11 +67,6 @@ class CleanUpWhisksDbSkriptTests
 
     val rr = TestUtils.runCmd(0, new File("."), cmd: _*)
 
-    rr.stdout.lines.foreach {
-      case (line) =>
-        println(s"line: $line")
-    }
-
     val Seq(marking, marked, deleting, skipping, keeping, statistic) =
       Seq("marking: ", "marked: ", "deleting: ", "skipping: ", "keeping: ", "statistic: ").map { linePrefix =>
         rr.stdout.lines.collect {

--- a/tools/db/README.md
+++ b/tools/db/README.md
@@ -1,16 +1,16 @@
 <!--
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more contributor 
-# license agreements.  See the NOTICE file distributed with this work for additional 
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for additional
 # information regarding copyright ownership.  The ASF licenses this file to you
-# under the Apache License, Version 2.0 (the # "License"); you may not use this 
-# file except in compliance with the License.  You may obtain a copy of the License 
+# under the Apache License, Version 2.0 (the # "License"); you may not use this
+# file except in compliance with the License.  You may obtain a copy of the License
 # at:
 #
 # http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software distributed 
-# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations under the License.
 #
@@ -39,9 +39,9 @@ Detailed instructions are found in the [ansible readme](../../ansible/README.md)
 
 ## Using Cloudant
 
-As an alternative to a self-managed CouchDB, you may want to try [Cloudant](https://cloudant.com) which is a cloud-based database service. 
-There are two ways to get a Cloudant account and configure OpenWhisk to use it. 
-You only need to establish an account once, either through IBM Bluemix or with Cloudant directly. 
+As an alternative to a self-managed CouchDB, you may want to try [Cloudant](https://cloudant.com) which is a cloud-based database service.
+There are two ways to get a Cloudant account and configure OpenWhisk to use it.
+You only need to establish an account once, either through IBM Bluemix or with Cloudant directly.
 
 ### Create a Cloudant account via IBM Bluemix
 Sign up for an account via [IBM Bluemix](https://bluemix.net). Bluemix offers trial accounts and its signup process is straightforward so it is not described here in detail. Using Bluemix, the most convenient way to create a Cloudant instance is via the `cf` command-line tool. See [here](https://www.ng.bluemix.net/docs/starters/install_cli.html) for instructions on how to download and configure `cf` to work with your Bluemix account.
@@ -89,7 +89,7 @@ If you are [using an ephemeral CouchDB container](#using-an-ephemeral-couchdb-co
   ```
   # Work out of your openwhisk directory
   cd /your/path/to/openwhisk/ansible
-  
+
   # Initialize data store containing authorization keys
   ansible-playbook initdb.yml
   ```
@@ -164,3 +164,17 @@ Run `moveCodeToAttachment.py` to update actions in an existing database to the n
 
 * `--dbUrl`: Server URL of the database. E.g. 'https://xxx:yyy@domain.couch.com:443'.
 * `--dbName`: Name of the Database to update.
+
+## Cleanup of OpenWhisk Databases
+
+The script `cleanUpWhisk.py` can be used to cleanup the OpenWhisk databases from inactive entries. It runs over all documents in the specified OpenWhisk database and checks if the referenced namespace still exists. A document will either be marked for deletion or deleted if already marked for certain period of time if its namespace does not exists.
+
+Run `cleanUpWhisk.py` to cleanup inactive documents in the specified database. The following parameters are required:
+
+* `--dbUrl`: Server URL of the database. E.g. 'https://xxx:yyy@domain.couch.com:443'.
+* `--dbNameWhisks`: Name of the Database to cleanup.
+* `--dbNameSubjects`: Name of the Subjects Database used to lookup the namespace.
+* `--whiskDBType`: Type of the OpenWhisk database. Supported types are `whisks`, `cloudanttrigger`, `kafkatrigger`, `alarmservice`.
+* `--days`: Number of days to keep database documents that are marked for deletion before deleting them in the database. Optional parameter, defaults to 7.
+* `--docsPerRequest`: Number of documents handled on each CouchDB request. Optional parameter, defaults to 100.
+* `--bufferLen`: Length of internal cache to store already checked namespaces. Optional parameter, defaults to 100.

--- a/tools/db/cleanUpWhisks.py
+++ b/tools/db/cleanUpWhisks.py
@@ -124,16 +124,12 @@ def updateLastNamespaceInfo(namespace, lastNamespaceInfo):
 def getDelimiters(whiskDatabaseType):
 
     if whiskDatabaseType == "whisks":
-        # "_id": "whisk.system/utils",
         return None, '/'
     elif whiskDatabaseType == "cloudanttrigger":
-        # "_id": ":AHA04676_dev:vision-cloudant-trigger",
         return ':', ':'
     elif whiskDatabaseType == "kafkatrigger":
-        # "_id": "/AJackson@uk.ibm.com_dev/badgers",
         return '/', '/'
     elif whiskDatabaseType == "alarmservice":
-        # "_id": "02e116e9-b66f-4ed3-8159-a40048ae829b:XXX/swapna_gen4_org_dev/trigger_2bd1d70424a7b627ef18827fac212dae"
         return '/', '/'
     else:
         print('{0}: error: {1} is not supported for --whiskDBType'.format(sys.argv[0], whiskDatabaseType))
@@ -199,7 +195,7 @@ parser.add_argument("--dbNameWhisks", required=True, help="Name of the Whisks Da
 parser.add_argument("--dbNameSubjects", required=True, help="Name of the Subjects Database.")
 parser.add_argument("--whiskDBType", required=True, help="Type of the Whisks Database. Supported are whisks, cloudanttrigger, kafkatrigger, alarmservice")
 parser.add_argument("--days", required=True, type=int, default=7, help="How many days whisks keep entries marked for deletion before deleting them.")
-parser.add_argument("--docsPerRequest", type=int, default=200, help="Number of documents handled on each CouchDb Request. Default is 200.")
+parser.add_argument("--docsPerRequest", type=int, default=200, help="Number of documents handled on each CouchDb Request. Default is 100.")
 parser.add_argument("--bufferLen", type=int, default=100, help="Maximum buffer length to cache already checked ns. Default is 100.")
 args = parser.parse_args()
 checkWhisks(args)

--- a/tools/db/cleanUpWhisks.py
+++ b/tools/db/cleanUpWhisks.py
@@ -22,8 +22,10 @@
 import argparse
 import time
 import couchdb.client
+import sys
 
 skipWhisks = 0
+marking = marked = deleting = skipping = keeping = 0
 
 try:
     long        # Python 2
@@ -38,36 +40,34 @@ DAY = HOUR * 24
 #
 class SimpleRingBuffer:
     def __init__(self, size):
-        self.index = -1
+        self.index = 0
         self.data = []
-        self.maxsize = size * 2
+        self.maxsize = size
 
-    def append(self, ns, bool):
-
-        self.index=(self.index+2)%self.maxsize
-
+    def append(self, ns, exists):
         if len(self.data) < self.maxsize:
-            self.data.append(ns)
-            self.data.append(bool)
+            self.data.append((ns,exists))
         else:
-            self.data[self.index-1]=ns
-            self.data[(self.index)]=bool
+            self.data[self.index]=(ns,exists)
+        self.index=(self.index+1)%self.maxsize
 
     def getself(self):
         return self.data
 
     def get(self, ns):
-        if ns in self.data:
-            return self.data[self.data.index(ns)+1]
+        if (ns,True) in self.data:
+            return True
+        elif (ns,False) in self.data:
+            return False
         else:
             return None
 
 #
 # mark whisks entry for deletion of delete if already marked
 #
-def deleteWhisk(dbWhisks, wdoc):
+def deleteWhisk(dbWhisks, wdoc, days):
 
-    global skipWhisks
+    global skipWhisks, marking, marked, deleting
 
     wdocd = dbWhisks[wdoc['id']]
     if not 'markedForDeletion' in wdocd:
@@ -75,18 +75,21 @@ def deleteWhisk(dbWhisks, wdoc):
         dts = int(time.time() * 1000)
         wdocd['markedForDeletion'] = dts
         dbWhisks.save(wdocd)
+        marking+=1
     else:
         dts = wdocd['markedForDeletion']
         now = int(time.time() * 1000)
         elapsedh = int((now - dts) / HOUR)
         elapsedd = int((now - dts) / DAY)
 
-        if elapsedd >= args.days:
+        if elapsedd >= days:
             print('deleting: {0}'.format(wdoc['id']))
             dbWhisks.delete(wdocd)
             skipWhisks-=1
+            deleting+=1
         else:
             print('marked: {0}, elapsed hours: {1}, elapsed days: {2}'.format(wdoc['id'], elapsedh, elapsedd))
+            marked+=1
 
 
 #
@@ -95,13 +98,45 @@ def deleteWhisk(dbWhisks, wdoc):
 def checkNamespace(dbSubjects, namespace):
 
     while True:
-
         allNamespaces = dbSubjects.view('subjects/identities', startkey=[namespace], endkey=[namespace])
-
         if allNamespaces:
             return True
         else:
             return False
+
+
+#
+# update last namespace info and print number of kept documents
+#
+def updateLastNamespaceInfo(namespace, lastNamespaceInfo):
+
+    if namespace != lastNamespaceInfo[0]:
+        if lastNamespaceInfo[0] != None:
+            print('keeping: {0} doc(s) for namespace {1}'.format(lastNamespaceInfo[1], lastNamespaceInfo[0]))
+        lastNamespaceInfo = (namespace,0)
+    lastNamespaceInfo = (namespace, lastNamespaceInfo[1]+1)
+    return lastNamespaceInfo
+
+
+#
+# extract namespace for doc id
+#
+def getNamespaceFromDocID(docID, whiskDatabaseType):
+
+    if whiskDatabaseType == "whisks":
+        return docID[0:docID.find('/')]
+    elif whiskDatabaseType == "cloudanttrigger":
+        # "_id": ":AHA04676_dev:vision-cloudant-trigger",
+        return docID[1:docID.find(':',1)]
+    elif whiskDatabaseType == "kafkatrigger":
+        # "_id": "/AJackson@uk.ibm.com_dev/badgers",
+        return docID[1:docID.find('/',1)]
+    elif whiskDatabaseType == "alarmservice":
+        print('{0}: error: {1} is not yet implemented for --whiskDBType'.format(sys.argv[0], whiskDatabaseType))
+        exit(1)
+    else:
+        print('{0}: error: {1} is not supported for --whiskDBType'.format(sys.argv[0], whiskDatabaseType))
+        exit(1)
 
 
 #
@@ -115,36 +150,46 @@ def checkWhisks(args):
     rb = SimpleRingBuffer(args.bufferLen)
 
     global skipWhisks
+    global skipWhisks, skipping, keeping, marking, marked, deleting
+    lastNamespaceInfo = (None, 0)
     while True:
         allWhisks = dbWhisks.view('_all_docs', limit=args.docsPerRequest, skip=skipWhisks)
         skipWhisks += args.docsPerRequest
         if allWhisks:
             for wdoc in allWhisks:
                 if wdoc['id'].startswith('_design/'):
+                    skipping += 1
                     print('skipping: {0}'.format(wdoc['id']))
                     continue
-                namespace = wdoc['id'][0:wdoc['id'].find('/')]
+                namespace = getNamespaceFromDocID(wdoc['id'], args.whiskDBType)
+                lastNamespaceInfo = updateLastNamespaceInfo(namespace, lastNamespaceInfo)
 
                 exists = rb.get(namespace)
                 if exists == None:
                     exists = checkNamespace(dbSubjects, namespace)
                     rb.append(namespace, exists)
 
-                if exists:
-                    print('keeping: {0}'.format(wdoc['id']))
+                if not exists:
+                    deleteWhisk(dbWhisks, wdoc, args.days)
+                    lastNamespaceInfo = (None, 0)
                 else:
-                    deleteWhisk(dbWhisks, wdoc)
+                    keeping += 1
+
         else:
-            return
+            break
+
+    # print final statistic
+    updateLastNamespaceInfo(None, lastNamespaceInfo)
+    print('statistic: skipped({0}), kept({1}), marked for deletion({2}), already marked({3}), deleted({4})'.format(skipping, keeping, marking, marked, deleting))
 
 
 parser = argparse.ArgumentParser(description="Utility to mark/delete whisks entries where the ns does not exist in the subjects database.")
 parser.add_argument("--dbUrl", required=True, help="Server URL of the database, that has to be cleaned of old activations. E.g. 'https://xxx:yyy@domain.couch.com:443'")
 parser.add_argument("--dbNameWhisks", required=True, help="Name of the Whisks Database of the whisks entries to be marked for deletion or deleted if already marked.")
 parser.add_argument("--dbNameSubjects", required=True, help="Name of the Subjects Database.")
+parser.add_argument("--whiskDBType", required=True, help="Type of the Whisks Database. Supported are whisks, cloudanttrigger, kafkatrigger, alarmservice")
 parser.add_argument("--days", required=True, type=int, default=7, help="How many days whisks keep entries marked for deletion before deleting them.")
 parser.add_argument("--docsPerRequest", type=int, default=200, help="Number of documents handled on each CouchDb Request. Default is 200.")
 parser.add_argument("--bufferLen", type=int, default=100, help="Maximum buffer length to cache already checked ns. Default is 100.")
 args = parser.parse_args()
-
 checkWhisks(args)


### PR DESCRIPTION
Python script for cleanup that runs over all documents in specified whisk database and checks if its namespace still exists. The document will be marked for deletion or deleted if already marked for certain period of time if its namespace does not exists. Supported database types are whisks, cloudanttrigger and kafkatrigger.