### PR TITLE
bump reference for NodeJS images, updating NodeJS6 & NodeJS8

### DIFF
--- a/actionRuntimes/nodejs6Action/Dockerfile
+++ b/actionRuntimes/nodejs6Action/Dockerfile
@@ -1,4 +1,4 @@
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements; and to You under the Apache License, Version 2.0.
 
-FROM openwhisk/nodejs6action:1.9.0
+FROM openwhisk/nodejs6action:1.9.1

--- a/actionRuntimes/nodejs8Action/Dockerfile
+++ b/actionRuntimes/nodejs8Action/Dockerfile
@@ -1,4 +1,4 @@
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements; and to You under the Apache License, Version 2.0.
 
-FROM openwhisk/action-nodejs-v8:1.6.0
+FROM openwhisk/action-nodejs-v8:1.6.1

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -228,9 +228,9 @@ JavaScript actions can be executed in Node.js version 6 or Node.js version 8.
 Currently actions are executed by default in a Node.js version 6 environment.
 
 ### Node.js version 6 environment
-The Node.js 6.14.1 environment will be used for an action if the `--kind` flag is explicitly specified with a value of 'nodejs:6' when creating/updating the action.
+The Node.js 6.14.2 environment will be used for an action if the `--kind` flag is explicitly specified with a value of 'nodejs:6' when creating/updating the action.
 
-The following packages are available to be used in the Node.js 6.14.1 environment:
+The following packages are available to be used in the Node.js 6.14.2 environment:
 
 - [apn v2.1.2](https://www.npmjs.com/package/apn) - A Node.js module for interfacing with the Apple Push Notification service.
 - [async v2.1.4](https://www.npmjs.com/package/async) - Provides functions for working with asynchronous functions.
@@ -285,9 +285,9 @@ The following packages are available to be used in the Node.js 6.14.1 environmen
 - [yauzl v2.7.0](https://www.npmjs.com/package/yauzl) - Yet another unzip library for node. For zipping.
 
 ### Node.js version 8 environment
-The Node.js version 8.11.1 environment is used if the `--kind` flag is explicitly specified with a value of 'nodejs:8' when creating or updating an Action.
+The Node.js version 8.11.2 environment is used if the `--kind` flag is explicitly specified with a value of 'nodejs:8' when creating or updating an Action.
 
-The following packages are pre-installed in the Node.js version 8.11.1 environment:
+The following packages are pre-installed in the Node.js version 8.11.2 environment:
 
 - [openwhisk v3.15.0](https://www.npmjs.com/package/openwhisk) - JavaScript client library for the OpenWhisk platform. Provides a wrapper around the OpenWhisk APIs.
 


### PR DESCRIPTION
Updating the NodeJS runtime version for NodeJS 6 and NodeJS 8. 
NodeJS 6 went from `6.14.1` to `6.14.2`
NodeJS 8 went from `8.11.1` to `8.11.2`

Diff of changes can be seen here:
NodeJS 6: https://github.com/apache/incubator-openwhisk-runtime-nodejs/compare/6@1.9.0...6@1.9.1
NodeJS 8: https://github.com/apache/incubator-openwhisk-runtime-nodejs/compare/8@1.6.0...8@1.6.1