### PR TITLE
Refactor `ensureTopic` to expose failure details.

### DIFF
--- a/common/scala/src/main/scala/whisk/common/CausedBy.scala
+++ b/common/scala/src/main/scala/whisk/common/CausedBy.scala
@@ -15,28 +15,21 @@
  * limitations under the License.
  */
 
-package whisk.core.connector
-
-import akka.actor.ActorSystem
-
-import scala.concurrent.duration.DurationInt
-import scala.concurrent.duration.FiniteDuration
-import whisk.common.Logging
-import whisk.core.WhiskConfig
-import whisk.spi.Spi
-
-import scala.util.Try
+package whisk.common
 
 /**
- * An Spi for providing Messaging implementations.
+ * Helper to match on exceptions caused by other exceptions.
+ *
+ * Use this like:
+ *
+ * ```
+ * try {
+ *   block()
+ * } catch {
+ *   case CausedBy(internalException: MyFancyException) => ...
+ * }
+ * ```
  */
-trait MessagingProvider extends Spi {
-  def getConsumer(
-    config: WhiskConfig,
-    groupId: String,
-    topic: String,
-    maxPeek: Int = Int.MaxValue,
-    maxPollInterval: FiniteDuration = 5.minutes)(implicit logging: Logging, actorSystem: ActorSystem): MessageConsumer
-  def getProducer(config: WhiskConfig)(implicit logging: Logging, actorSystem: ActorSystem): MessageProducer
-  def ensureTopic(config: WhiskConfig, topic: String, topicConfig: String)(implicit logging: Logging): Try[Unit]
+object CausedBy {
+  def unapply(e: Throwable): Option[Throwable] = Option(e.getCause)
 }

--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaMessagingProvider.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaMessagingProvider.scala
@@ -18,18 +18,18 @@
 package whisk.connector.kafka
 
 import java.util.Properties
-import java.util.concurrent.ExecutionException
 
 import akka.actor.ActorSystem
 import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
 import org.apache.kafka.common.errors.TopicExistsException
 import pureconfig._
-import whisk.common.Logging
+import whisk.common.{CausedBy, Logging}
 import whisk.core.{ConfigKeys, WhiskConfig}
 import whisk.core.connector.{MessageConsumer, MessageProducer, MessagingProvider}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.FiniteDuration
+import scala.util.{Failure, Success, Try}
 
 case class KafkaConfig(replicationFactor: Short)
 
@@ -47,31 +47,28 @@ object KafkaMessagingProvider extends MessagingProvider {
   def getProducer(config: WhiskConfig)(implicit logging: Logging, actorSystem: ActorSystem): MessageProducer =
     new KafkaProducerConnector(config.kafkaHosts)
 
-  def ensureTopic(config: WhiskConfig, topic: String, topicConfig: String)(implicit logging: Logging): Boolean = {
-    val kc = loadConfigOrThrow[KafkaConfig](ConfigKeys.kafka)
-    val tc = KafkaConfiguration.configMapToKafkaConfig(
-      loadConfigOrThrow[Map[String, String]](ConfigKeys.kafkaTopics + s".$topicConfig"))
+  def ensureTopic(config: WhiskConfig, topic: String, topicConfigKey: String)(implicit logging: Logging): Try[Unit] = {
+    val kafkaConfig = loadConfigOrThrow[KafkaConfig](ConfigKeys.kafka)
+    val topicConfig = KafkaConfiguration.configMapToKafkaConfig(
+      loadConfigOrThrow[Map[String, String]](ConfigKeys.kafkaTopics + "." + topicConfigKey))
 
-    val baseConfig = Map(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> config.kafkaHosts)
     val commonConfig = configMapToKafkaConfig(loadConfigOrThrow[Map[String, String]](ConfigKeys.kafkaCommon))
-    val client = AdminClient.create(baseConfig ++ commonConfig)
-    val numPartitions = 1
-    val nt = new NewTopic(topic, numPartitions, kc.replicationFactor).configs(tc.asJava)
-    val results = client.createTopics(List(nt).asJava)
-    try {
-      results.values().get(topic).get()
-      logging.info(this, s"created topic $topic")
-      true
-    } catch {
-      case e: ExecutionException if e.getCause.isInstanceOf[TopicExistsException] =>
-        logging.info(this, s"topic $topic already existed")
-        true
-      case e: Exception =>
-        logging.error(this, s"ensureTopic for $topic failed due to $e")
-        false
-    } finally {
-      client.close()
-    }
+    val client = AdminClient.create(commonConfig + (AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> config.kafkaHosts))
+    val partitions = 1
+    val nt = new NewTopic(topic, partitions, kafkaConfig.replicationFactor).configs(topicConfig.asJava)
+
+    val result = Try(client.createTopics(List(nt).asJava).values().get(topic).get())
+      .map(_ => logging.info(this, s"created topic $topic"))
+      .recoverWith {
+        case CausedBy(_: TopicExistsException) =>
+          Success(logging.info(this, s"topic $topic already existed"))
+        case t =>
+          logging.error(this, s"ensureTopic for $topic failed due to $t")
+          Failure(t)
+      }
+
+    client.close()
+    result
   }
 }
 

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -223,7 +223,7 @@ object Controller {
       "cacheInvalidation" -> "cache-invalidation",
       "events" -> "events").foreach {
       case (topic, topicConfigurationKey) =>
-        if (msgProvider.ensureTopic(config, topic + instance, topicConfigurationKey).isFailure) {
+        if (msgProvider.ensureTopic(config, topic, topicConfigurationKey).isFailure) {
           abort(s"failure during msgProvider.ensureTopic for topic $topic")
         }
     }

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -216,18 +216,16 @@ object Controller {
     }
 
     val msgProvider = SpiLoader.get[MessagingProvider]
-    if (!msgProvider.ensureTopic(config, topic = "completed" + instance, topicConfig = "completed")) {
-      abort(s"failure during msgProvider.ensureTopic for topic completed$instance")
-    }
-    if (!msgProvider.ensureTopic(config, topic = "health", topicConfig = "health")) {
-      abort(s"failure during msgProvider.ensureTopic for topic health")
-    }
-    if (!msgProvider.ensureTopic(config, topic = "cacheInvalidation", topicConfig = "cache-invalidation")) {
-      abort(s"failure during msgProvider.ensureTopic for topic cacheInvalidation")
-    }
 
-    if (!msgProvider.ensureTopic(config, topic = "events", topicConfig = "events")) {
-      abort(s"failure during msgProvider.ensureTopic for topic events")
+    Map(
+      "completed" + instance -> "completed",
+      "health" -> "health",
+      "cacheInvalidation" -> "cache-invalidation",
+      "events" -> "events").foreach {
+      case (topic, topicConfigurationKey) =>
+        if (msgProvider.ensureTopic(config, topic + instance, topicConfigurationKey).isFailure) {
+          abort(s"failure during msgProvider.ensureTopic for topic $topic")
+        }
     }
 
     ExecManifest.initialize(config) match {

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -168,7 +168,7 @@ object Invoker {
 
     val invokerInstance = InstanceId(assignedInvokerId, invokerName)
     val msgProvider = SpiLoader.get[MessagingProvider]
-    if (!msgProvider.ensureTopic(config, topic = "invoker" + assignedInvokerId, topicConfig = "invoker")) {
+    if (msgProvider.ensureTopic(config, topic = "invoker" + assignedInvokerId, topicConfig = "invoker").isFailure) {
       abort(s"failure during msgProvider.ensureTopic for topic invoker$assignedInvokerId")
     }
     val producer = msgProvider.getProducer(config)


### PR DESCRIPTION
ensureTopic returns a `Boolean` value of whether it successfully created a topic or not.

This changes that behavior to actually return the Exception in case of an error. That enables the client-side code to handle (or log) that failure appropriately while maintaining the ease of checking a successful result by using `isSuccess`.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [X] Controller
- [X] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [X] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

