### PR TITLE
Recover image pulls by trying to run the container anyways.

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
@@ -39,6 +39,7 @@ import akka.stream.stage._
 import akka.util.ByteString
 import spray.json._
 import whisk.core.containerpool.logging.LogLine
+import whisk.core.entity.ExecManifest.ImageName
 import whisk.http.Messages
 
 object DockerContainer {
@@ -54,9 +55,7 @@ object DockerContainer {
    * Creates a container running on a docker daemon.
    *
    * @param transid transaction creating the container
-   * @param image image to create the container from
-   * @param userProvidedImage whether the image is provided by the user
-   *     or is an OpenWhisk provided image
+   * @param image either a user provided (Left) or OpenWhisk provided (Right) image
    * @param memory memorylimit of the container
    * @param cpuShares sharefactor for the container
    * @param environment environment variables to set on the container
@@ -67,8 +66,7 @@ object DockerContainer {
    * @return a Future which either completes with a DockerContainer or one of two specific failures
    */
   def create(transid: TransactionId,
-             image: String,
-             userProvidedImage: Boolean = false,
+             image: Either[ImageName, String],
              memory: ByteSize = 256.MB,
              cpuShares: Int = 0,
              environment: Map[String, String] = Map.empty,
@@ -104,22 +102,44 @@ object DockerContainer {
       dnsServers.flatMap(d => Seq("--dns", d)) ++
       name.map(n => Seq("--name", n)).getOrElse(Seq.empty) ++
       params
-    val pulled = if (userProvidedImage) {
-      docker.pull(image).recoverWith {
-        case _ => Future.failed(BlackboxStartupError(Messages.imagePullError(image)))
-      }
-    } else Future.successful(())
+
+    val imageToUse = image.fold(_.publicImageName, identity)
+
+    val pulled = image match {
+      case Left(userProvided) if userProvided.tag.map(_ == "latest").getOrElse(true) =>
+        // Iff the image tag is "latest" explicitly (or implicitly because no tag is given at all), failing to pull will
+        // fail the whole container bringup process, because it is expected to pick up the very latest version every
+        // time.
+        docker.pull(imageToUse).map(_ => true).recoverWith {
+          case _ => Future.failed(BlackboxStartupError(Messages.imagePullError(imageToUse)))
+        }
+      case Left(_) =>
+        // Iff the image tag is something else than latest, we tolerate an outdated image if one is available locally.
+        // A `docker run` will be tried nonetheless to try to start a container (which will succeed if the image is
+        // already available locally)
+        docker.pull(imageToUse).map(_ => true).recover { case _ => false }
+      case Right(_) =>
+        // Iff we're not pulling at all (OpenWhisk provided image) we act as if the pull was successful.
+        Future.successful(true)
+    }
 
     for {
-      _ <- pulled
-      id <- docker.run(image, args).recoverWith {
-        case BrokenDockerContainer(brokenId, message) =>
+      pullSuccessful <- pulled
+      id <- docker.run(imageToUse, args).recoverWith {
+        case BrokenDockerContainer(brokenId, _) =>
           // Remove the broken container - but don't wait or check for the result.
           // If the removal fails, there is nothing we could do to recover from the recovery.
           docker.rm(brokenId)
           Future.failed(WhiskContainerStartupError(Messages.resourceProvisionError))
         case _ =>
-          Future.failed(WhiskContainerStartupError(Messages.resourceProvisionError))
+          // Iff the pull was successful, we assume that the error is not due to an image pull error, otherwise
+          // the docker run was a backup measure to try and start the container anyway. If it fails again, we assume
+          // the image could still not be pulled and wasn't available locally.
+          if (pullSuccessful) {
+            Future.failed(WhiskContainerStartupError(Messages.resourceProvisionError))
+          } else {
+            Future.failed(BlackboxStartupError(Messages.imagePullError(imageToUse)))
+          }
       }
       ip <- docker.inspectIPAddress(id, network).recoverWith {
         // remove the container immediately if inspect failed as

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
@@ -108,8 +108,8 @@ object DockerContainer {
     val pulled = image match {
       case Left(userProvided) if userProvided.tag.map(_ == "latest").getOrElse(true) =>
         // Iff the image tag is "latest" explicitly (or implicitly because no tag is given at all), failing to pull will
-        // fail the whole container bringup process, because it is expected to pick up the very latest version every
-        // time.
+        // fail the whole container bringup process, because it is expected to pick up the very latest "untagged"
+        // version every time.
         docker.pull(imageToUse).map(_ => true).recoverWith {
           case _ => Future.failed(BlackboxStartupError(Messages.imagePullError(imageToUse)))
         }

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainerFactory.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainerFactory.scala
@@ -58,16 +58,9 @@ class DockerContainerFactory(instance: InvokerInstanceId,
                                userProvidedImage: Boolean,
                                memory: ByteSize,
                                cpuShares: Int)(implicit config: WhiskConfig, logging: Logging): Future[Container] = {
-    val image = if (userProvidedImage) {
-      actionImage.publicImageName
-    } else {
-      actionImage.localImageName(config.runtimesRegistry)
-    }
-
     DockerContainer.create(
       tid,
-      image = image,
-      userProvidedImage = userProvidedImage,
+      image = if (userProvidedImage) Left(actionImage) else Right(actionImage.localImageName(config.runtimesRegistry)),
       memory = memory,
       cpuShares = cpuShares,
       environment = Map("__OW_API_HOST" -> config.wskApiHost),

--- a/docs/actions-docker.md
+++ b/docs/actions-docker.md
@@ -105,6 +105,10 @@ The instructions that follow show you how to use the OpenWhisk Docker skeleton.
   Notice the use of `--docker` when creating an action. Currently all Docker images are assumed
   to be hosted on Docker Hub.
 
+  *Note:* It is considered best-practice for production images to be versioned via docker image tags. The tag "latest" or no tag will guarantee to always be on the latest state when creating new containers, but that contains the possibility of failing because pulling the image fails. For tagged images however, the system will allow a failing pull and gracefully recover it by using the image that is already locally available, making it much more resilient against Dockerhub outages etc.
+
+  The "latest" tag should therefore only be used for rapid prototyping where guaranteeing the latest code state is more important than runtime stability at scale.
+
 ## Invoking a Docker action
 
 Docker actions are invoked as [any other OpenWhisk action](actions.md#the-basics).
@@ -136,6 +140,10 @@ This will indicate to the system that for new invocations it should execute a do
   ```
   wsk action update example --docker janesmith/blackboxdemo
   ```
+
+**Note:** As noted above, only images with the tag "latest" or no tag will guarantee to be pulled again, even after updating the action. Any other tag might fall back to use the old image for stability reasons.
+
+To force an updated image after an action update, consider using versioned tags on the image.
 
 ## Creating native actions
 

--- a/docs/actions-docker.md
+++ b/docs/actions-docker.md
@@ -105,9 +105,11 @@ The instructions that follow show you how to use the OpenWhisk Docker skeleton.
   Notice the use of `--docker` when creating an action. Currently all Docker images are assumed
   to be hosted on Docker Hub.
 
-  *Note:* It is considered best-practice for production images to be versioned via docker image tags. The tag "latest" or no tag will guarantee to always be on the latest state when creating new containers, but that contains the possibility of failing because pulling the image fails. For tagged images however, the system will allow a failing pull and gracefully recover it by using the image that is already locally available, making it much more resilient against Dockerhub outages etc.
+  *Note:* It is considered best-practice for production images to be versioned via docker image tags. The absence of a tag will be treated the same as using the tag "latest", which will guarantee to pull from the registry when creating new containers. That contains the possibility of failing because pulling the image fails. For tagged images however, the system will allow a failing pull and gracefully recover it by using the image that is already locally available, making it much more resilient against Dockerhub outages etc.
 
   The "latest" tag should therefore only be used for rapid prototyping where guaranteeing the latest code state is more important than runtime stability at scale.
+
+  Please also note that "latest" doesn't mean newest tag, but rather "latest" is an alias for any image built without an explicit tag.
 
 ## Invoking a Docker action
 


### PR DESCRIPTION
A `docker pull` can fail due to various reasons. One of them is network throttling by the image registry. Since we try to pull on each blackbox invocation, high volume load can cause lots of errors due to failing pulls unnecessarily.

Instead, we try to run the container even if the pull failed in the first place. If the image is available locally, the container will start just fine and recover the error gracefully. If the image is not available locally, the run will fail as well and return the same error as the docker pull would've returned.

This behavior will only be enabled for blackbox actions that specify a tag. Blackbox actions not using a tag *or* using "latest" as a tag will exhibit the very same behavior as today. That is: There will always be a pull before each container start and a failing pull will result in an error reported to the user. This is to enable rapid prototyping on images and enable determinism in the workflow. Updating the action will then force a pull and will fail early if that pull fails. With the new behavior, the developer might be surprised by the image not being updated because the pull is swallowed.

For production workload it is considered best-practice to version images through labels, thus we can "safely" assume that we can fall back to a local image in case the pull fails.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [X] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [X] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [X] I updated the documentation where necessary.

