### PR TITLE
Make amount of parallel docker runs configurable.

### DIFF
--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -84,6 +84,7 @@
     - "{{ db.whisk.actions }}"
     - "{{ db.whisk.auth }}"
     - "{{ db.whisk.activations }}"
+  run_once: true
 
 - name: prepare controller port
   set_fact:

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -84,7 +84,6 @@
     - "{{ db.whisk.actions }}"
     - "{{ db.whisk.auth }}"
     - "{{ db.whisk.activations }}"
-  run_once: true
 
 - name: prepare controller port
   set_fact:

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -206,7 +206,7 @@
       "INVOKER_CONTAINER_POLICY": "{{ invoker_container_policy_name | default()}}"
       "CONFIG_whisk_containerPool_numCore": "{{ invoker.numcore }}"
       "CONFIG_whisk_containerPool_coreShare": "{{ invoker.coreshare }}"
-      "CONFIG_whisk_docker_parallelRuns": "{{ invoker_parallel_runs | default() }}"
+      "CONFIG_whisk_docker_client_parallelRuns": "{{ invoker_parallel_runs | default() }}"
       "CONFIG_whisk_docker_containerFactory_useRunc": "{{ invoker.useRunc }}"
       "WHISK_LOGS_DIR": "{{ whisk_logs_dir }}"
       "METRICS_KAMON": "{{ metrics.kamon.enabled }}"

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -95,6 +95,7 @@
   with_items:
   - "{{ db.whisk.actions }}"
   - "{{ db.whisk.activations }}"
+  run_once: true
 
 - name: get running invoker information
   uri: url="http://{{ ansible_host }}:{{ docker.port }}/containers/json?filters={{ '{"name":[ "invoker" ],"ancestor":[ "invoker" ]}' | urlencode }}" return_content=yes
@@ -206,6 +207,7 @@
       "INVOKER_CONTAINER_POLICY": "{{ invoker_container_policy_name | default()}}"
       "CONFIG_whisk_containerPool_numCore": "{{ invoker.numcore }}"
       "CONFIG_whisk_containerPool_coreShare": "{{ invoker.coreshare }}"
+      "CONFIG_whisk_docker_parallelRuns": "{{ invoker_parallel_runs | default() }}"
       "CONFIG_whisk_docker_containerFactory_useRunc": "{{ invoker.useRunc }}"
       "WHISK_LOGS_DIR": "{{ whisk_logs_dir }}"
       "METRICS_KAMON": "{{ metrics.kamon.enabled }}"
@@ -271,7 +273,7 @@
     volumes: "{{ volumes|default('') }},{{ coverage_logs_dir }}/invoker:/coverage"
   when: coverage_enabled
 
-- name: start invoker using docker cli
+- name: start invoker
   docker_container:
     userns_mode: "host"
     pid_mode: "host"

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -95,7 +95,6 @@
   with_items:
   - "{{ db.whisk.actions }}"
   - "{{ db.whisk.activations }}"
