### PR TITLE
Fixes Kubernetes logging issues from #3439 re: activation logs where timestamp errors caused logging failures

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesContainer.scala
@@ -147,6 +147,10 @@ class KubernetesContainer(protected[core] val id: ContainerId,
         // Adding + 1 since we know there's a newline byte being read
         obj.jsonSize.toLong + 1
       }
+      .map { line =>
+        lastTimestamp.set(Option(line.time))
+        line
+      }
       .via(new CompleteAfterOccurrences(_.log == stringSentinel, 2, waitForSentinel))
       .recover {
         case _: StreamLimitReachedException =>
@@ -160,9 +164,6 @@ class KubernetesContainer(protected[core] val id: ContainerId,
           TypedLogLine(Instant.now, "stderr", Messages.logFailure)
       }
       .takeWithin(waitForLogs)
-      .map { line =>
-        lastTimestamp.set(Some(line.time))
-        line.toByteString
-      }
+      .map { _.toByteString }
   }
 }


### PR DESCRIPTION
## Description
- Fixed an issue where empty results from K8S log HTTP could cause a downstream error propagation
- Moved the last entry timestamp update up before the CompleteAfterOccurrences stage.
  When it was below, it meant that we never saw the activation marker Lines
  missing the marker lines meant the last timestamp we saved was only from
  valid logging, and we kept refetching the past activation lines
- On occasions Kubernetes didn't have invoker logs ready at request, it
  would simply stop; fixed code to retry. However, there's no pause If no results
  come back from Kubernetes, retry until they do.

Switched K8S Logging Graph Stage to a Timer based one.
- With this, added a retry scheduler to delay 100 ms when the logs come back empty.

## Related issue and scope
- I opened an issue, #3439, describing the problem.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [X] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

