### PR TITLE
Fixes for vagrant installation versus oracle jdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ wsk action invoke /whisk.system/utils/echo -p message hello --result
 These steps were tested on Mac OS X El Capitan, Ubuntu 14.04.3 LTS and Windows using Vagrant.
 For more information about using OpenWhisk on Vagrant see the [tools/vagrant/README.md](tools/vagrant/README.md)
 
-During the Vagrant setup, Open JDK 8 is used as the default Java environment. If you would like to use Oracle JDK 8, please change the line "su vagrant -c 'source all.sh'" into "su vagrant -c 'source all.sh oracle'" in tools/vagrant/Vagrantfile.
+During the Vagrant setup, the Oracle JDK 8 is used as the default Java environment. If you would like to use OpenJDK 8, please change the line "su vagrant -c 'source all.sh oracle'" into "su vagrant -c 'source all.sh'" in tools/vagrant/Vagrantfile.
 
 ### Native development
 

--- a/tools/ubuntu-setup/java8.sh
+++ b/tools/ubuntu-setup/java8.sh
@@ -34,5 +34,6 @@ else
     sudo add-apt-repository ppa:webupd8team/java -y
     sudo apt-get update
 
+    echo 'oracle-java8-installer shared/accepted-oracle-license-v1-1 boolean true' | sudo debconf-set-selections
     sudo apt-get install oracle-java8-installer -y
 fi


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

Vagrant installation is broken, due to a hang waiting for acceptance of the Oracle JDK license. This PR adds an acceptance script, and updates the top-level README.md, which erroneously references OpenJDK as being the default for Vagrant.

Truthfully, I'm not sure if a modification to tools/ubuntu-setup is the right place for a Vagrant-specific modification? Unless the Oracle JDK is used there, as well.

Fixes #3765 

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#3765)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [x] I updated the documentation where necessary.

