### PR TITLE
Allow for init to specify if artifact should be treated as binary 

### DIFF
--- a/actionRuntimes/actionProxy/invoke.py
+++ b/actionRuntimes/actionProxy/invoke.py
@@ -76,6 +76,7 @@ def parseArgs():
     subparsers = parser.add_subparsers(title='available commands', dest='cmd')
 
     initmenu = subparsers.add_parser('init', help='initialize container with src or zip/tgz file')
+    initmenu.add_argument('-b', '--binary', help='treat artifact as binary', action='store_true')
     initmenu.add_argument('main', nargs='?', default='main', help='name of the "main" entry method for the action')
     initmenu.add_argument('artifact', help='a source file or zip/tgz archive')
 
@@ -90,7 +91,7 @@ def init(args):
     main = args.main
     artifact = args.artifact
 
-    if artifact and (artifact.endswith('.zip') or artifact.endswith('tgz') or artifact.endswith('jar')):
+    if artifact and (args.binary or artifact.endswith('.zip') or artifact.endswith('tgz') or artifact.endswith('jar')):
         with open(artifact, 'rb') as fp:
             contents = fp.read()
         contents = base64.b64encode(contents)


### PR DESCRIPTION
## Description

The invoke.py script infers a binary init artifact based on the file extension but sometimes the binary has no extension or one that is not recognized by the script. Rather than make changes to the set of extensions, add a binary option to the init commands.

example use: `invoke.py init -b main.exe`

The presence of the flag overrides any extension that might be set otherwise.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [x] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

