### PR TITLE
enable concurrent runs on ActionContainer test utility 

### DIFF
--- a/common/scala/src/main/scala/whisk/core/containerpool/HttpUtils.scala
+++ b/common/scala/src/main/scala/whisk/core/containerpool/HttpUtils.scala
@@ -20,12 +20,16 @@ package whisk.core.containerpool
 import java.net.NoRouteToHostException
 import java.nio.charset.StandardCharsets
 
-import scala.annotation.tailrec
 import scala.concurrent.duration._
+import scala.annotation.tailrec
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 import scala.util.control.NoStackTrace
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
+
 import org.apache.commons.io.IOUtils
 import org.apache.http.HttpHeaders
 import org.apache.http.client.config.RequestConfig
@@ -35,6 +39,7 @@ import org.apache.http.client.utils.URIBuilder
 import org.apache.http.conn.HttpHostConnectException
 import org.apache.http.entity.StringEntity
 import org.apache.http.impl.client.HttpClientBuilder
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager
 import spray.json._
 import whisk.common.Logging
 import whisk.common.TransactionId
@@ -53,10 +58,12 @@ import whisk.core.entity.size.SizeLong
  * @param hostname the host name
  * @param timeout the timeout in msecs to wait for a response
  * @param maxResponse the maximum size in bytes the connection will accept
+ * @param maxConcurrent the maximum number of concurrent requests allowed
  */
-protected[core] class HttpUtils(hostname: String, timeout: FiniteDuration, maxResponse: ByteSize)(
+protected[core] class HttpUtils(hostname: String, timeout: FiniteDuration, maxResponse: ByteSize, maxConcurrent: Int)(
   implicit logging: Logging) {
-
+  def this(hostname: String, timeout: FiniteDuration, maxResponse: ByteSize)(implicit logging: Logging) =
+    this(hostname: String, timeout: FiniteDuration, maxResponse: ByteSize, 1)
   def close() = Try(connection.close())
 
   /**
@@ -80,14 +87,14 @@ protected[core] class HttpUtils(hostname: String, timeout: FiniteDuration, maxRe
     request.addHeader(HttpHeaders.ACCEPT, "application/json")
     request.setEntity(entity)
 
-    execute(request, timeout, retry)
+    execute(request, timeout, maxConcurrent, retry)
   }
 
   // Used internally to wrap all exceptions for which the request can be retried
   private case class RetryableConnectionError(t: Throwable) extends Exception(t) with NoStackTrace
 
   // Annotation will make the compiler complain if no tail recursion is possible
-  @tailrec private def execute(request: HttpRequestBase, timeout: FiniteDuration, retry: Boolean)(
+  @tailrec private def execute(request: HttpRequestBase, timeout: FiniteDuration, maxConcurrent: Int, retry: Boolean)(
     implicit tid: TransactionId): Either[ContainerHttpError, ContainerResponse] = {
     Try(connection.execute(request)).map { response =>
       val containerResponse = Option(response.getEntity)
@@ -130,7 +137,7 @@ protected[core] class HttpUtils(hostname: String, timeout: FiniteDuration, maxRe
         if (timeout > Duration.Zero) {
           Thread.sleep(sleepTime.toMillis)
           val newTimeout = timeout - sleepTime
-          execute(request, newTimeout, retry = true)
+          execute(request, newTimeout, maxConcurrent, retry = true)
         } else {
           logging.warn(this, s"POST failed with ${t} - no retry because timeout exceeded.")
           Left(Timeout(t))
@@ -151,8 +158,15 @@ protected[core] class HttpUtils(hostname: String, timeout: FiniteDuration, maxRe
     .setSocketTimeout(timeout.toMillis.toInt)
     .build
 
+  // Use PoolingHttpClientConnectionManager so that concurrent activation processing (if enabled) will reuse connections
+  val cm = new PoolingHttpClientConnectionManager
+  // Increase default max connections per route (default is 2)
+  cm.setDefaultMaxPerRoute(maxConcurrent)
+  // Increase max total connections (default is 20)
+  cm.setMaxTotal(maxConcurrent)
   private val connection = HttpClientBuilder.create
     .setDefaultRequestConfig(httpconfig)
+    .setConnectionManager(if (maxConcurrent > 1) cm else null) //set the Pooling connection manager IFF maxConcurrent > 1
     .useSystemProperties()
     .disableAutomaticRetries()
     .build
@@ -164,9 +178,27 @@ object HttpUtils {
   def post(host: String, port: Int, endPoint: String, content: JsValue)(implicit logging: Logging,
                                                                         tid: TransactionId): (Int, Option[JsObject]) = {
     val connection = new HttpUtils(s"$host:$port", 90.seconds, 1.MB)
-    val response = connection.post(endPoint, content, retry = true)
+    val response = executeRequest(connection, endPoint, content)
     connection.close()
-    response match {
+    response
+  }
+
+  /** A helper method to post multiple concurrent requests to a single connection. Used for container tests. */
+  def concurrentPost(host: String, port: Int, endPoint: String, contents: Seq[JsValue], timeout: Duration)(
+    implicit logging: Logging,
+    tid: TransactionId,
+    ec: ExecutionContext): Seq[(Int, Option[JsObject])] = {
+    val connection = new HttpUtils(s"$host:$port", 90.seconds, 1.MB, contents.size)
+    val futureResults = contents.map(content => Future { executeRequest(connection, endPoint, content) })
+    val results = Await.result(Future.sequence(futureResults), timeout)
+    connection.close()
+    results
+  }
+
+  private def executeRequest(connection: HttpUtils, endpoint: String, content: JsValue)(
+    implicit logging: Logging,
+    tid: TransactionId): (Int, Option[JsObject]) = {
+    connection.post(endpoint, content, retry = true) match {
       case Right(r)                   => (r.statusCode, Try(r.entity.parseJson.asJsObject).toOption)
       case Left(NoResponseReceived()) => throw new IllegalStateException("no response from container")
       case Left(Timeout(_))           => throw new java.util.concurrent.TimeoutException()


### PR DESCRIPTION
support for tests in https://github.com/apache/incubator-openwhisk-runtime-nodejs/pull/41


<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
Enable ActionContainer test execute concurrent /run requests on containers, to support testing containers that enable concurrency activation processing. 

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

