### PR TITLE
Update the document regarding Open JDK and Oracle JDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ wsk action invoke /whisk.system/utils/echo -p message hello --result
 These steps were tested on Mac OS X El Capitan, Ubuntu 14.04.3 LTS and Windows using Vagrant.
 For more information about using OpenWhisk on Vagrant see the [tools/vagrant/README.md](tools/vagrant/README.md)
 
+During the Vagrant setup, Open JDK 8 is used as the default Java environment. If you would like to use Oracle JDK 8, please change the line "su vagrant -c 'source all.sh'" into "su vagrant -c 'source all.sh oracle'" in tools/vagrant/Vagrantfile.
+
 ### Native development
 
 Docker must be natively installed in order to build and deploy OpenWhisk.

--- a/tools/macos/README.md
+++ b/tools/macos/README.md
@@ -27,7 +27,7 @@ If you prefer to use Docker-machine, you can follow instructions in [docker-mach
 The following are required to build and deploy OpenWhisk from a Mac host:
 
 - [Docker 1.12.0](https://docs.docker.com/docker-for-mac/)
-- [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
+- [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html) or [Open JDK 8](https://adoptopenjdk.net/releases.html#x64_mac)
 - [Scala 2.11](http://scala-lang.org/download/)
 - [Ansible 2.5.2](http://docs.ansible.com/ansible/intro_installation.html)
 
@@ -46,6 +46,24 @@ brew tap caskroom/cask
 brew tap caskroom/versions
 # install java 8
 brew cask install java8
+# install scala
+brew install scala
+# install pip
+sudo easy_install pip
+# install script prerequisites
+sudo -H pip install docker==2.2.1 ansible==2.5.2 jinja2==2.9.6 couchdb==1.1 httplib2==0.9.2 requests==2.10.0' | bash
+```
+
+The above section of command installs Oracle JDK 8 as the default Java environment. If you would like to install Open JDK 8 instead of Oracle JDK 8, please run the following section.
+
+```
+echo '
+# install homebrew
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+# install for finding alternative versions (Open JDK 8)
+brew tap AdoptOpenJDK/openjdk
+# install Open JDK 8
+brew install adoptopenjdk-openjdk8
 # install scala
 brew install scala
 # install pip

--- a/tools/ubuntu-setup/README.md
+++ b/tools/ubuntu-setup/README.md
@@ -32,9 +32,20 @@ The commands below should be executed on the host machine for single VM/server d
 
   # Change current directory to openwhisk
   cd openwhisk
+  ```
 
+Open JDK 8 is installed by running the following script as the default Java environment.
+
+  ```
   # Install all required software
   (cd tools/ubuntu-setup && ./all.sh)
+  ```
+
+If you choose to install Oracle JDK 8 instead of Open JDK 8, please run the following script.
+
+  ```
+  # Install all required software
+  (cd tools/ubuntu-setup && ./all.sh oracle)
   ```
 
 If you are deploying OpenWhisk in a distributed environment across multiple VMs, then follow the instructions in [ansible/README_DISTRIBUTED.md](../../ansible/README_DISTRIBUTED.md) to complete the deployment. Otherwise, continue with the instructions below.

--- a/tools/ubuntu-setup/all.sh
+++ b/tools/ubuntu-setup/all.sh
@@ -25,6 +25,9 @@
 
 set -e
 set -x
+
+JAVA_SOURCE=${1:-"open"}
+
 SOURCE="${BASH_SOURCE[0]}"
 SCRIPTDIR="$( dirname "$SOURCE" )"
 
@@ -35,7 +38,7 @@ echo "*** installing python dependences"
 /bin/bash "$SCRIPTDIR/pip.sh"
 
 echo "*** installing java"
-/bin/bash "$SCRIPTDIR/java8.sh"
+/bin/bash "$SCRIPTDIR/java8.sh" $JAVA_SOURCE
 
 echo "*** installing ansible"
 /bin/bash "$SCRIPTDIR/ansible.sh"

--- a/tools/ubuntu-setup/java8.sh
+++ b/tools/ubuntu-setup/java8.sh
@@ -19,10 +19,20 @@
 set -e
 set -x
 
-if [ "$(lsb_release -cs)" == "trusty" ]; then
-    sudo apt-get install -y software-properties-common python-software-properties
-    sudo add-apt-repository ppa:jonathonf/openjdk -y
-    sudo apt-get update
-fi
+JAVA_SOURCE=${1:-"open"}
 
-sudo apt-get install openjdk-8-jdk -y
+if [ "$JAVA_SOURCE" != "oracle" ] ; then
+    if [ "$(lsb_release -cs)" == "trusty" ]; then
+        sudo apt-get install -y software-properties-common python-software-properties
+        sudo add-apt-repository ppa:jonathonf/openjdk -y
+        sudo apt-get update
+    fi
+
+    sudo apt-get install openjdk-8-jdk -y
+else
+    sudo apt-get install -y software-properties-common python-software-properties
+    sudo add-apt-repository ppa:webupd8team/java -y
+    sudo apt-get update
+
+    sudo apt-get install oracle-java8-installer -y
+fi

--- a/tools/vagrant/Vagrantfile
+++ b/tools/vagrant/Vagrantfile
@@ -87,7 +87,7 @@ Vagrant.configure('2') do |config|
       echo PATH=${PATH}:${HOME}/bin:${OPENWHISK_HOME}/tools/build >> /etc/environment
       cd ${OPENWHISK_HOME}
       cd tools/ubuntu-setup
-      su vagrant -c 'source all.sh'
+      su vagrant -c 'source all.sh oracle'
       echo "`date`: ubuntu-setup-end" >> /tmp/vagrant-times.txt
     SCRIPT
 


### PR DESCRIPTION
Our documents need to be changed to point according to the usage of
Open JDK or Oracle JDK. This PR adds the instructions to install
either of them as the Java environment of OpenWhisk.

Partially-closes: apache/incubator-openwhisk-release#169

<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

