### PR TITLE
Immutable attachments via putAndAttach

### DIFF
--- a/common/scala/src/main/scala/whisk/core/database/ArtifactStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/ArtifactStore.scala
@@ -74,8 +74,9 @@ trait ArtifactStore[DocumentAbstraction] {
    * @param ma manifest for A to determine its runtime type, required by some db APIs
    * @return a future that completes either with DocumentAbstraction if the document exists and is deserializable into desired type
    */
-  protected[database] def get[A <: DocumentAbstraction](doc: DocInfo)(implicit transid: TransactionId,
-                                                                      ma: Manifest[A]): Future[A]
+  protected[database] def get[A <: DocumentAbstraction](doc: DocInfo, attachmentHandler: Option[(A, Attached) => A])(
+    implicit transid: TransactionId,
+    ma: Manifest[A]): Future[A]
 
   /**
    * Gets all documents from database view that match a start key, up to an end key, using a future.

--- a/common/scala/src/main/scala/whisk/core/database/ArtifactStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/ArtifactStore.scala
@@ -70,6 +70,7 @@ trait ArtifactStore[DocumentAbstraction] {
    * If the operation is successful, the future completes with the requested document if it exists.
    *
    * @param doc the document info for the record to get (must contain valid id and rev)
+   * @param attachmentHandler function to update the attachment details in document
    * @param transid the transaction id for logging
    * @param ma manifest for A to determine its runtime type, required by some db APIs
    * @return a future that completes either with DocumentAbstraction if the document exists and is deserializable into desired type
@@ -121,6 +122,10 @@ trait ArtifactStore[DocumentAbstraction] {
 
   /**
    * Attaches a "file" of type `contentType` to an existing document. The revision for the document must be set.
+   *
+   * @param update - function to transform the document with new attachment details
+   * @param oldAttachment Optional old document instance for the update scenario. It would be used to determine
+   *                      the existing attachment details.
    */
   protected[database] def putAndAttach[A <: DocumentAbstraction](
     d: A,

--- a/common/scala/src/main/scala/whisk/core/database/ArtifactStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/ArtifactStore.scala
@@ -75,9 +75,9 @@ trait ArtifactStore[DocumentAbstraction] {
    * @param ma manifest for A to determine its runtime type, required by some db APIs
    * @return a future that completes either with DocumentAbstraction if the document exists and is deserializable into desired type
    */
-  protected[database] def get[A <: DocumentAbstraction](doc: DocInfo, attachmentHandler: Option[(A, Attached) => A])(
-    implicit transid: TransactionId,
-    ma: Manifest[A]): Future[A]
+  protected[database] def get[A <: DocumentAbstraction](
+    doc: DocInfo,
+    attachmentHandler: Option[(A, Attached) => A] = None)(implicit transid: TransactionId, ma: Manifest[A]): Future[A]
 
   /**
    * Gets all documents from database view that match a start key, up to an end key, using a future.

--- a/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
@@ -228,7 +228,8 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
       e match {
         case Right(response) =>
           transid.finished(this, start, s"[GET] '$dbName' completed: found document '$doc'")
-          deserialize[A, DocumentAbstraction](doc, response)
+          val deserializedDoc = deserialize[A, DocumentAbstraction](doc, response)
+          attachmentHandler.map(processAttachments(deserializedDoc, response, _)).getOrElse(deserializedDoc)
         case Left(StatusCodes.NotFound) =>
           transid.finished(this, start, s"[GET] '$dbName', document: '${doc}'; not found.")
           // for compatibility

--- a/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
+++ b/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
@@ -95,9 +95,10 @@ trait DocumentFactory[W <: DocumentRevisionProvider] extends MultipleReadersSing
    * @param doc the entity to store
    * @param transid the transaction id for logging
    * @param notifier an optional callback when cache changes
+   * @param old an optional old document in case of update
    * @return Future[DocInfo] with completion to DocInfo containing the save document id and revision
    */
-  def put[Wsuper >: W](db: ArtifactStore[Wsuper], doc: W)(
+  def put[Wsuper >: W](db: ArtifactStore[Wsuper], doc: W, old: Option[W])(
     implicit transid: TransactionId,
     notifier: Option[CacheChangeNotification]): Future[DocInfo] = {
     Try {

--- a/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
+++ b/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
@@ -141,12 +141,12 @@ trait DocumentFactory[W <: DocumentRevisionProvider] extends MultipleReadersSing
 
       val key = CacheKey(doc)
       val src = StreamConverters.fromInputStream(() => bytes)
-      val cacheDoc = postProcess map { _(doc) } getOrElse doc
 
       db.putAndAttach[W](doc, update, contentType, src, oldAttachment) flatMap {
         case (newDocInfo, attached) =>
           val newDoc = update(doc, attached).revision[W](newDocInfo.rev)
           val cacheDoc = postProcess map { _(newDoc) } getOrElse doc
+          cacheDoc.revision[W](newDocInfo.rev)
           cacheUpdate(cacheDoc, key, Future.successful(newDocInfo))
       }
 

--- a/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
+++ b/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
@@ -261,10 +261,18 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
     } else generator // not caching
   }
 
+  protected def cacheUpdate(doc: W, key: CacheKey, generator: => Future[Winfo])(
+    implicit ec: ExecutionContext,
+    transid: TransactionId,
+    logger: Logging,
+    notifier: Option[CacheChangeNotification]): Future[Winfo] = {
+    cacheUpdate(Future.successful(doc), key, generator)
+  }
+
   /**
    * This method posts an update to the backing store, and potentially stores the result in the cache.
    */
-  protected def cacheUpdate(doc: W, key: CacheKey, generator: => Future[Winfo])(
+  protected def cacheUpdate(f: Future[W], key: CacheKey, generator: => Future[Winfo])(
     implicit ec: ExecutionContext,
     transid: TransactionId,
     logger: Logging,
@@ -272,7 +280,7 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
     if (cacheEnabled) {
 
       // try inserting our desired entry...
-      val desiredEntry = Entry(transid, WriteInProgress, Some(Future.successful(doc)))
+      val desiredEntry = Entry(transid, WriteInProgress, Some(f))
       cache(key)(desiredEntry) flatMap { actualEntry =>
         // ... and see what we get back
 

--- a/common/scala/src/main/scala/whisk/core/entity/Attachments.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Attachments.scala
@@ -41,7 +41,11 @@ object Attachments {
 
   case class Inline[T](value: T) extends Attachment[T]
 
-  case class Attached(attachmentName: String, attachmentType: ContentType) extends Attachment[Nothing]
+  case class Attached(attachmentName: String,
+                      attachmentType: ContentType,
+                      length: Option[Int] = None,
+                      digest: Option[String] = None)
+      extends Attachment[Nothing]
 
   // Attachments are considered free because the name/content type are system determined
   // and a size check for the content is done during create/update
@@ -65,7 +69,7 @@ object Attachments {
           }
       }
 
-      jsonFormat2(Attached.apply)
+      jsonFormat4(Attached.apply)
     }
   }
 

--- a/common/scala/src/main/scala/whisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Exec.scala
@@ -155,10 +155,8 @@ protected[core] case class CodeExecAsAttachment(manifest: RuntimeManifest,
     copy(code = Inline(encoded))
   }
 
-  def attach: CodeExecAsAttachment = {
-    manifest.attached.map { a =>
-      copy(code = Attached(a.attachmentName, a.attachmentType))
-    } getOrElse this
+  def attach(attached: Attached): CodeExecAsAttachment = {
+    copy(code = attached)
   }
 }
 

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -371,7 +371,7 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
 
     fa.flatMap { action =>
       action.exec match {
-        case exec @ CodeExecAsAttachment(_, Attached(attachmentName, _), _) =>
+        case exec @ CodeExecAsAttachment(_, Attached(attachmentName, _, _, _), _) =>
           val boas = new ByteArrayOutputStream()
           val b64s = Base64.getEncoder().wrap(boas)
 

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -317,7 +317,7 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
   val requireWhiskAuthHeader = "x-require-whisk-auth"
 
   // overriden to store attached code
-  override def put[A >: WhiskAction](db: ArtifactStore[A], doc: WhiskAction)(
+  override def put[A >: WhiskAction](db: ArtifactStore[A], doc: WhiskAction, old: Option[WhiskAction])(
     implicit transid: TransactionId,
     notifier: Option[CacheChangeNotification]): Future[DocInfo] = {
 
@@ -336,7 +336,7 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
           val stream = new ByteArrayInputStream(Base64.getDecoder().decode(code))
           val manifest = exec.manifest.attached.get
 
-          for (i1 <- super.put(db, newDoc);
+          for (i1 <- super.put(db, newDoc, old);
                i2 <- attach[A](
                  db,
                  newDoc.revision(i1.rev),
@@ -348,7 +348,7 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
                  })) yield i2
 
         case _ =>
-          super.put(db, doc)
+          super.put(db, doc, old)
       }
     } match {
       case Success(f) => f

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
@@ -21,15 +21,11 @@ import java.time.Instant
 
 import scala.concurrent.Future
 import scala.util.Try
-
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import whisk.common.TransactionId
 import whisk.core.ConfigKeys
-import whisk.core.database.ArtifactStore
-import whisk.core.database.DocumentFactory
-import whisk.core.database.StaleParameter
-
+import whisk.core.database.{ArtifactStore, CacheChangeNotification, DocumentFactory, StaleParameter}
 import pureconfig._
 
 /**
@@ -200,4 +196,10 @@ object WhiskActivation
     val endKey = List(namespace.addPath(path).asString, upto map { _.toEpochMilli } getOrElse TOP, TOP)
     query(db, filtersView, startKey, endKey, skip, limit, reduce = false, stale, convert)
   }
+
+  def put[Wsuper >: WhiskActivation](db: ArtifactStore[Wsuper], doc: WhiskActivation)(
+    implicit transid: TransactionId,
+    notifier: Option[CacheChangeNotification]): Future[DocInfo] =
+    //As activations are not updated we just pass None for the old document
+    super.put(db, doc, None)
 }

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
@@ -177,10 +177,10 @@ object InvokerPool {
     WhiskAction
       .get(db, action.docid)
       .flatMap { oldAction =>
-        WhiskAction.put(db, action.revision(oldAction.rev))(tid, notifier = None)
+        WhiskAction.put(db, action.revision(oldAction.rev), Some(oldAction))(tid, notifier = None)
       }
       .recover {
-        case _: NoDocumentException => WhiskAction.put(db, action)(tid, notifier = None)
+        case _: NoDocumentException => WhiskAction.put(db, action, old = None)(tid, notifier = None)
       }
       .map(_ => {})
       .andThen {

--- a/tests/src/test/scala/whisk/core/database/test/AttachmentTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/AttachmentTests.scala
@@ -110,6 +110,9 @@ class AttachmentTests
       .attached
       .get
       .attachmentType
+    attached(action2).length shouldBe Some(size)
+    attached(action2).digest should not be empty
+
     action3.exec shouldBe exec
     inlined(action3).value shouldBe base64
   }

--- a/tests/src/test/scala/whisk/core/database/test/AttachmentTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/AttachmentTests.scala
@@ -17,6 +17,7 @@
 
 package whisk.core.database.test
 
+import akka.http.scaladsl.model.Uri
 import akka.stream.ActorMaterializer
 import common.{StreamLogging, WskActorSystem}
 import org.junit.runner.RunWith
@@ -76,6 +77,10 @@ class AttachmentTests
     docsToDelete += ((datastore, i2))
 
     attached(action2).attachmentName should not be attached(action3).attachmentName
+
+    //Check that attachment name is actually a uri
+    val attachmentUri = Uri(attached(action2).attachmentName)
+    attachmentUri.isAbsolute shouldBe true
   }
 
   private def attached(a: WhiskAction): Attached =

--- a/tests/src/test/scala/whisk/core/database/test/AttachmentTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/AttachmentTests.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.database.test
+
+import akka.stream.ActorMaterializer
+import common.{StreamLogging, WskActorSystem}
+import org.junit.runner.RunWith
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FlatSpec}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.junit.JUnitRunner
+import whisk.common.TransactionId
+import whisk.core.controller.test.WhiskAuthHelpers
+import whisk.core.database.CacheChangeNotification
+import whisk.core.entity.Attachments.{Attached, Attachment}
+import whisk.core.entity._
+import whisk.core.entity.test.ExecHelpers
+
+@RunWith(classOf[JUnitRunner])
+class AttachmentTests
+    extends FlatSpec
+    with BeforeAndAfterEach
+    with BeforeAndAfterAll
+    with WskActorSystem
+    with DbUtils
+    with ExecHelpers
+    with ScalaFutures
+    with StreamLogging {
+
+  implicit val materializer = ActorMaterializer()
+  private val namespace = EntityPath(WhiskAuthHelpers.newIdentity().subject.asString)
+  private val datastore = WhiskEntityStore.datastore()
+
+  implicit val cacheUpdateNotifier: Option[CacheChangeNotification] = None
+  implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = dbOpTimeout)
+
+  override def afterEach() = {
+    cleanup()
+  }
+
+  override def afterAll() = {
+    datastore.shutdown()
+    super.afterAll()
+  }
+
+  behavior of "Datastore"
+
+  it should "generate different attachment name on update" in {
+    implicit val tid: TransactionId = transid()
+    val exec = javaDefault("ZHViZWU=", Some("hello"))
+    val javaAction =
+      WhiskAction(namespace, EntityName("attachment_unique"), exec)
+
+    val i1 = WhiskAction.put(datastore, javaAction, old = None).futureValue
+    val action2 = datastore.get[WhiskAction](i1).futureValue
+
+    //Change attachment to inline one otherwise WhiskAction would not go for putAndAttach
+    val action2Updated = action2.copy(exec = exec).revision[WhiskAction](i1.rev)
+    val i2 = WhiskAction.put(datastore, action2Updated, old = Some(action2)).futureValue
+    val action3 = datastore.get[WhiskAction](i2).futureValue
+
+    docsToDelete += ((datastore, i2))
+
+    attached(action2).attachmentName should not be attached(action3).attachmentName
+  }
+
+  private def attached(a: WhiskAction): Attached =
+    a.exec.asInstanceOf[CodeExec[Attachment[Nothing]]].code.asInstanceOf[Attached]
+}

--- a/tests/src/test/scala/whisk/core/database/test/behavior/ArtifactStoreAttachmentBehaviors.scala
+++ b/tests/src/test/scala/whisk/core/database/test/behavior/ArtifactStoreAttachmentBehaviors.scala
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.database.test.behavior
+
+import java.util.Base64
+
+import akka.http.scaladsl.model.Uri
+import whisk.common.TransactionId
+import whisk.core.database.CacheChangeNotification
+import whisk.core.entity.Attachments.{Attached, Attachment, Inline}
+import whisk.core.entity.test.ExecHelpers
+import whisk.core.entity.{CodeExec, EntityName, ExecManifest, WhiskAction}
+
+import scala.util.Random
+
+trait ArtifactStoreAttachmentBehaviors extends ArtifactStoreBehaviorBase with ExecHelpers {
+  behavior of "Attachments"
+
+  private val namespace = newNS()
+  private val attachmentHandler = Some(WhiskAction.attachmentHandler _)
+  private implicit val cacheUpdateNotifier: Option[CacheChangeNotification] = None
+
+  it should "generate different attachment name on update" in {
+    implicit val tid: TransactionId = transid()
+    val exec = javaDefault("ZHViZWU=", Some("hello"))
+    val javaAction =
+      WhiskAction(namespace, EntityName("attachment_unique"), exec)
+
+    val i1 = WhiskAction.put(entityStore, javaAction, old = None).futureValue
+    val action2 = entityStore.get[WhiskAction](i1, attachmentHandler).futureValue
+
+    //Change attachment to inline one otherwise WhiskAction would not go for putAndAttach
+    val action2Updated = action2.copy(exec = exec).revision[WhiskAction](i1.rev)
+    val i2 = WhiskAction.put(entityStore, action2Updated, old = Some(action2)).futureValue
+    val action3 = entityStore.get[WhiskAction](i2, attachmentHandler).futureValue
+
+    docsToDelete += ((entityStore, i2))
+
+    attached(action2).attachmentName should not be attached(action3).attachmentName
+
+    //Check that attachment name is actually a uri
+    val attachmentUri = Uri(attached(action2).attachmentName)
+    attachmentUri.isAbsolute shouldBe true
+  }
+
+  it should "put and read same attachment" in {
+    implicit val tid: TransactionId = transid()
+    val size = 4000
+    val bytes = randomBytes(size)
+    val base64 = Base64.getEncoder.encodeToString(bytes)
+
+    val exec = javaDefault(base64, Some("hello"))
+    val javaAction =
+      WhiskAction(namespace, EntityName("attachment_unique"), exec)
+
+    val i1 = WhiskAction.put(entityStore, javaAction, old = None).futureValue
+    val action2 = entityStore.get[WhiskAction](i1, attachmentHandler).futureValue
+    val action3 = WhiskAction.get(entityStore, i1.id, i1.rev).futureValue
+
+    docsToDelete += ((entityStore, i1))
+
+    attached(action2).attachmentType shouldBe ExecManifest.runtimesManifest
+      .resolveDefaultRuntime(JAVA_DEFAULT)
+      .get
+      .attached
+      .get
+      .attachmentType
+    attached(action2).length shouldBe Some(size)
+    attached(action2).digest should not be empty
+
+    action3.exec shouldBe exec
+    inlined(action3).value shouldBe base64
+  }
+
+  private def attached(a: WhiskAction): Attached =
+    a.exec.asInstanceOf[CodeExec[Attachment[Nothing]]].code.asInstanceOf[Attached]
+
+  private def inlined(a: WhiskAction): Inline[String] =
+    a.exec.asInstanceOf[CodeExec[Attachment[String]]].code.asInstanceOf[Inline[String]]
+
+  private def randomBytes(size: Int): Array[Byte] = {
+    val arr = new Array[Byte](size)
+    Random.nextBytes(arr)
+    arr
+  }
+}

--- a/tests/src/test/scala/whisk/core/database/test/behavior/ArtifactStoreBehavior.scala
+++ b/tests/src/test/scala/whisk/core/database/test/behavior/ArtifactStoreBehavior.scala
@@ -24,3 +24,4 @@ trait ArtifactStoreBehavior
     with ArtifactStoreSubjectQueryBehaviors
     with ArtifactStoreWhisksQueryBehaviors
     with ArtifactStoreActivationsQueryBehaviors
+    with ArtifactStoreAttachmentBehaviors

--- a/tests/src/test/scala/whisk/core/entity/test/DatastoreTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/DatastoreTests.scala
@@ -352,7 +352,7 @@ class DatastoreTests
       assert(false)
     }
     intercept[IllegalArgumentException] {
-      Await.result(WhiskAction.put(null, null), dbOpTimeout)
+      Await.result(WhiskAction.put(null, null, None), dbOpTimeout)
       assert(false)
     }
   }


### PR DESCRIPTION
This PR implements the approach B of #3500 by adding a new `putAndAttach` method to `ArtifactStore`

## Description

This PR adds a new `ArtifactStore#putAndAttach` method and removes the `ArtifactStore#attach` method. Following are the main changes

### Key points

#### A - Refactor the flow to pass in old document

For old attachment to be removed we need access to old attachment name. To facilitate that refactoring has been done to pass in old document to `put` method. As for update we were anyway reading existing document first (to know the revision) this change does not introduce any extra calls

For `WhiskActivation` refactoring was reduced by passing `None` for old document as so activations are not updated

#### B - Cache Update flow

See inline comments in code for details

#### C - Attachment names as Uri

The attachmentName stored in document would be a Uri consisting of scheme and path. So the format would be

    <scheme>:<attachment name/path >

Where

* `scheme` - Would indicate where the attachment is stored or attachment store type. It can have values like
    * `mem` - If attachment content is inlined in name itself (TBD)
    * `couch` - If attachment is stored in CouchDB
    * `s3` - If attachment is  stored in S3
* attachment name/path - Is the actual attachment name in the storage

For e.g. with CouchDB the attachmentName Uri would be something like `couch:73d6c4cc-3670-4328-96c4-cc3670a328ac`

```javascript
"code": {
      "attachmentName": "couch:73d6c4cc-3670-4328-96c4-cc3670a328ac",
      "attachmentType": "application/java-archive"
    }
```

However the actual name of attachment would just be the path part.

```
"_attachments": {
    "73d6c4cc-3670-4328-96c4-cc3670a328ac": {
      "content_type": "application/java-archive",
      "revpos": 4,
      "digest": "md5-6PkVAZ00zzZKPoquAJj5Lw==",
      "length": 5,
      "stub": true
    }
```

The `readAttachment` flow would make use of scheme  to determine from where to read the attachment. This would help to support lazy migration of attachments to a different `AttachmentStore`

For e.g. we have an existing setup where attachments are stored in CouchDB. So attachment names would be like `jarfile` or `couch:some-uuid`. Now we can configure a `S3AttachmentStore` in this setup such that new attachments are stored in S3 while existing remain in CouchDB. So  in such a setup

* Newer attachment writes would be routed to S3
* On read side - Logic would check if scheme is `couch` then it would read it from CouchDB while if it is something else it would read from configured `AttachmentStore`

#### D - Attachement Meta

The `Attached` class now supports 2 more attributes

``` scala
  case class Attached(attachmentName: String,
                      attachmentType: ContentType,
                      length: Option[Int] = None,
                      digest: Option[String] = None)
      extends Attachment[Nothing]
```

* length - Captures the length of attachment
* digest - Digest of attachment with format "<algorithm>-<digest value>" e.g. "md5-6PkVAZ00zzZKPoquAJj5Lw=="

##### Length and Digest for CouchDB AttachmentStore

As for CouchDB attachment storage we set the attachment properties first in the document and then upload the attachment its not possible to  set these value. For non CouchDB `AttachmentStores` this would be lot simpler as there its first upload and then attach. So there these values would be populated.

So for CouchDB these values are extracted at time of deserialization by having the deserializer look into `_attachments` sub document and extract  it from there. 

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#3500)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

