### PR TITLE
introduce timeout factor to control invoker queue behavior

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -66,6 +66,7 @@ controller:
   heap: "{{ controller_heap | default('2g') }}"
   arguments: "{{ controller_arguments | default('') }}"
   blackboxFraction: "{{ controller_blackbox_fraction | default(0.10) }}"
+  timeoutFactor: "{{ controller_timeout_factor | default(2) }}"
   instances: "{{ groups['controllers'] | length }}"
   localBookkeeping: "{{ controller_local_bookkeeping | default('false') }}"
   akka:

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -226,6 +226,8 @@
         "{{ invoker.busyThreshold }}"
       "CONFIG_whisk_loadbalancer_blackboxFraction":
         "{{ controller.blackboxFraction }}"
+      "CONFIG_whisk_loadbalancer_timeoutFactor":
+        "{{ controller.timeoutFactor }}"
 
       "CONFIG_kamon_statsd_hostname": "{{ metrics.kamon.host }}"
       "CONFIG_kamon_statsd_port": "{{ metrics.kamon.port }}"

--- a/core/controller/src/main/resources/reference.conf
+++ b/core/controller/src/main/resources/reference.conf
@@ -8,6 +8,10 @@ whisk {
   loadbalancer {
     invoker-busy-threshold: 4
     blackbox-fraction: 10%
+    # factor to increase the timeout for forced active acks
+    # timeout = time-limit.std * timeoutfactor + 1m
+    # default is 2 because init and run can both use the configured timeout fully
+    timeout-factor = 2
   }
   controller {
     protocol: http


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
This PR introduces a configurable multiplicator to influence the forced active ack timeout period.

## Description
In rare condition one can see that the load balancer put activations into queues of invokers falsely 
identified to have free capacity because forced active acks  are send out for activation that are waiting in the queue to be executed. With increasing  the timeout the loadbalancer can be influenced to distribute the load wider in this cases. 

## Related issue and scope

## My changes affect the following components

- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [x] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

[PG3:2420 succeeded]