### PR TITLE
Move uuid into namespace to decouple it from authkey

### DIFF
--- a/common/scala/src/main/scala/whisk/core/containerpool/logging/DockerToActivationFileLogStore.scala
+++ b/common/scala/src/main/scala/whisk/core/containerpool/logging/DockerToActivationFileLogStore.scala
@@ -101,7 +101,7 @@ class DockerToActivationFileLogStore(system: ActorSystem, destinationDirectory: 
     val logs = container.logs(action.limits.logs.asMegaBytes, action.exec.sentinelledLogs)(transid)
 
     // Adding the userId field to every written record, so any background process can properly correlate.
-    val userIdField = Map("namespaceId" -> user.authkey.uuid.toJson)
+    val userIdField = Map("namespaceId" -> user.namespace.uuid.toJson)
 
     val additionalMetadata = Map(
       "activationId" -> activation.activationId.asString.toJson,

--- a/common/scala/src/main/scala/whisk/core/containerpool/logging/ElasticSearchLogStore.scala
+++ b/common/scala/src/main/scala/whisk/core/containerpool/logging/ElasticSearchLogStore.scala
@@ -97,7 +97,7 @@ class ElasticSearchLogStore(
     EsQuery(queryString, Some(queryOrder))
   }
 
-  private def generatePath(user: Identity) = elasticSearchConfig.path.format(user.uuid.asString)
+  private def generatePath(user: Identity) = elasticSearchConfig.path.format(user.namespace.uuid.asString)
 
   override def fetchLogs(user: Identity, activation: WhiskActivation, request: HttpRequest): Future[ActivationLogs] = {
     val headers = extractRequiredHeaders(request.headers)

--- a/common/scala/src/main/scala/whisk/core/entity/EntityPath.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/EntityPath.scala
@@ -82,6 +82,14 @@ protected[core] class EntityPath private (private val path: Seq[String]) extends
    * Replaces root of this path with given namespace iff the root is
    * the default namespace.
    */
+  def resolveNamespace(newNamespace: Namespace): EntityPath = {
+    resolveNamespace(newNamespace.name)
+  }
+
+  /**
+   * Replaces root of this path with given namespace iff the root is
+   * the default namespace.
+   */
   def resolveNamespace(newNamespace: EntityName): EntityPath = {
     // check if namespace is default
     if (root.toPath == EntityPath.DEFAULT) {

--- a/common/scala/src/main/scala/whisk/core/entity/Identity.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Identity.scala
@@ -19,7 +19,6 @@ package whisk.core.entity
 
 import scala.concurrent.Future
 import scala.util.Try
-
 import spray.json._
 import types.AuthStore
 import whisk.common.Logging
@@ -38,12 +37,18 @@ object UserLimits extends DefaultJsonProtocol {
   implicit val serdes = jsonFormat3(UserLimits.apply)
 }
 
+protected[core] case class Namespace(name: EntityName, uuid: UUID)
+
+protected[core] object Namespace extends DefaultJsonProtocol {
+  implicit val serdes = jsonFormat2(Namespace.apply)
+}
+
 protected[core] case class Identity(subject: Subject,
-                                    namespace: EntityName,
+                                    namespace: Namespace,
                                     authkey: AuthKey,
                                     rights: Set[Privilege],
                                     limits: UserLimits = UserLimits()) {
-  def uuid = authkey.uuid
+  def uuid = namespace.uuid
 }
 
 object Identity extends MultipleReadersSingleWriterCache[Identity, DocInfo] with DefaultJsonProtocol {
@@ -126,7 +131,12 @@ object Identity extends MultipleReadersSingleWriterCache[Identity, DocInfo] with
         val JsString(uuid) = value("uuid")
         val JsString(secret) = value("key")
         val JsString(namespace) = value("namespace")
-        Identity(subject, EntityName(namespace), AuthKey(UUID(uuid), Secret(secret)), Privilege.ALL, limits)
+        Identity(
+          subject,
+          Namespace(EntityName(namespace), UUID(uuid)),
+          AuthKey(UUID(uuid), Secret(secret)),
+          Privilege.ALL,
+          limits)
       case _ =>
         logger.error(this, s"$viewName[$key] has malformed view '${row.compactPrint}'")
         throw new IllegalStateException("identities view malformed")

--- a/common/scala/src/main/scala/whisk/core/entity/Identity.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Identity.scala
@@ -47,9 +47,7 @@ protected[core] case class Identity(subject: Subject,
                                     namespace: Namespace,
                                     authkey: AuthKey,
                                     rights: Set[Privilege],
-                                    limits: UserLimits = UserLimits()) {
-  def uuid = namespace.uuid
-}
+                                    limits: UserLimits = UserLimits())
 
 object Identity extends MultipleReadersSingleWriterCache[Identity, DocInfo] with DefaultJsonProtocol {
 

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -59,7 +59,7 @@ case class WhiskActionPut(exec: Option[Exec] = None,
   /**
    * Resolves sequence components if they contain default namespace.
    */
-  protected[core] def resolve(userNamespace: EntityName): WhiskActionPut = {
+  protected[core] def resolve(userNamespace: Namespace): WhiskActionPut = {
     exec map {
       case SequenceExec(components) =>
         val newExec = SequenceExec(components map { c =>
@@ -143,6 +143,13 @@ case class WhiskAction(namespace: EntityPath,
   /**
    * Resolves sequence components if they contain default namespace.
    */
+  protected[core] def resolve(userNamespace: Namespace): WhiskAction = {
+    resolve(userNamespace.name)
+  }
+
+  /**
+   * Resolves sequence components if they contain default namespace.
+   */
   protected[core] def resolve(userNamespace: EntityName): WhiskAction = {
     exec match {
       case SequenceExec(components) =>
@@ -202,11 +209,11 @@ case class WhiskActionMetaData(namespace: EntityPath,
   /**
    * Resolves sequence components if they contain default namespace.
    */
-  protected[core] def resolve(userNamespace: EntityName): WhiskActionMetaData = {
+  protected[core] def resolve(userNamespace: Namespace): WhiskActionMetaData = {
     exec match {
       case SequenceExecMetaData(components) =>
         val newExec = SequenceExecMetaData(components map { c =>
-          FullyQualifiedEntityName(c.path.resolveNamespace(userNamespace), c.name)
+          FullyQualifiedEntityName(c.path.resolveNamespace(userNamespace.name), c.name)
         })
         copy(exec = newExec).revision[WhiskActionMetaData](rev)
       case _ => this

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAuth.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAuth.scala
@@ -25,18 +25,18 @@ import scala.util.Try
  * database. Each namespace has its own key which is used to determine
  * the {@ Identity} of the user calling.
  */
-protected[core] case class WhiskNamespace(name: EntityName, authkey: AuthKey)
+protected[core] case class WhiskNamespace(namespace: Namespace, authkey: AuthKey)
 
 protected[core] object WhiskNamespace extends DefaultJsonProtocol {
   implicit val serdes = new RootJsonFormat[WhiskNamespace] {
     def write(w: WhiskNamespace) =
-      JsObject("name" -> w.name.toJson, "uuid" -> w.authkey.uuid.toJson, "key" -> w.authkey.key.toJson)
+      JsObject("name" -> w.namespace.name.toJson, "uuid" -> w.namespace.uuid.toJson, "key" -> w.authkey.key.toJson)
 
     def read(value: JsValue) =
       Try {
         value.asJsObject.getFields("name", "uuid", "key") match {
           case Seq(JsString(n), JsString(u), JsString(k)) =>
-            WhiskNamespace(EntityName(n), AuthKey(UUID(u), Secret(k)))
+            WhiskNamespace(Namespace(EntityName(n), UUID(u)), AuthKey(UUID(u), Secret(k)))
         }
       } getOrElse deserializationError("namespace record malformed")
   }

--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -186,7 +186,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
   override def create(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
     parameter('overwrite ? false) { overwrite =>
       entity(as[WhiskActionPut]) { content =>
-        val request = content.resolve(user.namespace.name)
+        val request = content.resolve(user.namespace)
 
         onComplete(entitleReferencedEntities(user, Privilege.READ, request.exec)) {
           case Success(_) =>
@@ -221,7 +221,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
         getEntity(WhiskActionMetaData.get(entityStore, entityName.toDocId), Some {
           act: WhiskActionMetaData =>
             // resolve the action --- special case for sequences that may contain components with '_' as default package
-            val action = act.resolve(user.namespace.name)
+            val action = act.resolve(user.namespace)
             onComplete(entitleReferencedEntitiesMetaData(user, Privilege.ACTIVATE, Some(action.exec))) {
               case Success(_) =>
                 val actionWithMergedParams = env.map(action.inherit(_)) getOrElse action
@@ -362,7 +362,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
                                       user: Identity): Vector[FullyQualifiedEntityName] = {
     // if components are part of the default namespace, they contain `_`; replace it!
     val resolvedComponents = components map { c =>
-      FullyQualifiedEntityName(c.path.resolveNamespace(user.namespace.name), c.name)
+      FullyQualifiedEntityName(c.path.resolveNamespace(user.namespace), c.name)
     }
     resolvedComponents
   }

--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -186,7 +186,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
   override def create(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
     parameter('overwrite ? false) { overwrite =>
       entity(as[WhiskActionPut]) { content =>
-        val request = content.resolve(user.namespace)
+        val request = content.resolve(user.namespace.name)
 
         onComplete(entitleReferencedEntities(user, Privilege.READ, request.exec)) {
           case Success(_) =>
@@ -221,7 +221,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
         getEntity(WhiskActionMetaData.get(entityStore, entityName.toDocId), Some {
           act: WhiskActionMetaData =>
             // resolve the action --- special case for sequences that may contain components with '_' as default package
-            val action = act.resolve(user.namespace)
+            val action = act.resolve(user.namespace.name)
             onComplete(entitleReferencedEntitiesMetaData(user, Privilege.ACTIVATE, Some(action.exec))) {
               case Success(_) =>
                 val actionWithMergedParams = env.map(action.inherit(_)) getOrElse action
@@ -362,7 +362,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
                                       user: Identity): Vector[FullyQualifiedEntityName] = {
     // if components are part of the default namespace, they contain `_`; replace it!
     val resolvedComponents = components map { c =>
-      FullyQualifiedEntityName(c.path.resolveNamespace(user.namespace), c.name)
+      FullyQualifiedEntityName(c.path.resolveNamespace(user.namespace.name), c.name)
     }
     resolvedComponents
   }

--- a/core/controller/src/main/scala/whisk/core/controller/AuthorizedRouteDispatcher.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/AuthorizedRouteDispatcher.scala
@@ -114,7 +114,7 @@ trait BasicAuthorizedRouteProvider extends Directives {
         } else {
           Messages.namespaceIllegal
         }
-      }) & extract(_ => EntityPath(if (EntityPath(ns) == EntityPath.DEFAULT) user.namespace.asString else ns))
+      }) & extract(_ => EntityPath(if (EntityPath(ns) == EntityPath.DEFAULT) user.namespace.name.asString else ns))
   }
 
   /** Validates entity name from the matched path segment. */

--- a/core/controller/src/main/scala/whisk/core/controller/Namespaces.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Namespaces.scala
@@ -42,7 +42,7 @@ trait WhiskNamespacesApi extends Directives with AuthenticatedRouteProvider {
    */
   override def routes(user: Identity)(implicit transid: TransactionId) = {
     (pathPrefix(collection.path) & collectionOps) {
-      complete(OK, List(user.namespace))
+      complete(OK, List(user.namespace.name))
     }
   }
 }

--- a/core/controller/src/main/scala/whisk/core/controller/Packages.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Packages.scala
@@ -172,7 +172,7 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
       'skip.as[ListSkip] ? ListSkip(collection.defaultListSkip),
       'limit.as[ListLimit] ? ListLimit(collection.defaultListLimit),
       'count ? false) { (skip, limit, count) =>
-      val viewName = if (user.namespace.toPath == namespace) WhiskPackage.view else WhiskPackage.publicPackagesView
+      val viewName = if (user.namespace.name.toPath == namespace) WhiskPackage.view else WhiskPackage.publicPackagesView
       if (!count) {
         listEntities {
           WhiskPackage

--- a/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
@@ -138,7 +138,7 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
           val triggerActivationId = activationIdFactory.make()
           logging.info(this, s"[POST] trigger activation id: ${triggerActivationId}")
           val triggerActivation = WhiskActivation(
-            namespace = user.namespace.toPath, // all activations should end up in the one space regardless trigger.namespace,
+            namespace = user.namespace.name.toPath, // all activations should end up in the one space regardless trigger.namespace,
             entityName.name,
             user.subject,
             triggerActivationId,

--- a/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
@@ -112,7 +112,7 @@ private case class Context(propertyMap: WebApiDirectives,
         .toMap
         .toJson,
       propertyMap.path -> path.toJson) ++
-      user.map(u => propertyMap.namespace -> u.namespace.asString.toJson)
+      user.map(u => propertyMap.namespace -> u.namespace.name.asString.toJson)
   }
 
   def toActionArgument(user: Option[Identity], boxQueryAndBody: Boolean): Map[String, JsValue] = {

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
@@ -344,7 +344,7 @@ protected[actions] trait PrimitiveActions {
               // no next action, end composition execution, return to caller
               Future.successful(ActivationResponse(activation.response.statusCode, Some(params.getOrElse(result))))
             case Some(next) =>
-              FullyQualifiedEntityName.resolveName(next, user.namespace) match {
+              FullyQualifiedEntityName.resolveName(next, user.namespace.name) match {
                 case Some(fqn) if session.accounting.components < actionSequenceLimit =>
                   tryInvokeNext(user, fqn, params, session)
 
@@ -512,7 +512,7 @@ protected[actions] trait PrimitiveActions {
 
     // create the whisk activation
     val activation = WhiskActivation(
-      namespace = user.namespace.toPath,
+      namespace = user.namespace.name.toPath,
       name = session.action.name,
       user.subject,
       activationId = session.activationId,
@@ -552,7 +552,7 @@ protected[actions] trait PrimitiveActions {
     implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
     val result = Promise[Either[ActivationId, WhiskActivation]]
 
-    val docid = new DocId(WhiskEntity.qualifiedName(user.namespace.toPath, activationId))
+    val docid = new DocId(WhiskEntity.qualifiedName(user.namespace.name.toPath, activationId))
     logging.debug(this, s"action activation will block for result upto $totalWaitTime")
 
     // 1. Wait for the active-ack to happen. Either immediately resolve the promise or poll the database quickly

--- a/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
@@ -358,7 +358,7 @@ protected[actions] trait SequenceActions {
   private def resolveDefaultNamespace(components: Vector[FullyQualifiedEntityName],
                                       user: Identity): Vector[FullyQualifiedEntityName] = {
     // resolve any namespaces that may appears as "_" (the default namespace)
-    components.map(c => FullyQualifiedEntityName(c.path.resolveNamespace(user.namespace.name), c.name))
+    components.map(c => FullyQualifiedEntityName(c.path.resolveNamespace(user.namespace), c.name))
   }
 
   /** Max atomic action count allowed for sequences */

--- a/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
@@ -196,7 +196,7 @@ protected[actions] trait SequenceActions {
 
     // create the whisk activation
     WhiskActivation(
-      namespace = user.namespace.toPath,
+      namespace = user.namespace.name.toPath,
       name = action.name,
       user.subject,
       activationId = activationId,
@@ -358,7 +358,7 @@ protected[actions] trait SequenceActions {
   private def resolveDefaultNamespace(components: Vector[FullyQualifiedEntityName],
                                       user: Identity): Vector[FullyQualifiedEntityName] = {
     // resolve any namespaces that may appears as "_" (the default namespace)
-    components.map(c => FullyQualifiedEntityName(c.path.resolveNamespace(user.namespace), c.name))
+    components.map(c => FullyQualifiedEntityName(c.path.resolveNamespace(user.namespace.name), c.name))
   }
 
   /** Max atomic action count allowed for sequences */

--- a/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
@@ -42,11 +42,11 @@ class ActivationThrottler(loadBalancer: LoadBalancer, concurrencyLimit: Identity
    * Checks whether the operation should be allowed to proceed.
    */
   def check(user: Identity)(implicit tid: TransactionId): Future[RateLimit] = {
-    loadBalancer.activeActivationsFor(user.uuid).map { concurrentActivations =>
+    loadBalancer.activeActivationsFor(user.namespace.uuid).map { concurrentActivations =>
       val currentLimit = concurrencyLimit(user)
       logging.debug(
         this,
-        s"namespace = ${user.uuid.asString}, concurrent activations = $concurrentActivations, below limit = $currentLimit")
+        s"namespace = ${user.namespace.uuid.asString}, concurrent activations = $concurrentActivations, below limit = $currentLimit")
       ConcurrentRateLimit(concurrentActivations, currentLimit)
     }
   }

--- a/core/controller/src/main/scala/whisk/core/entitlement/RateThrottler.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/RateThrottler.scala
@@ -45,7 +45,7 @@ class RateThrottler(description: String, maxPerMinute: Identity => Int)(implicit
    * @return true iff subject namespace is below allowed limit
    */
   def check(user: Identity)(implicit transid: TransactionId): RateLimit = {
-    val uuid = user.uuid // this is namespace identifier
+    val uuid = user.namespace.uuid // this is namespace identifier
     val throttle = rateMap.getOrElseUpdate(uuid, new RateInfo)
     val limit = maxPerMinute(user)
     val rate = TimedRateLimit(throttle.update(limit), limit)

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
@@ -221,13 +221,14 @@ object InvokerPool {
   /** A stub identity for invoking the test action. This does not need to be a valid identity. */
   val healthActionIdentity = {
     val whiskSystem = "whisk.system"
-    Identity(Subject(whiskSystem), EntityName(whiskSystem), AuthKey(UUID(), Secret()), Set[Privilege]())
+    val uuid = UUID()
+    Identity(Subject(whiskSystem), Namespace(EntityName(whiskSystem), uuid), AuthKey(uuid, Secret()), Set[Privilege]())
   }
 
   /** An action to use for monitoring invoker health. */
   def healthAction(i: InstanceId) = ExecManifest.runtimesManifest.resolveDefaultRuntime("nodejs:6").map { manifest =>
     new WhiskAction(
-      namespace = healthActionIdentity.namespace.toPath,
+      namespace = healthActionIdentity.namespace.name.toPath,
       name = EntityName(s"invokerHealthTestAction${i.toInt}"),
       exec = CodeExecAsString(manifest, """function main(params) { return params; }""", None))
   }

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
@@ -162,7 +162,7 @@ class ShardingContainerPoolBalancer(config: WhiskConfig, controllerInstance: Ins
                               instance: InstanceId): ActivationEntry = {
 
     totalActivations.increment()
-    activationsPerNamespace.getOrElseUpdate(msg.user.uuid, new LongAdder()).increment()
+    activationsPerNamespace.getOrElseUpdate(msg.user.namespace.uuid, new LongAdder()).increment()
 
     val timeout = action.limits.timeout.duration.max(TimeLimit.STD_DURATION) + 1.minute
     // Install a timeout handler for the catastrophic case where an active ack is not received at all
@@ -178,7 +178,7 @@ class ShardingContainerPoolBalancer(config: WhiskConfig, controllerInstance: Ins
         // please note: timeoutHandler.cancel must be called on all non-timeout paths, e.g. Success
         ActivationEntry(
           msg.activationId,
-          msg.user.uuid,
+          msg.user.namespace.uuid,
           instance,
           timeoutHandler,
           Promise[Either[ActivationId, WhiskActivation]]())

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
@@ -138,7 +138,7 @@ class ShardingContainerPoolBalancer(config: WhiskConfig, controllerInstance: Ins
       if (!action.exec.pull) (schedulingState.managedInvokers, schedulingState.managedStepSizes)
       else (schedulingState.blackboxInvokers, schedulingState.blackboxStepSizes)
     val chosen = if (invokersToUse.nonEmpty) {
-      val hash = ShardingContainerPoolBalancer.generateHash(msg.user.namespace, action.fullyQualifiedName(false))
+      val hash = ShardingContainerPoolBalancer.generateHash(msg.user.namespace.name, action.fullyQualifiedName(false))
       val homeInvoker = hash % invokersToUse.size
       val stepSize = stepSizes(hash % stepSizes.size)
       ShardingContainerPoolBalancer.schedule(invokersToUse, schedulingState.invokerSlots, homeInvoker, stepSize)

--- a/core/invoker/src/main/scala/whisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/ContainerPool.scala
@@ -95,7 +95,7 @@ class ContainerPool(childFactory: ActorRefFactory => ActorRef,
 
         // Schedule a job to a warm container
         ContainerPool
-          .schedule(r.action, r.msg.user.namespace, freePool)
+          .schedule(r.action, r.msg.user.namespace.name, freePool)
           .map(container => {
             (container, "warm")
           })
@@ -141,7 +141,7 @@ class ContainerPool(childFactory: ActorRefFactory => ActorRef,
               this,
               s"Rescheduling Run message, too many message in the pool, freePoolSize: ${freePool.size}, " +
                 s"busyPoolSize: ${busyPool.size}, maxActiveContainers ${poolConfig.maxActiveContainers}, " +
-                s"userNamespace: ${r.msg.user.namespace}, action: ${r.action}")(r.msg.transid)
+                s"userNamespace: ${r.msg.user.namespace.name}, action: ${r.action}")(r.msg.transid)
             Some(logMessageInterval.fromNow)
           } else {
             r.retryLogDeadline

--- a/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesInvokerAgentLogStore.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesInvokerAgentLogStore.scala
@@ -51,7 +51,7 @@ class KubernetesInvokerAgentLogStore(system: ActorSystem) extends LogDriverLogSt
     val sentinelledLogs = action.exec.sentinelledLogs
 
     // Add the userId field to every written record, so any background process can properly correlate.
-    val userIdField = Map("namespaceId" -> user.authkey.uuid.toJson)
+    val userIdField = Map("namespaceId" -> user.namespace.uuid.toJson)
 
     val additionalMetadata = Map(
       "activationId" -> activation.activationId.asString.toJson,

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
@@ -234,7 +234,7 @@ class InvokerReactive(
 
                 val activation = generateFallbackActivation(msg, response)
                 activationFeed ! MessageFeed.Processed
-                ack(msg.transid, activation, msg.blocking, msg.rootControllerIndex, msg.user.authkey.uuid)
+                ack(msg.transid, activation, msg.blocking, msg.rootControllerIndex, msg.user.namespace.uuid)
                 store(msg.transid, activation)
                 Future.successful(())
             }
@@ -244,8 +244,8 @@ class InvokerReactive(
           activationFeed ! MessageFeed.Processed
           val activation =
             generateFallbackActivation(msg, ActivationResponse.applicationError(Messages.namespacesBlacklisted))
-          ack(msg.transid, activation, false, msg.rootControllerIndex, msg.user.authkey.uuid)
-          logging.warn(this, s"namespace ${msg.user.namespace} was blocked in invoker.")
+          ack(msg.transid, activation, false, msg.rootControllerIndex, msg.user.namespace.uuid)
+          logging.warn(this, s"namespace ${msg.user.namespace.name} was blocked in invoker.")
           Future.successful(())
         }
       }
@@ -268,7 +268,7 @@ class InvokerReactive(
 
     WhiskActivation(
       activationId = msg.activationId,
-      namespace = msg.user.namespace.toPath,
+      namespace = msg.user.namespace.name.toPath,
       subject = msg.user.subject,
       cause = msg.cause,
       name = msg.action.name,

--- a/core/invoker/src/main/scala/whisk/core/invoker/NamespaceBlacklist.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/NamespaceBlacklist.scala
@@ -44,7 +44,7 @@ class NamespaceBlacklist(authStore: AuthStore) {
    * @param identity which invoked the action.
    * @return whether or not the current identity is considered blacklisted
    */
-  def isBlacklisted(identity: Identity): Boolean = blacklist.contains(identity.namespace.name)
+  def isBlacklisted(identity: Identity): Boolean = blacklist.contains(identity.namespace.name.asString)
 
   /** Refreshes the current blacklist from the database. */
   def refreshBlacklist()(implicit ec: ExecutionContext, tid: TransactionId): Future[Set[String]] = {

--- a/tests/src/test/scala/whisk/core/containerpool/logging/ElasticSearchLogStoreTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/logging/ElasticSearchLogStoreTests.scala
@@ -167,7 +167,7 @@ class ElasticSearchLogStoreTests
       ElasticSearchLogStoreConfig("https", "host", 443, "/elasticsearch/logstash-%s*/_search", defaultLogSchema)
     val httpRequest = HttpRequest(
       POST,
-      Uri(s"/elasticsearch/logstash-${user.uuid.asString}*/_search"),
+      Uri(s"/elasticsearch/logstash-${user.namespace.uuid.asString}*/_search"),
       List(Accept(MediaTypes.`application/json`)),
       HttpEntity(ContentTypes.`application/json`, defaultPayload))
     val esLogStore = new ElasticSearchLogStore(

--- a/tests/src/test/scala/whisk/core/containerpool/logging/ElasticSearchLogStoreTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/logging/ElasticSearchLogStoreTests.scala
@@ -52,7 +52,8 @@ class ElasticSearchLogStoreTests
   implicit val ec: ExecutionContext = system.dispatcher
   implicit val materializer: ActorMaterializer = ActorMaterializer()
 
-  private val user = Identity(Subject(), EntityName("testSpace"), AuthKey(), Set())
+  private val uuid = UUID()
+  private val user = Identity(Subject(), Namespace(EntityName("testSpace"), uuid), AuthKey(uuid, Secret()), Set())
   private val activationId = ActivationId.generate()
 
   private val defaultLogSchema =

--- a/tests/src/test/scala/whisk/core/containerpool/logging/SplunkLogStoreTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/logging/SplunkLogStoreTests.scala
@@ -68,7 +68,8 @@ class SplunkLogStoreTests
   val startTime = "2007-12-03T10:15:30Z"
   val endTime = "2007-12-03T10:15:45Z"
   val endTimePlus5 = "2007-12-03T10:15:50Z" //queried end time range is endTime+5
-  val user = Identity(Subject(), EntityName("testSpace"), AuthKey(), Set())
+  val uuid = UUID()
+  val user = Identity(Subject(), Namespace(EntityName("testSpace"), uuid), AuthKey(uuid, Secret()), Set())
   val request = HttpRequest(
     method = POST,
     uri = "https://some.url",

--- a/tests/src/test/scala/whisk/core/containerpool/logging/test/DockerToActivationFileLogStoreTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/logging/test/DockerToActivationFileLogStoreTests.scala
@@ -57,7 +57,7 @@ class DockerToActivationFileLogStoreTests
   }
 
   def toLoggedActivation(activation: WhiskActivation): String = {
-    JsObject(activation.toJson.fields ++ Map("namespaceId" -> user.authkey.uuid.asString.toJson)).compactPrint + "\n"
+    JsObject(activation.toJson.fields ++ Map("namespaceId" -> user.namespace.uuid.asString.toJson)).compactPrint + "\n"
   }
 
   behavior of "DockerCouchDbFileLogStore"
@@ -77,7 +77,7 @@ class DockerToActivationFileLogStoreTests
     await(collected) shouldBe ActivationLogs(logs.map(_.toFormattedString).toVector)
     logs.foreach { line =>
       testActor.expectMsg(
-        toLoggedEvent(line, user.authkey.uuid, activation.activationId, action.fullyQualifiedName(false)))
+        toLoggedEvent(line, user.namespace.uuid, activation.activationId, action.fullyQualifiedName(false)))
     }
 
     // Last message should be the full activation

--- a/tests/src/test/scala/whisk/core/containerpool/logging/test/DockerToActivationLogStoreTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/logging/test/DockerToActivationLogStoreTests.scala
@@ -40,12 +40,13 @@ import scala.concurrent.duration._
 class DockerToActivationLogStoreTests extends FlatSpec with Matchers with WskActorSystem with StreamLogging {
   def await[T](future: Future[T]) = Await.result(future, 1.minute)
 
-  val user = Identity(Subject(), EntityName("testSpace"), AuthKey(), Set())
+  val uuid = UUID()
+  val user = Identity(Subject(), Namespace(EntityName("testSpace"), uuid), AuthKey(uuid, Secret()), Set())
   val exec = CodeExecAsString(RuntimeManifest("actionKind", ImageName("testImage")), "testCode", None)
-  val action = ExecutableWhiskAction(user.namespace.toPath, EntityName("actionName"), exec)
+  val action = ExecutableWhiskAction(user.namespace.name.toPath, EntityName("actionName"), exec)
   val activation =
     WhiskActivation(
-      user.namespace.toPath,
+      user.namespace.name.toPath,
       action.name,
       user.subject,
       ActivationId.generate(),

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerPoolTests.scala
@@ -71,11 +71,12 @@ class ContainerPoolTests
 
   /** Creates a `Run` message */
   def createRunMessage(action: ExecutableWhiskAction, invocationNamespace: EntityName) = {
+    val uuid = UUID()
     val message = ActivationMessage(
       TransactionId.testing,
       action.fullyQualifiedName(true),
       action.rev,
-      Identity(Subject(), invocationNamespace, AuthKey(), Set()),
+      Identity(Subject(), Namespace(invocationNamespace, uuid), AuthKey(uuid, Secret()), Set()),
       ActivationId.generate(),
       InstanceId(0),
       blocking = false,

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
@@ -79,11 +79,13 @@ class ContainerProxyTests
     Interval(now, now.plusMillis(200))
   }
 
+  val uuid = UUID()
+
   val message = ActivationMessage(
     messageTransId,
     action.fullyQualifiedName(true),
     action.rev,
-    Identity(Subject(), invocationNamespace, AuthKey(), Set()),
+    Identity(Subject(), Namespace(invocationNamespace, uuid), AuthKey(uuid, Secret()), Set()),
     ActivationId.generate(),
     InstanceId(0),
     blocking = false,
@@ -760,7 +762,7 @@ class ContainerProxyTests
       implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
       runCount += 1
       environment.fields("api_key") shouldBe message.user.authkey.toJson
-      environment.fields("namespace") shouldBe invocationNamespace.toJson
+      environment.fields("namespace") shouldBe invocationNamespace.name.toJson
       environment.fields("action_name") shouldBe message.action.qualifiedNameWithLeadingSlash.toJson
       environment.fields("activation_id") shouldBe message.activationId.toJson
       val deadline = Instant.ofEpochMilli(environment.fields("deadline").convertTo[String].toLong)

--- a/tests/src/test/scala/whisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/PackagesApiTests.scala
@@ -264,7 +264,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
       waitOnView(entityStore, WhiskPackage, namespaces(0), 1)
       waitOnView(entityStore, WhiskPackage, namespaces(1), 1)
       waitOnView(entityStore, WhiskPackage, namespaces(2), 1)
-      val expected = providers filter (_.namespace == creds.namespace.toPath)
+      val expected = providers filter (_.namespace == creds.namespace.name.toPath)
 
       Get(s"$collectionPath?public=true") ~> Route.seal(routes(creds)) ~> check {
         status should be(OK)

--- a/tests/src/test/scala/whisk/core/controller/test/WhiskAuthHelpers.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/WhiskAuthHelpers.scala
@@ -24,13 +24,14 @@ import whisk.core.entity.WhiskAuth
 import whisk.core.entity.Subject
 import whisk.core.entitlement.Privilege
 import whisk.core.entity.Identity
+import whisk.core.entity.Namespace
 
 object WhiskAuthHelpers {
   def newAuth(s: Subject = Subject(), k: AuthKey = AuthKey()) = {
-    WhiskAuth(s, Set(WhiskNamespace(EntityName(s.asString), k)))
+    WhiskAuth(s, Set(WhiskNamespace(Namespace(EntityName(s.asString), k.uuid), k)))
   }
 
   def newIdentity(s: Subject = Subject(), k: AuthKey = AuthKey()) = {
-    Identity(s, EntityName(s.asString), k, Privilege.ALL)
+    Identity(s, Namespace(EntityName(s.asString), k.uuid), k, Privilege.ALL)
   }
 }

--- a/tests/src/test/scala/whisk/core/database/test/behavior/ArtifactStoreBehaviorBase.scala
+++ b/tests/src/test/scala/whisk/core/database/test/behavior/ArtifactStoreBehaviorBase.scala
@@ -108,7 +108,8 @@ trait ArtifactStoreBehaviorBase
   }
 
   protected def wskNS(name: String) = {
-    WhiskNamespace(EntityName(name), AuthKey())
+    val uuid = UUID()
+    WhiskNamespace(Namespace(EntityName(name), uuid), AuthKey(uuid, Secret()))
   }
 
   private val exec = BlackBoxExec(ExecManifest.ImageName("image"), None, None, native = false)

--- a/tests/src/test/scala/whisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/SchemaTests.scala
@@ -187,6 +187,9 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with ExecHelpers with Mat
     EntityPath.DEFAULT.resolveNamespace(EntityName("a")) shouldBe EntityPath("a")
     EntityPath("a").resolveNamespace(EntityName("b")) shouldBe EntityPath("a")
 
+    EntityPath.DEFAULT.resolveNamespace(Namespace(EntityName("a"), UUID())) shouldBe EntityPath("a")
+    EntityPath("a").resolveNamespace(Namespace(EntityName("b"), UUID())) shouldBe EntityPath("a")
+
     EntityPath("a").defaultPackage shouldBe true
     EntityPath("a/b").defaultPackage shouldBe false
 

--- a/tests/src/test/scala/whisk/core/invoker/test/NamespaceBlacklistTests.scala
+++ b/tests/src/test/scala/whisk/core/invoker/test/NamespaceBlacklistTests.scala
@@ -62,32 +62,44 @@ class NamespaceBlacklistTests
     dbConfig.databaseFor[WhiskAuth])
 
   /* Identities needed for the first test */
+  val uuid1 = UUID()
+  val uuid2 = UUID()
+  val uuid3 = UUID()
   val identities = Seq(
-    Identity(Subject(), EntityName("testnamespace1"), AuthKey(), Set.empty, UserLimits(invocationsPerMinute = Some(0))),
     Identity(
       Subject(),
-      EntityName("testnamespace2"),
-      AuthKey(),
+      Namespace(EntityName("testnamespace1"), uuid1),
+      AuthKey(uuid1, Secret()),
+      Set.empty,
+      UserLimits(invocationsPerMinute = Some(0))),
+    Identity(
+      Subject(),
+      Namespace(EntityName("testnamespace2"), uuid2),
+      AuthKey(uuid2, Secret()),
       Set.empty,
       UserLimits(concurrentInvocations = Some(0))),
     Identity(
       Subject(),
-      EntityName("testnamespace3"),
-      AuthKey(),
+      Namespace(EntityName("testnamespace3"), uuid3),
+      AuthKey(uuid3, Secret()),
       Set.empty,
       UserLimits(invocationsPerMinute = Some(1), concurrentInvocations = Some(1))))
 
   /* Subject document needed for the second test */
-  val subject = WhiskAuth(
-    Subject(),
-    Set(WhiskNamespace(EntityName("different1"), AuthKey()), WhiskNamespace(EntityName("different2"), AuthKey())))
+  val uuid4 = UUID()
+  val uuid5 = UUID()
+  val ak4 = AuthKey(uuid4, Secret())
+  val ak5 = AuthKey(uuid5, Secret())
+  val ns4 = Namespace(EntityName("different1"), uuid4)
+  val ns5 = Namespace(EntityName("different2"), uuid5)
+  val subject = WhiskAuth(Subject(), Set(WhiskNamespace(ns4, ak4), WhiskNamespace(ns5, ak5)))
   val blockedSubject = JsObject(subject.toJson.fields + ("blocked" -> true.toJson))
 
   val blockedNamespacesCount = 2 + subject.namespaces.size
 
   def authToIdentities(auth: WhiskAuth): Set[Identity] = {
     auth.namespaces.map { ns =>
-      Identity(auth.subject, ns.name, ns.authkey, Set(), UserLimits())
+      Identity(auth.subject, ns.namespace, ns.authkey, Set(), UserLimits())
     }
   }
 

--- a/tests/src/test/scala/whisk/core/limits/ActionLimitsTests.scala
+++ b/tests/src/test/scala/whisk/core/limits/ActionLimitsTests.scala
@@ -245,7 +245,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers {
     val allowedSize = ActivationEntityLimit.MAX_ACTIVATION_ENTITY_LIMIT.toBytes
 
     // Needs some bytes grace since activation message is not only the payload.
-    val args = Map("p" -> ("a" * (allowedSize - 700).toInt).toJson)
+    val args = Map("p" -> ("a" * (allowedSize - 750).toInt).toJson)
     val rr = wsk.action.invoke(name, args, blocking = true, expectedExitCode = TestUtils.SUCCESS_EXIT)
     val activation = wsk.parseJsonString(rr.respData).convertTo[ActivationResult]
 

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/InvokerSupervisionTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/InvokerSupervisionTests.scala
@@ -48,17 +48,7 @@ import whisk.core.WhiskConfig
 import whisk.core.connector.ActivationMessage
 import whisk.core.connector.PingMessage
 import whisk.core.entity.ActivationId.ActivationIdGenerator
-import whisk.core.entity.AuthKey
-import whisk.core.entity.DocRevision
-import whisk.core.entity.EntityName
-import whisk.core.entity.EntityPath
-import whisk.core.entity.ExecManifest
-import whisk.core.entity.FullyQualifiedEntityName
-import whisk.core.entity.Identity
-import whisk.core.entity.InstanceId
-import whisk.core.entity.Secret
-import whisk.core.entity.Subject
-import whisk.core.entity.UUID
+import whisk.core.entity._
 import whisk.core.loadBalancer.ActivationRequest
 import whisk.core.loadBalancer.GetStatus
 import whisk.core.loadBalancer.Healthy
@@ -189,14 +179,15 @@ class InvokerSupervisionTests
     val supervisor = system.actorOf(InvokerPool.props(childFactory, sendActivationToInvoker, pC))
 
     // Send ActivationMessage to InvokerPool
+    val uuid = UUID()
     val activationMessage = ActivationMessage(
       transid = TransactionId.invokerHealth,
       action = FullyQualifiedEntityName(EntityPath("whisk.system/utils"), EntityName("date")),
       revision = DocRevision.empty,
       user = Identity(
         Subject("unhealthyInvokerCheck"),
-        EntityName("unhealthyInvokerCheck"),
-        AuthKey(UUID(), Secret()),
+        Namespace(EntityName("unhealthyInvokerCheck"), uuid),
+        AuthKey(uuid, Secret()),
         Set[Privilege]()),
       activationId = new ActivationIdGenerator {}.make(),
       rootControllerIndex = InstanceId(0),


### PR DESCRIPTION
This PR makes the uuid an explicit part of a namespace  object containing name and uuid of a namespace.

## Description
In many places the uuid stored in the authkey is now used as the unique way to identify
a namespace. This behavior entangles the authorization mechanisms
with other unrelated parts of the code, making changes and extensions of the authentication mechanism unnecessarily hard.

This PR makes the uuid a member of a new namespace object containing the name and the
uuid of the namespace. All references to the uuid that are not used on the context of authorization are using the new namespace object as source.

[PG3:2375 succceded]

## Related issue and scope
N/A

## My changes affect the following components>
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

