### PR TITLE
Generate keystore without generating certificates

### DIFF
--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -46,7 +46,7 @@
 
 
   - name: generate kafka certificates
-    local_action: shell "{{ playbook_dir }}/files/genssl.sh" "openwhisk-kafka" "server_with_JKS_keystore" "{{ playbook_dir }}/roles/kafka/files" openwhisk "generateKey" "kafka-"
+    local_action: shell "{{ playbook_dir }}/files/genssl.sh" "openwhisk-kafka" "server_with_JKS_keystore" "{{ playbook_dir }}/roles/kafka/files" openwhisk "kafka-" "generateKey"
     when: kafka_protocol_for_setup == 'SSL'
 
   - name: ensure controller files directory exists
@@ -59,4 +59,4 @@
 
   - name: generate controller certificates
     when: controllerProtocolForSetup == 'https'
-    local_action: shell "{{ playbook_dir }}/files/genssl.sh" "openwhisk-controllers" "server" "{{ playbook_dir }}/roles/controller/files" {{ controllerKeystorePassword }} "generateKey" {{ controllerKeyPrefix }}
+    local_action: shell "{{ playbook_dir }}/files/genssl.sh" "openwhisk-controllers" "server" "{{ playbook_dir }}/roles/controller/files" {{ controllerKeystorePassword }} {{ controllerKeyPrefix }} "generateKey"


### PR DESCRIPTION
For some use cases it might be helpful to use pre-generated certs for controller keystore. 
Thus skip ssl key/cert generation step and use pre-defined values in the form:
controller-openwhisk-server-cert.pem
controller-openwhisk-server-key.pem

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [x ] Controller
- [x ] Deployment

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

