### PR TITLE
Fix outdated `limit section` in ansible doc

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -305,24 +305,17 @@ the path to your OpenWhisk `ansible` directory contains spaces. To fix this, ple
 without spaces as there is no current fix available to this problem.
 
 #### Changing limits
-The default system throttling limits are configured in this file [./group_vars/all](./group_vars/all).
+The default system throttling limits are configured in this file [./group_vars/all](./group_vars/all) and may be changed by modifying the group_vars for your specific environment.
 ```
 limits:
-  invocationsPerMinute: "{{ limit_invocations_per_minute | default(120) }}"
-  concurrentInvocations: "{{ limit_invocations_concurrent | default(100) }}"
+  invocationsPerMinute: "{{ limit_invocations_per_minute | default(60) }}"
+  concurrentInvocations: "{{ limit_invocations_concurrent | default(30) }}"
   concurrentInvocationsSystem:  "{{ limit_invocations_concurrent_system | default(5000) }}"
   firesPerMinute: "{{ limit_fires_per_minute | default(60) }}"
   sequenceMaxLength: "{{ limit_sequence_max_length | default(50) }}"
 ```
-These values may be changed by modifying the `group_vars` for your environment. For example,
-mac users will find the limits in this file [./environments/mac/group_vars/all](./environments/mac/group_vars/all):
-```
-limit_invocations_per_minute: 60
-limit_invocations_concurrent: 30
-limit_invocations_concurrent_system: 5000
-limit_fires_per_minute: 60
-```
-- The `limit_invocations_per_minute` represents the allowed namespace action invocations per minute.
-- The `limit_invocations_concurrent` represents the maximum concurrent invocations allowed per namespace.
-- The `limit_invocations_concurrent_system` represents the maximum concurrent invocations the system will allow across all namespaces.
-- The `limit_fires_per_minute` represents the allowed namespace trigger firings per minute.
+- The `limits.invocationsPerMinute` represents the allowed namespace action invocations per minute.
+- The `limits.concurrentInvocations` represents the maximum concurrent invocations allowed per namespace.
+- The `limits.concurrentInvocationsSystem` represents the maximum concurrent invocations the system will allow across all namespaces.
+- The `limits.firesPerMinute` represents the allowed namespace trigger firings per minute.
+- The `limits.sequenceMaxLength` represents the maximum length of a sequence action.


### PR DESCRIPTION
Update the outdated default value of limits. Also, remove the unused
section of environment/mac/group_vars/all, the detailed description in each feild is now pointed to the
default group vars.


<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] Existed/opened issue to propose and discuss this change (#3020)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [x] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] ~~I added tests to cover my changes.~~
- [x] ~~My changes require further changes to the documentation.~~
- [x] I updated the documentation where necessary.

