### PR TITLE
Makes db tools python2 and python3 compatible

### DIFF
--- a/tools/db/cleanUpActivations.py
+++ b/tools/db/cleanUpActivations.py
@@ -39,7 +39,7 @@ def deleteOldActivations(args):
     while True:
         activationIds = db.view("activations/byDate", limit=args.docsPerRequest, start_key=0, end_key=endkey)
         if activationIds:
-            documentsToDelete = map(lambda entry: couchdb.client.Document(_id=entry.value[0], _rev=entry.value[1], _deleted=True), activationIds)
+            documentsToDelete = [couchdb.client.Document(_id=entry.value[0], _rev=entry.value[1], _deleted=True) for entry in activationIds]
             db.update(documentsToDelete)
         else:
             return

--- a/tools/db/deleteLogsFromActivations.py
+++ b/tools/db/deleteLogsFromActivations.py
@@ -44,7 +44,7 @@ def deleteLogsFromOldActivations(args):
     while True:
         activations = db.view("logCleanup/byDateWithLogs", limit=args.docsPerRequest, start_key=0, end_key=endkey, include_docs=True)
         if activations:
-            activationsWithoutLogs = map(removeLogFromActivation, activations)
+            activationsWithoutLogs = [removeLogFromActivation(activation) for activation in activations]
             db.update(activationsWithoutLogs)
         else:
             return


### PR DESCRIPTION
The map in python2 and python3 is not compatible on subscription.
Therefore, this caused an error subscription thrown from couchdb.client in python3.

Signed-off-by: tz70s <su3g4284zo6y7@gmail.com>


<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

See #3466 for better improvement on compatibility between python2, and 3.

Focus on this proposed change, I think it'll be better to doc the python version limitation on theses tools.
For example, couchdb bindings on python is currently not actively maintained, the latest version only support on 3.4. I'm not that sure there would be any breaking changes from 3.4 to 3.6, though.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] Related pull request, see  #3466 

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [x] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.
