### PR TITLE
Remove Eclipse license header and IBM copyright from a test file

### DIFF
--- a/tests/src/test/scala/common/Pair.java
+++ b/tests/src/test/scala/common/Pair.java
@@ -15,16 +15,6 @@
  * limitations under the License.
  */
 
-/*******************************************************************************
- * Copyright (c) 2002 - 2006 IBM Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
- *******************************************************************************/
 package common;
 
 import java.util.Iterator;


### PR DESCRIPTION
Remove Eclipse license header and IBM copyright from a test file `tests/src/test/scala/common/Pair.java`