### PR TITLE
Move version information to pureconfig and remove `whisk_version_name`.

### DIFF
--- a/ansible/environments/distributed/group_vars/all
+++ b/ansible/environments/distributed/group_vars/all
@@ -2,6 +2,9 @@
 # license agreements; and to You under the Apache License, Version 2.0.
 
 ---
+
+environment_type: "distributed"
+
 db_provider: CouchDB
 db_port: 5984
 db_protocol: http
@@ -10,7 +13,6 @@ db_password: couch_password
 db_host: "{{ groups['db'] | first }}"
 db_prefix: whisk_distributed_
 
-whisk_version_name: distributed
 config_root_dir: /tmp/wskconf
 whisk_logs_dir: /tmp/wsklogs
 registry_storage_dir: "/"

--- a/ansible/environments/docker-machine/group_vars/all
+++ b/ansible/environments/docker-machine/group_vars/all
@@ -1,12 +1,13 @@
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements; and to You under the Apache License, Version 2.0.
 
-whisk_version_name: mac
 config_root_dir: /Users/Shared/wskconf
 whisk_logs_dir: /Users/Shared/wsklogs
 docker_registry: ""
 docker_dns: ""
 runtimes_bypass_pull_for_local_images: true
+
+environment_type: "docker-machine"
 
 env_hosts_dir: "{{ playbook_dir }}/environments/docker-machine"
 

--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -1,7 +1,6 @@
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements; and to You under the Apache License, Version 2.0.
 
-whisk_version_name: local
 openwhisk_tmp_dir: "{{ lookup('env', 'OPENWHISK_TMP_DIR')|default('/tmp', true) }}"
 config_root_dir: "{{ openwhisk_tmp_dir }}/wskconf"
 whisk_logs_dir: "{{ openwhisk_tmp_dir }}/wsklogs"

--- a/ansible/environments/vagrant/group_vars/all
+++ b/ansible/environments/vagrant/group_vars/all
@@ -9,8 +9,6 @@ docker_dns: ""
 runtimes_bypass_pull_for_local_images: true
 invoker_use_runc: "{{ ansible_distribution != 'MacOSX' }}"
 
-environment_type: "distributed"
-
 db_prefix: whisk_local_
 
 # Auto lookup to find the db credentials

--- a/ansible/environments/vagrant/group_vars/all
+++ b/ansible/environments/vagrant/group_vars/all
@@ -1,7 +1,6 @@
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements; and to You under the Apache License, Version 2.0.
 
-whisk_version_name: local
 openwhisk_tmp_dir: "{{ lookup('env', 'OPENWHISK_TMP_DIR')|default('/tmp', true) }}"
 config_root_dir: "{{ openwhisk_tmp_dir }}/wskconf"
 whisk_logs_dir: "{{ openwhisk_tmp_dir }}/wsklogs"
@@ -9,6 +8,8 @@ docker_registry: ""
 docker_dns: ""
 runtimes_bypass_pull_for_local_images: true
 invoker_use_runc: "{{ ansible_distribution != 'MacOSX' }}"
+
+environment_type: "distributed"
 
 db_prefix: whisk_local_
 

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -22,7 +22,14 @@ exclude_logs_from: []
 #   whisk_api_localhost_name_default (last)
 whisk_api_localhost_name_default: "localhost"
 
-hosts_dir: "{{ inventory_dir | default(env_hosts_dir) }}"
+# Type of your environment.
+# If you want to deploy everything on your local machine use 'local'.
+# If you use a docker-machine on a mac use 'docker-machine'
+# If you want to deploy Openwhisk to other machines use 'distributed'
+environmentInformation:
+  type: "{{ environment_type | default('local') }}"
+
+hosts_dir: "{{ inventory_dir | default(env_hosts_dir) }}"
 
 whisk:
   version:

--- a/ansible/logs.yml
+++ b/ansible/logs.yml
@@ -44,7 +44,7 @@
   - name: set host flag when using docker remote API
     set_fact:
       docker_host_flag: "--host tcp://{{ ansible_host }}:{{ docker.port }}"
-    when: whisk_version_name != "local"
+    when: environmentInformation.type != "local"
   - name: get all docker containers
     local_action: shell docker {{ docker_host_flag }} ps -a --format="{% raw %}{{.Names}}{% endraw %}"
     register: container_names

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -124,8 +124,8 @@
       "COMPONENT_NAME": "{{ controller_name }}"
       "PORT": 8080
 
