### PR TITLE
Generic plugins for deployment

### DIFF
--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -109,7 +109,7 @@
 
 - name: populate environment variables for controller
   set_fact:
-    controller_env:
+    env:
       "JAVA_OPTS":
         -Xmx{{ controller.heap }}
         -XX:+CrashOnOutOfMemoryError
@@ -238,7 +238,7 @@
 
 - name: merge extra env variables
   set_fact:
-    controller_env: "{{ controller_env | combine(controller.extraEnv) }}"
+    env: "{{ env | combine(controller.extraEnv) }}"
 
 - name: include plugins
   include_tasks: "{{ item }}.yml"
@@ -253,7 +253,7 @@
     recreate: true
     restart_policy: "{{ docker.restart.policy }}"
     hostname: "{{ controller_name }}"
-    env: "{{ controller_env }}"
+    env: "{{ env }}"
     volumes:
       - "{{ whisk_logs_dir }}/{{ controller_name }}:/logs"
       - "{{ controller.confdir }}/{{ controller_name }}:/conf"

--- a/ansible/roles/controller/tasks/join_akka_cluster.yml
+++ b/ansible/roles/controller/tasks/join_akka_cluster.yml
@@ -15,8 +15,8 @@
 
 - name: add seed nodes to controller environment
   set_fact:
-    controller_env: >-
-      {{ controller_env | combine({
+    env: >-
+      {{ env | combine({
         'CONFIG_akka_cluster_seedNodes_' ~ item.0:
           'akka.tcp://controller-actor-system@'~item.1~':'~(controller.akka.cluster.basePort+item.0)
       }) }}
@@ -33,4 +33,4 @@
       "CONFIG_akka_remote_netty_tcp_bindPort":
         "{{ controller.akka.cluster.bindPort }}"
   set_fact:
-    controller_env: "{{ controller_env | combine(akka_env) }}"
+    env: "{{ env | combine(akka_env) }}"


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
Refactors `controller_env` to a generic name of `env` so that deploy script plugins can be used interchangeably for deploying other components. For instance, these changes allow the same plugin to be used for the controller and invoker if need be.
 
Related to https://github.com/apache/incubator-openwhisk/pull/3785.
## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

