### PR TITLE
Avoid converting ByteString to bytes in attachment inlining flow

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -117,7 +117,7 @@ whisk {
 
         # Size limit for inlined attachments. Attachments having size less than this would
         # be inlined with there content encoded in attachmentName
-        max-inline-size = 0 k
+        max-inline-size = 16 k
 
         # Chunk sized for converting source of bytes to ByteString as part of attachment
         # upload flow

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -118,10 +118,6 @@ whisk {
         # Size limit for inlined attachments. Attachments having size less than this would
         # be inlined with there content encoded in attachmentName
         max-inline-size = 16 k
-
-        # Chunk sized for converting source of bytes to ByteString as part of attachment
-        # upload flow
-        chunk-size = 8 k
     }
 
     # CouchDB related configuration

--- a/common/scala/src/main/scala/whisk/core/database/AttachmentSupport.scala
+++ b/common/scala/src/main/scala/whisk/core/database/AttachmentSupport.scala
@@ -152,7 +152,7 @@ trait AttachmentSupport[DocumentAbstraction <: DocumentSerializer] extends Defau
 
     for {
       bytesOrSource <- inlineOrAttach(docStream)
-      uri <- Future.successful(uriOf(bytesOrSource, UUID().asString))
+      uri = uriOf(bytesOrSource, UUID().asString)
       attached <- {
         // Upload if cannot be inlined
         bytesOrSource match {

--- a/common/scala/src/main/scala/whisk/core/database/AttachmentSupport.scala
+++ b/common/scala/src/main/scala/whisk/core/database/AttachmentSupport.scala
@@ -40,7 +40,7 @@ object AttachmentSupport {
   val MemScheme: String = "mem"
 }
 
-case class InliningConfig(maxInlineSize: ByteSize, chunkSize: ByteSize)
+case class InliningConfig(maxInlineSize: ByteSize)
 
 /**
  * Provides support for inlining small attachments. Inlined attachment contents are encoded as part of attachment
@@ -140,14 +140,15 @@ trait AttachmentSupport[DocumentAbstraction <: DocumentSerializer] extends Defau
    */
   def maxInlineSize: ByteSize = inliningConfig.maxInlineSize
 
-  def chunkSize: ByteSize = inliningConfig.chunkSize
-
   protected def inliningConfig: InliningConfig
 
   protected def attachmentScheme: String
 
   protected def executionContext: ExecutionContext
 
+  /**
+   * See {{ ArtifactStore#put }}
+   */
   protected[database] def put(d: DocumentAbstraction)(implicit transid: TransactionId): Future[DocInfo]
 
   private def encode(bytes: Seq[Byte]): String = {

--- a/common/scala/src/main/scala/whisk/core/database/AttachmentSupport.scala
+++ b/common/scala/src/main/scala/whisk/core/database/AttachmentSupport.scala
@@ -24,12 +24,12 @@ import akka.http.scaladsl.model.Uri
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
-import whisk.core.database.AttachmentInliner.MemScheme
+import whisk.core.database.AttachmentSupport.MemScheme
 import whisk.core.entity.ByteSize
 
 import scala.concurrent.{ExecutionContext, Future}
 
-object AttachmentInliner {
+object AttachmentSupport {
 
   /**
    * Scheme name for attachments which are inlined
@@ -43,7 +43,7 @@ case class InliningConfig(maxInlineSize: ByteSize, chunkSize: ByteSize)
  * Provides support for inlining small attachments. Inlined attachment contents are encoded as part of attachment
  * name itself.
  */
-trait AttachmentInliner {
+trait AttachmentSupport {
 
   /** Materializer required for stream processing */
   protected[core] implicit val materializer: Materializer

--- a/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
@@ -382,7 +382,7 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
       } yield (i2, attached)
     } else {
       for {
-        bytesOrSource <- inlineAndTail(docStream)
+        bytesOrSource <- inlineOrAttach(docStream)
         uri <- Future.successful(uriOf(bytesOrSource, UUID().asString))
         attached <- {
           val a = bytesOrSource match {

--- a/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
@@ -383,7 +383,7 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
     } else {
       for {
         bytesOrSource <- inlineOrAttach(docStream)
-        uri <- Future.successful(uriOf(bytesOrSource, UUID().asString))
+        uri = uriOf(bytesOrSource, UUID().asString)
         attached <- {
           val a = bytesOrSource match {
             case Left(bytes) => Attached(uri.toString, contentType, Some(bytes.size), Some(digest(bytes)))

--- a/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
@@ -61,7 +61,7 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
   docReader: DocumentReader)
     extends ArtifactStore[DocumentAbstraction]
     with DefaultJsonProtocol
-    with AttachmentInliner {
+    with AttachmentSupport {
 
   protected[core] implicit val executionContext = system.dispatchers.lookup("dispatchers.couch-dispatcher")
 
@@ -488,7 +488,7 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
     val name = attached.attachmentName
     val attachmentUri = Uri(name)
     attachmentUri.scheme match {
-      case AttachmentInliner.MemScheme =>
+      case AttachmentSupport.MemScheme =>
         memorySource(attachmentUri).runWith(sink)
       case s if s == couchScheme || attachmentUri.isRelative =>
         //relative case is for compatibility with earlier naming approach where attachment name would be like 'jarfile'

--- a/common/scala/src/main/scala/whisk/core/database/memory/MemoryArtifactStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/memory/MemoryArtifactStore.scala
@@ -94,7 +94,7 @@ class MemoryArtifactStore[DocumentAbstraction <: DocumentSerializer](dbName: Str
     extends ArtifactStore[DocumentAbstraction]
     with DefaultJsonProtocol
     with DocumentProvider
-    with AttachmentInliner {
+    with AttachmentSupport {
 
   override protected[core] implicit val executionContext: ExecutionContext = system.dispatcher
 

--- a/common/scala/src/main/scala/whisk/core/database/memory/MemoryAttachmentStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/memory/MemoryAttachmentStore.scala
@@ -62,7 +62,8 @@ class MemoryAttachmentStore(dbName: String)(implicit system: ActorSystem,
     contentType: ContentType,
     docStream: Source[ByteString, _])(implicit transid: TransactionId): Future[AttachResult] = {
     require(name != null, "name undefined")
-    val start = transid.started(this, DATABASE_ATT_SAVE, s"[ATT_PUT] uploading attachment '$name' of document '$docId'")
+    val start =
+      transid.started(this, DATABASE_ATT_SAVE, s"[ATT_PUT] uploading attachment '$name' of document 'id: $docId'")
 
     val uploadSink = Sink.fold[ByteStringBuilder, ByteString](new ByteStringBuilder)((builder, b) => builder ++= b)
 
@@ -78,7 +79,8 @@ class MemoryAttachmentStore(dbName: String)(implicit system: ActorSystem,
     reportFailure(
       g,
       start,
-      failure => s"[ATT_PUT] '$dbName' internal error, name: '$name', doc: '$docId', failure: '${failure.getMessage}'")
+      failure =>
+        s"[ATT_PUT] '$dbName' internal error, name: '$name', doc: 'id: $docId', failure: '${failure.getMessage}'")
   }
 
   /**
@@ -88,7 +90,10 @@ class MemoryAttachmentStore(dbName: String)(implicit system: ActorSystem,
     implicit transid: TransactionId): Future[T] = {
 
     val start =
-      transid.started(this, DATABASE_ATT_GET, s"[ATT_GET] '$dbName' finding attachment '$name' of document '$docId'")
+      transid.started(
+        this,
+        DATABASE_ATT_GET,
+        s"[ATT_GET] '$dbName' finding attachment '$name' of document 'id: $docId'")
 
     val f = attachments.get(attachmentKey(docId, name)) match {
       case Some(Attachment(bytes)) =>

--- a/tests/src/test/scala/whisk/core/database/test/AttachmentSupportTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/AttachmentSupportTests.scala
@@ -39,7 +39,7 @@ class AttachmentSupportTests extends FlatSpec with Matchers with ScalaFutures wi
   implicit val materializer: Materializer = ActorMaterializer()
 
   it should "not inline if maxInlineSize set to zero" in {
-    val inliner = new AttachmentSupportTestMock(InliningConfig(maxInlineSize = 0.KB, chunkSize = 8.KB))
+    val inliner = new AttachmentSupportTestMock(InliningConfig(maxInlineSize = 0.KB))
     val bs = CompactByteString("hello world")
 
     val bytesOrSource = inliner.inlineAndTail(Source.single(bs)).futureValue

--- a/tests/src/test/scala/whisk/core/database/test/AttachmentSupportTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/AttachmentSupportTests.scala
@@ -26,11 +26,11 @@ import org.junit.runner.RunWith
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{FlatSpec, Matchers}
-import whisk.core.database.{AttachmentInliner, InliningConfig}
+import whisk.core.database.{AttachmentSupport, InliningConfig}
 import whisk.core.entity.size._
 
 @RunWith(classOf[JUnitRunner])
-class AttachmentInlinerTests extends FlatSpec with Matchers with ScalaFutures with WskActorSystem {
+class AttachmentSupportTests extends FlatSpec with Matchers with ScalaFutures with WskActorSystem {
 
   behavior of "Attachment inlining"
 
@@ -46,7 +46,7 @@ class AttachmentInlinerTests extends FlatSpec with Matchers with ScalaFutures wi
     uri shouldBe Uri("test:foo")
   }
 
-  class TestInliner(val inliningConfig: InliningConfig) extends AttachmentInliner {
+  class TestInliner(val inliningConfig: InliningConfig) extends AttachmentSupport {
     override protected[core] implicit val materializer: Materializer = ActorMaterializer()
     override protected def attachmentScheme: String = "test"
   }

--- a/tests/src/test/scala/whisk/core/database/test/AttachmentSupportTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/AttachmentSupportTests.scala
@@ -42,7 +42,7 @@ class AttachmentSupportTests extends FlatSpec with Matchers with ScalaFutures wi
     val inliner = new AttachmentSupportTestMock(InliningConfig(maxInlineSize = 0.KB))
     val bs = CompactByteString("hello world")
 
-    val bytesOrSource = inliner.inlineAndTail(Source.single(bs)).futureValue
+    val bytesOrSource = inliner.inlineOrAttach(Source.single(bs)).futureValue
     val uri = inliner.uriOf(bytesOrSource, "foo")
 
     uri shouldBe Uri("test:foo")

--- a/tests/src/test/scala/whisk/core/database/test/DbUtils.scala
+++ b/tests/src/test/scala/whisk/core/database/test/DbUtils.scala
@@ -309,9 +309,7 @@ trait DbUtils extends Assertions {
   def nonInlinedAttachmentSize(db: ArtifactStore[_]): Int = {
     db match {
       case inliner: AttachmentSupport[_] =>
-        val inlineSize = inliner.maxInlineSize.toBytes.toInt
-        val chunkSize = inliner.chunkSize.toBytes.toInt
-        Math.max(inlineSize, chunkSize) * 2
+        inliner.maxInlineSize.toBytes.toInt * 2
       case _ =>
         42
     }

--- a/tests/src/test/scala/whisk/core/database/test/DbUtils.scala
+++ b/tests/src/test/scala/whisk/core/database/test/DbUtils.scala
@@ -296,7 +296,7 @@ trait DbUtils extends Assertions {
    */
   def inlinedAttachmentSize(db: ArtifactStore[_]): Int = {
     db match {
-      case inliner: AttachmentSupport =>
+      case inliner: AttachmentSupport[_] =>
         inliner.maxInlineSize.toBytes.toInt - 1
       case _ =>
         throw new IllegalStateException(s"ArtifactStore does not support attachment inlining $db")
@@ -308,7 +308,7 @@ trait DbUtils extends Assertions {
    */
   def nonInlinedAttachmentSize(db: ArtifactStore[_]): Int = {
     db match {
-      case inliner: AttachmentSupport =>
+      case inliner: AttachmentSupport[_] =>
         val inlineSize = inliner.maxInlineSize.toBytes.toInt
         val chunkSize = inliner.chunkSize.toBytes.toInt
         Math.max(inlineSize, chunkSize) * 2

--- a/tests/src/test/scala/whisk/core/database/test/DbUtils.scala
+++ b/tests/src/test/scala/whisk/core/database/test/DbUtils.scala
@@ -296,7 +296,7 @@ trait DbUtils extends Assertions {
    */
   def inlinedAttachmentSize(db: ArtifactStore[_]): Int = {
     db match {
-      case inliner: AttachmentInliner =>
+      case inliner: AttachmentSupport =>
         inliner.maxInlineSize.toBytes.toInt - 1
       case _ =>
         throw new IllegalStateException(s"ArtifactStore does not support attachment inlining $db")
@@ -308,7 +308,7 @@ trait DbUtils extends Assertions {
    */
   def nonInlinedAttachmentSize(db: ArtifactStore[_]): Int = {
     db match {
-      case inliner: AttachmentInliner =>
+      case inliner: AttachmentSupport =>
         val inlineSize = inliner.maxInlineSize.toBytes.toInt
         val chunkSize = inliner.chunkSize.toBytes.toInt
         Math.max(inlineSize, chunkSize) * 2

--- a/tests/src/test/scala/whisk/core/database/test/behavior/ArtifactStoreAttachmentBehaviors.scala
+++ b/tests/src/test/scala/whisk/core/database/test/behavior/ArtifactStoreAttachmentBehaviors.scala
@@ -26,7 +26,7 @@ import akka.stream.scaladsl.{Sink, StreamConverters}
 import akka.util.{ByteString, ByteStringBuilder}
 import whisk.common.TransactionId
 import whisk.core.entity.size._
-import whisk.core.database.{AttachmentInliner, CacheChangeNotification, NoDocumentException}
+import whisk.core.database.{AttachmentSupport, CacheChangeNotification, NoDocumentException}
 import whisk.core.entity.Attachments.{Attached, Attachment, Inline}
 import whisk.core.entity.test.ExecHelpers
 import whisk.core.entity.{CodeExec, DocInfo, EntityName, ExecManifest, WhiskAction}
@@ -162,7 +162,7 @@ trait ArtifactStoreAttachmentBehaviors extends ArtifactStoreBehaviorBase with Ex
     val a = attached(action2)
 
     val attachmentUri = Uri(a.attachmentName)
-    attachmentUri.scheme shouldBe AttachmentInliner.MemScheme
+    attachmentUri.scheme shouldBe AttachmentSupport.MemScheme
     a.length shouldBe Some(attachmentSize)
     a.digest should not be empty
   }

--- a/tests/src/test/scala/whisk/core/database/test/behavior/ArtifactStoreAttachmentBehaviors.scala
+++ b/tests/src/test/scala/whisk/core/database/test/behavior/ArtifactStoreAttachmentBehaviors.scala
@@ -25,6 +25,7 @@ import akka.stream.IOResult
 import akka.stream.scaladsl.{Sink, StreamConverters}
 import akka.util.{ByteString, ByteStringBuilder}
 import whisk.common.TransactionId
+import whisk.core.entity.size._
 import whisk.core.database.{AttachmentInliner, CacheChangeNotification, NoDocumentException}
 import whisk.core.entity.Attachments.{Attached, Attachment, Inline}
 import whisk.core.entity.test.ExecHelpers
@@ -112,14 +113,14 @@ trait ArtifactStoreAttachmentBehaviors extends ArtifactStoreBehaviorBase with Ex
     getAttachmentBytes(i2, attached(action2)).futureValue.result() shouldBe decode(code1)
   }
 
-  it should "put and read same attachment" in {
+  it should "put and read 5 MB attachment" in {
     implicit val tid: TransactionId = transid()
-    val size = nonInlinedAttachmentSize(entityStore)
+    val size = Math.max(nonInlinedAttachmentSize(entityStore), 5.MB.toBytes.toInt)
     val base64 = encodedRandomBytes(size)
 
     val exec = javaDefault(base64, Some("hello"))
     val javaAction =
-      WhiskAction(namespace, EntityName("attachment_unique"), exec)
+      WhiskAction(namespace, EntityName("attachment_large"), exec)
 
     val i1 = WhiskAction.put(entityStore, javaAction, old = None).futureValue
     val action2 = entityStore.get[WhiskAction](i1, attachmentHandler).futureValue


### PR DESCRIPTION
This PR modifies the current attachment inlining logic to work at `ByteString` level and avoid converting ByteString to bytes and back. This fixes #3770

## Description

So far the inlining logic was converting a stream of `ByteString` to byte array and then working at byte level. This was causing the upload to slow down and also reverse conversion of stream of bytes to `ByteString` was not working as expected.

Instead of doing that it now uses approach mentioned [here](https://groups.google.com/forum/#!topic/akka-user/FdQAAzcwrqM) and works at `ByteString` level. 

See [this commit](https://github.com/apache/incubator-openwhisk/pull/3777/commits/a36bfb14a47bf3773b5dce13790c57f159874467) for this specific change

1. Do a `prefixAndTail` of 1 element
2. If extracted byteString prefix 
    1. is empty then stream is considered inline
    2. else merge the byteString prefix with `previousPrefix` and see if the size is still less than maxInlineSize or not
        1. If yes then recursively call `inlineAndTail` with new source and bytestring accumulated so far
        2. otherwise stream cannot be inlined and return a combined source of prefix extracted so far with tail

```scala 
  protected[database] def inlineAndTail(docStream: Source[ByteString, _],
                                        previousPrefix: ByteString = ByteString.empty)(
    implicit ec: ExecutionContext): Future[Either[ByteString, Source[ByteString, _]]] = {
    docStream.prefixAndTail(1).runWith(Sink.head).flatMap {
      case (prefix, tail) =>
        prefix.headOption.fold {
          Future.successful[Either[ByteString, Source[ByteString, _]]](Left(previousPrefix))
        } { prefix =>
          val completePrefix = previousPrefix ++ prefix
          if (completePrefix.size < maxInlineSize.toBytes) {
            inlineAndTail(tail, completePrefix)
          } else {
            Future.successful(Right(tail.prepend(Source.single(completePrefix))))
          }
        }
    }
  }
```

With new impl the time taken to attach is similar to setup where inlining is disabled. 

Some other aspects

1. Re-enables the attachment inlining by setting `max-inline-size` to 16 kb (same as one before #3769)
2. Removed the `chunk-size` config as its not needed
3. Refactors the logic related to uploading attachment to an `AttachmentStore` to `AttachmentSupport` trait as that remains same irrespective of `ArtifactStore`
4. Also includes a test which uploads 5MB attachment so as to check working with mid size attachments

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#3770)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