-      "CONFIG_whisk_build_information_date": "{{ whisk.version.date }}"
-      "CONFIG_whisk_build_information_buildNo": "{{ docker.image.tag }}"
+      "CONFIG_whisk_info_date": "{{ whisk.version.date }}"
+      "CONFIG_whisk_info_buildNo": "{{ docker.image.tag }}"
 
       "KAFKA_HOSTS": "{{ kafka_connect_string }}"
       "CONFIG_whisk_kafka_replicationFactor":

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -124,9 +124,8 @@
       "COMPONENT_NAME": "{{ controller_name }}"
       "PORT": 8080
 
-      "WHISK_VERSION_NAME": "{{ whisk_version_name }}"
-      "WHISK_VERSION_DATE": "{{ whisk.version.date }}"
-      "WHISK_VERSION_BUILDNO": "{{ docker.image.tag }}"
+      "CONFIG_whisk_build_information_date": "{{ whisk.version.date }}"
+      "CONFIG_whisk_build_information_buildNo": "{{ docker.image.tag }}"
 
       "KAFKA_HOSTS": "{{ kafka_connect_string }}"
       "CONFIG_whisk_kafka_replicationFactor":

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -41,22 +41,22 @@
 - name: "determine docker root dir on docker-machine"
   uri:  url="http://{{ ansible_host }}:{{ docker.port }}/info" return_content=yes
   register: dockerInfo_output
-  when: whisk_version_name == "mac"
+  when: environmentInformation.type == 'docker-machine'
 
 - set_fact:
     dockerInfo: "{{ dockerInfo_output['json'] }}"
-  when: whisk_version_name == "mac"
+  when: environmentInformation.type == "docker-machine"
 
 - name: "determine docker root dir"
   shell: echo -e "GET http:/v1.24/info HTTP/1.0\r\n" | nc -U /var/run/docker.sock | grep "{"
   args:
     executable: /bin/bash
   register: dockerInfo_output
-  when: whisk_version_name != "mac"
+  when: environmentInformation.type != "docker-machine"
 
 - set_fact:
     dockerInfo: "{{ dockerInfo_output.stdout|from_json }}"
-  when: whisk_version_name != "mac"
+  when: environmentInformation.type != "docker-machine"
 
 - name: ensure invoker log directory is created with permissions
   file:
@@ -89,11 +89,11 @@
 - name: get running invoker information
   uri: url="http://{{ ansible_host }}:{{ docker.port }}/containers/json?filters={{ '{"name":[ "invoker" ],"ancestor":[ "invoker" ]}' | urlencode }}" return_content=yes
   register: invokerInfo_output
-  when: whisk_version_name == "mac"
+  when: environmentInformation.type == "docker-machine"
 
 - set_fact:
     invokerInfo: "{{ invokerInfo_output['json'] }}"
-  when: whisk_version_name == "mac"
+  when: environmentInformation.type == "docker-machine"
 
 - name: "get invoker info"
   shell: |
@@ -106,11 +106,11 @@
   args:
     executable: /bin/bash
   register: invokerInfo_output
-  when: whisk_version_name != "mac"
+  when: environmentInformation.type != "docker-machine"
 
 - set_fact:
     invokerInfo: "{{ invokerInfo_output.stdout|from_json }}"
-  when: whisk_version_name != "mac"
+  when: environmentInformation.type != "docker-machine"
 
 - name: determine if more than one invoker is running
   fail:

--- a/ansible/templates/whisk.properties.j2
+++ b/ansible/templates/whisk.properties.j2
@@ -7,7 +7,7 @@ testing.auth={{ openwhisk_home }}/ansible/files/auth.guest
 vcap.services.file=
 
 whisk.logs.dir={{ whisk_logs_dir }}
-whisk.version.name={{ whisk_version_name }}
+environment.type={{ environmentInformation.type }}
 whisk.ssl.client.verification={{ nginx.ssl.verify_client }}
 whisk.ssl.cert={{ nginx.ssl.path }}/{{ nginx.ssl.cert }}
 whisk.ssl.key={{ nginx.ssl.path }}/{{ nginx.ssl.key }}

--- a/ansible/templates/whisk.properties.j2
+++ b/ansible/templates/whisk.properties.j2
@@ -8,8 +8,6 @@ vcap.services.file=
 
 whisk.logs.dir={{ whisk_logs_dir }}
 whisk.version.name={{ whisk_version_name }}
