### PR TITLE
Remove env_hosts_dir ansible variable.

### DIFF
--- a/ansible/environments/distributed/group_vars/all
+++ b/ansible/environments/distributed/group_vars/all
@@ -14,8 +14,6 @@ registry_storage_dir: "/"
 docker_registry: "{{ groups['registry'] | first }}:5000/"
 docker_dns: ""
 
-env_hosts_dir: "{{ playbook_dir }}/environments/distributed"
-
 registry:
   version: 2.3.1
   port: 5000

--- a/ansible/environments/docker-machine/group_vars/all
+++ b/ansible/environments/docker-machine/group_vars/all
@@ -5,8 +5,6 @@ docker_registry: ""
 docker_dns: ""
 runtimes_bypass_pull_for_local_images: true
 
-env_hosts_dir: "{{ playbook_dir }}/environments/docker-machine"
-
 # The whisk_api_localhost_name is used to configure nginx to permit vanity URLs for web actions.
 # It is also used for the SSL certificate generation. For a local deployment, this is typically
 # a hostname that is resolved on the client, via /etc/hosts for example.

--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -32,5 +32,3 @@ kafka_topics_health_retentionBytes: 104857600
 kafka_topics_health_retentionMS: 300000
 kafka_topics_invoker_retentionBytes: 104857600
 kafka_topics_invoker_retentionMS: 300000
-
-env_hosts_dir: "{{ playbook_dir }}/environments/local"

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -19,7 +19,7 @@ exclude_logs_from: []
 #   whisk_api_localhost_name_default (last)
 whisk_api_localhost_name_default: "localhost"
 
-hosts_dir: "{{ inventory_dir| default(env_hosts_dir) }}"
+hosts_dir: "{{ inventory_dir if inventory_dir else (ansible_inventory_sources[0] | dirname) }}"
 
 whisk:
   version:
@@ -323,4 +323,3 @@ metrics:
     tags: "{{ metrics_kamon_tags | default(false) }}"
     host: "{{ metrics_kamon_statsd_host | default('') }}"
     port: "{{ metrics_kamon_statsd_port | default('8125') }}"
-


### PR DESCRIPTION
## Description

We are setting the variable `env_hosts_dir` for each environment to the path, were the configuration files of the environments are located. As this is equal to the environment location, this can be set with ansible to `{{ inventory_dir if inventory_dir else (ansible_inventory_sources[0] | dirname) }}`.


<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

@mhenke1 Could you please review this PR?

PG5#227 is running.