### PR TITLE
Allow command runner to retry on network exit with custom retry

### DIFF
--- a/common/scala/src/main/scala/whisk/utils/Retry.scala
+++ b/common/scala/src/main/scala/whisk/utils/Retry.scala
@@ -22,12 +22,13 @@ import scala.concurrent.duration._
 object retry {
 
   /**
-   * Retry a method which returns a value or throws an exception on failure, up to N times,
+   * Retries a method which returns a value or throws an exception on failure, up to N times,
    * and optionally sleeping up to specified duration between retries.
    *
-   * @param fn the method to retry, fn is expected to throw an exception if it fails, else should return a value of type T
+   * @param fn the function to retry; fn is expected to throw an exception if it fails, else should return a value of type T
    * @param N the maximum number of times to apply fn, must be >= 1
    * @param waitBeforeRetry an option specifying duration to wait before retrying method, will not wait if none given
+   * @param retryMessage an optional message to emit before retrying function
    * @return the result of fn iff it is successful
    * @throws Throwable exception from fn (or an illegal argument exception if N is < 1)
    */

--- a/tests/src/test/scala/common/TestUtils.java
+++ b/tests/src/test/scala/common/TestUtils.java
@@ -57,9 +57,9 @@ public class TestUtils {
     public static final int SUCCESS_EXIT        = 0;
     public static final int ERROR_EXIT          = 1;
     public static final int MISUSE_EXIT         = 2;
+    public static final int NETWORK_ERROR_EXIT  = 3;
     public static final int DONTCARE_EXIT       = -1;       // any value is ok
     public static final int ANY_ERROR_EXIT      = -2;       // any non-zero value is ok
-    public static final int NETWORK_ERROR_EXIT  = 3;
 
     public static final int ACCEPTED        = 202;      // 202
     public static final int BAD_REQUEST     = 144;      // 400 - 256 = 144


### PR DESCRIPTION
This PR addresses a small bug introduced in https://github.com/apache/incubator-openwhisk/pull/3694 which prevents a test from dictating that it does not care about the exit code. Using the `common.retry` method which requires the retried function to throw an exception makes it difficult to restore the previous behavior while also allowing for retry on network hiccups.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->

I did not open an issue but there is extensive discussion in this PR https://github.com/apache/incubator-openwhisk-cli/pull/327.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