-whisk.version.date={{ whisk.version.date }}
-whisk.version.buildno={{ docker.image.tag }}
 whisk.ssl.client.verification={{ nginx.ssl.verify_client }}
 whisk.ssl.cert={{ nginx.ssl.path }}/{{ nginx.ssl.cert }}
 whisk.ssl.key={{ nginx.ssl.path }}/{{ nginx.ssl.key }}

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -197,7 +197,7 @@ object WhiskConfig {
 object ConfigKeys {
   val cluster = "whisk.cluster"
   val loadbalancer = "whisk.loadbalancer"
-  val buildInformation = "whisk.build.information"
+  val buildInformation = "whisk.info"
 
   val couchdb = "whisk.couchdb"
   val kafka = "whisk.kafka"

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -154,10 +154,6 @@ object WhiskConfig {
   // in the invoker (they are part of the environment
   // passed to the user container)
   val edgeHostName = "edge.host"
-  val whiskVersionDate = "whisk.version.date"
-  val whiskVersionBuildno = "whisk.version.buildno"
-
-  val whiskVersion = Map(whiskVersionDate -> null, whiskVersionBuildno -> null)
 
   val invokerName = "invoker.name"
 
@@ -201,6 +197,7 @@ object WhiskConfig {
 object ConfigKeys {
   val cluster = "whisk.cluster"
   val loadbalancer = "whisk.loadbalancer"
+  val buildInformation = "whisk.build.information"
 
   val couchdb = "whisk.couchdb"
   val kafka = "whisk.kafka"

--- a/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
@@ -17,37 +17,29 @@
 
 package whisk.core.controller
 
-import scala.concurrent.ExecutionContext
-
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
-
 import akka.actor.ActorSystem
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.Uri
-import akka.http.scaladsl.server.Directives
-import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.model.headers._
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.server.{Directives, Route}
 import akka.stream.ActorMaterializer
-
-import spray.json._
+import pureconfig.loadConfigOrThrow
 import spray.json.DefaultJsonProtocol._
-import whisk.core.database.CacheChangeNotification
-import whisk.core.WhiskConfig
-import whisk.core.WhiskConfig.whiskVersionBuildno
-import whisk.core.WhiskConfig.whiskVersionDate
-import whisk.common.Logging
-import whisk.common.TransactionId
+import spray.json._
+import whisk.common.{Logging, TransactionId}
 import whisk.core.containerpool.logging.LogStore
+import whisk.core.database.CacheChangeNotification
 import whisk.core.entitlement._
-import whisk.core.entity._
 import whisk.core.entity.ActivationId.ActivationIdGenerator
-import whisk.core.entity.WhiskAuthStore
+import whisk.core.entity._
 import whisk.core.entity.types._
 import whisk.core.loadBalancer.LoadBalancer
+import whisk.core.{ConfigKeys, WhiskConfig}
 import whisk.http.Messages
+
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success, Try}
 
 /**
  * Abstract class which provides basic Directives which are used to construct route structures
@@ -86,14 +78,12 @@ protected[controller] class SwaggerDocs(apipath: Uri.Path, doc: String)(implicit
 protected[controller] object RestApiCommons {
   def requiredProperties =
     Map(WhiskConfig.servicePort -> 8080.toString) ++
-      WhiskConfig.whiskVersion ++
       EntitlementProvider.requiredProperties ++
       WhiskActionsApi.requiredProperties
 
   import akka.http.scaladsl.model.HttpCharsets
   import akka.http.scaladsl.model.MediaTypes.`application/json`
-  import akka.http.scaladsl.unmarshalling.FromEntityUnmarshaller
-  import akka.http.scaladsl.unmarshalling.Unmarshaller
+  import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshaller}
 
   /**
    * Extract an empty entity into a JSON object. This is useful for the
@@ -162,6 +152,8 @@ protected[controller] trait RespondWithHeaders extends Directives {
   val sendCorsHeaders = respondWithHeaders(allowOrigin, allowHeaders)
 }
 
+case class WhiskBuildInformation(buildNo: String, date: String)
+
 class RestAPIVersion(config: WhiskConfig, apiPath: String, apiVersion: String)(
   implicit val activeAckTopicIndex: InstanceId,
   implicit val actorSystem: ActorSystem,
@@ -181,6 +173,7 @@ class RestAPIVersion(config: WhiskConfig, apiPath: String, apiVersion: String)(
     with RespondWithHeaders {
   implicit val executionContext = actorSystem.dispatcher
   implicit val authStore = WhiskAuthStore.datastore()
+  val buildInformation = loadConfigOrThrow[WhiskBuildInformation](ConfigKeys.buildInformation)
 
   def prefix = pathPrefix(apiPath / apiVersion)
 
@@ -193,8 +186,8 @@ class RestAPIVersion(config: WhiskConfig, apiPath: String, apiVersion: String)(
         "description" -> "OpenWhisk API".toJson,
         "api_version" -> SemVer(1, 0, 0).toJson,
         "api_version_path" -> apiVersion.toJson,
-        "build" -> whiskConfig(whiskVersionDate).toJson,
-        "buildno" -> whiskConfig(whiskVersionBuildno).toJson,
+        "build" -> buildInformation.date.toJson,
+        "buildno" -> buildInformation.buildNo.toJson,
         "swagger_paths" -> JsObject("ui" -> s"/$swaggeruipath".toJson, "api-docs" -> s"/$swaggerdocpath".toJson)))
   }
 

--- a/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
@@ -152,7 +152,7 @@ protected[controller] trait RespondWithHeaders extends Directives {
   val sendCorsHeaders = respondWithHeaders(allowOrigin, allowHeaders)
 }
 
-case class WhiskBuildInformation(buildNo: String, date: String)
+case class WhiskInformation(buildNo: String, date: String)
 
 class RestAPIVersion(config: WhiskConfig, apiPath: String, apiVersion: String)(
   implicit val activeAckTopicIndex: InstanceId,
@@ -173,7 +173,7 @@ class RestAPIVersion(config: WhiskConfig, apiPath: String, apiVersion: String)(
     with RespondWithHeaders {
   implicit val executionContext = actorSystem.dispatcher
   implicit val authStore = WhiskAuthStore.datastore()
-  val buildInformation = loadConfigOrThrow[WhiskBuildInformation](ConfigKeys.buildInformation)
+  val whiskInfo = loadConfigOrThrow[WhiskInformation](ConfigKeys.buildInformation)
 
   def prefix = pathPrefix(apiPath / apiVersion)
 
@@ -186,8 +186,8 @@ class RestAPIVersion(config: WhiskConfig, apiPath: String, apiVersion: String)(
         "description" -> "OpenWhisk API".toJson,
         "api_version" -> SemVer(1, 0, 0).toJson,
         "api_version_path" -> apiVersion.toJson,
-        "build" -> buildInformation.date.toJson,
-        "buildno" -> buildInformation.buildNo.toJson,
+        "build" -> whiskInfo.date.toJson,
+        "buildno" -> whiskInfo.buildNo.toJson,
         "swagger_paths" -> JsObject("ui" -> s"/$swaggeruipath".toJson, "api-docs" -> s"/$swaggerdocpath".toJson)))
   }
 

--- a/tests/src/test/resources/application.conf.j2
+++ b/tests/src/test/resources/application.conf.j2
@@ -10,10 +10,6 @@ akka.http.host-connection-pool.idle-timeout = 90 s
 akka.http.host-connection-pool.client.idle-timeout = 90 s
 
 whisk {
-    version {
-        date = "{{ whisk.version.date }}"
-        version-no = "{{ docker.image.tag }}"
-    }
     # kafka related configuration
     kafka {
         replication-factor = 1

--- a/tests/src/test/resources/application.conf.j2
+++ b/tests/src/test/resources/application.conf.j2
@@ -10,6 +10,10 @@ akka.http.host-connection-pool.idle-timeout = 90 s
 akka.http.host-connection-pool.client.idle-timeout = 90 s
 
 whisk {
+    version {
+        date = "{{ whisk.version.date }}"
+        version-no = "{{ docker.image.tag }}"
+    }
     # kafka related configuration
     kafka {
         replication-factor = 1

--- a/tests/src/test/scala/actionContainers/ActionContainer.scala
+++ b/tests/src/test/scala/actionContainers/ActionContainer.scala
@@ -117,7 +117,7 @@ object ActionContainer {
         .orElse(sys.env.get("DOCKER_HOST"))
         .orElse {
           // Check if we are running on docker-machine env.
-          Option(WhiskProperties.getProperty("whisk.version.name")).filter(_.toLowerCase.contains("mac")).map {
+          Option(WhiskProperties.getProperty("environment.type")).filter(_.toLowerCase.contains("docker-machine")).map {
             case _ => s"tcp://${WhiskProperties.getMainDockerEndpoint}"
           }
         }


### PR DESCRIPTION
## Description

This PR moves the version information to pureconfig. In addition, it removes the deployment variable `whisk_version_name` as it is only used to determine which type of deployment it is.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [X] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

