### PR TITLE
wsk test framework update to support --web-secure cli option

### DIFF
--- a/tests/src/test/scala/common/BaseWsk.scala
+++ b/tests/src/test/scala/common/BaseWsk.scala
@@ -204,6 +204,7 @@ trait BaseAction extends BaseRunWsk with BaseDeleteFromCollection with BaseListO
              shared: Option[Boolean] = None,
              update: Boolean = false,
              web: Option[String] = None,
+             websecure: Option[String] = None,
              expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RunResult
 
   def invoke(name: String,

--- a/tests/src/test/scala/common/Wsk.scala
+++ b/tests/src/test/scala/common/Wsk.scala
@@ -249,6 +249,7 @@ class WskAction()
     shared: Option[Boolean] = None,
     update: Boolean = false,
     web: Option[String] = None,
+    websecure: Option[String] = None,
     expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RunResult = {
     val params = Seq(noun, if (!update) "create" else "update", "--auth", wp.authKey, fqn(name)) ++ {
       artifact map { Seq(_) } getOrElse Seq()
@@ -300,6 +301,10 @@ class WskAction()
     } ++ {
       web map { w =>
         Seq("--web", w)
+      } getOrElse Seq()
+    } ++ {
+      websecure map { ws =>
+        Seq("--web-secure", ws)
       } getOrElse Seq()
     }
     cli(wp.overrides ++ params, expectedExitCode)

--- a/tests/src/test/scala/common/rest/WskRest.scala
+++ b/tests/src/test/scala/common/rest/WskRest.scala
@@ -299,6 +299,7 @@ class WskRestAction
     shared: Option[Boolean] = None,
     update: Boolean = false,
     web: Option[String] = None,
+    websecure: Option[String] = None,
     expectedExitCode: Int = OK.intValue)(implicit wp: WskProps): RestResult = {
 
     val (namespace, actName) = getNamespaceEntityName(name)


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
Test framework preparation to support a new CLI option, --web-secure, that will be used
to manage the require-whisk-auth annotation for web actions.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] ~I opened an issue to propose and discuss this change (#????)~
- related openwhisk PR https://github.com/apache/incubator-openwhisk/pull/3388
- related openwhisk cli PR https://github.com/apache/incubator-openwhisk-cli/pull/244

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes. (see CLI repo tests; link provided above)
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

