### PR TITLE
Bump reference for PHP 7.1 image

### DIFF
--- a/actionRuntimes/php7.1Action/Dockerfile
+++ b/actionRuntimes/php7.1Action/Dockerfile
@@ -1,4 +1,4 @@
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements; and to You under the Apache License, Version 2.0.
 
-FROM openwhisk/action-php-v7.1:1.0.0
+FROM openwhisk/action-php-v7.1:1.0.1

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -411,7 +411,7 @@ Swift 4.1 action runtime doesn't embed any packages, follow the instructions for
 
 ## PHP actions
 
-PHP actions are executed using PHP 7.1. To use this runtime, specify the `wsk` CLI parameter `--kind php:7.1` when creating or updating an action. This is the default when creating an action with file that has a `.php` extension.
+PHP actions are executed using PHP 7.1.18. To use this runtime, specify the `wsk` CLI parameter `--kind php:7.1` when creating or updating an action. This is the default when creating an action with file that has a `.php` extension.
 
 The following PHP extensions are available in addition to the standard ones:
 
@@ -431,8 +431,8 @@ The following PHP extensions are available in addition to the standard ones:
 
 The following Composer packages are also available:
 
-- guzzlehttp/guzzle       v6.3.0
-- ramsey/uuid             v3.6.1
+- guzzlehttp/guzzle       v6.7.3
+- ramsey/uuid             v3.6.3
 
 ## Docker actions
 


### PR DESCRIPTION
Updating the PHP 7.1 runtime version from 7.1.9 to 7.1.18.

See https://github.com/apache/incubator-openwhisk-runtime-php/compare/7.1@1.0.0...7.1@1.0.1 for differences.
