### PR TITLE
swagger generation update

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -207,7 +207,7 @@ apigateway:
     api: 9000
     api_secure: 443
     mgmt: 9001
-  version: 0.9.8
+  version: 0.9.10
 
 redis:
   version: 3.2

--- a/core/routemgmt/common/apigw-utils.js
+++ b/core/routemgmt/common/apigw-utils.js
@@ -516,6 +516,7 @@ function generateBaseSwaggerApi(basepath, apiname) {
  *                    backendUrl:
  *                    name:
  *                    namespace:
+ *                    secureKey
  *                  }
  *                }
  *   responsetype Optional. The web action invocation .extension.  Defaults to json
@@ -569,6 +570,10 @@ function setActionOperationInvocationDetails(swagger, endpoint, operationId, res
   _.set(swagger, 'x-ibm-configuration.assembly.execute[0].operation-switch.case['+caseIdx+'].operations', operations);
   _.set(swagger, 'x-ibm-configuration.assembly.execute[0].operation-switch.case['+caseIdx+'].execute[0].invoke.target-url',  makeWebActionBackendUrl(endpoint.action, responsetype, getPathParameters(endpoint.gatewayPath)));
   _.set(swagger, 'x-ibm-configuration.assembly.execute[0].operation-switch.case['+caseIdx+'].execute[0].invoke.verb', 'keep');
+  if (endpoint.action.secureKey) {
+    _.set(swagger, 'x-ibm-configuration.assembly.execute[0].operation-switch.case['+caseIdx+'].execute[1].set-variable.actions[0].set', 'message.headers.X-Require-Whisk-Auth' );
+    _.set(swagger, 'x-ibm-configuration.assembly.execute[0].operation-switch.case['+caseIdx+'].execute[1].set-variable.actions[0].value', endpoint.action.secureKey );
+  }
 }
 
 // Return the numeric index into case[] into which the associated operation will be configured

--- a/core/routemgmt/createApi/createApi.js
+++ b/core/routemgmt/createApi/createApi.js
@@ -44,6 +44,7 @@
   *           backendMethod    Required.  Action invocation REST verb.  "POST"
   *           backendUrl       Required.  Action invocation REST url
   *           authkey          Required.  Action invocation auth key
+  *           secureKey        Optional.  Action's require-whisk-auth value
   *      swagger             Required if gatewayBasePath not provided.  API swagger JSON
   *
   * NOTE: The package containing this action will be bound to the following values:
@@ -122,6 +123,7 @@ function main(message) {
     console.log('action backendUrl: '+doc.action.backendUrl);
     console.log('action backendMethod: '+doc.action.backendMethod);
     console.log('action authkey: '+utils.confidentialPrint(doc.action.authkey));
+    console.log('action secureKey: '+utils.confidentialPrint(doc.action.secureKey));
   }
   console.log('calledAsWebAction: '+calledAsWebAction);
   console.log('apidoc        :\n'+JSON.stringify(doc));


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
In support of creating APIs with secured (`require-whisk-auth` annotation with number or string) web-actions
- swagger update causes `X-Require-Whisk-Auth` header injection during action invocation
- use apigateway to v0.9.10 that handles `X-Require-Whisk-Auth header injection
- local testing with v0.9.10 apigateway

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [x] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

