### PR TITLE
Make test-instances of Exec depend on the loaded manifest.

### DIFF
--- a/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
@@ -47,11 +47,7 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
   private def attFmt[T: JsonFormat] = Attachments.serdes[T]
 
   protected def imagename(name: String) = {
-    var image = s"${name}action".replace(":", "")
-    if (name.equals(SWIFT3)) {
-      image = SWIFT3_IMAGE
-    }
-    ExecManifest.ImageName(image, Some("openwhisk"), Some("latest"))
+    ExecManifest.runtimesManifest.runtimes.flatMap(_.versions).find(_.kind == name).get.image
   }
 
   protected def js(code: String, main: Option[String] = None) = {


### PR DESCRIPTION
Exec.serdes very implicitly relies on a manifest to be loaded, which makes the test-instances of Exec take values from there as well. The hard-coded versions of those in ExecHelper need to respect those values as well to be correctly assertable.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).

