### PR TITLE
Update Bluemix references in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,11 +18,11 @@
 -->
 # Getting started with OpenWhisk
 
-OpenWhisk is an [Apache Incubator Project](https://incubator.apache.org/projects/openwhisk.html). It is an open source implementation of a distributed, event-driven compute service. You can run it on your own hardware on-prem, or in the cloud. When running in the cloud you could use a Platform as as Service (PaaS) version of the OpenWhisk provided by IBM Bluemix, or you can provision it yourself into Infrastructure as a Service (IaaS) clouds, such as Bluemix, Amazon EC2, Microsoft Azure, Google GCP, etc.
+OpenWhisk is an [Apache Incubator Project](https://incubator.apache.org/projects/openwhisk.html). It is an open source implementation of a distributed, event-driven compute service. You can run it on your own hardware on-prem, or in the cloud. When running in the cloud you could use a Platform as as Service (PaaS) version of the OpenWhisk provided by IBM Cloud Functions, or you can provision it yourself into Infrastructure as a Service (IaaS) clouds, such as IBM Cloud, Amazon EC2, Microsoft Azure, Google GCP, etc.
 
-OpenWhisk runs application logic in response to events or direct invocations from web or mobile apps over HTTP. Events can be provided from Bluemix services like Cloudant and from external sources. Developers can focus on writing application logic, and creating actions that are executed on demand. The benefits of this new paradigm are that you do not explicitly provision servers and worry about auto-scaling, or worry about high availability, updates, maintenance and pay for hours of processor time when your server is running but not serving requests. Your code executes whenever there is an HTTP call, database state change, or other type of event that triggers the execution of your code. You get billed by millisecond of execution time (rounded up to the nearest 100ms in case of OpenWhisk) or on some platforms per request (not supported on OpenWhisk yet), not per hour of JVM regardless whether that VM was doing useful work or not.
+OpenWhisk runs application logic in response to events or direct invocations from web or mobile apps over HTTP. Events can be provided from IBM Cloud services like Cloudant and from external sources. Developers can focus on writing application logic, and creating actions that are executed on demand. The benefits of this new paradigm are that you do not explicitly provision servers and worry about auto-scaling, or worry about high availability, updates, maintenance and pay for hours of processor time when your server is running but not serving requests. Your code executes whenever there is an HTTP call, database state change, or other type of event that triggers the execution of your code. You get billed by millisecond of execution time (rounded up to the nearest 100ms in case of OpenWhisk) or on some platforms per request (not supported on OpenWhisk yet), not per hour of JVM regardless whether that VM was doing useful work or not.
 
-This programming model is a perfect match for microservices, mobile, IoT and many other apps – you get inherent auto-scaling and load balancing out of the box without having to manually configure clusters, load balancers, http plugins, etc. If you happen to run on IBM Bluemix, you also get a benefit of zero administration - meaning that all of the hardware, networking and software is maintaned by IBM. All you need to do is to provide the code you want to execute and give it to your cloud vendor. The rest is “magic”. A good introduction into the serverless programming model is available on [Martin Fowler's blog](https://martinfowler.com/articles/serverless.html).
+This programming model is a perfect match for microservices, mobile, IoT and many other apps – you get inherent auto-scaling and load balancing out of the box without having to manually configure clusters, load balancers, http plugins, etc. If you happen to run on IBM Cloud, you also get a benefit of zero administration - meaning that all of the hardware, networking and software is maintaned by IBM. All you need to do is to provide the code you want to execute and give it to your cloud vendor. The rest is “magic”. A good introduction into the serverless programming model is available on [Martin Fowler's blog](https://martinfowler.com/articles/serverless.html).
 
 ## Overview
 - [How OpenWhisk works](./about.md)
@@ -39,7 +39,7 @@ This programming model is a perfect match for microservices, mobile, IoT and man
 - Security
 - Scalability
 - Logging
-- Pricing (for Bluemix only)
+- Pricing (for IBM Cloud only)
 -->
 
 ## Implementation guide

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -29,7 +29,7 @@ OpenWhisk actions, triggers, and rules belong in a namespace, and optionally a p
 
 Packages can contain actions and feeds. A package cannot contain another package, so package nesting is not allowed. Also, entities do not have to be contained in a package.
 
-In Bluemix, an organization+space pair corresponds to a OpenWhisk namespace. For example, the organization `BobsOrg` and space `dev` would correspond to the OpenWhisk namespace `/BobsOrg_dev`.
+In IBM Cloud, an organization+space pair corresponds to a OpenWhisk namespace. For example, the organization `BobsOrg` and space `dev` would correspond to the OpenWhisk namespace `/BobsOrg_dev`.
 
 You can create your own namespaces if you're entitled to do so. The `/whisk.system` namespace is reserved for entities that are distributed with the OpenWhisk system.
 
@@ -453,7 +453,7 @@ Information about the REST API can be found [here](rest_api.md)
 ### Actions
 OpenWhisk has a few system limits, including how much memory an action can use and how many action invocations are allowed per minute.
 
-**Note:** This default limits are for the open source distribution; production deployments like Bluemix likely have higher limits.
+**Note:** This default limits are for the open source distribution; production deployments like IBM Cloud Functions likely have higher limits.
 As an operator or developer you can change some of the limits using [ansible inventory variables](../ansible/README.md#changing-limits).
 
 The following table lists the default limits for actions.

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -30,13 +30,13 @@ The modular and inherently scalable nature of OpenWhisk makes it ideal for imple
 
 Even though OpenWhisk was originally designed for event based programming, it offers several benefits for user-facing applications. For example, when you combine it with a small Node.js stub, you can use it to serve applications that are relatively easy to debug. And because OpenWhisk applications are a lot less computationally intensive than running a server process on a PaaS platform, they are considerably cheaper, as well.
 
-Full web applications can be built and run with OpenWhisk. Combining serverless APIs with static file hosting for site resources, e.g. HTML, JavaScript and CSS, means we can build entire serverless web applications. The simplicity of operating a hosted OpenWhisk environment (or rather not having to operate anything at all since it is hosted on Bluemix) is a great benefit compared to standing up and operating a Node.js Express or other traditional server runtime.
+Full web applications can be built and run with OpenWhisk. Combining serverless APIs with static file hosting for site resources, e.g. HTML, JavaScript and CSS, means we can build entire serverless web applications. The simplicity of operating a hosted OpenWhisk environment (or rather not having to operate anything at all since it is hosted on IBM Cloud) is a great benefit compared to standing up and operating a Node.js Express or other traditional server runtime.
 
 One of the things that helps is the option of OpenWhisk CLI *wsk* tool called "--annotation web-export true", which makes the code accessible from a web browser.
 
 Here are few examples on how to use OpenWhisk to build a web app:
 - [Web Actions: Serverless Web Apps with OpenWhisk](https://medium.com/openwhisk/web-actions-serverless-web-apps-with-openwhisk-f21db459f9ba).
-- [Build a user-facing OpenWhisk application with Bluemix and Node.js](https://www.ibm.com/developerworks/cloud/library/cl-openwhisk-node-bluemix-user-facing-app/index.html)
+- [Build a user-facing OpenWhisk application with IBM Cloud Functions and Node.js](https://www.ibm.com/developerworks/cloud/library/cl-openwhisk-node-bluemix-user-facing-app/index.html)
 - [Serverless HTTP handlers with OpenWhisk](https://medium.com/openwhisk/serverless-http-handlers-with-openwhisk-90a986cc7cdd)
 
 ## IoT
@@ -57,7 +57,7 @@ Here is an example and a discussion of [using Serverless as an API backend](http
 
 ## Mobile back end
 
-Many mobile applications require server-side logic. For mobile developers that don't want to manage server-side logic and would rather focus on the app that is running on the device or browser, using OpenWhisk as the server-side back end is a good solution. In addition, the built-in support for Swift allows developers to reuse their existing iOS programming skills. Mobile applications often have unpredictable load patterns and hosted OpenWhisk solution, such as IBM Bluemix can scale to meet practically any demand in workload without the need to provision resources ahead of time.
+Many mobile applications require server-side logic. For mobile developers that don't want to manage server-side logic and would rather focus on the app that is running on the device or browser, using OpenWhisk as the server-side back end is a good solution. In addition, the built-in support for Swift allows developers to reuse their existing iOS programming skills. Mobile applications often have unpredictable load patterns and hosted OpenWhisk solution, such as IBM Cloud Functions, can scale to meet practically any demand in workload without the need to provision resources ahead of time.
 
 ## Data processing
 
@@ -67,4 +67,4 @@ With the amount of data now available, application development requires the abil
 
 Cognitive technologies can be effectively combined with OpenWhisk to create powerful applications. For example, IBM Alchemy API and Watson Visual Recognition can be used with OpenWhisk to automatically extract useful information from videos without having to actually watch them.
 
-Here is a sample application [Dark vision](https://github.com/IBM-Bluemix/openwhisk-darkvisionapp) that does just that. In this application the user uploads a video or image using the Dark Vision web application, which stores it in a Cloudant DB. Once the video is uploaded, OpenWhisk detects the new video by listening to Cloudant changes (trigger). OpenWhisk then triggers the video extractor action. During its execution, the extractor produces frames (images) and stores them in Cloudant. The frames are then processed using Watson Visual Recognition and the results are stored in the same Cloudant DB. The results can be viewed using Dark Vision web application OR an iOS application. Object Storage can be used in addition to Cloudant. When doing so, video and image medadata are stored in Cloudant and the media files are stored in Object Storage.
+Here is a sample application [Dark vision](https://github.com/IBM-Cloud/openwhisk-darkvisionapp) that does just that. In this application the user uploads a video or image using the Dark Vision web application, which stores it in a Cloudant DB. Once the video is uploaded, OpenWhisk detects the new video by listening to Cloudant changes (trigger). OpenWhisk then triggers the video extractor action. During its execution, the extractor produces frames (images) and stores them in Cloudant. The frames are then processed using Watson Visual Recognition and the results are stored in the same Cloudant DB. The results can be viewed using Dark Vision web application OR an iOS application. Object Storage can be used in addition to Cloudant. When doing so, video and image medadata are stored in Cloudant and the media files are stored in Object Storage.

--- a/tools/db/README.md
+++ b/tools/db/README.md
@@ -42,10 +42,10 @@ Detailed instructions are found in the [ansible readme](../../ansible/README.md)
 
 As an alternative to a self-managed CouchDB, you may want to try [Cloudant](https://cloudant.com) which is a cloud-based database service.
 There are two ways to get a Cloudant account and configure OpenWhisk to use it.
-You only need to establish an account once, either through IBM Bluemix or with Cloudant directly.
+You only need to establish an account once, either through IBM Cloud or with Cloudant directly.
 
-### Create a Cloudant account via IBM Bluemix
-Sign up for an account via [IBM Bluemix](https://bluemix.net). Bluemix offers trial accounts and its signup process is straightforward so it is not described here in detail. Using Bluemix, the most convenient way to create a Cloudant instance is via the `cf` command-line tool. See [here](https://www.ng.bluemix.net/docs/starters/install_cli.html) for instructions on how to download and configure `cf` to work with your Bluemix account.
+### Create a Cloudant account via IBM Cloud
+Sign up for an account via [IBM Cloud](https://bluemix.net). IBM Cloud offers trial accounts and its signup process is straightforward so it is not described here in detail. Using IBM Cloud, the most convenient way to create a Cloudant instance is via the `cf` command-line tool. See [here](https://www.ng.bluemix.net/docs/starters/install_cli.html) for instructions on how to download and configure `cf` to work with your IBM Cloud account.
 
 When `cf` is set up, issue the following commands to create a Cloudant database.
 
@@ -64,7 +64,7 @@ Make note of the Cloudant `username` and `password` from the last `cf` command s
 
 ### Create a Cloudant account directly with Cloudant
 
-As an alternative to IBM Bluemix, you may sign up for an account with [Cloudant](https://cloudant.com) directly. Cloudant is free to try and offers a metered pricing where the first $50 of usage is free each month. The signup process is straightforward so it is not described here in detail.
+As an alternative to IBM Cloud, you may sign up for an account with [Cloudant](https://cloudant.com) directly. Cloudant is free to try and offers a metered pricing where the first $50 of usage is free each month. The signup process is straightforward so it is not described here in detail.
 Once you have created a Cloudant account, make note of the account `username` and `password` from the Cloudant dashboard, so you can create the required `db_local.ini`.
 
 ### Setting the Cloudant credentials

--- a/tools/db/README.md
+++ b/tools/db/README.md
@@ -41,8 +41,6 @@ Detailed instructions are found in the [ansible readme](../../ansible/README.md)
 ## Using Cloudant
 
 As an alternative to a self-managed CouchDB, you may want to try [Cloudant](https://cloudant.com) which is a cloud-based database service.
-There are two ways to get a Cloudant account and configure OpenWhisk to use it.
-You only need to establish an account once, either through IBM Cloud or with Cloudant directly.
 
 ### Create a Cloudant account via IBM Cloud
 Sign up for an account via [IBM Cloud](https://bluemix.net). IBM Cloud offers trial accounts and its signup process is straightforward so it is not described here in detail. Using IBM Cloud, the most convenient way to create a Cloudant instance is via the `cf` command-line tool. See [here](https://www.ng.bluemix.net/docs/starters/install_cli.html) for instructions on how to download and configure `cf` to work with your IBM Cloud account.
@@ -61,11 +59,6 @@ When `cf` is set up, issue the following commands to create a Cloudant database.
   ```
 
 Make note of the Cloudant `username` and `password` from the last `cf` command so you can create the required `db_local.ini`.
-
-### Create a Cloudant account directly with Cloudant
-
-As an alternative to IBM Cloud, you may sign up for an account with [Cloudant](https://cloudant.com) directly. Cloudant is free to try and offers a metered pricing where the first $50 of usage is free each month. The signup process is straightforward so it is not described here in detail.
-Once you have created a Cloudant account, make note of the account `username` and `password` from the Cloudant dashboard, so you can create the required `db_local.ini`.
 
 ### Setting the Cloudant credentials
 


### PR DESCRIPTION
## Description
- Refer to IBM Cloud (Functions) instead of Bluemix in docs
- Remove reference to standalone cloudant.com from DB docs

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [x] Documentation
