### PR TITLE
switching vagrant to use cli remote mode

### DIFF
--- a/ansible/environments/vagrant/group_vars/all
+++ b/ansible/environments/vagrant/group_vars/all
@@ -37,6 +37,6 @@ env_hosts_dir: "{{ playbook_dir }}/environments/local"
 
 controller_protocol: "http"
 
-cli_installation_mode: "local"
+cli_installation_mode: "remote"
 
 invoker_use_runc: false

--- a/tools/vagrant/Vagrantfile
+++ b/tools/vagrant/Vagrantfile
@@ -144,15 +144,6 @@ Vagrant.configure('2') do |config|
     su vagrant -c './gradlew distDocker'
     echo "`date`: build-core-end" >> /tmp/vagrant-times.txt
 
-    # Clone and Build CLI
-    echo "`date`: build-cli-start" >> /tmp/vagrant-times.txt
-    cd ${OPENWHISK_HOME}/bin
-    rm -rf openwhisk-cli
-    su vagrant -c 'git clone --depth=1 https://github.com/apache/incubator-openwhisk-cli.git openwhisk-cli'
-    cd openwhisk-cli
-    su vagrant -c './gradlew releaseBinaries'
-    echo "`date`: build-cli-end" >> /tmp/vagrant-times.txt
-
     # Deploy OpenWhisk using ansible
     echo "`date`: deploy-start" >> /tmp/vagrant-times.txt
     cd ${ANSIBLE_HOME}


### PR DESCRIPTION
On windows using vagrant can't create soft links to the windows filesystem.
Making deployment use remote CLI download
Closes #3649 
## Description
## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#3649)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

