### PR TITLE
bump nodejs6 1.8.1 -> 1.9.0, bump nodejs8 1.5.1 -> 1.6.0

### DIFF
--- a/actionRuntimes/nodejs6Action/Dockerfile
+++ b/actionRuntimes/nodejs6Action/Dockerfile
@@ -1,1 +1,1 @@
-FROM openwhisk/nodejs6action:1.8.1
+FROM openwhisk/nodejs6action:1.9.0

--- a/actionRuntimes/nodejs8Action/Dockerfile
+++ b/actionRuntimes/nodejs8Action/Dockerfile
@@ -1,1 +1,1 @@
-FROM openwhisk/action-nodejs-v8:1.5.1
+FROM openwhisk/action-nodejs-v8:1.6.0

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -255,7 +255,7 @@ The following packages are available to be used in the Node.js 6.14.1 environmen
 - [node-uuid v1.4.7](https://www.npmjs.com/package/node-uuid) - Deprecated UUID packaged.
 - [nodemailer v2.6.4](https://www.npmjs.com/package/nodemailer) - Send e-mails from Node.js – easy as cake!
 - [oauth2-server v2.4.1](https://www.npmjs.com/package/oauth2-server) - Complete, compliant, and well tested module for implementing an OAuth2 Server/Provider with express in Node.js.
-- [openwhisk v3.14.0](https://www.npmjs.com/package/openwhisk) - JavaScript client library for the OpenWhisk platform. Provides a wrapper around the OpenWhisk APIs.
+- [openwhisk v3.15.0](https://www.npmjs.com/package/openwhisk) - JavaScript client library for the OpenWhisk platform. Provides a wrapper around the OpenWhisk APIs.
 - [pkgcloud v1.4.0](https://www.npmjs.com/package/pkgcloud) - pkgcloud is a standard library for Node.js that abstracts away differences among multiple cloud providers.
 - [process v0.11.9](https://www.npmjs.com/package/process) - Require('process'); just like any other module.
 - [pug v2.0.0-beta6](https://www.npmjs.com/package/pug) - Implements the Pug templating language.
@@ -288,7 +288,7 @@ The Node.js version 8.11.1 environment is used if the `--kind` flag is explicitl
 
 The following packages are pre-installed in the Node.js version 8.11.1 environment:
 
-- [openwhisk v3.14.0](https://www.npmjs.com/package/openwhisk) - JavaScript client library for the OpenWhisk platform. Provides a wrapper around the OpenWhisk APIs.
+- [openwhisk v3.15.0](https://www.npmjs.com/package/openwhisk) - JavaScript client library for the OpenWhisk platform. Provides a wrapper around the OpenWhisk APIs.
 
 ### Packaging npm packages with your actions
 For any `npm` packages that are not pre-installed in the Node.js environment, you can bundle them as dependencies when you create or update your action.


### PR DESCRIPTION
This PR bumps the NodejS runtimes versions level to bring in the latest updates to that runtime. 
NodeJS6 is bumped from `1.8.1` to `1.9.0`
NodeJS8 is bumped from `1.5.1` to `1.6.0`

The main change is an update to the packages to bring in the latest version of the "openwhisk" NPM package, which will be at v3.15.0

A diff of these changes can be found below:
NodeJS6/NodeJS8 changes comparison: https://github.com/apache/incubator-openwhisk-runtime-nodejs/compare/8@1.5.1...8@1.6.0
