### PR TITLE
Retry in feed tests to avoid race condition

### DIFF
--- a/tests/src/test/scala/whisk/core/cli/test/WskEntitlementTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskEntitlementTests.scala
@@ -31,6 +31,8 @@ import spray.json._
 import spray.json.DefaultJsonProtocol._
 import whisk.core.entity.Subject
 import whisk.core.entity.WhiskPackage
+import whisk.utils.retry
+import scala.concurrent.duration._
 
 @RunWith(classOf[JUnitRunner])
 abstract class WskEntitlementTests extends TestHelpers with WskTestHelpers with BeforeAndAfterAll {
@@ -366,7 +368,8 @@ abstract class WskEntitlementTests extends TestHelpers with WskTestHelpers with 
         assetHelper.withCleaner(wsk.trigger, "badfeed", confirmDelete = false) { (trigger, name) =>
           trigger.create(name, feed = Some(fullyQualifiedFeedName), expectedExitCode = timeoutCode)(wp)
         }
-        wsk.trigger.get("badfeed", expectedExitCode = notFoundCode)(wp)
+        // with several active controllers race condition with cache invalidation might occur, thus retry
+        retry(wsk.trigger.get("badfeed", expectedExitCode = notFoundCode)(wp), 10, Some(500.milliseconds))
       }
   }
 


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
It provides a fix for test failure on mainWhisk/8244. 
Given current round robin load balancing for controllers and cache invalidation, a race condition might occur for the mentioned test. For example, a trigger for a broken feed was deleted on one controller, but cache invalidation didn't yet make it and we already check for 404 response code. 
## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

