### PR TITLE
Bump timeout of activation logs test.

### DIFF
--- a/tests/src/test/scala/system/basic/WskActivationTests.scala
+++ b/tests/src/test/scala/system/basic/WskActivationTests.scala
@@ -54,7 +54,7 @@ abstract class WskActivationTests extends TestHelpers with WskTestHelpers {
 
         logs should include regex logFormat.format("stdout", "this is stdout")
         logs should include regex logFormat.format("stderr", "this is stderr")
-      }, 60, Some(1.second))
+      }, 60 * 5, Some(1.second)) // retry for 5 minutes
     }
   }
 }

--- a/tests/src/test/scala/system/basic/WskActivationTests.scala
+++ b/tests/src/test/scala/system/basic/WskActivationTests.scala
@@ -20,14 +20,14 @@ package system.basic
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
-import common.{BaseWsk, JsHelpers, TestHelpers, TestUtils, WskProps, WskTestHelpers}
+import common.{BaseWsk, TestHelpers, TestUtils, WskProps, WskTestHelpers}
 
 import whisk.utils.retry
 
 import scala.concurrent.duration._
 
 @RunWith(classOf[JUnitRunner])
-abstract class WskActivationTests extends TestHelpers with WskTestHelpers with JsHelpers {
+abstract class WskActivationTests extends TestHelpers with WskTestHelpers {
   implicit val wskprops = WskProps()
 
   val wsk: BaseWsk
@@ -44,14 +44,17 @@ abstract class WskActivationTests extends TestHelpers with WskTestHelpers with J
 
     val run = wsk.action.invoke(name, blocking = true)
 
-    // Use withActivation() to reduce intermittent failures that may result from eventually consistent DBs
+    // Even though the activation was blocking, the activation itself might not have appeared in the database.
     withActivation(wsk.activation, run) { activation =>
+      // Needs to be retried because there might be an SPI being plugged in which is handling logs not consistent with
+      // the database where the activation itself comes from (activation in CouchDB, logs in Elasticsearch for
+      // example).
       retry({
         val logs = wsk.activation.logs(Some(activation.activationId)).stdout
 
-        logs should include regex (logFormat.format("stdout", "this is stdout"))
-        logs should include regex (logFormat.format("stderr", "this is stderr"))
-      }, 10, Some(1.second))
+        logs should include regex logFormat.format("stdout", "this is stdout")
+        logs should include regex logFormat.format("stderr", "this is stderr")
+      }, 60, Some(1.second))
     }
   }
 }


### PR DESCRIPTION
There are SPIs in active development which exchange the backend of the "activation logs" call. This backend is not necessarily consistent with the activations database itself, hence the test needs to poll "activation logs" for a set amount of time.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes.
- [ ] ~~My changes require further changes to the documentation.~~
- [ ] ~~I updated the documentation where necessary.~~

