### PR TITLE
Add support for PHP 7.2 runtime

### DIFF
--- a/ansible/files/runtimes.json
+++ b/ansible/files/runtimes.json
@@ -125,11 +125,21 @@
         "php": [
             {
                 "kind": "php:7.1",
-                "default": true,
+                "default": false,
                 "deprecated": false,
                 "image": {
                     "prefix": "openwhisk",
                     "name": "action-php-v7.1",
+                    "tag": "latest"
+                }
+            },
+            {
+                "kind": "php:7.2",
+                "default": true,
+                "deprecated": false,
+                "image": {
+                    "prefix": "openwhisk",
+                    "name": "action-php-v7.2",
                     "tag": "latest"
                 }
             }

--- a/core/controller/src/main/resources/apiv1swagger.json
+++ b/core/controller/src/main/resources/apiv1swagger.json
@@ -1499,6 +1499,8 @@
                         "nodejs:8",
                         "python:2",
                         "python:3",
+                        "php:7.1",
+                        "php:7.2",
                         "swift:3.1.1",
                         "java",
                         "blackbox"

--- a/docs/actions-php.md
+++ b/docs/actions-php.md
@@ -101,8 +101,8 @@ The PHP runtime will automatically include Composer's autoloader for you, so you
 use the dependencies in your action code. Note that if you don't include your own `vendor` folder,
 then the runtime will include one for you with the following Composer packages:
 
-- guzzlehttp/guzzle       v6.7.3
-- ramsey/uuid             v3.6.3
+- guzzlehttp/guzzle       v6.3.3
+- ramsey/uuid             v3.7.3
 
 ## Built-in PHP extensions
 

--- a/docs/actions-php.md
+++ b/docs/actions-php.md
@@ -23,9 +23,10 @@ The process of creating PHP actions is similar to that of [other actions](action
 The following sections guide you through creating and invoking a single PHP action,
 and demonstrate how to bundle multiple PHP files and third party dependencies.
 
-PHP actions are executed using PHP 7.1.18.
-To use this runtime, specify the `wsk` CLI parameter `--kind php:7.1` when creating or updating an action.
+PHP actions are executed using PHP 7.2.6, with PHP 7.1.18 also available.
+To use the PHP 7.2 runtime, specify the `wsk` CLI parameter `--kind php:7.2` when creating or updating an action.
 This is the default when creating an action with file that has a `.php` extension.
+You can use `-- kind php:7.1 to use the PHP 7.1 runtime.
 
 An action is simply a top-level PHP function. For example, create a file called `hello.php`
 with the following source code:
@@ -52,7 +53,7 @@ wsk action create helloPHP hello.php
 ```
 
 The CLI automatically infers the type of the action from the source file extension.
-For `.php` source files, the action runs using a PHP 7.1 runtime.
+For `.php` source files, the action runs using a PHP 7.2 runtime.
 
 Action invocation is the same for PHP actions as it is for [any other action](actions.md#the-basics).
 

--- a/docs/webactions.md
+++ b/docs/webactions.md
@@ -372,7 +372,7 @@ $ wsk update create /guest/demo/hello hello.js --web false
 ### Decoding binary body content from Base64
 
 When using raw HTTP handling, the `__ow_body` content will be encoded in Base64 when the request content-type is binary.
-Below are functions demonstrating how to decode the body content in Node, Python, and Swift. Simply save a method shown
+Below are functions demonstrating how to decode the body content in Node, Python, Swift and PHP. Simply save a method shown
 below to file, create a raw HTTP web action utilizing the saved artifact, and invoke the web action.
 
 #### Node


### PR DESCRIPTION
## Description
This PR adds PHP 7.2 as a new kind and sets the default PHP runtime to version 7.2.

I have not provided runtime tests here as they are in the runtime-php repository and they are being removed anyway via https://github.com/apache/incubator-openwhisk/pull/3467. I'm not sure which additional tests are needed in this repo.

## Related issue and scope

https://github.com/apache/incubator-openwhisk-runtime-php/pull/28 needs to be merged and the relevant Docker containers built and uploaded to the Docker Hub first.

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [x] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [x] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [x] I updated the documentation where necessary.
