### PR TITLE
Check zookeeper (not log) to see that kafka's running

### DIFF
--- a/ansible/roles/kafka/tasks/deploy.yml
+++ b/ansible/roles/kafka/tasks/deploy.yml
@@ -88,8 +88,11 @@
   delay: "{{ docker.pull.delay }}"
 
 - name: wait until the kafka server started up
-  shell: docker logs kafka{{ groups['kafkas'].index(inventory_hostname) }}
+  shell:
+    (echo dump; sleep 1) |
+    nc {{hostvars[groups['zookeepers']|first].ansible_host}} {{zookeeper.port}} |
+    grep /brokers/ids/{{ groups['kafkas'].index(inventory_hostname) }}
   register: result
-  until: (('[Kafka Server ' + (groups['kafkas'].index(inventory_hostname)|string) + '], started') in result.stdout)
+  until: (result.rc == 0)
   retries: 10
   delay: 5


### PR DESCRIPTION
## Description
Current ansible processing looks for a docker log text string to determine if Kafka's running.  Unfortunately, this string can (and has) changed between versions of kafka.

Kafka registers its brokers with zookeeperer, so this this task checks the zookeeper node to determine whether kafka has started -- a likely to be much more forward-compatible approach.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [X] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

