### PR TITLE
wrap filed rev of BulkEntityResult using Option

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/DocInfo.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/DocInfo.scala
@@ -97,11 +97,8 @@ protected[core] case class DocInfo protected[entity] (id: DocId, rev: DocRevisio
  * @param error the error, that occured on trying to put this document into CouchDB
  * @param reason the error message that correspands to the error
  */
-case class BulkEntityResult(id: String,
-                            rev: DocRevision = DocRevision.empty,
-                            error: Option[String],
-                            reason: Option[String]) {
-  def toDocInfo = DocInfo(DocId(id), rev)
+case class BulkEntityResult(id: String, rev: Option[DocRevision], error: Option[String], reason: Option[String]) {
+  def toDocInfo = DocInfo(DocId(id), rev.getOrElse(DocRevision.empty))
 }
 
 protected[core] object DocId extends ArgNormalizer[DocId] {


### PR DESCRIPTION
Some normal results of API `_bulk_docs` can not be deserialization to BulkEntityResult

## Description
some items in the return jsArray of `_bulk_docs` may not contain filed `rev`, this lead to a spray json error

## Related issue and scope
- [x] I opened an issue to propose and discuss this change (#3511)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

