### PR TITLE
Only join cluster if seed nodes are provided.

### DIFF
--- a/core/controller/src/main/scala/whisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
@@ -56,12 +56,16 @@ class ShardingContainerPoolBalancer(config: WhiskConfig, controllerInstance: Ins
   private implicit val executionContext: ExecutionContext = actorSystem.dispatcher
 
   /** Build a cluster of all loadbalancers */
-  val seedNodesProvider = new StaticSeedNodesProvider(config.controllerSeedNodes, actorSystem.name)
-  val cluster = Cluster(actorSystem)
-  cluster.joinSeedNodes(seedNodesProvider.getSeedNodes())
+  private val seedNodesProvider = new StaticSeedNodesProvider(config.controllerSeedNodes, actorSystem.name)
+  private val seedNodes = seedNodesProvider.getSeedNodes()
 
-  /** Used to manage an action for testing invoker health */
-  private val entityStore = WhiskEntityStore.datastore()
+  private val cluster: Option[Cluster] = if (seedNodes.nonEmpty) {
+    val cluster = Cluster(actorSystem)
+    cluster.joinSeedNodes(seedNodes)
+    Some(cluster)
+  } else {
+    None
+  }
 
   /** State related to invocations and throttling */
   private val activations = TrieMap[ActivationId, ActivationEntry]()
@@ -79,7 +83,7 @@ class ShardingContainerPoolBalancer(config: WhiskConfig, controllerInstance: Ins
    */
   private val monitor = actorSystem.actorOf(Props(new Actor {
     override def preStart(): Unit = {
-      cluster.subscribe(self, classOf[MemberEvent], classOf[ReachabilityEvent])
+      cluster.foreach(_.subscribe(self, classOf[MemberEvent], classOf[ReachabilityEvent]))
     }
 
     // all members of the cluster that are available
@@ -197,7 +201,7 @@ class ShardingContainerPoolBalancer(config: WhiskConfig, controllerInstance: Ins
           start,
           s"posted to ${status.topic()}[${status.partition()}][${status.offset()}]",
           logLevel = InfoLevel)
-      case Failure(e) => transid.failed(this, start, s"error on posting to topic $topic")
+      case Failure(_) => transid.failed(this, start, s"error on posting to topic $topic")
     }
   }
 
@@ -243,7 +247,7 @@ class ShardingContainerPoolBalancer(config: WhiskConfig, controllerInstance: Ins
     val aid = response.fold(l => l, r => r.activationId)
 
     // treat left as success (as it is the result of a message exceeding the bus limit)
-    val isSuccess = response.fold(l => true, r => !r.response.isWhiskError)
+    val isSuccess = response.fold(_ => true, r => !r.response.isWhiskError)
 
     activations.remove(aid) match {
       case Some(entry) =>


### PR DESCRIPTION
This PR adds the ability to configure, if a controller should join the the akka cluster or not.
This cluster is necessary to detect if other controllers are joining or crashing.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change

## My changes affect the following components
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [x] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

PG2#2942 is 🔵 .