### PR TITLE
Bump ansible version

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -9,7 +9,7 @@ If you want to deploy OpenWhisk locally using Ansible, you first need to install
 #### Ubuntu users
 ```
 sudo apt-get install python-pip
-sudo pip install ansible==2.3.0.0
+sudo pip install ansible==2.4.2.0
 sudo pip install jinja2==2.9.6
 ```
 
@@ -21,7 +21,7 @@ You may jump directly to [Deploying Using CouchDB](#deploying-using-couchdb)
 #### Docker for Mac users
 ```
 sudo easy_install pip
-sudo pip install ansible==2.3.0.0
+sudo pip install ansible==2.4.2.0
 pip install jinja2==2.9.6
 ```
 Docker for Mac does not provide any official ways to meet some requirements for OpenWhisk.

--- a/ansible/roles/cli/tasks/deploy.yml
+++ b/ansible/roles/cli/tasks/deploy.yml
@@ -66,9 +66,8 @@
       recurse: true
   register: individual_zipfiles
 
+# Use old good unzip instead of unarchive due to a known issue on MacOS
+# https://github.com/ansible/ansible-modules-core/issues/3952
 - name: "Unarchive the individual zipfiles into binaries"
-  unarchive:
-    remote_src: yes
-    src: "{{ item.path }}"
-    dest: "{{ item.path | dirname }}"
+  shell: unzip {{ item.path }} -d {{ item.path | dirname }}
   with_items: "{{ individual_zipfiles.files }}"

--- a/tools/macos/README.md
+++ b/tools/macos/README.md
@@ -28,7 +28,7 @@ The following are required to build and deploy OpenWhisk from a Mac host:
 - [Docker 1.12.0](https://docs.docker.com/docker-for-mac/)
 - [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 - [Scala 2.11](http://scala-lang.org/download/)
-- [Ansible 2.3.0.0](http://docs.ansible.com/ansible/intro_installation.html)
+- [Ansible 2.4.2.0](http://docs.ansible.com/ansible/intro_installation.html)
 
 **Tip** Versions of Docker and Ansible are lower than the latest released versions, the versions used in OpenWhisk are pinned to have stability during continuous integration and deployment.
 
@@ -48,7 +48,7 @@ brew install scala
 # install pip
 sudo easy_install pip
 # install script prerequisites
-sudo -H pip install docker==2.2.1 ansible==2.3.0.0 jinja2==2.9.6 couchdb==1.1 httplib2==0.9.2 requests==2.10.0' | bash
+sudo -H pip install docker==2.2.1 ansible==2.4.2.0 jinja2==2.9.6 couchdb==1.1 httplib2==0.9.2 requests==2.10.0' | bash
 ```
 
 # Build

--- a/tools/macos/docker-machine/README.md
+++ b/tools/macos/docker-machine/README.md
@@ -55,7 +55,7 @@ brew install scala
 # install pip
 sudo easy_install pip
 # install script prerequisites
-sudo -H pip install docker==2.2.1 ansible==2.3.0.0 jinja2==2.9.6 couchdb==1.1 httplib2==0.9.2 requests==2.10.0' | bash
+sudo -H pip install docker==2.2.1 ansible==2.4.2.0 jinja2==2.9.6 couchdb==1.1 httplib2==0.9.2 requests==2.10.0' | bash
 ```
 
 # Create and configure Docker machine
@@ -131,7 +131,7 @@ cd /your/path/to/openwhisk
 
 ```
 brew install python
-pip install ansible==2.3.0.0
+pip install ansible==2.4.2.0
 pip install jinja2==2.9.6
 
 cd ansible

--- a/tools/ubuntu-setup/ansible.sh
+++ b/tools/ubuntu-setup/ansible.sh
@@ -25,7 +25,7 @@ sudo apt-add-repository -y ppa:ansible/ansible
 sudo apt-get update
 sudo apt-get install -y python-dev libffi-dev libssl-dev
 sudo pip install markupsafe
-sudo pip install ansible==2.3.0.0
+sudo pip install ansible==2.4.2.0
 sudo pip install docker==2.2.1
 sudo pip install jinja2==2.9.6
 sudo pip install httplib2==0.9.2


### PR DESCRIPTION
Bump ansible version in the documentation and vagrant setup.
Apart from that I have adapted the cli deploy step in ansible to use unzip instead of unarchive module, due to some issues on MacOS, e.g. https://github.com/ansible/ansible-modules-core/issues/3631

## My changes affect the following components
- [x ] Deployment
- [x ] Documentation

