### PR TITLE
Configure the number of network threads in kafka

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -116,6 +116,8 @@ kafka:
     port: 8093
   heap: "{{ kafka_heap | default('1g') }}"
   replicationFactor: "{{ kafka_replicationFactor | default((groups['kafkas']|length)|int) }}"
+  # adapt this param for production deployments depending on the number of kafka consumers
+  networkThreads: "{{ kafka_network_threads | default(3) }}"
 
 kafka_connect_string: "{% set ret = [] %}\
                        {% for host in groups['kafkas'] %}\

--- a/ansible/roles/kafka/tasks/deploy.yml
+++ b/ansible/roles/kafka/tasks/deploy.yml
@@ -27,6 +27,7 @@
       "KAFKA_ZOOKEEPER_CONNECT": "{{ zookeeper_connect_string }}"
       "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR": "{{ kafka.replicationFactor }}"
       "KAFKA_AUTO_CREATE_TOPICS_ENABLE": "false"
+      "KAFKA_NUM_NETWORK_THREADS": "{{ kafka.networkThreads }}"
 
 - name: add kafka non-ssl vars
   when: kafka.protocol != 'SSL'


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
Increasing the number of network threads in kafka solves the performance bottleneck on some deployments where the number of invokers is high. 
If one deploys kafka with the default value of network threads (3), it would have only a couple of CPU that are fully utilized amid others that are idling, which could reduce the throughput for blocking and non-blocking invocations, it could setback even more dramatically if encryption is enabled. 

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).


