### PR TITLE
bump nodejs6 from 6.14.0 -> 6.14.1, nodejs8 from 8.11.0 -> 8.11.1

### DIFF
--- a/actionRuntimes/nodejs6Action/Dockerfile
+++ b/actionRuntimes/nodejs6Action/Dockerfile
@@ -1,2 +1,2 @@
-FROM openwhisk/nodejs6action:1.8.0
+FROM openwhisk/nodejs6action:1.8.1
 

--- a/actionRuntimes/nodejs8Action/Dockerfile
+++ b/actionRuntimes/nodejs8Action/Dockerfile
@@ -1,2 +1,2 @@
-FROM openwhisk/action-nodejs-v8:1.5.0
+FROM openwhisk/action-nodejs-v8:1.5.1
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -210,9 +210,9 @@ JavaScript actions can be executed in Node.js version 6 or Node.js version 8.
 Currently actions are executed by default in a Node.js version 6 environment.
 
 ### Node.js version 6 environment
-The Node.js 6.14.0 environment will be used for an action if the `--kind` flag is explicitly specified with a value of 'nodejs:6' when creating/updating the action.
+The Node.js 6.14.1 environment will be used for an action if the `--kind` flag is explicitly specified with a value of 'nodejs:6' when creating/updating the action.
 
-The following packages are available to be used in the Node.js 6.14.0 environment:
+The following packages are available to be used in the Node.js 6.14.1 environment:
 
 - [apn v2.1.2](https://www.npmjs.com/package/apn) - A Node.js module for interfacing with the Apple Push Notification service.
 - [async v2.1.4](https://www.npmjs.com/package/async) - Provides functions for working with asynchronous functions.
@@ -267,9 +267,9 @@ The following packages are available to be used in the Node.js 6.14.0 environmen
 - [yauzl v2.7.0](https://www.npmjs.com/package/yauzl) - Yet another unzip library for node. For zipping.
 
 ### Node.js version 8 environment
-The Node.js version 8.11.0 environment is used if the `--kind` flag is explicitly specified with a value of 'nodejs:8' when creating or updating an Action.
+The Node.js version 8.11.1 environment is used if the `--kind` flag is explicitly specified with a value of 'nodejs:8' when creating or updating an Action.
 
-The following packages are pre-installed in the Node.js version 8.11.0 environment:
+The following packages are pre-installed in the Node.js version 8.11.1 environment:
 
 - [openwhisk v3.14.0](https://www.npmjs.com/package/openwhisk) - JavaScript client library for the OpenWhisk platform. Provides a wrapper around the OpenWhisk APIs.
 


### PR DESCRIPTION
bump nodejs6 from 6.14.0 -> 6.14.1, nodejs8 from 8.11.0 -> 8.11.1

Bumping the nodejs version for both NodeJs 6 and NodeJS 8 runtimes, 
NodeJS 6 is moving from 6.14.0 to 6.14.1
NodeJS 8 is moving from 8.11.0 -> 8.11.1
