### PR TITLE
Introduce separate Akka dispatchers for CouchDB and Kafka Clients (#2954)

### DIFF
--- a/common/scala/src/main/resources/reference.conf
+++ b/common/scala/src/main/resources/reference.conf
@@ -8,3 +8,56 @@ whisk.spi {
   LogStoreProvider = whisk.core.containerpool.logging.DockerToActivationLogStoreProvider
   LoadBalancerProvider = whisk.core.loadBalancer.ShardingContainerPoolBalancer
 }
+
+dispatchers {
+  # Custom dispatcher for CouchDB Client. Tune as needed.
+  couch-dispatcher {
+    type = Dispatcher
+    executor = "thread-pool-executor"
+
+    # Underlying thread pool implementation is java.util.concurrent.ThreadPoolExecutor
+    thread-pool-executor {
+      # Min number of threads to cap factor-based corePoolSize number to
+      core-pool-size-min = 2
+
+      # The core-pool-size-factor is used to determine corePoolSize of the
+      # ThreadPoolExecutor using the following formula:
+      # ceil(available processors * factor).
+      # Resulting size is then bounded by the core-pool-size-min and
+      # core-pool-size-max values.
+      core-pool-size-factor = 2.0
+
+      # Max number of threads to cap factor-based corePoolSize number to
+      core-pool-size-max = 32
+    }
+    # Throughput defines the number of messages that are processed in a batch
+    # before the thread is returned to the pool. Set to 1 for as fair as possible.
+    throughput = 5
+  }
+
+  # Custom dispatcher for Kafka client. Tune as needed.
+  kafka-dispatcher {
+    type = Dispatcher
+    executor = "thread-pool-executor"
+
+    # Underlying thread pool implementation is java.util.concurrent.ThreadPoolExecutor
+    thread-pool-executor {
+      # Min number of threads to cap factor-based corePoolSize number to
+      core-pool-size-min = 2
+
+      # The core-pool-size-factor is used to determine corePoolSize of the
+      # ThreadPoolExecutor using the following formula:
+      # ceil(available processors * factor).
+      # Resulting size is then bounded by the core-pool-size-min and
+      # core-pool-size-max values.
+      core-pool-size-factor = 2.0
+
+      # Max number of threads to cap factor-based corePoolSize number to
+      core-pool-size-max = 32
+    }
+
+    # Throughput defines the number of messages that are processed in a batch
+    # before the thread is returned to the pool. Set to 1 for as fair as possible.
+    throughput = 5
+  }
+}

--- a/common/scala/src/main/scala/whisk/core/connector/MessageConsumer.scala
+++ b/common/scala/src/main/scala/whisk/core/connector/MessageConsumer.scala
@@ -170,7 +170,7 @@ class MessageFeed(description: String,
   startWith(Idle, MessageFeed.NoData)
   initialize()
 
-  private implicit val ec = context.system.dispatcher
+  private implicit val ec = context.system.dispatchers.lookup("dispatchers.kafka-dispatcher")
 
   private def fillPipeline(): Unit = {
     if (outstandingMessages.size <= pipelineFillThreshold) {

--- a/common/scala/src/main/scala/whisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/whisk/core/database/CouchDbRestClient.scala
@@ -18,7 +18,6 @@
 package whisk.core.database
 
 import scala.concurrent.Future
-
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
@@ -27,10 +26,8 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
 import akka.stream.scaladsl._
 import akka.util.ByteString
-
 import spray.json._
 import spray.json.DefaultJsonProtocol._
-
 import whisk.common.Logging
 import whisk.http.PoolingRestClient
 
@@ -46,6 +43,8 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
   implicit system: ActorSystem,
   logging: Logging)
     extends PoolingRestClient(protocol, host, port, 16 * 1024) {
+
+  implicit override val context = system.dispatchers.lookup("dispatchers.couch-dispatcher")
 
   // Headers common to all requests.
   val baseHeaders: List[HttpHeader] =

--- a/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
@@ -62,7 +62,7 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
     with DefaultJsonProtocol
     with AttachmentInliner {
 
-  protected[core] implicit val executionContext = system.dispatcher
+  protected[core] implicit val executionContext = system.dispatchers.lookup("dispatchers.couch-dispatcher")
 
   val attachmentScheme: String = "couch"
 

--- a/common/scala/src/main/scala/whisk/core/database/RemoteCacheInvalidation.scala
+++ b/common/scala/src/main/scala/whisk/core/database/RemoteCacheInvalidation.scala
@@ -54,7 +54,7 @@ object CacheInvalidationMessage extends DefaultJsonProtocol {
 class RemoteCacheInvalidation(config: WhiskConfig, component: String, instance: InstanceId)(implicit logging: Logging,
                                                                                             as: ActorSystem) {
 
-  implicit private val ec = as.dispatcher
+  implicit private val ec = as.dispatchers.lookup("dispatchers.kafka-dispatcher")
 
   private val topic = "cacheInvalidation"
   private val instanceId = s"$component${instance.toInt}"


### PR DESCRIPTION
- Rest of system continues to use the default system dispatcher


Refs #2954


<!--- Provide a concise summary of your changes in the Title -->

## Description

This reopens the previous  #2956 PR; fork-join-executor wasn't the right choice previously and it is using Thread Pool dispatchers now, which are the correct way to handle this kind of IO separation with Akka. Defaults are set to what should be a reasonable starting point, especially given that couch and kafka now have their own separate execution pools from the "Default"/main system.

<!--- Provide a detailed description of your changes. -->

 Kafka and CouchDB clients each get their own dispatchers
  * This should prevent all of the akka based stuff from competing constantly for threads
  * Kafka and Couch can be tuned now based on individual needs
  * Using thread-pool dispatchers, which are best suited for these processes (default is fork-join)
- Dispatchers are defined in common `reference.conf`, so config can be overridden by dependents

<!--- Include details of what problem you are solving and how your changes are tested. -->

Currently, OpenWhisk is sharing a single fork-join-executor across the board for the entire `ActorSystem`, which is less than ideal especially when dealing with potentially blocking IO. 

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#2954 )

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [x] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue). (sort of a bug fix)
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes. (not easily testable in unit/integration)
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

