### PR TITLE
Add retries in test around package list and enhance debugging inform…

### DIFF
--- a/tests/src/test/scala/whisk/core/cli/test/WskEntitlementTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskEntitlementTests.scala
@@ -153,13 +153,16 @@ abstract class WskEntitlementTests extends TestHelpers with WskTestHelpers with 
       pkg.create(samplePackage, shared = Some(true))(wp)
     }
 
-    val packageList = wsk.pkg.list(Some(s"/$guestNamespace"))(defaultWskProps)
-    verifyPackageSharedList(packageList, guestNamespace, samplePackage)
+    retry({
+      val packageList = wsk.pkg.list(Some(s"/$guestNamespace"))(defaultWskProps)
+      verifyPackageSharedList(packageList, guestNamespace, samplePackage)
+    }, 10, Some(500.milliseconds))
   }
 
   def verifyPackageSharedList(packageList: RunResult, namespace: String, packageName: String): Unit = {
     val fullyQualifiedPackageName = s"/$namespace/$packageName"
-    packageList.stdout should include regex (fullyQualifiedPackageName + """\s+shared""")
+    withClue(s"Packagelist is: ${packageList.stdout}; Packagename is: $fullyQualifiedPackageName")(
+      packageList.stdout should include regex (fullyQualifiedPackageName + """\s+shared"""))
   }
 
   it should "not list private packages" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
@@ -167,13 +170,16 @@ abstract class WskEntitlementTests extends TestHelpers with WskTestHelpers with 
       pkg.create(samplePackage)(wp)
     }
 
-    val packageList = wsk.pkg.list(Some(s"/$guestNamespace"))(defaultWskProps)
-    verifyPackageNotSharedList(packageList, guestNamespace, samplePackage)
+    retry({
+      val packageList = wsk.pkg.list(Some(s"/$guestNamespace"))(defaultWskProps)
+      verifyPackageNotSharedList(packageList, guestNamespace, samplePackage)
+    }, 10, Some(500.milliseconds))
   }
 
   def verifyPackageNotSharedList(packageList: RunResult, namespace: String, packageName: String): Unit = {
     val fullyQualifiedPackageName = s"/$namespace/$packageName"
-    packageList.stdout should not include (fullyQualifiedPackageName)
+    withClue(s"Packagelist is: ${packageList.stdout}; Packagename is: $fullyQualifiedPackageName")(
+      packageList.stdout should not include (fullyQualifiedPackageName))
   }
 
   it should "list shared package actions" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
@@ -188,8 +194,10 @@ abstract class WskEntitlementTests extends TestHelpers with WskTestHelpers with 
     }
 
     val fullyQualifiedPackageName = s"/$guestNamespace/$samplePackage"
-    val packageList = wsk.action.list(Some(fullyQualifiedPackageName))(defaultWskProps)
-    verifyPackageList(packageList, guestNamespace, samplePackage, sampleAction)
+    retry({
+      val packageList = wsk.action.list(Some(fullyQualifiedPackageName))(defaultWskProps)
+      verifyPackageList(packageList, guestNamespace, samplePackage, sampleAction)
+    }, 10, Some(500.milliseconds))
   }
 
   def verifyPackageList(packageList: RunResult, namespace: String, packageName: String, actionName: String): Unit = {


### PR DESCRIPTION
…ation.

One of these tests failed, because the newly created package has not been returned by the controller. My assumption is, the is has not been returned, because couchdb has not added it to it's view yet.

This PR adds some retires around fetching a package to let the test not fail again.

In addition we added some more debug information if the test fails.

PG4#1713 is 🔵 .

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

