### PR TITLE
Fix attachment name compatibility issue

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -393,7 +393,7 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
       case exec @ CodeExecAsAttachment(_, Attached(attachmentName, _, _, _), _) =>
         require(
           attachmentName == attached.attachmentName,
-          s"Attachment name '$attachmentName' does not match the expected name '${attached.attachmentName}'")
+          s"Attachment name '${attached.attachmentName}' does not match the expected name '$attachmentName'")
         exec.attach(attached)
       case exec => exec
     }

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -391,7 +391,9 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
   def attachmentHandler(action: WhiskAction, attached: Attached): WhiskAction = {
     val eu = action.exec match {
       case exec @ CodeExecAsAttachment(_, Attached(attachmentName, _, _, _), _) =>
-        require(attachmentName == attached.attachmentName)
+        require(
+          attachmentName == attached.attachmentName,
+          s"Attachment name '$attachmentName' does not match the expected name '${attached.attachmentName}'")
         exec.attach(attached)
       case exec => exec
     }

--- a/tests/src/test/scala/whisk/core/database/test/AttachmentCompatibilityTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/AttachmentCompatibilityTests.scala
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.database.test
+
+import java.io.ByteArrayInputStream
+import java.util.Base64
+
+import akka.http.scaladsl.model.{ContentType, StatusCodes}
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Source, StreamConverters}
+import akka.util.ByteString
+import common.{StreamLogging, WskActorSystem}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FlatSpec, Matchers}
+import pureconfig.loadConfigOrThrow
+import spray.json.DefaultJsonProtocol
+import whisk.common.TransactionId
+import whisk.core.ConfigKeys
+import whisk.core.database.{CouchDbConfig, CouchDbRestClient, NoDocumentException}
+import whisk.core.entity.Attachments.Inline
+import whisk.core.entity.test.ExecHelpers
+import whisk.core.entity.{
+  CodeExecAsAttachment,
+  DocInfo,
+  EntityName,
+  EntityPath,
+  WhiskAction,
+  WhiskEntity,
+  WhiskEntityStore
+}
+
+import scala.concurrent.Future
+
+class AttachmentCompatibilityTests
+    extends FlatSpec
+    with Matchers
+    with ScalaFutures
+    with BeforeAndAfterEach
+    with BeforeAndAfterAll
+    with WskActorSystem
+    with ExecHelpers
+    with DbUtils
+    with DefaultJsonProtocol
+    with StreamLogging {
+
+  //Bring in sync the timeout used by ScalaFutures and DBUtils
+  implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = dbOpTimeout)
+  implicit val materializer = ActorMaterializer()
+  val config = loadConfigOrThrow[CouchDbConfig](ConfigKeys.couchdb)
+  val entityStore = WhiskEntityStore.datastore()
+  val client =
+    new CouchDbRestClient(
+      config.protocol,
+      config.host,
+      config.port,
+      config.username,
+      config.password,
+      config.databaseFor[WhiskEntity])
+
+  override def afterEach(): Unit = {
+    cleanup()
+  }
+
+  override protected def withFixture(test: NoArgTest) = {
+    assume(isCouchStore(entityStore))
+    super.withFixture(test)
+  }
+
+  behavior of "Attachments"
+
+  it should "read attachments created using old scheme" in {
+    implicit val tid: TransactionId = transid()
+    val namespace = EntityPath("attachment-compat-test1")
+    val exec = javaDefault("ZHViZWU=", Some("hello"))
+    val doc =
+      WhiskAction(namespace, EntityName("attachment_unique"), exec)
+
+    doc.exec match {
+      case exec @ CodeExecAsAttachment(_, Inline(code), _) =>
+        val attached = exec.manifest.attached.get
+
+        val newDoc = doc.copy(exec = exec.copy(code = attached))
+        newDoc.revision(doc.rev)
+
+        val codeBytes = Base64.getDecoder().decode(code)
+        val stream = new ByteArrayInputStream(codeBytes)
+        val src = StreamConverters.fromInputStream(() => stream)
+        val info = entityStore.put(newDoc).futureValue
+        val info2 = attach(info, attached.attachmentName, attached.attachmentType, src).futureValue
+        docsToDelete += ((entityStore, info2))
+      case _ =>
+        fail("Exec must be code attachment")
+    }
+
+    val doc2 = WhiskAction.get(entityStore, doc.docid).futureValue
+    doc2.exec shouldBe exec
+  }
+
+  private def attach(doc: DocInfo,
+                     name: String,
+                     contentType: ContentType,
+                     docStream: Source[ByteString, _]): Future[DocInfo] = {
+    client.putAttachment(doc.id.id, doc.rev.rev, name, contentType, docStream).map {
+      case Right(response) =>
+        val id = response.fields("id").convertTo[String]
+        val rev = response.fields("rev").convertTo[String]
+        DocInfo ! (id, rev)
+
+      case Left(StatusCodes.NotFound) =>
+        throw NoDocumentException("Not found on 'readAttachment'.")
+
+      case Left(code) =>
+        throw new Exception("Unexpected http response code: " + code)
+    }
+  }
+}

--- a/tests/src/test/scala/whisk/core/database/test/AttachmentCompatibilityTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/AttachmentCompatibilityTests.scala
@@ -25,7 +25,9 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Source, StreamConverters}
 import akka.util.ByteString
 import common.{StreamLogging, WskActorSystem}
+import org.junit.runner.RunWith
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FlatSpec, Matchers}
 import pureconfig.loadConfigOrThrow
 import spray.json.DefaultJsonProtocol
@@ -46,6 +48,7 @@ import whisk.core.entity.{
 
 import scala.concurrent.Future
 
+@RunWith(classOf[JUnitRunner])
 class AttachmentCompatibilityTests
     extends FlatSpec
     with Matchers


### PR DESCRIPTION
Immutable attachments support #3502 introduced a regression due to which attachment name created using old scheme were not getting read.

This PR fixes that by checking if attachment names are as per old scheme or generated via new scheme. If using old scheme then attachment names do not use the URI format.



## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

