### PR TITLE
Move kafka/zookeeper hosts to pureconfig based configuration.

### DIFF
--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -128,7 +128,8 @@
       "WHISK_VERSION_DATE": "{{ whisk.version.date }}"
       "WHISK_VERSION_BUILDNO": "{{ docker.image.tag }}"
 
-      "KAFKA_HOSTS": "{{ kafka_connect_string }}"
+      "CONFIG_whisk_kafka_common_bootstrapHosts": 
+        "{{ kafka_connect_string }}"
       "CONFIG_whisk_kafka_replicationFactor":
         "{{ kafka.replicationFactor | default() }}"
       "CONFIG_whisk_kafka_topics_cacheInvalidation_retentionBytes":

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -149,7 +149,7 @@
       "JMX_REMOTE": "{{ jmx.enabled }}"
       "COMPONENT_NAME": "invoker{{ groups['invokers'].index(inventory_hostname) }}"
       "PORT": 8080
-      "KAFKA_HOSTS": "{{ kafka_connect_string }}"
+      "CONFIG_whisk_kafka_common_bootstrapHosts": "{{ kafka_connect_string }}"
       "CONFIG_whisk_kafka_replicationFactor": "{{ kafka.replicationFactor | default() }}"
       "CONFIG_whisk_kafka_topics_invoker_retentionBytes": "{{ kafka_topics_invoker_retentionBytes | default() }}"
       "CONFIG_whisk_kafka_topics_invoker_retentionMs": "{{ kafka_topics_invoker_retentionMS | default() }}"

--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaConsumerConnector.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaConsumerConnector.scala
@@ -34,11 +34,9 @@ import scala.concurrent.{blocking, ExecutionContext, Future}
 
 case class KafkaConsumerConfig(sessionTimeoutMs: Long, metricFlushIntervalS: Int)
 
