### PR TITLE
Allow invoker pools to overlap for small N.

### DIFF
--- a/tests/src/test/scala/whisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
@@ -83,6 +83,33 @@ class ShardingContainerPoolBalancerTests extends FlatSpec with Matchers with Str
     state.blackboxStepSizes shouldBe Seq(1)
   }
 
+  it should "allow managed partition to overlap with blackbox for small N" in {
+    Seq(0.1, 0.2, 0.3, 0.4, 0.5).foreach { bf =>
+      val state = ShardingContainerPoolBalancerState()(ShardingContainerPoolBalancerConfig(bf, 1))
+
+      (1 to 100).toSeq.foreach { i =>
+        state.updateInvokers((1 to i).map(_ => healthy(1)))
+
+        withClue(s"invoker count $bf $i:") {
+          state.managedInvokers.length should be <= i
+          state.blackboxInvokers should have size Math.max(1, (bf * i).toInt)
+
+          val m = state.managedInvokers.length
+          val b = state.blackboxInvokers.length
+          bf match {
+            // written out explicitly for clarity
+            case 0.1 if i < 10 => m + b shouldBe i + 1
+            case 0.2 if i < 5  => m + b shouldBe i + 1
+            case 0.3 if i < 4  => m + b shouldBe i + 1
+            case 0.4 if i < 3  => m + b shouldBe i + 1
+            case 0.5 if i < 2  => m + b shouldBe i + 1
+            case _             => m + b shouldBe i
+          }
+        }
+      }
+    }
+  }
+
   it should "update the cluster size, adjusting the invoker slots accordingly" in {
     val slots = 10
     val state = ShardingContainerPoolBalancerState()(ShardingContainerPoolBalancerConfig(0.5, slots))


### PR DESCRIPTION
## Description

For small N, allow the managed invokers to overlap with blackbox invokers.
As an example, for a blackbox fraction of 10%, and two invokers, the blackbox
pool will have size 1, but the managed pool will utilize both invokers.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#3693)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [x] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

