### PR TITLE
update swift runtime to workaround "struct" bug, issue 3646

### DIFF
--- a/actionRuntimes/swift4.1Action/Dockerfile
+++ b/actionRuntimes/swift4.1Action/Dockerfile
@@ -1,1 +1,1 @@
-FROM openwhisk/action-swift-v4.1:1.0.4
+FROM openwhisk/action-swift-v4.1:1.0.5


### PR DESCRIPTION
This PR is to address issue https://github.com/apache/incubator-openwhisk/issues/3646

That issue describes how there is a current bug in the Docker Swift image for 4.1 that causes a compiler failure when a certain condition is met around using structs. 

The fix temporarily is to add a compiler flag to disable compile optimizations until it is fixed within the Swift Docker image. 

The PR https://github.com/apache/incubator-openwhisk-runtime-swift/pull/59 addressed that. 
This PR is to bring those changes into the Openwhisk environment. 