### PR TITLE
Support string based status code from actions.

### DIFF
--- a/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
@@ -233,18 +233,13 @@ protected[core] object WhiskWebActionsApi extends Directives {
 
       val code = fields.get(rp.statusCode).map {
         case JsNumber(c) =>
-          // the following throws an exception if the code is
-          // not a whole number or a valid code
+          // the following throws an exception if the code is not a whole number or a valid code
           StatusCode.int2StatusCode(c.toIntExact)
         case JsString(c) =>
-          try {
-            val intCode = c.toInt
-            // contrast to JsNumber, already parse the string to Int instead of BigInt.
-            StatusCode.int2StatusCode(intCode)
-          } catch {
-            // rethrow NumberFormatException to an unified exception
-            case e: NumberFormatException => throw new Throwable("Illegal status code")
-          }
+          // parse the string to an Int (not a BigInt) matching JsNumber case match above
+          // c.toInt could throw an exception if the string isn't an integer
+          StatusCode.int2StatusCode(c.toInt)
+
         case _ => throw new Throwable("Illegal status code")
       }
 

--- a/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
@@ -236,8 +236,16 @@ protected[core] object WhiskWebActionsApi extends Directives {
           // the following throws an exception if the code is
           // not a whole number or a valid code
           StatusCode.int2StatusCode(c.toIntExact)
-
-        case _ => throw new Throwable("Illegal code")
+        case JsString(c) =>
+          try {
+            val intCode = c.toInt
+            // contrast to JsNumber, already parse the string to Int instead of BigInt.
+            StatusCode.int2StatusCode(intCode)
+          } catch {
+            // rethrow NumberFormatException to an unified exception
+            case e: NumberFormatException => throw new Throwable("Illegal status code")
+          }
+        case _ => throw new Throwable("Illegal status code")
       }
 
       body.collect {

--- a/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
@@ -1711,6 +1711,21 @@ trait WebActionsApiBaseTests extends ControllerTestCommon with BeforeAndAfterEac
           }
         }
     }
+
+    it should s"allowed string based status code (auth? ${creds.isDefined})" in {
+      implicit val tid = transid()
+      invocationsAllowed += 2
+
+      actionResult = Some(JsObject(webApiDirectives.statusCode -> JsString("200")))
+      Head(s"$testRoutePath/$systemId/proxy/export_c.http") ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+      }
+
+      actionResult = Some(JsObject(webApiDirectives.statusCode -> JsString("xyz")))
+      Head(s"$testRoutePath/$systemId/proxy/export_c.http") ~> Route.seal(routes(creds)) ~> check {
+        status should be(BadRequest)
+      }
+    }
   }
 
   class TestingEntitlementProvider(config: WhiskConfig, loadBalancer: LoadBalancer)


### PR DESCRIPTION
Add an additional option to parse status code from string to int, throws
out illegal code if parsing failed. Also, add a relevant test code.

Signed-off-by: Tzu-Chiao Yeh <su3g4284zo6y7@gmail.com>


<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

Refer to #2971, changes support status code written in string from an action.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] Opened issue to propose and discuss this change (#2971 )

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

