### PR TITLE
Retry `ensureTopic` on transient, retriable exceptions.

### DIFF
--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaMessagingProvider.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaMessagingProvider.scala
@@ -21,14 +21,14 @@ import java.util.Properties
 
 import akka.actor.ActorSystem
 import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
-import org.apache.kafka.common.errors.TopicExistsException
+import org.apache.kafka.common.errors.{RetriableException, TopicExistsException}
 import pureconfig._
 import whisk.common.{CausedBy, Logging}
 import whisk.core.{ConfigKeys, WhiskConfig}
 import whisk.core.connector.{MessageConsumer, MessageProducer, MessagingProvider}
 
 import scala.collection.JavaConverters._
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
 case class KafkaConfig(replicationFactor: Short)
@@ -57,15 +57,23 @@ object KafkaMessagingProvider extends MessagingProvider {
     val partitions = 1
     val nt = new NewTopic(topic, partitions, kafkaConfig.replicationFactor).configs(topicConfig.asJava)
 
-    val result = Try(client.createTopics(List(nt).asJava).values().get(topic).get())
-      .map(_ => logging.info(this, s"created topic $topic"))
-      .recoverWith {
-        case CausedBy(_: TopicExistsException) =>
-          Success(logging.info(this, s"topic $topic already existed"))
-        case t =>
-          logging.error(this, s"ensureTopic for $topic failed due to $t")
-          Failure(t)
-      }
+    def createTopic(retries: Int = 5): Try[Unit] = {
+      Try(client.createTopics(List(nt).asJava).values().get(topic).get())
+        .map(_ => logging.info(this, s"created topic $topic"))
+        .recoverWith {
+          case CausedBy(_: TopicExistsException) =>
+            Success(logging.info(this, s"topic $topic already existed"))
+          case CausedBy(t: RetriableException) if retries > 0 =>
+            logging.warn(this, s"topic $topic could not be created because of $t, retries left: $retries")
+            Thread.sleep(1.second.toMillis)
+            createTopic(retries - 1)
+          case t =>
+            logging.error(this, s"ensureTopic for $topic failed due to $t")
+            Failure(t)
+        }
+    }
+
+    val result = createTopic()
 
     client.close()
     result


### PR DESCRIPTION
Like writing and reading from Kafka, creating topics can be subject to a battery of transient errors. Retrying those errors is safe and keeps us sane.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [X] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] ~~I added tests to cover my changes.~~
- [ ] ~~My changes require further changes to the documentation.~~
- [ ] ~~I updated the documentation where necessary.~~

