### PR TITLE
Allow Elasticsearch client to retrieve hit count

### DIFF
--- a/common/scala/src/main/scala/whisk/core/containerpool/logging/ElasticSearchRestClient.scala
+++ b/common/scala/src/main/scala/whisk/core/containerpool/logging/ElasticSearchRestClient.scala
@@ -70,7 +70,7 @@ case class EsQuery(query: EsQueryMethod,
 
 // Schema of ES query results
 case class EsSearchHit(source: JsObject)
-case class EsSearchHits(hits: Vector[EsSearchHit])
+case class EsSearchHits(hits: Vector[EsSearchHit], total: Int)
 case class EsSearchResult(hits: EsSearchHits)
 
 object ElasticSearchJsonProtocol extends DefaultJsonProtocol {
@@ -148,7 +148,7 @@ object ElasticSearchJsonProtocol extends DefaultJsonProtocol {
 
   implicit val esQueryFormat = jsonFormat4(EsQuery.apply)
   implicit val esSearchHitFormat = jsonFormat(EsSearchHit.apply _, "_source")
-  implicit val esSearchHitsFormat = jsonFormat1(EsSearchHits.apply)
+  implicit val esSearchHitsFormat = jsonFormat2(EsSearchHits.apply)
   implicit val esSearchResultFormat = jsonFormat1(EsSearchResult.apply)
 }
 

--- a/tests/src/test/scala/whisk/core/containerpool/logging/ElasticSearchRestClientTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/logging/ElasticSearchRestClientTests.scala
@@ -185,6 +185,7 @@ class ElasticSearchRestClientTests
 
     response shouldBe 'right
     response.right.get.hits.hits should have size 1
+    response.right.get.hits.total shouldBe 1375
     response.right.get.hits.hits(0).source shouldBe defaultResponseSource.parseJson.asJsObject
   }
 


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
`EsSearchResult` will now be able to get the total number of hits from a search.

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