-class KafkaConsumerConnector(
-  kafkahost: String,
-  groupid: String,
-  topic: String,
-  override val maxPeek: Int = Int.MaxValue)(implicit logging: Logging, actorSystem: ActorSystem)
+class KafkaConsumerConnector(groupid: String, topic: String, override val maxPeek: Int = Int.MaxValue)(
+  implicit logging: Logging,
+  actorSystem: ActorSystem)
     extends MessageConsumer {
 
   implicit val ec: ExecutionContext = actorSystem.dispatcher
@@ -114,7 +112,6 @@ class KafkaConsumerConnector(
   private def createConsumer(topic: String) = {
     val config = Map(
       ConsumerConfig.GROUP_ID_CONFIG -> groupid,
-      ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG -> kafkahost,
       ConsumerConfig.MAX_POLL_RECORDS_CONFIG -> maxPeek.toString) ++
       configMapToKafkaConfig(loadConfigOrThrow[Map[String, String]](ConfigKeys.kafkaCommon)) ++
       configMapToKafkaConfig(loadConfigOrThrow[Map[String, String]](ConfigKeys.kafkaConsumer))

--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaProducerConnector.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaProducerConnector.scala
@@ -33,8 +33,8 @@ import scala.concurrent.duration._
 import scala.concurrent.{blocking, ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success}
 
-class KafkaProducerConnector(kafkahosts: String, id: String = UUIDs.randomUUID().toString)(implicit logging: Logging,
-                                                                                           actorSystem: ActorSystem)
+class KafkaProducerConnector(id: String = UUIDs.randomUUID().toString)(implicit logging: Logging,
+                                                                       actorSystem: ActorSystem)
     extends MessageProducer {
 
   implicit val ec: ExecutionContext = actorSystem.dispatcher
@@ -92,8 +92,7 @@ class KafkaProducerConnector(kafkahosts: String, id: String = UUIDs.randomUUID()
   private val sentCounter = new Counter()
 
   private def createProducer(): KafkaProducer[String, String] = {
-    val config = Map(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> kafkahosts) ++
-      configMapToKafkaConfig(loadConfigOrThrow[Map[String, String]](ConfigKeys.kafkaCommon)) ++
+    val config = configMapToKafkaConfig(loadConfigOrThrow[Map[String, String]](ConfigKeys.kafkaCommon)) ++
       configMapToKafkaConfig(loadConfigOrThrow[Map[String, String]](ConfigKeys.kafkaProducer))
 
     new KafkaProducer(config, new StringSerializer, new StringSerializer)

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -67,12 +67,10 @@ class WhiskConfig(requiredProperties: Map[String, String],
   val controllerInstances = this(WhiskConfig.controllerInstances)
 
   val edgeHost = this(WhiskConfig.edgeHostName) + ":" + this(WhiskConfig.edgeHostApiPort)
-  val kafkaHosts = this(WhiskConfig.kafkaHostList)
 
   val edgeHostName = this(WhiskConfig.edgeHostName)
 
   val invokerHosts = this(WhiskConfig.invokerHostsList)
-  val zookeeperHosts = this(WhiskConfig.zookeeperHostList)
 
   val dbPrefix = this(WhiskConfig.dbPrefix)
   val mainDockerEndpoint = this(WhiskConfig.mainDockerEndpoint)
@@ -181,9 +179,6 @@ object WhiskConfig {
 
   val loadbalancerInvokerBusyThreshold = "loadbalancer.invokerBusyThreshold"
 
-  val kafkaHostList = "kafka.hosts"
-  val zookeeperHostList = "zookeeper.hosts"
-
   private val edgeHostApiPort = "edge.host.apiport"
 
   val invokerHostsList = "invoker.hosts"
@@ -191,8 +186,6 @@ object WhiskConfig {
 
   val edgeHost = Map(edgeHostName -> null, edgeHostApiPort -> null)
   val invokerHosts = Map(invokerHostsList -> null)
-  val kafkaHosts = Map(kafkaHostList -> null)
-  val zookeeperHosts = Map(zookeeperHostList -> null)
 
   val runtimesManifest = "runtimes.manifest"
 
@@ -209,6 +202,9 @@ object ConfigKeys {
   val loadbalancer = "whisk.loadbalancer"
 
   val couchdb = "whisk.couchdb"
+
+  val zookeeper = "whisk.zookeeper"
+
   val kafka = "whisk.kafka"
   val kafkaCommon = s"$kafka.common"
   val kafkaProducer = s"$kafka.producer"
@@ -228,7 +224,7 @@ object ConfigKeys {
 
   val docker = "whisk.docker"
   val dockerTimeouts = s"$docker.timeouts"
-  val dockerContainerFactory = s"${docker}.container-factory"
+  val dockerContainerFactory = s"$docker.container-factory"
   val runc = "whisk.runc"
   val runcTimeouts = s"$runc.timeouts"
   val containerFactory = "whisk.container-factory"

--- a/common/scala/src/main/scala/whisk/core/connector/MessagingProvider.scala
+++ b/common/scala/src/main/scala/whisk/core/connector/MessagingProvider.scala
@@ -22,7 +22,6 @@ import akka.actor.ActorSystem
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.duration.FiniteDuration
 import whisk.common.Logging
-import whisk.core.WhiskConfig
 import whisk.spi.Spi
 
 /**
@@ -30,11 +29,10 @@ import whisk.spi.Spi
  */
 trait MessagingProvider extends Spi {
   def getConsumer(
-    config: WhiskConfig,
     groupId: String,
     topic: String,
     maxPeek: Int = Int.MaxValue,
     maxPollInterval: FiniteDuration = 5.minutes)(implicit logging: Logging, actorSystem: ActorSystem): MessageConsumer
-  def getProducer(config: WhiskConfig)(implicit logging: Logging, actorSystem: ActorSystem): MessageProducer
-  def ensureTopic(config: WhiskConfig, topic: String, topicConfig: String)(implicit logging: Logging): Boolean
+  def getProducer()(implicit logging: Logging, actorSystem: ActorSystem): MessageProducer
+  def ensureTopic(topic: String, topicConfig: String)(implicit logging: Logging): Boolean
 }

--- a/common/scala/src/main/scala/whisk/core/database/RemoteCacheInvalidation.scala
+++ b/common/scala/src/main/scala/whisk/core/database/RemoteCacheInvalidation.scala
@@ -29,7 +29,6 @@ import akka.actor.ActorSystem
 import akka.actor.Props
 import spray.json._
 import whisk.common.Logging
-import whisk.core.WhiskConfig
 import whisk.core.connector.Message
 import whisk.core.connector.MessageFeed
 import whisk.core.connector.MessagingProvider
@@ -51,8 +50,7 @@ object CacheInvalidationMessage extends DefaultJsonProtocol {
   implicit val serdes = jsonFormat(CacheInvalidationMessage.apply _, "key", "instanceId")
 }
 
-class RemoteCacheInvalidation(config: WhiskConfig, component: String, instance: InstanceId)(implicit logging: Logging,
-                                                                                            as: ActorSystem) {
+class RemoteCacheInvalidation(component: String, instance: InstanceId)(implicit logging: Logging, as: ActorSystem) {
 
   implicit private val ec = as.dispatcher
 
@@ -61,8 +59,8 @@ class RemoteCacheInvalidation(config: WhiskConfig, component: String, instance: 
 
   private val msgProvider = SpiLoader.get[MessagingProvider]
   private val cacheInvalidationConsumer =
-    msgProvider.getConsumer(config, s"$topic$instanceId", topic, maxPeek = 128)
-  private val cacheInvalidationProducer = msgProvider.getProducer(config)
+    msgProvider.getConsumer(s"$topic$instanceId", topic, maxPeek = 128)
+  private val cacheInvalidationProducer = msgProvider.getProducer()
 
   def notifyOtherInstancesAboutInvalidation(key: CacheKey): Future[Unit] = {
     cacheInvalidationProducer.send(topic, CacheInvalidationMessage(key, instanceId)).map(_ => Unit)

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancer.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancer.scala
@@ -21,7 +21,6 @@ import scala.concurrent.Future
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import whisk.common.{Logging, TransactionId}
-import whisk.core.WhiskConfig
 import whisk.core.connector._
 import whisk.core.entity._
 import whisk.spi.Spi
@@ -80,11 +79,10 @@ trait LoadBalancer {
  * An Spi for providing load balancer implementations.
  */
 trait LoadBalancerProvider extends Spi {
-  def requiredProperties: Map[String, String]
 
-  def loadBalancer(whiskConfig: WhiskConfig, instance: InstanceId)(implicit actorSystem: ActorSystem,
-                                                                   logging: Logging,
-                                                                   materializer: ActorMaterializer): LoadBalancer
+  def loadBalancer(instance: InstanceId)(implicit actorSystem: ActorSystem,
+                                         logging: Logging,
+                                         materializer: ActorMaterializer): LoadBalancer
 }
 
 /** Exception thrown by the loadbalancer */

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
@@ -97,12 +97,8 @@ class InvokerReactive(
   private val topic = s"invoker${instance.toInt}"
   private val maximumContainers = poolConfig.maxActiveContainers
   private val msgProvider = SpiLoader.get[MessagingProvider]
-  private val consumer = msgProvider.getConsumer(
-    config,
-    topic,
-    topic,
-    maximumContainers,
-    maxPollInterval = TimeLimit.MAX_DURATION + 1.minute)
+  private val consumer =
+    msgProvider.getConsumer(topic, topic, maximumContainers, maxPollInterval = TimeLimit.MAX_DURATION + 1.minute)
 
   private val activationFeed = actorSystem.actorOf(Props {
     new MessageFeed("activation", logging, consumer, maximumContainers, 500.milliseconds, processActivationMessage)

--- a/tests/src/test/resources/application.conf.j2
+++ b/tests/src/test/resources/application.conf.j2
@@ -21,6 +21,7 @@ whisk {
             }
         }
         common {
+          bootstrap-hosts: "{{ kafka_connect_string }}"
           security-protocol: {{ kafka.protocol }}
           ssl-truststore-location: {{ openwhisk_home }}/ansible/roles/kafka/files/{{ kafka.ssl.keystore.name }}
           ssl-truststore-password: {{ kafka.ssl.keystore.password }}


### PR DESCRIPTION
`KAFKA_HOSTS` being in WhiskConfig forces many classes to thread through the loaded config object.


## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [X] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [X] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [X] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] ~~I added tests to cover my changes.~~
- [ ] ~~My changes require further changes to the documentation.~~
- [ ] ~~I updated the documentation where necessary.~~

