### PR TITLE
Ensure clean up testspace under wskadmin test.

### DIFF
--- a/tests/src/test/scala/whisk/core/admin/WskAdminTests.scala
+++ b/tests/src/test/scala/whisk/core/admin/WskAdminTests.scala
@@ -22,6 +22,7 @@ import scala.concurrent.duration.DurationInt
 import org.junit.runner.RunWith
 import org.scalatest.Matchers
 import org.scalatest.junit.JUnitRunner
+import org.scalatest.BeforeAndAfterAll
 
 import common.RunWskAdminCmd
 import common.TestHelpers
@@ -31,9 +32,26 @@ import common.WskProps
 import whisk.core.entity.AuthKey
 import whisk.core.entity.Subject
 import common.TestUtils
+import scala.util.Try
 
 @RunWith(classOf[JUnitRunner])
-class WskAdminTests extends TestHelpers with Matchers {
+class WskAdminTests extends TestHelpers with Matchers with BeforeAndAfterAll {
+
+  override def beforeAll() = {
+    val wskadmin = new RunWskAdminCmd {}
+    val testSpaces = Seq("testspace", "testspace1", "testspace2")
+    testSpaces.foreach(testspace => {
+      Try {
+        val identities = wskadmin.cli(Seq("user", "list", "-a", testspace))
+        identities.stdout
+          .split("\n")
+          .foreach(ident => {
+            val sub = ident.split("\\s+").last
+            wskadmin.cli(Seq("user", "delete", sub, "-ns", testspace))
+          })
+      }
+    })
+  }
 
   behavior of "Wsk Admin CLI"
 


### PR DESCRIPTION
Fix up testsuite `block and unblock a user respectively` fails when
`testspace` contains pre-existing users.

Signed-off-by: Tzu-Chiao Yeh <su3g4284zo6y7@gmail.com>


<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
The change clean up **all** users under namespace `testspace`, `testspace1` and `testspace2`.

To reproduce this, create a pre-existed user under `testspace`.
```bash
./bin/wskadmin user create test-123 -ns testspace
```
The test should be passed now.

Sorry for creating pr twice, I forgot to reopen previous pr #3469  and force push to squash the redundant commit. 

Refer to #3469 , seems like the test can be passed after trying couple times. 

No idea how's going on travis uncertainly got failed.

<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)
- [x] Reference issue #3137 

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.