### PR TITLE
Bump retries for view based tests.

### DIFF
--- a/tests/src/test/scala/whisk/core/invoker/test/NamespaceBlacklistTests.scala
+++ b/tests/src/test/scala/whisk/core/invoker/test/NamespaceBlacklistTests.scala
@@ -32,6 +32,7 @@ import whisk.core.ConfigKeys
 import whisk.core.database.test.{DbUtils, ExtendedCouchDbRestClient}
 import whisk.core.entity._
 import whisk.core.invoker.NamespaceBlacklist
+import whisk.utils.{retry => testRetry}
 
 import scala.concurrent.duration._
 
@@ -128,7 +129,9 @@ class NamespaceBlacklistTests
   it should "mark a namespace as blocked if limit is 0 in database or if one of its subjects is blocked" in {
     val blacklist = new NamespaceBlacklist(authStore)
 
-    blacklist.refreshBlacklist().futureValue should have size blockedNamespacesCount
+    testRetry({
+      blacklist.refreshBlacklist().futureValue should have size blockedNamespacesCount
+    }, 60, Some(1.second))
 
     identities.map(blacklist.isBlacklisted) shouldBe Seq(true, true, false)
     authToIdentities(subject).toSeq.map(blacklist.isBlacklisted) shouldBe Seq(true, true)


### PR DESCRIPTION
The view based retry logic is a bit deep and overloaded. To bump the retries and make all those tests more stable this bumps the general retry count for all those tests.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes.
- [ ] ~~My changes require further changes to the documentation.~~
- [ ] ~~I updated the documentation where necessary.~~

