### PR TITLE
remove unused imports or dead variables as reported in travis build.

### DIFF
--- a/actionRuntimes/actionProxy/invoke.py
+++ b/actionRuntimes/actionProxy/invoke.py
@@ -36,7 +36,6 @@ import json
 import base64
 import requests
 import codecs
-import traceback
 import argparse
 try:
     import argcomplete

--- a/performance/gatling_tests/src/gatling/resources/data/pythonAction.py
+++ b/performance/gatling_tests/src/gatling/resources/data/pythonAction.py
@@ -1,7 +1,6 @@
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements; and to You under the Apache License, Version 2.0.imitations under the License.
 
-import sys
 def main(dict):
     if 'text' in dict:
         text = dict['text']

--- a/tests/dat/actions/sleep.py
+++ b/tests/dat/actions/sleep.py
@@ -9,7 +9,6 @@
 # @param parm Object with Number property sleepTimeInMs
 # @returns Object with String property msg describing how long the function slept
 #
-import sys
 import time
 
 def main(parm):

--- a/tools/admin/wskadmin
+++ b/tools/admin/wskadmin
@@ -531,7 +531,6 @@ def setLimitsCmd(args, props):
         return 1
 
 def getLimitsCmd(args, props):
-    argsDict = vars(args)
     docId = args.namespace + "/limits"
     (dbDoc, res) = getDocumentFromDb(props, quote_plus(docId), args.verbose)
 
@@ -550,7 +549,6 @@ def getLimitsCmd(args, props):
         return 1
 
 def deleteLimitsCmd(args, props):
-    argsDict = vars(args)
     docId = quote_plus(args.namespace + "/limits")
     (dbDoc, res) = getDocumentFromDb(props, docId, args.verbose)
 


### PR DESCRIPTION
I noticed in travis builds there are several python related warnings from the flake8 - so I removed them.

```
/tests/dat/actions/sleep.py:12:1: F401 'sys' imported but unused
./performance/gatling_tests/src/gatling/resources/data/pythonAction.py:4:1: F401 'sys' imported but unused
./actionRuntimes/actionProxy/invoke.py:39:1: F401 'traceback' imported but unused
3     F401 'traceback' imported but unused
./tools/admin/wskadmin:534:5: F841 local variable 'argsDict' is assigned to but never used
./tools/admin/wskadmin:553:5: F841 local variable 'argsDict' is assigned to but never used
2     F841 local variable 'argsDict' is assigned to but never used
```


## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Enhancement or new feature (adds new functionality).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

