### PR TITLE
Fixes asymmetry between reading and writing of ByteSize.

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/Size.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Size.scala
@@ -79,18 +79,23 @@ case class ByteSize(size: Long, unit: SizeUnits.Unit) extends Ordered[ByteSize] 
 }
 
 object ByteSize {
+  private val regex = """(?i)\s?(\d+)\s?(MB|KB|B|M|K)\s?""".r.pattern
+  protected[entity] val formatError = """Size Unit not supported. Only "B", "K[B]" and "M[B]" are supported."""
+
   def fromString(sizeString: String): ByteSize = {
-    val unitprefix = sizeString.takeRight(1).toUpperCase
-    val size = sizeString.dropRight(1).trim.toLong
+    val matcher = regex.matcher(sizeString)
+    if (matcher.matches()) {
+      val size = matcher.group(1).toInt
+      val unit = matcher.group(2).charAt(0).toUpper match {
+        case 'B' => SizeUnits.BYTE
+        case 'K' => SizeUnits.KB
+        case 'M' => SizeUnits.MB
+      }
 
-    val unit = unitprefix match {
-      case "B" => SizeUnits.BYTE
-      case "K" => SizeUnits.KB
-      case "M" => SizeUnits.MB
-      case _   => throw new IllegalArgumentException("""Size Unit not supported. Only "B", "K" and "M" are supported.""")
+      ByteSize(size, unit)
+    } else {
+      throw new IllegalArgumentException(formatError)
     }
-
-    ByteSize(size, unit)
   }
 }
 

--- a/tests/src/test/scala/whisk/core/entity/test/SizeTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/SizeTests.scala
@@ -119,24 +119,42 @@ class SizeTests extends FlatSpec with Matchers {
 
   // Create ObjectSize from String
   it should "create ObjectSize from String 3B" in {
-    val fromString = ByteSize.fromString("3B")
-    fromString equals (3 B)
+    ByteSize.fromString("3b") equals (3 B)
+    ByteSize.fromString("3B") equals (3 B)
+    ByteSize.fromString("3 b") equals (3 B)
+    ByteSize.fromString("3 B") equals (3 B)
   }
 
   it should "create ObjectSize from String 7K" in {
-    val fromString = ByteSize.fromString("7K")
-    fromString equals (7 KB)
+    ByteSize.fromString("7k") equals (7 KB)
+    ByteSize.fromString("7K") equals (7 KB)
+    ByteSize.fromString("7KB") equals (7 KB)
+    ByteSize.fromString("7kB") equals (7 KB)
+    ByteSize.fromString("7kb") equals (7 KB)
+    ByteSize.fromString("7 k") equals (7 KB)
+    ByteSize.fromString("7 K") equals (7 KB)
+    ByteSize.fromString("7 KB") equals (7 KB)
+    ByteSize.fromString("7 kB") equals (7 KB)
+    ByteSize.fromString("7 kb") equals (7 KB)
   }
 
   it should "create ObjectSize from String 120M" in {
-    val fromString = ByteSize.fromString("120M")
-    fromString equals (120 MB)
+    ByteSize.fromString("120m") equals (120 MB)
+    ByteSize.fromString("120M") equals (120 MB)
+    ByteSize.fromString("120MB") equals (120 MB)
+    ByteSize.fromString("120mB") equals (120 MB)
+    ByteSize.fromString("120mb") equals (120 MB)
+    ByteSize.fromString("120 m") equals (120 MB)
+    ByteSize.fromString("120 M") equals (120 MB)
+    ByteSize.fromString("120 MB") equals (120 MB)
+    ByteSize.fromString("120 mB") equals (120 MB)
+    ByteSize.fromString("120 mb") equals (120 MB)
   }
 
   it should "throw error on creating ObjectSize from String 120A" in {
     the[IllegalArgumentException] thrownBy {
       ByteSize.fromString("120A")
-    } should have message """Size Unit not supported. Only "B", "K" and "M" are supported."""
+    } should have message ByteSize.formatError
   }
 
   it should "throw error on creating ByteSize object with negative size" in {


### PR DESCRIPTION
Constructing a ByteSize form String will accept MB or M, KB or K (and is case insenstive).
This is to match the toString method which writes out the units as MB or KB (so that a serialized value can be parsed back to the identity).


<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [x] Controller

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

