### PR TITLE
Add Ruby2.5 runtime support

### DIFF
--- a/ansible/files/runtimes.json
+++ b/ansible/files/runtimes.json
@@ -149,8 +149,8 @@
                 "default": true,
                 "deprecated": false,
                 "image": {
-                    "prefix": "remore",
-                    "name": "openwhisk-runtime-ruby",
+                    "prefix": "openwhisk",
+                    "name": "action-ruby-v2.5",
                     "tag": "latest"
                 }
             }

--- a/ansible/files/runtimes.json
+++ b/ansible/files/runtimes.json
@@ -142,6 +142,18 @@
                     "tag": "latest"
                 }
             }
+        ],
+        "ruby": [
+            {
+                "kind": "ruby:2.5",
+                "default": true,
+                "deprecated": false,
+                "image": {
+                    "prefix": "remore",
+                    "name": "openwhisk-runtime-ruby",
+                    "tag": "latest"
+                }
+            }
         ]
     },
     "blackboxes": [

--- a/core/controller/src/main/resources/apiv1swagger.json
+++ b/core/controller/src/main/resources/apiv1swagger.json
@@ -1495,15 +1495,17 @@
                 "kind": {
                     "type": "string",
                     "enum": [
+                        "blackbox",
+                        "java",
                         "nodejs:6",
                         "nodejs:8",
-                        "python:2",
-                        "python:3",
                         "php:7.1",
                         "php:7.2",
+                        "python:2",
+                        "python:3",
+                        "ruby:2.5",
                         "swift:3.1.1",
-                        "java",
-                        "blackbox"
+                        "swift:4.1"
                     ],
                     "description": "the type of action"
                 },

--- a/docs/actions-ruby.md
+++ b/docs/actions-ruby.md
@@ -1,0 +1,87 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
+## Creating and invoking Ruby actions
+
+The process of creating Ruby actions is similar to that of [other actions](actions.md#the-basics).
+The following sections guide you through creating and invoking a single Ruby action,
+and demonstrate how to bundle multiple Ruby files and third party dependencies.
+
+Ruby actions are executed using Ruby 2.5. To use this runtime, specify the `wsk` CLI parameter
+`--kind ruby:2.5` when creating or updating an action. This is the default when creating an action
+with file that has a `.rb` extension.
+
+An action is simply a top-level Ruby method. For example, create a file called `hello.rb`
+with the following source code:
+
+```ruby
+def main(args)
+  name = args["name"] || "stranger"
+  greeting = "Hello #{name}!"
+  print greeting
+  { "greeting" => greeting }
+end
+```
+
+Ruby actions always consume a Hash and return a Hash.
+The entry method for the action is `main` by default but may be specified explicitly
+when creating the action with the `wsk` CLI using `--main`, as with any other action type.
+
+You can create an OpenWhisk action called `hello_ruby` from this function as follows:
+
+```
+wsk action create hello_ruby hello.rb
+```
+
+The CLI automatically infers the type of the action from the source file extension.
+For `.rb` source files, the action runs using a Ruby 2.5 runtime.
+
+Action invocation is the same for Ruby actions as it is for [any other action](actions.md#the-basics).
+
+```
+wsk action invoke --result hello_ruby --param name World
+```
+
+```json
+{
+  "greeting": "Hello World!"
+}
+```
+
+Find out more about parameters in the [Working with parameters](./parameters.md) section.
+
+## Packaging Ruby actions in zip files
+
+You can package a Ruby action along with other files and dependent packages in a zip file.
+The filename of the source file containing the entry point (e.g., `main`) must be `main.rb`.
+For example, to create an action that includes a second file called `helper.rb`,
+first create an archive containing your source files:
+
+```bash
+zip -r hello_ruby.zip main.rb helper.rb
+```
+
+and then create the action:
+
+```bash
+wsk action create hello_ruby --kind ruby:2.5 hello_ruby.zip
+```
+
+A few Ruby gems such as `mechanize` and `jwt` are available in addition to the default and bundled gems.
+You can use arbitrary gems so long as you use zipped actions to package all the dependencies.

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -58,6 +58,7 @@ paths more suitable. Or, you can [create a new runtime](actions-new.md).
 * [JavaScript](actions-node.md)
 * [PHP](actions-php.md)
 * [Python](actions-python.md)
+* [Ruby](actions-ruby.md)
 * [Swift](actions-swift.md)
 * [Docker and native binaries](actions-docker.md)
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -25,7 +25,8 @@ This page outlines how to configure parameters when deploying packages and actio
 
 ### Passing parameters to an action at invoke time
 
-Parameters can be passed to the action when it is invoked. These examples use JavaScript but all the other languages work the same way (see documentation on [Swift actions](./actions.md#creating-swift-actions), [Python actions](./actions.mdcreating-python-actions), [Java actions](./actions.mdcreating-java-actions), [PHP actions](./actions.mdcreating-php-actions), [Docker actions](./actions.mdcreating-docker-actions) or [Go actions](./actions.mdcreating-go-actions) as appropriate for more detailed examples).
+Parameters can be passed to the action when it is invoked. These examples use JavaScript but all [the other
+languages](actions.md#languages-and-runtimes) work the same way.
 
 1. Use parameters in the action. For example, create 'hello.js' file with the following content:
 

--- a/tests/dat/actions/unicode.tests/ruby-2.5.txt
+++ b/tests/dat/actions/unicode.tests/ruby-2.5.txt
@@ -1,0 +1,8 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
+def main(args)
+  str = args["delimiter"] + " ☃ " + args["delimiter"]
+  puts str
+  { "winter" => str }
+end


### PR DESCRIPTION
This PR adds a new ruby:2.5 kind to allow Ruby methods like this:

```
def main(param)
  { :result => param.upcase }
end
```

## Description
This PR is quite similar to #2415, but this time I did it in Ruby. I do believe there are certain number of developers who'd love to pick Ruby as a primary language (see #2046 for an instance).

Currently Ruby runtime is tentatively hosted at [remore/openwhisk-runtime-ruby](https://github.com/remore/openwhisk-runtime-ruby), but needless to say I'd love to move/transfer this to anywhere The Apache Software Foundation manage.

## Related issue and scope
#2046 is most likely related

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [x] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [x] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [x] My changes require further changes to the documentation.
- [x] I updated the documentation where necessary.

