### PR TITLE
Allow spaces when generating keystore and certificates

### DIFF
--- a/ansible/files/genssl.sh
+++ b/ansible/files/genssl.sh
@@ -34,7 +34,7 @@ function gen_cert(){
   openssl x509 -req \
       -in "$SCRIPTDIR/${NAME_PREFIX}openwhisk-server-request.csr" \
       -signkey "$SCRIPTDIR/${NAME_PREFIX}openwhisk-server-key.pem" \
-      -out ${SCRIPTDIR}/${NAME_PREFIX}openwhisk-server-cert.pem \
+      -out "${SCRIPTDIR}/${NAME_PREFIX}openwhisk-server-cert.pem" \
       -days 365
 }
 
@@ -53,7 +53,7 @@ if [ "$TYPE" == "server_with_JKS_keystore" ]; then
   keytool -genkey -v \
     -alias $CN \
     -dname "C=US,ST=NY,L=Yorktown,O=OpenWhisk,CN=$CN" \
-    -keystore ${SCRIPTDIR}/${NAME_PREFIX}keystore.jks \
+    -keystore "${SCRIPTDIR}/${NAME_PREFIX}keystore.jks" \
     -keypass:env TRUSTSTORE_PASSWORD \
     -storepass:env TRUSTSTORE_PASSWORD \
     -keyalg RSA \
@@ -61,13 +61,13 @@ if [ "$TYPE" == "server_with_JKS_keystore" ]; then
     -ext BasicConstraints:critical="ca:true" \
     -validity 365
   echo export private key from the keystore
-  keytool -keystore ${SCRIPTDIR}/${NAME_PREFIX}keystore.jks -alias $CN -certreq -file ${SCRIPTDIR}/${NAME_PREFIX}cert-file -storepass:env TRUSTSTORE_PASSWORD
+  keytool -keystore "${SCRIPTDIR}/${NAME_PREFIX}keystore.jks" -alias $CN -certreq -file "${SCRIPTDIR}/${NAME_PREFIX}cert-file" -storepass:env TRUSTSTORE_PASSWORD
   echo sign the certificate with private key
-  openssl x509 -req -CA ${SCRIPTDIR}/${NAME_PREFIX}openwhisk-server-cert.pem -CAkey "$SCRIPTDIR/${NAME_PREFIX}openwhisk-server-key.pem" -in ${SCRIPTDIR}/${NAME_PREFIX}cert-file -out ${SCRIPTDIR}/${NAME_PREFIX}cert-signed -days 365 -CAcreateserial -passin pass:$TRUSTSTORE_PASSWORD
+  openssl x509 -req -CA "${SCRIPTDIR}/${NAME_PREFIX}openwhisk-server-cert.pem" -CAkey "$SCRIPTDIR/${NAME_PREFIX}openwhisk-server-key.pem" -in "${SCRIPTDIR}/${NAME_PREFIX}cert-file" -out "${SCRIPTDIR}/${NAME_PREFIX}cert-signed" -days 365 -CAcreateserial -passin pass:$TRUSTSTORE_PASSWORD
   echo import CA cert in the keystore
-  keytool -keystore ${SCRIPTDIR}/${NAME_PREFIX}keystore.jks -alias CARoot -import -file ${SCRIPTDIR}/${NAME_PREFIX}openwhisk-server-cert.pem -storepass:env TRUSTSTORE_PASSWORD -noprompt
+  keytool -keystore "${SCRIPTDIR}/${NAME_PREFIX}keystore.jks" -alias CARoot -import -file "${SCRIPTDIR}/${NAME_PREFIX}openwhisk-server-cert.pem" -storepass:env TRUSTSTORE_PASSWORD -noprompt
   echo import the private key in the keystore
-  keytool -keystore ${SCRIPTDIR}/${NAME_PREFIX}keystore.jks -alias $CN -import -file ${SCRIPTDIR}/${NAME_PREFIX}cert-signed -storepass:env TRUSTSTORE_PASSWORD -noprompt
+  keytool -keystore "${SCRIPTDIR}/${NAME_PREFIX}keystore.jks" -alias $CN -import -file "${SCRIPTDIR}/${NAME_PREFIX}cert-signed" -storepass:env TRUSTSTORE_PASSWORD -noprompt
 
 elif [ "$TYPE" == "server" ]; then
     gen_csr


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
Generating certificates will fail if spaces are in arguments passed to openssl commands.

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

