### PR TITLE
Fixes #3470 - Changed hardcoded timeouts for idle containers and pause grace to config entries

### DIFF
--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -250,4 +250,8 @@ object ConfigKeys {
   val elasticSearch = s"$logStore.elasticsearch"
 
   val mesos = "whisk.mesos"
+
+  val containerProxy = "whisk.container-proxy"
+  val containerProxyTimeouts = s"$containerProxy.timeouts"
+
 }

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -44,4 +44,13 @@ whisk {
     dns-servers: []
     extra-args: {}
   }
+
+  container-proxy {
+    timeouts {
+      # The "unusedTimeout" in the ContainerProxy,
+      #aka 'How long should a container sit idle until we kill it?'
+      idle-container = 10 minutes
+      pause-grace = 50 milliseconds
+    }
+  }
 }

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
@@ -669,57 +669,6 @@ class ContainerProxyTests
     }
   }
 
-  "the ContainerProxy's timeout configuration" should "load the configuration properly" in {
-
-    val tsConfig1 = ConfigFactory.parseString("""
-        |whisk {
-        |  container-proxy {
-        |    timeouts {
-        |      # The "unusedTimeout" in the ContainerProxy,
-        |      #aka 'How long should a container sit idle until we kill it?'
-        |      idle-container = 10 minutes
-        |      pause-grace = 50 milliseconds
-        |    }
-        |  }
-        |}
-      """.stripMargin)
-
-    val tsConfig2 = ConfigFactory.parseString("""
-        |whisk {
-        |  container-proxy {
-        |    timeouts {
-        |      # The "unusedTimeout" in the ContainerProxy,
-        |      #aka 'How long should a container sit idle until we kill it?'
-        |      idle-container = 512 seconds
-        |      pause-grace = 2048 hours
-        |    }
-        |  }
-        |}
-      """.stripMargin)
-
-    val timeouts1 =
-      pureconfig.loadConfigOrThrow[ContainerProxyTimeoutConfig](tsConfig1, ConfigKeys.containerProxyTimeouts)
-
-    timeouts1 should not be (null)
-    timeouts1 shouldBe a[ContainerProxyTimeoutConfig]
-
-    inside(timeouts1) {
-      case ContainerProxyTimeoutConfig(idleContainer: FiniteDuration, pauseGrace: FiniteDuration) =>
-        idleContainer should be(10.minutes)
-        pauseGrace should be(50.milliseconds)
-    }
-
-    val timeouts2 =
-      pureconfig.loadConfigOrThrow[ContainerProxyTimeoutConfig](tsConfig2, ConfigKeys.containerProxyTimeouts)
-
-    inside(timeouts2) {
-      case ContainerProxyTimeoutConfig(idleContainer: FiniteDuration, pauseGrace: FiniteDuration) =>
-        idleContainer should be(512.seconds)
-        pauseGrace should be(2048.hours)
-    }
-
-  }
-
   /**
    * Implements all the good cases of a perfect run to facilitate error case overriding.
    */

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
@@ -23,7 +23,9 @@ import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration._
 import org.junit.runner.RunWith
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Inside, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.FlatSpecLike
+import org.scalatest.Matchers
 import org.scalatest.junit.JUnitRunner
 import akka.actor.ActorRef
 import akka.actor.ActorSystem
@@ -35,7 +37,6 @@ import akka.stream.scaladsl.Source
 import akka.testkit.ImplicitSender
 import akka.testkit.TestKit
 import akka.util.ByteString
-import com.typesafe.config.ConfigFactory
 import common.LoggedFunction
 import common.StreamLogging
 
@@ -44,7 +45,6 @@ import spray.json._
 import spray.json.DefaultJsonProtocol._
 import whisk.common.Logging
 import whisk.common.TransactionId
-import whisk.core.ConfigKeys
 import whisk.core.connector.ActivationMessage
 import whisk.core.containerpool._
 import whisk.core.containerpool.logging.LogCollectingException
@@ -60,7 +60,6 @@ class ContainerProxyTests
     with ImplicitSender
     with FlatSpecLike
     with Matchers
-    with Inside
     with BeforeAndAfterAll
     with StreamLogging {
 


### PR DESCRIPTION

<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
Previously, the `idleTimeout` and `pauseGrace` settings for `ContainerProxy` have hardcoded defaults. This code changes to use pureconfig entries, allowing the defaults to be changed in configuration.

<!--- Include details of what problem you are solving and how your changes are tested. -->

Tests have been added to the `ContainerProxyTests` to verify the changes (and config parsing).

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#3470 )

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

