### PR TITLE
Fix README.md's scanCode issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The easiest way to start using OpenWhisk is to get Docker installed on on Mac, W
 
 ```
 git clone https://github.com/apache/incubator-openwhisk-devtools.git
-cd docker-compose 
+cd docker-compose
 make quick-start
 ```
 


### PR DESCRIPTION
`master` is broken due to trailing whitespace.

@mrutkows did scanCode's config change without updating the main repo?