### PR TITLE
add register and until to ansible invoker pull runtime images tasks

### DIFF
--- a/ansible/roles/apigateway/tasks/deploy.yml
+++ b/ansible/roles/apigateway/tasks/deploy.yml
@@ -20,8 +20,6 @@
       - "{{ apigateway.port.mgmt }}:8080"
       - "{{ apigateway.port.api }}:9000"
     pull: "{{ apigateway_local_build is undefined }}"
-  retries: "{{ docker.pull.retries }}"
-  delay: "{{ docker.pull.delay }}"
 
 - name: wait until the API Gateway in this host is up and running
   uri:

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -13,10 +13,10 @@
       "{{ (controller_index_base|int) + host_group.index(inventory_hostname) }}"
 
 - name: "pull the {{ docker.image.tag }} image of controller"
-  shell:
-    docker pull
-    {{ docker_registry~docker.image.prefix }}/controller:{{docker.image.tag}}
+  shell: "docker pull {{docker_registry}}{{ docker.image.prefix }}/controller:{{docker.image.tag}}"
   when: docker_registry != ""
+  register: result
+  until: (result.rc == 0)
   retries: "{{ docker.pull.retries }}"
   delay: "{{ docker.pull.delay }}"
 

--- a/ansible/roles/couchdb/tasks/deploy.yml
+++ b/ansible/roles/couchdb/tasks/deploy.yml
@@ -42,8 +42,6 @@
       COUCHDB_PASSWORD: "{{ db_password }}"
       NODENAME: "{{ ansible_host }}"
     pull: "{{ couchdb.pull_couchdb | default(true) }}"
-  retries: "{{ docker.pull.retries }}"
-  delay: "{{ docker.pull.delay }}"
 
 - name: wait until CouchDB in this host is up and running
   uri:

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -6,10 +6,10 @@
 - import_tasks: docker_login.yml
 
 - name: "pull invoker image with tag {{docker.image.tag}}"
-  shell: "docker pull {{docker_registry}}{{item}}:{{docker.image.tag}}"
-  with_items:
-    - '{{ docker.image.prefix }}/invoker'
+  shell: "docker pull {{docker_registry}}{{ docker.image.prefix }}/invoker:{{docker.image.tag}}"
   when: docker_registry != ""
+  register: result
+  until: (result.rc == 0)
   retries: "{{ docker.pull.retries }}"
   delay: "{{ docker.pull.delay }}"
 
@@ -22,8 +22,10 @@
 #
 - name: "pull runtime action images per manifest"
   shell: "docker pull {{runtimes_registry | default()}}{{item.prefix}}/{{item.name}}:{{item.tag | default()}}"
-  with_items: "{{ runtimesManifest.runtimes.values() | sum(start=[]) | selectattr('deprecated', 'equalto',false)  | map(attribute='image') | list | unique }}"
+  loop: "{{ runtimesManifest.runtimes.values() | sum(start=[]) | selectattr('deprecated', 'equalto',false)  | map(attribute='image') | list | unique }}"
   when: skip_pull_runtimes is not defined or skip_pull_runtimes != True
+  register: result
+  until: (result.rc == 0)
   retries: "{{ docker.pull.retries }}"
   delay: "{{ docker.pull.delay }}"
 
@@ -32,9 +34,10 @@
 #
 - name: "pull blackboxes action images per manifest"
   shell: "docker pull {{runtimes_registry | default()}}{{item.prefix}}/{{item.name}}:{{item.tag | default()}}"
-  with_items:
-    - "{{ runtimesManifest.blackboxes }}"
+  loop: "{{ runtimesManifest.blackboxes }}"
   when: skip_pull_runtimes is not defined or skip_pull_runtimes != True
+  register: result
+  until: (result.rc == 0)
   retries: "{{ docker.pull.retries }}"
   delay: "{{ docker.pull.delay }}"
 

--- a/ansible/roles/kafka/tasks/deploy.yml
+++ b/ansible/roles/kafka/tasks/deploy.yml
@@ -84,8 +84,6 @@
     volumes:
       - "{{ config_root_dir }}/kafka/certs:/config"
     pull: true
-  retries: "{{ docker.pull.retries }}"
-  delay: "{{ docker.pull.delay }}"
 
 - name: wait until the kafka server started up
   shell:

--- a/ansible/roles/nginx/tasks/deploy.yml
+++ b/ansible/roles/nginx/tasks/deploy.yml
@@ -47,6 +47,8 @@
 
 - name: "pull the nginx:{{ nginx.version }} image"
   shell: "docker pull nginx:{{ nginx.version }}"
+  register: result
+  until: (result.rc == 0)
   retries: "{{ docker.pull.retries }}"
   delay: "{{ docker.pull.delay }}"
 

--- a/ansible/roles/redis/tasks/deploy.yml
+++ b/ansible/roles/redis/tasks/deploy.yml
@@ -5,6 +5,8 @@
 
 - name: "pull the redis:{{ redis.version }} image"
   shell: "docker pull redis:{{ redis.version }}"
+  register: result
+  until: (result.rc == 0)
   retries: "{{ docker.pull.retries }}"
   delay: "{{ docker.pull.delay }}"
 

--- a/ansible/roles/registry/tasks/deploy.yml
+++ b/ansible/roles/registry/tasks/deploy.yml
@@ -5,6 +5,8 @@
 
 - name: "pull the {{ registry.version }} image of registry"
   shell: "docker pull registry:{{ registry.version }}"
+  register: result
+  until: (result.rc == 0)
   retries: "{{ docker.pull.retries }}"
   delay: "{{ docker.pull.delay }}"
 

--- a/ansible/roles/zookeeper/tasks/deploy.yml
+++ b/ansible/roles/zookeeper/tasks/deploy.yml
@@ -5,6 +5,8 @@
 
 - name: "pull the zookeeper:{{ zookeeper.version }} image"
   shell: "docker pull zookeeper:{{ zookeeper.version }}"
+  register: result
+  until: (result.rc == 0)
   retries: "{{ docker.pull.retries }}"
   delay: "{{ docker.pull.delay }}"
 


### PR DESCRIPTION
`retries` and `delays` in ansible only applies to tasks/plugins that have `until` present
The `retries` and `delays` curently present are being ignored, this PR adds the `until` and changes to the new form of `loop` from `whith_items`

Ref: https://docs.ansible.com/ansible/latest/user_guide/playbooks_loops.html#do-until-loops

`If the until parameter isn’t defined, the value for the retries parameter is forced to 1.`

