### PR TITLE
Restrict allowed namespaces when creating action of certain kinds

### DIFF
--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -206,12 +206,13 @@ object ConfigKeys {
   val userEvents = "whisk.user-events"
 
   val runtimes = "whisk.runtimes"
+  val runtimesWhitelists = s"$runtimes.whitelists"
 
   val db = "whisk.db"
 
   val docker = "whisk.docker"
   val dockerClient = s"$docker.client"
-  val dockerContainerFactory = s"${docker}.container-factory"
+  val dockerContainerFactory = s"$docker.container-factory"
   val runc = "whisk.runc"
   val runcTimeouts = s"$runc.timeouts"
 

--- a/common/scala/src/main/scala/whisk/core/entity/Identity.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Identity.scala
@@ -31,10 +31,11 @@ import whisk.core.entitlement.Privilege
 
 case class UserLimits(invocationsPerMinute: Option[Int] = None,
                       concurrentInvocations: Option[Int] = None,
-                      firesPerMinute: Option[Int] = None)
+                      firesPerMinute: Option[Int] = None,
+                      allowedKinds: Option[Set[String]] = None)
 
 object UserLimits extends DefaultJsonProtocol {
-  implicit val serdes = jsonFormat3(UserLimits.apply)
+  implicit val serdes = jsonFormat4(UserLimits.apply)
 }
 
 protected[core] case class Namespace(name: EntityName, uuid: UUID)

