### PR TITLE
Adjust the behavior when update controller cluster

### DIFF
--- a/core/controller/src/main/scala/whisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
@@ -604,7 +604,7 @@ case class ShardingContainerPoolBalancerState(
         totalInvokerThreshold / actualSize
       }
       currentInvokerThreshold = newTreshold
-      _invokerSlots = _invokerSlots.map(_ => new ForcibleSemaphore(currentInvokerThreshold.toMB.toInt))
+      _invokerSlots.foreach(_.setMaxPermits(currentInvokerThreshold.toMB.toInt))
 
       logging.info(
         this,

--- a/tests/src/test/scala/whisk/common/ForcibleSemaphoreTests.scala
+++ b/tests/src/test/scala/whisk/common/ForcibleSemaphoreTests.scala
@@ -85,4 +85,18 @@ class ForcibleSemaphoreTests extends FlatSpec with Matchers {
       acquires should contain theSameElementsAs result
     }
   }
+
+  it should "set the max allowed permits dynamically" in {
+    val s = new ForcibleSemaphore(10)
+    s.tryAcquire(2) shouldBe true // 8 permits left
+
+    s.setMaxPermits(5) // reduce max permits
+    s.availablePermits shouldBe 3
+
+    s.setMaxPermits(10) // increase max permits
+    s.availablePermits shouldBe 8
+
+    s.setMaxPermits(10) // nothing changed
+    s.availablePermits shouldBe 8
+  }
 }

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
@@ -127,7 +127,8 @@ class ShardingContainerPoolBalancerTests extends FlatSpec with Matchers with Str
     state.invokerSlots.head.availablePermits shouldBe (memory - memoryPerSlot).toMB
 
     state.updateCluster(2)
-    state.invokerSlots.head.availablePermits shouldBe memory.toMB / 2 // state reset + divided by 2
+    // state reset + divided by 2 and minus the already acquired shared
+    state.invokerSlots.head.availablePermits shouldBe memory.toMB / 2 - memoryPerSlot.toMB.toInt
   }
 
   it should "fallback to a size of 1 (alone) if cluster size is < 1" in {


### PR DESCRIPTION
Set the max permits for each invokerSlot instead of creating new ForcibleSemaphore. New ForcibleSemaphore will ignore acquired permits, so after these permits are released, the max permits of invokerSlot will exceed the `currentInvokerThreshold`, which is not what we want



## Description
in some case, the `availablePermits` may exceed the  `currentInvokerThreshold`, which may cause some invokers take more invoking requests than the number they can handle and other invokers are still idle

## Related issue and scope
- [x] I opened an issue to propose and discuss this change (#3655)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [x] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

