### PR TITLE
Add quotes to avoid parsing errors of application.conf

### DIFF
--- a/tests/src/test/resources/application.conf.j2
+++ b/tests/src/test/resources/application.conf.j2
@@ -33,16 +33,16 @@ whisk {
     }
 
     couchdb {
-        protocol = {{ db_protocol }}
-        host     = {{ db_host }}
-        port     = {{ db_port }}
-        username = {{ db_username }}
-        password = {{ db_password }}
-        provider = {{ db_provider }}
+        protocol = "{{ db_protocol }}"
+        host     = "{{ db_host }}"
+        port     = "{{ db_port }}"
+        username = "{{ db_username }}"
+        password = "{{ db_password }}"
+        provider = "{{ db_provider }}"
         databases {
-          WhiskAuth       = {{ db.whisk.auth }}
-          WhiskEntity     = {{ db.whisk.actions }}
-          WhiskActivation = {{ db.whisk.activations }}
+          WhiskAuth       = "{{ db.whisk.auth }}"
+          WhiskEntity     = "{{ db.whisk.actions }}"
+          WhiskActivation = "{{ db.whisk.activations }}"
         }
     }
 


### PR DESCRIPTION


## Description
application.conf will fail when an invalid formed password is passed

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

