### PR TITLE
Add retries to CLI test framework for network errors

### DIFF
--- a/common/scala/src/main/scala/whisk/utils/Retry.scala
+++ b/common/scala/src/main/scala/whisk/utils/Retry.scala
@@ -41,10 +41,7 @@ object retry {
     try fn
     catch {
       case _ if N > 1 =>
-        retryMessage match {
-          case Some(msg) => println(msg)
-          case None      =>
-        }
+        retryMessage.foreach(println)
         waitBeforeRetry.foreach(t => Thread.sleep(t.toMillis))
         retry(fn, N - 1, waitBeforeRetry, retryMessage)
     }

--- a/common/scala/src/main/scala/whisk/utils/Retry.scala
+++ b/common/scala/src/main/scala/whisk/utils/Retry.scala
@@ -31,15 +31,22 @@ object retry {
    * @return the result of fn iff it is successful
    * @throws Throwable exception from fn (or an illegal argument exception if N is < 1)
    */
-  def apply[T](fn: => T, N: Int = 3, waitBeforeRetry: Option[Duration] = Some(50.milliseconds)): T = {
+  def apply[T](fn: => T,
+               N: Int = 3,
+               waitBeforeRetry: Option[Duration] = Some(50.milliseconds),
+               retryMessage: Option[String] = None): T = {
     require(N >= 1, "maximum number of fn applications must be greater than 1")
     waitBeforeRetry.foreach(t => Thread.sleep(t.toMillis)) // initial wait if any
 
     try fn
     catch {
       case _ if N > 1 =>
+        retryMessage match {
+          case Some(msg) => println(msg)
+          case None      =>
+        }
         waitBeforeRetry.foreach(t => Thread.sleep(t.toMillis))
-        retry(fn, N - 1, waitBeforeRetry)
+        retry(fn, N - 1, waitBeforeRetry, retryMessage)
     }
   }
 }

--- a/tests/src/test/scala/common/TestUtils.java
+++ b/tests/src/test/scala/common/TestUtils.java
@@ -54,11 +54,12 @@ import junit.runner.Version;
 public class TestUtils {
     protected static final Logger logger = Logger.getLogger("basic");
 
-    public static final int SUCCESS_EXIT    = 0;
-    public static final int ERROR_EXIT      = 1;
-    public static final int MISUSE_EXIT     = 2;
-    public static final int DONTCARE_EXIT   = -1;       // any value is ok
-    public static final int ANY_ERROR_EXIT  = -2;       // any non-zero value is ok
+    public static final int SUCCESS_EXIT        = 0;
+    public static final int ERROR_EXIT          = 1;
+    public static final int MISUSE_EXIT         = 2;
+    public static final int DONTCARE_EXIT       = -1;       // any value is ok
+    public static final int ANY_ERROR_EXIT      = -2;       // any non-zero value is ok
+    public static final int NETWORK_ERROR_EXIT  = 3;
 
     public static final int ACCEPTED        = 202;      // 202
     public static final int BAD_REQUEST     = 144;      // 400 - 256 = 144

--- a/tests/src/test/scala/common/Wsk.scala
+++ b/tests/src/test/scala/common/Wsk.scala
@@ -1047,15 +1047,17 @@ trait RunWskCmd extends BaseRunWsk {
             stdinFile.getOrElse(null),
             args ++ params: _*)
 
-          if (expectedExitCode != NETWORK_ERROR_EXIT && rr.exitCode == NETWORK_ERROR_EXIT) {
-            println("A network error occurred.")
-            assert(false, hideStr(reportFailure(args ++ params, expectedExitCode, rr).toString(), hideFromOutput))
+          if (expectedExitCode != NETWORK_ERROR_EXIT) {
+            withClue(hideStr(reportFailure(args ++ params, expectedExitCode, rr).toString(), hideFromOutput)) {
+              rr.exitCode should not be NETWORK_ERROR_EXIT
+            }
           }
 
           rr
         },
         3,
-        Some(1.second))
+        Some(1.second),
+        Some(s"CLI encountered a network error, retrying command..."))
 
     withClue(hideStr(reportFailure(args ++ params, expectedExitCode, rr).toString(), hideFromOutput)) {
       if (expectedExitCode != TestUtils.DONTCARE_EXIT) {

--- a/tests/src/test/scala/common/Wsk.scala
+++ b/tests/src/test/scala/common/Wsk.scala
@@ -1047,7 +1047,7 @@ trait RunWskCmd extends BaseRunWsk {
             stdinFile.getOrElse(null),
             args ++ params: _*)
 
-          if (rr.exitCode == NETWORK_ERROR_EXIT) {
+          if (expectedExitCode != NETWORK_ERROR_EXIT && rr.exitCode == NETWORK_ERROR_EXIT) {
             println(rr)
             throw new Exception("A network error occurred.")
           }

--- a/tests/src/test/scala/common/Wsk.scala
+++ b/tests/src/test/scala/common/Wsk.scala
@@ -1036,7 +1036,7 @@ trait RunWskCmd extends BaseRunWsk {
     val args = baseCommand
     if (verbose) args += "--verbose"
     if (showCmd) println(args.mkString(" ") + " " + params.mkString(" "))
-    val rr: RunResult =
+    val rr =
       retry(
         {
           val rr = TestUtils.runCmd(
@@ -1047,14 +1047,15 @@ trait RunWskCmd extends BaseRunWsk {
             stdinFile.getOrElse(null),
             args ++ params: _*)
 
-          if (expectedExitCode != NETWORK_ERROR_EXIT && rr.exitCode == NETWORK_ERROR_EXIT) {
-            println(rr)
-            throw new Exception("A network error occurred.")
+          withClue(hideStr(reportFailure(args ++ params, expectedExitCode, rr).toString(), hideFromOutput)) {
+            if (expectedExitCode != NETWORK_ERROR_EXIT) {
+              rr.exitCode should not be NETWORK_ERROR_EXIT
+            }
           }
 
           rr
         },
-        10,
+        3,
         Some(1.second))
 
     withClue(hideStr(reportFailure(args ++ params, expectedExitCode, rr).toString(), hideFromOutput)) {

--- a/tests/src/test/scala/common/Wsk.scala
+++ b/tests/src/test/scala/common/Wsk.scala
@@ -1047,10 +1047,9 @@ trait RunWskCmd extends BaseRunWsk {
             stdinFile.getOrElse(null),
             args ++ params: _*)
 
-          withClue(hideStr(reportFailure(args ++ params, expectedExitCode, rr).toString(), hideFromOutput)) {
-            if (expectedExitCode != NETWORK_ERROR_EXIT) {
-              rr.exitCode should not be NETWORK_ERROR_EXIT
-            }
+          if (expectedExitCode != NETWORK_ERROR_EXIT && rr.exitCode == NETWORK_ERROR_EXIT) {
+            println("A network error occurred.")
+            assert(false, hideStr(reportFailure(args ++ params, expectedExitCode, rr).toString(), hideFromOutput))
           }
 
           rr


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
Allows the CLI test framework to perform retries when a network error occurs.

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

