### PR TITLE
use whisk_api_host_name as part of api host ansible selection

### DIFF
--- a/ansible/roles/routemgmt/tasks/deploy.yml
+++ b/ansible/roles/routemgmt/tasks/deploy.yml
@@ -16,6 +16,6 @@
 ---
 # Install the API Gateway route management actions.
 - name: install route management actions
-  shell: ./installRouteMgmt.sh {{ catalog_auth_key }} {{ groups['edge'] | first }} {{ catalog_namespace }} {{ cli.path }} chdir="{{ openwhisk_home }}/ansible/roles/routemgmt/files"
+  shell: ./installRouteMgmt.sh {{ catalog_auth_key }} {{ whisk_api_host_name | default(groups['edge'] | first) }} {{ catalog_namespace }} {{ cli.path }} chdir="{{ openwhisk_home }}/ansible/roles/routemgmt/files"
   environment:
     OPENWHISK_HOME: "{{ openwhisk_home }}"

--- a/ansible/tasks/installOpenwhiskCatalog.yml
+++ b/ansible/tasks/installOpenwhiskCatalog.yml
@@ -19,7 +19,7 @@
 - set_fact:
     catalog_location={{ item.value.location }}
     catalog_repo_url={{ item.value.url }}
-    api_host={{ groups['edge'] | first }}
+    api_host={{ whisk_api_host_name | default(groups['edge'] | first) }}
     version="HEAD"
     repo_update="yes"
 


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
Update API GW and Catalog package deployment ansible tasks to use `whisk_api_host_name` before defaulting to the `['edge']` host

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
Maintain consistency with other deployment scripts (i.e. nginx) that leverage `whisk_api_host_name`

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