-  run_once: true
 
 - name: get running invoker information
   uri: url="http://{{ ansible_host }}:{{ docker.port }}/containers/json?filters={{ '{"name":[ "invoker" ],"ancestor":[ "invoker" ]}' | urlencode }}" return_content=yes

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -215,6 +215,7 @@ object ConfigKeys {
   val docker = "whisk.docker"
   val dockerTimeouts = s"$docker.timeouts"
   val dockerContainerFactory = s"${docker}.container-factory"
+  val dockerParallelRuns = s"$docker.parallel-runs"
   val runc = "whisk.runc"
   val runcTimeouts = s"$runc.timeouts"
 

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -213,9 +213,8 @@ object ConfigKeys {
   val db = "whisk.db"
 
   val docker = "whisk.docker"
-  val dockerTimeouts = s"$docker.timeouts"
+  val dockerClient = s"$docker.client"
   val dockerContainerFactory = s"${docker}.container-factory"
-  val dockerParallelRuns = s"$docker.parallel-runs"
   val runc = "whisk.runc"
   val runcTimeouts = s"$runc.timeouts"
 

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -10,23 +10,25 @@ whisk {
     poll-interval: 5 minutes
   }
 
-  # Docker < 1.13.1 has a known problem: if more than 10 containers are created (docker run)
-  # concurrently, there is a good chance that some of them will fail.
-  # See https://github.com/moby/moby/issues/29369
-  # Use a semaphore to make sure that at most 10 `docker run` commands are active
-  # the same time.
-  # 0 means that there are infinite parallel runs.
-  docker.parallel-runs: 10
+  docker.client {
+    # Docker < 1.13.1 has a known problem: if more than 10 containers are created (docker run)
+    # concurrently, there is a good chance that some of them will fail.
+    # See https://github.com/moby/moby/issues/29369
+    # Use a semaphore to make sure that at most 10 `docker run` commands are active
+    # the same time.
+    # 0 means that there are infinite parallel runs.
+    parallel-runs: 10
 
-  # Timeouts for docker commands. Set to "Inf" to disable timeout.
-  docker.timeouts {
-    run: 1 minute
-    rm: 1 minute
-    pull: 10 minutes
-    ps: 1 minute
-    inspect: 1 minute
-    pause: 10 seconds
-    unpause: 10 seconds
+    # Timeouts for docker commands. Set to "Inf" to disable timeout.
+    timeouts {
+      run: 1 minute
+      rm: 1 minute
+      pull: 10 minutes
+      ps: 1 minute
+      inspect: 1 minute
+      pause: 10 seconds
+      unpause: 10 seconds
+    }
   }
 
   docker.container-factory {

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -10,6 +10,14 @@ whisk {
     poll-interval: 5 minutes
   }
 
+  # Docker < 1.13.1 has a known problem: if more than 10 containers are created (docker run)
+  # concurrently, there is a good chance that some of them will fail.
+  # See https://github.com/moby/moby/issues/29369
+  # Use a semaphore to make sure that at most 10 `docker run` commands are active
+  # the same time.
+  # 0 means that there are infinite parallel runs.
+  docker.parallel-runs: 10
+
   # Timeouts for docker commands. Set to "Inf" to disable timeout.
   docker.timeouts {
     run: 1 minute

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClient.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClient.scala
@@ -66,6 +66,11 @@ case class DockerClientTimeoutConfig(run: Duration,
                                      inspect: Duration)
 
 /**
+ * Configuration for docker client
+ */
+case class DockerClientConfig(parallelRuns: Int, timeouts: DockerClientTimeoutConfig)
+
+/**
  * Serves as interface to the docker CLI tool.
  *
  * Be cautious with the ExecutionContext passed to this, as the
@@ -74,8 +79,7 @@ case class DockerClientTimeoutConfig(run: Duration,
  * You only need one instance (and you shouldn't get more).
  */
 class DockerClient(dockerHost: Option[String] = None,
-                   timeouts: DockerClientTimeoutConfig =
-                     loadConfigOrThrow[DockerClientTimeoutConfig](ConfigKeys.dockerTimeouts))(
+                   config: DockerClientConfig = loadConfigOrThrow[DockerClientConfig](ConfigKeys.dockerClient))(
   executionContext: ExecutionContext)(implicit log: Logging, as: ActorSystem)
     extends DockerApi
     with ProcessRunner {
@@ -96,7 +100,7 @@ class DockerClient(dockerHost: Option[String] = None,
     Seq(dockerBin) ++ host
   }
 
-  protected val maxParallelRuns = loadConfigOrThrow[Int](ConfigKeys.dockerParallelRuns)
+  protected val maxParallelRuns = config.parallelRuns
   protected val runSemaphore =
     new Semaphore( /* permits= */ if (maxParallelRuns > 0) maxParallelRuns else Int.MaxValue, /* fair= */ true)
 
@@ -115,7 +119,7 @@ class DockerClient(dockerHost: Option[String] = None,
       }
     }.flatMap { _ =>
       // Iff the semaphore was acquired successfully
-      runCmd(Seq("run", "-d") ++ args ++ Seq(image), timeouts.run)
+      runCmd(Seq("run", "-d") ++ args ++ Seq(image), config.timeouts.run)
         .andThen {
           // Release the semaphore as quick as possible regardless of the runCmd() result
           case _ => runSemaphore.release()
@@ -140,26 +144,26 @@ class DockerClient(dockerHost: Option[String] = None,
   def inspectIPAddress(id: ContainerId, network: String)(implicit transid: TransactionId): Future[ContainerAddress] =
     runCmd(
       Seq("inspect", "--format", s"{{.NetworkSettings.Networks.${network}.IPAddress}}", id.asString),
-      timeouts.inspect).flatMap {
+      config.timeouts.inspect).flatMap {
       case "<no value>" => Future.failed(new NoSuchElementException)
       case stdout       => Future.successful(ContainerAddress(stdout))
     }
 
   def pause(id: ContainerId)(implicit transid: TransactionId): Future[Unit] =
-    runCmd(Seq("pause", id.asString), timeouts.pause).map(_ => ())
+    runCmd(Seq("pause", id.asString), config.timeouts.pause).map(_ => ())
 
   def unpause(id: ContainerId)(implicit transid: TransactionId): Future[Unit] =
-    runCmd(Seq("unpause", id.asString), timeouts.unpause).map(_ => ())
+    runCmd(Seq("unpause", id.asString), config.timeouts.unpause).map(_ => ())
 
   def rm(id: ContainerId)(implicit transid: TransactionId): Future[Unit] =
-    runCmd(Seq("rm", "-f", id.asString), timeouts.rm).map(_ => ())
+    runCmd(Seq("rm", "-f", id.asString), config.timeouts.rm).map(_ => ())
 
   def ps(filters: Seq[(String, String)] = Seq.empty, all: Boolean = false)(
     implicit transid: TransactionId): Future[Seq[ContainerId]] = {
     val filterArgs = filters.flatMap { case (attr, value) => Seq("--filter", s"$attr=$value") }
     val allArg = if (all) Seq("--all") else Seq.empty[String]
     val cmd = Seq("ps", "--quiet", "--no-trunc") ++ allArg ++ filterArgs
-    runCmd(cmd, timeouts.ps).map(_.lines.toSeq.map(ContainerId.apply))
+    runCmd(cmd, config.timeouts.ps).map(_.lines.toSeq.map(ContainerId.apply))
   }
 
   /**
@@ -170,11 +174,11 @@ class DockerClient(dockerHost: Option[String] = None,
   private val pullsInFlight = TrieMap[String, Future[Unit]]()
   def pull(image: String)(implicit transid: TransactionId): Future[Unit] =
     pullsInFlight.getOrElseUpdate(image, {
-      runCmd(Seq("pull", image), timeouts.pull).map(_ => ()).andThen { case _ => pullsInFlight.remove(image) }
+      runCmd(Seq("pull", image), config.timeouts.pull).map(_ => ()).andThen { case _ => pullsInFlight.remove(image) }
     })
 
   def isOomKilled(id: ContainerId)(implicit transid: TransactionId): Future[Boolean] =
-    runCmd(Seq("inspect", id.asString, "--format", "{{.State.OOMKilled}}"), timeouts.inspect).map(_.toBoolean)
+    runCmd(Seq("inspect", id.asString, "--format", "{{.State.OOMKilled}}"), config.timeouts.inspect).map(_.toBoolean)
 
   private def runCmd(args: Seq[String], timeout: Duration)(implicit transid: TransactionId): Future[String] = {
     val cmd = dockerCmd ++ args

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClient.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClient.scala
@@ -96,8 +96,9 @@ class DockerClient(dockerHost: Option[String] = None,
     Seq(dockerBin) ++ host
   }
 
-  protected val maxParallelRuns = 10
-  protected val runSemaphore = new Semaphore( /* permits= */ maxParallelRuns, /* fair= */ true)
+  protected val maxParallelRuns = loadConfigOrThrow[Int](ConfigKeys.dockerParallelRuns)
+  protected val runSemaphore =
+    new Semaphore( /* permits= */ if (maxParallelRuns > 0) maxParallelRuns else Int.MaxValue, /* fair= */ true)
 
   // Docker < 1.13.1 has a known problem: if more than 10 containers are created (docker run)
   // concurrently, there is a good chance that some of them will fail.


### PR DESCRIPTION
This PR makes the amount of parallel docker runs configurable.
In addition, it reduces the amount of checks, if the database already exists during deployment.

PG5#346 is running.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

