### PR TITLE
Switch 'scala' image to use OpenJDK 8

### DIFF
--- a/common/scala/Dockerfile
+++ b/common/scala/Dockerfile
@@ -1,78 +1,13 @@
-FROM alpine:3.6
+FROM openjdk:8u151-jre-alpine3.7
 
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+RUN apk add --no-cache --update \
+        # Curl is more familiar for downloads, for the moment...
+        curl ca-certificates \
+        # Bash is the scripting language of choice for the moment
+        bash \
+        # GNU sed is needed by transformEnvironment.sh
+        sed \
+    && update-ca-certificates
 
-ENV VERSION 8
-ENV UPDATE 141
-ENV BUILD 15
-ENV SIG 336fa29ff2bb4ef291e347e091f7f4a7
-ENV GLIBC_VERSION 2.26-r0
-
-ENV JAVA_HOME /usr/lib/jvm/java-${VERSION}-oracle
-ENV JRE_HOME ${JAVA_HOME}/jre
-ENV PATH $JAVA_HOME/bin:$PATH
-
-
-RUN apk upgrade --update && \
-    apk add --update libstdc++ curl ca-certificates bash sed && \
-    update-ca-certificates && \
-    for pkg in glibc-${GLIBC_VERSION} glibc-bin-${GLIBC_VERSION} glibc-i18n-${GLIBC_VERSION}; do curl -sSL https://github.com/andyshinn/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/${pkg}.apk -o /tmp/${pkg}.apk; done && \
-    apk add --allow-untrusted /tmp/*.apk && \
-    rm -v /tmp/*.apk && \
-    ( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true ) && \
-    echo "export LANG=${LANG}" > /etc/profile.d/locale.sh && \
-    /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
-    curl --silent --location --retry 3 --header "Cookie: oraclelicense=accept-securebackup-cookie" \
-    http://download.oracle.com/otn-pub/java/jdk/"${VERSION}"u"${UPDATE}"-b"${BUILD}"/"${SIG}"/jdk-"${VERSION}"u"${UPDATE}"-linux-x64.tar.gz \
-    | tar xz -C /tmp && \
-    mkdir -p /usr/lib/jvm && mv /tmp/jdk1.${VERSION}.0_${UPDATE} "${JAVA_HOME}" && \
-    rm -rf "$JAVA_HOME"/*src.zip \
-           "$JAVA_HOME"/lib/missioncontrol \
-           "$JAVA_HOME"/lib/visualvm \
-           "$JAVA_HOME"/lib/*javafx* \
-           "$JAVA_HOME"/jre/plugin \
-           "$JAVA_HOME"/jre/bin/javaws \
-           "$JAVA_HOME"/jre/bin/jjs \
-           "$JAVA_HOME"/jre/bin/orbd \
-           "$JAVA_HOME"/jre/bin/pack200 \
-           "$JAVA_HOME"/jre/bin/policytool \
-           "$JAVA_HOME"/jre/bin/rmid \
-           "$JAVA_HOME"/jre/bin/rmiregistry \
-           "$JAVA_HOME"/jre/bin/servertool \
-           "$JAVA_HOME"/jre/bin/tnameserv \
-           "$JAVA_HOME"/jre/bin/unpack200 \
-           "$JAVA_HOME"/jre/lib/javaws.jar \
-           "$JAVA_HOME"/jre/lib/deploy* \
-           "$JAVA_HOME"/jre/lib/desktop \
-           "$JAVA_HOME"/jre/lib/*javafx* \
-           "$JAVA_HOME"/jre/lib/*jfx* \
-           "$JAVA_HOME"/jre/lib/amd64/libdecora_sse.so \
-           "$JAVA_HOME"/jre/lib/amd64/libprism_*.so \
-           "$JAVA_HOME"/jre/lib/amd64/libfxplugins.so \
-           "$JAVA_HOME"/jre/lib/amd64/libglass.so \
-           "$JAVA_HOME"/jre/lib/amd64/libgstreamer-lite.so \
-           "$JAVA_HOME"/jre/lib/amd64/libjavafx*.so \
-           "$JAVA_HOME"/jre/lib/amd64/libjfx*.so \
-           "$JAVA_HOME"/jre/lib/ext/jfxrt.jar \
-           "$JAVA_HOME"/jre/lib/ext/nashorn.jar \
-           "$JAVA_HOME"/jre/lib/oblique-fonts \
-           "$JAVA_HOME"/jre/lib/plugin.jar \
-           /tmp/* /var/cache/apk/* && \
-    echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
-    # https://github.com/anapsix/docker-alpine-java/issues/18#issue-167437838
-    # If you want to change the default values here, also change the values in 042-set-jvm-ttl.sh
-    sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=10/ ${JAVA_HOME}/jre/lib/security/java.security && \
-    sed -i s/networkaddress.cache.negative.ttl=10/networkaddress.cache.negative.ttl=0/ ${JAVA_HOME}/jre/lib/security/java.security
-
-
-
-
-RUN mkdir /logs
-
-COPY transformEnvironment.sh /
-RUN chmod +x transformEnvironment.sh
-
-COPY copyJMXFiles.sh /
-RUN chmod +x copyJMXFiles.sh
+COPY transformEnvironment.sh copyJMXFiles.sh /
+RUN mkdir /logs && chmod +x transformEnvironment.sh copyJMXFiles.sh


### PR DESCRIPTION
## Description
Earlier today (24 March), travis runs and my local builds started failing because the Oracle JDK download was no longer available for the 'scala' image.  We had been discussing moving to OpenJDK 8 for a while -- this is my port of the 'scala' Dockerfile to use the Docker library's OpenJDK build (Alpine 3.7).

Initial push to see if it builds cleanly in Travis after building cleanly and testing (mostly) cleanly on my local environment.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [X] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [X] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