--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -81,6 +81,8 @@ object Messages {
   val notAuthorizedtoOperateOnResource = "The supplied authentication is not authorized to access this resource."
   def notAuthorizedtoAccessResource(value: String) =
     s"The supplied authentication is not authorized to access '$value'."
+  def notAuthorizedtoActionKind(value: String) =
+    s"The supplied authentication is not authorized to access actions of kind '$value'."
 
   /** Standard error message for malformed fully qualified entity names. */
   val malformedFullyQualifiedEntityName =

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -204,12 +204,12 @@ protected[core] abstract class EntitlementProvider(
   private val kindRestrictor = new KindRestrictor()
 
   /**
-    * Checks if an action's kind is restricted for a given subject
-    *
-    * @param user    the identity to check for restrictions
-    * @param exec    the action's executable details
-    * @return a promise that completes with success iff the user's action kind is not restricted
-    */
+   * Checks if an action's kind is restricted for a given subject
+   *
+   * @param user    the identity to check for restrictions
+   * @param exec    the action's executable details
+   * @return a promise that completes with success iff the user's action kind is not restricted
+   */
   protected[core] def check(user: Identity, exec: Option[Exec])(implicit transid: TransactionId): Future[Unit] = {
     exec
       .map {

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -47,18 +47,21 @@ package object types {
  * Resource is a type that encapsulates details relevant to identify a specific resource.
  * It may be an entire collection, or an element in a collection.
  *
- * @param namespace the namespace the resource resides in
+ * @param namespace  the namespace the resource resides in
  * @param collection the collection (e.g., actions, triggers) identifying a resource
- * @param entity an optional entity name that identifies a specific item in the collection
- * @param env an optional environment to bind to the resource during an activation
+ * @param entity     an optional entity name that identifies a specific item in the collection
+ * @param env        an optional environment to bind to the resource during an activation
  */
 protected[core] case class Resource(namespace: EntityPath,
                                     collection: Collection,
                                     entity: Option[String],
                                     env: Option[Parameters] = None) {
   def parent: String = collection.path + EntityPath.PATHSEP + namespace
+
   def id: String = parent + entity.map(EntityPath.PATHSEP + _).getOrElse("")
+
   def fqname: String = namespace.asString + entity.map(EntityPath.PATHSEP + _).getOrElse("")
+
   override def toString: String = id
 }
 
@@ -92,13 +95,14 @@ protected[core] abstract class EntitlementProvider(
    * controllers
    */
   private def overcommit(clusterSize: Int) = if (clusterSize > 1) 1.2 else 1
+
   private def dilateLimit(limit: Int): Int = Math.ceil(limit.toDouble * overcommit(loadBalancer.clusterSize)).toInt
 
   /**
    * Calculates a possibly dilated limit relative to the current user.
    *
    * @param defaultLimit the default limit across the whole system
-   * @param user the user to apply that limit to
+   * @param user         the user to apply that limit to
    * @return a calculated limit
    */
   private def calculateLimit(defaultLimit: Int, overrideLimit: Identity => Option[Int])(user: Identity): Int = {
@@ -113,7 +117,7 @@ protected[core] abstract class EntitlementProvider(
    * limit, so it needs to be divided between the parties who want to perform that check.
    *
    * @param defaultLimit the default limit across the whole system
-   * @param user the user to apply that limit to
+   * @param user         the user to apply that limit to
    * @return a calculated limit
    */
   private def calculateIndividualLimit(defaultLimit: Int, overrideLimit: Identity => Option[Int])(
@@ -154,8 +158,8 @@ protected[core] abstract class EntitlementProvider(
   /**
    * Grants a subject the right to access a resources.
    *
-   * @param subject the subject to grant right to
-   * @param right the privilege to grant the subject
+   * @param user     the subject to grant right to
+   * @param right    the privilege to grant the subject
    * @param resource the resource to grant the subject access to
    * @return a promise that completes with true iff the subject is granted the right to access the requested resource
    */
@@ -165,8 +169,8 @@ protected[core] abstract class EntitlementProvider(
   /**
    * Revokes a subject the right to access a resources.
    *
-   * @param subject the subject to revoke right to
-   * @param right the privilege to revoke the subject
+   * @param user     the subject to revoke right to
+   * @param right    the privilege to revoke the subject
    * @param resource the resource to revoke the subject access to
    * @return a promise that completes with true iff the subject is revoked the right to access the requested resource
    */
@@ -176,8 +180,8 @@ protected[core] abstract class EntitlementProvider(
   /**
    * Checks if a subject is entitled to a resource because it was granted the right explicitly.
    *
-   * @param subject the subject to check rights for
-   * @param right the privilege the subject is requesting
+   * @param user     the subject to check rights for
+   * @param right    the privilege the subject is requesting
    * @param resource the resource the subject requests access to
    * @return a promise that completes with true iff the subject is permitted to access the request resource
    */
@@ -197,6 +201,29 @@ protected[core] abstract class EntitlementProvider(
       .flatMap(_ => checkThrottleOverload(concurrentInvokeThrottler.check(user), user))
   }
 
+  private val kindRestrictor = new KindRestrictor()
+
+  /**
+    * Checks if an action's kind is restricted for a given subject
+    *
+    * @param user    the identity to check for restrictions
+    * @param exec    the action's executable details
+    * @return a promise that completes with success iff the user's action kind is not restricted
+    */
+  protected[core] def check(user: Identity, exec: Option[Exec])(implicit transid: TransactionId): Future[Unit] = {
+    exec
+      .map {
+        case e =>
+          if (kindRestrictor.check(user, e.kind)) {
+            Future.successful(())
+          } else {
+            Future.failed(
+              RejectRequest(Forbidden, Some(ErrorResponse(Messages.notAuthorizedtoActionKind(e.kind), transid))))
+          }
+      }
+      .getOrElse(Future.successful(()))
+  }
+
   /**
    * Checks if a subject has the right to access a specific resource. The entitlement may be implicit,
    * that is, inferred based on namespaces that a subject belongs to and the namespace of the
@@ -208,8 +235,8 @@ protected[core] abstract class EntitlementProvider(
    * implicitly or explicitly granted. Instead, resolve the package binding first and use the alternate
    * method which authorizes a set of resources.
    *
-   * @param user the subject to check rights for
-   * @param right the privilege the subject is requesting (applies to the entire set of resources)
+   * @param user     the subject to check rights for
+   * @param right    the privilege the subject is requesting (applies to the entire set of resources)
    * @param resource the resource the subject requests access to
    * @return a promise that completes with success iff the subject is permitted to access the requested resource
    */
@@ -237,9 +264,9 @@ protected[core] abstract class EntitlementProvider(
    * resource for example, or explicit. The implicit check is computed here. The explicit check
    * is delegated to the service implementing this interface.
    *
-   * @param user the subject identity to check rights for
-   * @param right the privilege the subject is requesting (applies to the entire set of resources)
-   * @param resources the set of resources the subject requests access to
+   * @param user       the subject identity to check rights for
+   * @param right      the privilege the subject is requesting (applies to the entire set of resources)
+   * @param resources  the set of resources the subject requests access to
    * @param noThrottle ignore throttle limits
    * @return a promise that completes with success iff the subject is permitted to access all of the requested resources
    */
@@ -312,8 +339,8 @@ protected[core] abstract class EntitlementProvider(
    * While it is possible for the set of resources to contain more than one action or trigger, the plurality is ignored and treated
    * as one activation since these should originate from a single macro resources (e.g., a sequence).
    *
-   * @param user the subject identity to check rights for
-   * @param right the privilege, if ACTIVATE then check quota else return None
+   * @param user      the subject identity to check rights for
+   * @param right     the privilege, if ACTIVATE then check quota else return None
    * @param resources the set of resources must contain at least one resource that can be activated else return None
    * @return future completing successfully if user is below limits else failing with a rejection
    */
@@ -334,8 +361,8 @@ protected[core] abstract class EntitlementProvider(
    * While it is possible for the set of resources to contain more than one action, the plurality is ignored and treated
    * as one activation since these should originate from a single macro resources (e.g., a sequence).
    *
-   * @param user the subject identity to check rights for
-   * @param right the privilege, if ACTIVATE then check quota else return None
+   * @param user      the subject identity to check rights for
+   * @param right     the privilege, if ACTIVATE then check quota else return None
    * @param resources the set of resources must contain at least one resource that can be activated else return None
    * @return future completing successfully if user is below limits else failing with a rejection
    */

--- a/core/controller/src/main/scala/whisk/core/entitlement/KindRestrictor.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/KindRestrictor.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.entitlement
+
+import pureconfig.loadConfigOrThrow
+import whisk.common.{Logging, TransactionId}
+import whisk.core.ConfigKeys
+import whisk.core.entity.Identity
+
+/**
+ * @param whitelist set of default allowed kinds when not explicitly available via namespace limits.
+ */
+protected[core] case class AllowedKinds(whitelist: Option[Set[String]] = None) {
+  override def toString = {
+    whitelist
+      .map {
+        case list if list.nonEmpty => s"white-listed kinds: ${list.mkString(", ")}"
+        case _                     => "no kinds are allowed, the white-list is empty"
+      }
+      .getOrElse("all kinds are allowed, the white-list is not specified")
+  }
+}
+
+/**
+ * The runtimes manifest specifies all runtimes enabled for the deployment.
+ * Not all runtimes are available for all subject however.
+ *
+ * A subject is entitled to a runtime (kind) if:
+ * 1. they are explicitly granted rights to it in their identity record, or
+ * 2. the runtime kind is whitelisted
+ *
+ * If a white list is not specified (i.e., whitelist == None), then all runtimes are allowed.
+ * In other words, no whitelist is the same as setting the white list to all allowed runtimes.
+ */
+class KindRestrictor(allowedKinds: AllowedKinds = loadConfigOrThrow[AllowedKinds](ConfigKeys.runtimes))(
+  implicit logging: Logging) {
+
+  logging.info(this, allowedKinds.toString)(TransactionId.controller)
+
+  def check(user: Identity, kind: String): Boolean = {
+    user.limits.allowedKinds
+      .orElse(allowedKinds.whitelist)
+      .map(allowed => allowed.contains(kind))
+      .getOrElse(true)
+  }
+
+}

--- a/tests/src/test/scala/whisk/core/controller/test/EntitlementProviderTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/EntitlementProviderTests.scala
@@ -695,9 +695,12 @@ class EntitlementProviderTests extends ControllerTestCommon with ScalaFutures {
     implicit val ep = entitlementProvider
     val subject = WhiskAuthHelpers.newIdentity().copy(limits = UserLimits(allowedKinds = Some(allowedKinds)))
 
-    disallowedKinds.foreach(k =>
-      intercept[RejectRequest] {
+    disallowedKinds.foreach(k => {
+      val ex = intercept[RejectRequest] {
         Await.result(ep.check(subject, Some(getExec(k))), 1.seconds)
+      }
+      assert(ex
+        .toString() === s"RejectRequest(403 Forbidden) The supplied authentication is not authorized to access actions of kind '$k'.")
     })
   }
 

--- a/tests/src/test/scala/whisk/core/controller/test/EntitlementProviderTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/EntitlementProviderTests.scala
@@ -20,13 +20,10 @@ package whisk.core.controller.test
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
-
 import org.junit.runner.RunWith
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.junit.JUnitRunner
-
 import akka.http.scaladsl.model.StatusCodes._
-
 import whisk.core.controller.RejectRequest
 import whisk.core.entitlement._
 import whisk.core.entitlement.Privilege._
@@ -699,8 +696,9 @@ class EntitlementProviderTests extends ControllerTestCommon with ScalaFutures {
       val ex = intercept[RejectRequest] {
         Await.result(ep.check(subject, Some(getExec(k))), 1.seconds)
       }
-      assert(ex
-        .toString() === s"RejectRequest(403 Forbidden) The supplied authentication is not authorized to access actions of kind '$k'.")
+
+      ex.code shouldBe Forbidden
+      ex.message.get.error shouldBe Messages.notAuthorizedtoActionKind(k)
     })
   }
 

--- a/tests/src/test/scala/whisk/core/controller/test/KindRestrictorTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/KindRestrictorTests.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.controller.test
+
+import common.StreamLogging
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{FlatSpec, Matchers}
+import whisk.core.entitlement.{AllowedKinds, KindRestrictor}
+import whisk.core.entity._
+
+/**
+ * Tests authorization handler which guards resources.
+ *
+ * Unit tests of the controller service as a standalone component.
+ * These tests exercise a fresh instance of the service object in memory -- these
+ * tests do NOT communication with a whisk deployment.
+ *
+ * @Idioglossia
+ * "using Specification DSL to write unit tests, as in should, must, not, be"
+ */
+@RunWith(classOf[JUnitRunner])
+class KindRestrictorTests extends FlatSpec with Matchers with StreamLogging {
+
+  behavior of "Kind Restrictor"
+
+  val allowedKinds = Set("nodejs:6", "python")
+  val disallowedKinds = Set("golang", "blackbox")
+  val allKinds = allowedKinds ++ disallowedKinds
+
+  it should "grant subject access to all kinds when no limits exist and no white list is defined" in {
+    val subject = WhiskAuthHelpers.newIdentity()
+    val kr = new KindRestrictor()
+    allKinds.foreach(k => kr.check(subject, k) shouldBe true)
+  }
+
+  it should "not grant subject access to any kinds if limit is the empty set" in {
+    val subject = WhiskAuthHelpers.newIdentity().copy(limits = UserLimits(allowedKinds = Some(Set.empty)))
+    val kr = new KindRestrictor()
+    allKinds.foreach(k => kr.check(subject, k) shouldBe false)
+  }
+
+  it should "not grant subject access to any kinds if white list is the empty set" in {
+    val subject = WhiskAuthHelpers.newIdentity()
+    val kr = new KindRestrictor(AllowedKinds(whitelist = Some(Set.empty)))
+    allKinds.foreach(k => kr.check(subject, k) shouldBe false)
+  }
+
+  it should "grant subject access only to subject-limited kinds" in {
+    val subject = WhiskAuthHelpers.newIdentity().copy(limits = UserLimits(allowedKinds = Some(allowedKinds)))
+    val kr = new KindRestrictor()
+    allowedKinds.foreach(k => kr.check(subject, k) shouldBe true)
+    disallowedKinds.foreach(k => kr.check(subject, k) shouldBe false)
+  }
+
+  it should "grant subject access to white listed kinds when no limits exist" in {
+    val subject = WhiskAuthHelpers.newIdentity()
+    val kr = new KindRestrictor(AllowedKinds(whitelist = Some(allowedKinds)))
+    allowedKinds.foreach(k => kr.check(subject, k) shouldBe true)
+    disallowedKinds.foreach(k => kr.check(subject, k) shouldBe false)
+  }
+
+  it should "grant subject access only to explicitly limited kind" in {
+    val explicitKind = allowedKinds.head
+    val subject = WhiskAuthHelpers.newIdentity().copy(limits = UserLimits(allowedKinds = Some(Set(explicitKind))))
+    val kr = new KindRestrictor(AllowedKinds(whitelist = Some(allowedKinds.tail)))
+    allKinds.foreach(k => kr.check(subject, k) shouldBe (k == explicitKind))
+  }
+
+}

--- a/tests/src/test/scala/whisk/core/controller/test/KindRestrictorTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/KindRestrictorTests.scala
@@ -21,7 +21,7 @@ import common.StreamLogging
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{FlatSpec, Matchers}
-import whisk.core.entitlement.{AllowedKinds, KindRestrictor}
+import whisk.core.entitlement.KindRestrictor
 import whisk.core.entity._
 
 /**
@@ -45,32 +45,32 @@ class KindRestrictorTests extends FlatSpec with Matchers with StreamLogging {
 
   it should "grant subject access to all kinds when no limits exist and no white list is defined" in {
     val subject = WhiskAuthHelpers.newIdentity()
-    val kr = new KindRestrictor()
+    val kr = KindRestrictor()
     allKinds.foreach(k => kr.check(subject, k) shouldBe true)
   }
 
   it should "not grant subject access to any kinds if limit is the empty set" in {
     val subject = WhiskAuthHelpers.newIdentity().copy(limits = UserLimits(allowedKinds = Some(Set.empty)))
-    val kr = new KindRestrictor()
+    val kr = KindRestrictor()
     allKinds.foreach(k => kr.check(subject, k) shouldBe false)
   }
 
   it should "not grant subject access to any kinds if white list is the empty set" in {
     val subject = WhiskAuthHelpers.newIdentity()
-    val kr = new KindRestrictor(AllowedKinds(whitelist = Some(Set.empty)))
+    val kr = KindRestrictor(Set[String]())
     allKinds.foreach(k => kr.check(subject, k) shouldBe false)
   }
 
   it should "grant subject access only to subject-limited kinds" in {
     val subject = WhiskAuthHelpers.newIdentity().copy(limits = UserLimits(allowedKinds = Some(allowedKinds)))
-    val kr = new KindRestrictor()
+    val kr = KindRestrictor()
     allowedKinds.foreach(k => kr.check(subject, k) shouldBe true)
     disallowedKinds.foreach(k => kr.check(subject, k) shouldBe false)
   }
 
   it should "grant subject access to white listed kinds when no limits exist" in {
     val subject = WhiskAuthHelpers.newIdentity()
-    val kr = new KindRestrictor(AllowedKinds(whitelist = Some(allowedKinds)))
+    val kr = KindRestrictor(allowedKinds)
     allowedKinds.foreach(k => kr.check(subject, k) shouldBe true)
     disallowedKinds.foreach(k => kr.check(subject, k) shouldBe false)
   }
@@ -78,7 +78,7 @@ class KindRestrictorTests extends FlatSpec with Matchers with StreamLogging {
   it should "grant subject access only to explicitly limited kind" in {
     val explicitKind = allowedKinds.head
     val subject = WhiskAuthHelpers.newIdentity().copy(limits = UserLimits(allowedKinds = Some(Set(explicitKind))))
-    val kr = new KindRestrictor(AllowedKinds(whitelist = Some(allowedKinds.tail)))
+    val kr = KindRestrictor(allowedKinds.tail)
     allKinds.foreach(k => kr.check(subject, k) shouldBe (k == explicitKind))
   }
 


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
Currently, all kinds supported by the system are able to be created within any namespace to which a client has access. As new action kinds are added to the system, there is a need to restrict the creation of new actions to a particular _whitelist_ of accepted namespaces.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [X] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [X] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

