### PR TITLE
wskadmin scala db command to export and import

### DIFF
--- a/common/scala/src/main/scala/whisk/core/database/StreamingArtifactStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/StreamingArtifactStore.scala
@@ -19,7 +19,7 @@ package whisk.core.database
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{Sink, Source}
+import akka.stream.scaladsl.Sink
 import spray.json.JsObject
 import whisk.common.{Logging, TransactionId}
 

--- a/tests/src/test/scala/common/TestFolder.scala
+++ b/tests/src/test/scala/common/TestFolder.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import java.io.File
+
+import org.scalatest._
+
+/**
+ * Creates a temporary folder for the lifetime of a single test.
+ * The folder's name will exist in a `File` field named `testFolder`.
+ */
+trait TestFolder extends TestSuite { self: Suite =>
+  var testFolder: File = _
+
+  //Default value ensures that temp files are created under build dir
+  protected def parentFolder: File = new File("build/tmp/scalaTestFolder")
+
+  private def deleteFile(file: File) {
+    if (!file.exists) return
+    if (file.isFile) {
+      file.delete()
+    } else {
+      file.listFiles().foreach(deleteFile)
+      file.delete()
+    }
+  }
+
+  abstract override def withFixture(test: NoArgTest): Outcome = {
+    testFolder = createTemporaryFolderIn(parentFolder)
+    try {
+      super.withFixture(test)
+    } finally {
+      deleteFile(testFolder)
+    }
+  }
+
+  def newFile(): File = File.createTempFile("scalatest", null, rootFolder)
+
+  def newFolder(): File = createTemporaryFolderIn(rootFolder)
+
+  private def rootFolder = {
+    require(testFolder != null, "the temporary folder has not yet been created")
+    testFolder
+  }
+
+  private def createTemporaryFolderIn(parentFolder: File) = {
+    if (!parentFolder.exists()) {
+      parentFolder.mkdirs()
+    }
+    val createdFolder = File.createTempFile("scalatest", "", parentFolder)
+    createdFolder.delete
+    createdFolder.mkdir
+    createdFolder
+  }
+}

--- a/tests/src/test/scala/common/TestFolder.scala
+++ b/tests/src/test/scala/common/TestFolder.scala
@@ -21,6 +21,8 @@ import java.io.File
 
 import org.scalatest._
 
+import scala.util.Properties
+
 /**
  * Creates a temporary folder for the lifetime of a single test.
  * The folder's name will exist in a `File` field named `testFolder`.
@@ -28,8 +30,7 @@ import org.scalatest._
 trait TestFolder extends TestSuite { self: Suite =>
   var testFolder: File = _
 
-  //Default value ensures that temp files are created under build dir
-  protected def parentFolder: File = new File("build/tmp/scalaTestFolder")
+  protected def parentFolder: File = new File(Properties.tmpDir)
 
   private def deleteFile(file: File) {
     if (!file.exists) return

--- a/tests/src/test/scala/whisk/core/database/ArtifactNamingHelper.scala
+++ b/tests/src/test/scala/whisk/core/database/ArtifactNamingHelper.scala
@@ -46,6 +46,6 @@ trait ArtifactNamingHelper {
 
   private def randomString() = Random.alphanumeric.take(5).mkString
 
-  private val exec = BlackBoxExec(ExecManifest.ImageName("image"), None, None, native = false)
+  private val exec = BlackBoxExec(ExecManifest.ImageName("image"), None, None, native = false, binary = false)
 
 }

--- a/tests/src/test/scala/whisk/core/database/ArtifactNamingHelper.scala
+++ b/tests/src/test/scala/whisk/core/database/ArtifactNamingHelper.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.database
+
+import whisk.core.entity._
+
+import scala.util.Random
+
+trait ArtifactNamingHelper {
+
+  protected val prefix = s"artifactTCK_${Random.alphanumeric.take(4).mkString}"
+
+  protected def aname() = EntityName(s"${prefix}_name_${randomString()}")
+
+  protected def newNS() = EntityPath(s"${prefix}_ns_${randomString()}")
+
+  protected def newAction(ns: EntityPath): WhiskAction = {
+    WhiskAction(ns, aname(), exec)
+  }
+
+  protected def newAuth() = {
+    val subject = Subject()
+    val namespaces = Set(wskNS("foo"))
+    WhiskAuth(subject, namespaces)
+  }
+
+  protected def wskNS(name: String) = {
+    val uuid = UUID()
+    WhiskNamespace(Namespace(EntityName(name), uuid), BasicAuthenticationAuthKey(uuid, Secret()))
+  }
+
+  private def randomString() = Random.alphanumeric.take(5).mkString
+
+  private val exec = BlackBoxExec(ExecManifest.ImageName("image"), None, None, native = false)
+
+}

--- a/tests/src/test/scala/whisk/core/database/CouchDBArtifactStoreTests.scala
+++ b/tests/src/test/scala/whisk/core/database/CouchDBArtifactStoreTests.scala
@@ -21,6 +21,9 @@ import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
 import whisk.core.database.test.behavior.ArtifactStoreBehavior
+import whisk.core.entity.WhiskEntity
 
 @RunWith(classOf[JUnitRunner])
-class CouchDBArtifactStoreTests extends FlatSpec with CouchDBStoreBehaviorBase with ArtifactStoreBehavior {}
+class CouchDBArtifactStoreTests extends FlatSpec with CouchDBStoreBehaviorBase with ArtifactStoreBehavior {
+  override def entityStreamingStore = CouchDBStreamingStoreProvider.makeStore[WhiskEntity]()
+}

--- a/tests/src/test/scala/whisk/core/database/DbCommandTests.scala
+++ b/tests/src/test/scala/whisk/core/database/DbCommandTests.scala
@@ -97,7 +97,8 @@ class DbCommandTests
       .map(_.toDocumentRecord)
 
     val outFile = newFile()
-    resultOk("db", "get", "--out", outFile.getAbsolutePath, "whisks") should include(outFile.getAbsolutePath)
+    resultOk("db", "get", "--out", outFile.getAbsolutePath, "--attachments", "whisks") should include(
+      outFile.getAbsolutePath)
 
     //Compare the jsons ignoring _rev and updated and other private fields starting with '_' except '_id'
     (collectedEntities(outFile, idFilter(actionIds)) should contain theSameElementsAs actionJsons)(

--- a/tests/src/test/scala/whisk/core/database/DbCommandTests.scala
+++ b/tests/src/test/scala/whisk/core/database/DbCommandTests.scala
@@ -143,19 +143,19 @@ class DbCommandTests
   it should "determine entityType if missing" in {
     val action = newAction(newNS())
     getEntityType(stripType(action)).value shouldBe "action"
-    entityWithEntityType(stripType(action)) shouldBe action.toDocumentRecord
+    withEntityType(stripType(action)) shouldBe action.toDocumentRecord
 
     val pkg = WhiskPackage(newNS(), aname())
     getEntityType(stripType(pkg)).value shouldBe "package"
-    entityWithEntityType(stripType(pkg)) shouldBe pkg.toDocumentRecord
+    withEntityType(stripType(pkg)) shouldBe pkg.toDocumentRecord
 
     val trigger = WhiskTrigger(newNS(), aname())
     getEntityType(stripType(trigger)).value shouldBe "trigger"
-    entityWithEntityType(stripType(trigger)) shouldBe trigger.toDocumentRecord
+    withEntityType(stripType(trigger)) shouldBe trigger.toDocumentRecord
 
     val rule = WhiskRule(newNS(), aname(), trigger.fullyQualifiedName(false), action.fullyQualifiedName(false))
     getEntityType(stripType(rule)).value shouldBe "rule"
-    entityWithEntityType(stripType(rule)) shouldBe rule.toDocumentRecord
+    withEntityType(stripType(rule)) shouldBe rule.toDocumentRecord
   }
 
   it should "set entityType if missing" in {

--- a/tests/src/test/scala/whisk/core/database/DbCommandTests.scala
+++ b/tests/src/test/scala/whisk/core/database/DbCommandTests.scala
@@ -15,42 +15,19 @@
  * limitations under the License.
  */
 
-plugins {
-    id 'org.springframework.boot' version '2.0.2.RELEASE'
-    id 'scala'
+package whisk.core.database
+
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.junit.JUnitRunner
+import whisk.core.cli.CommandMessages
+
+@RunWith(classOf[JUnitRunner])
+class DbCommandTests extends FlatSpec with WhiskAdminCliTestBase {
+
+  behavior of "db get"
+
+  it should "get all artifacts" in {
+    resultOk("db", "get", "subjects") shouldBe CommandMessages.subjectDeleted
+  }
 }
-
-apply plugin: 'org.scoverage'
-apply plugin: 'maven'
-
-project.archivesBaseName = "openwhisk-admin-tools"
-
-repositories {
-    mavenCentral()
-}
-
-jar {
-    enabled = true
-}
-
-task copyBootJarToBin(type:Copy){
-    from ("${buildDir}/libs")
-    into file("${project.rootProject.projectDir}/bin")
-    rename("${project.archivesBaseName}-$version-cli.jar", "wskadmin-next")
-}
-
-bootJar {
-    classifier = 'cli'
-    mainClassName = 'whisk.core.cli.Main'
-    launchScript()
-    finalizedBy copyBootJarToBin
-}
-
-dependencies {
-    compile project(':common:scala')
-    compile 'org.rogach:scallop_2.11:3.1.2'
-    compile 'com.lightbend.akka:akka-stream-alpakka-json-streaming_2.11:0.19'
-    scoverage gradle.scoverage.deps
-}
-
-

--- a/tests/src/test/scala/whisk/core/database/DbCommandTests.scala
+++ b/tests/src/test/scala/whisk/core/database/DbCommandTests.scala
@@ -22,13 +22,13 @@ import java.io.File
 import akka.stream.scaladsl.{FileIO, Sink}
 import common.TestFolder
 import org.junit.runner.RunWith
-import org.scalactic.Uniformity
 import org.scalatest.{FlatSpec, OptionValues}
 import org.scalatest.junit.JUnitRunner
 import spray.json.{DefaultJsonProtocol, JsObject}
 import whisk.common.TransactionId
 import whisk.core.cli.CommandMessages
 import whisk.core.database.DbCommand._
+import whisk.core.database.test.behavior.ArtifactStoreTestUtil._
 import whisk.core.entity.{DocInfo, WhiskDocument, WhiskEntity, WhiskPackage, WhiskRule, WhiskTrigger}
 
 import scala.util.Try
@@ -117,10 +117,6 @@ class DbCommandTests
 
   private def stripType(e: WhiskEntity) = JsObject(e.toDocumentRecord.fields - "entityType")
 
-  private def idFilter(ids: Set[String]): JsObject => Boolean = js => ids.contains(idOf(js))
-
-  private def idOf(js: JsObject) = js.fields("_id").convertTo[String]
-
   private def collectedEntities(file: File, filter: JsObject => Boolean) =
     DbCommand
       .createJSStream(file)
@@ -147,17 +143,5 @@ class DbCommandTests
         delete(store, doc.docinfo)
       }
     }
-  }
-
-  /**
-   * Strips of the '_rev' field to allow comparing jsons where only rev may differ
-   */
-  private object strippedOfRevision extends Uniformity[JsObject] {
-    override def normalizedOrSame(b: Any) = b match {
-      case s: JsObject => normalized(s)
-      case _           => b
-    }
-    override def normalizedCanHandle(b: Any) = b.isInstanceOf[JsObject]
-    override def normalized(js: JsObject) = JsObject(js.fields - "_rev")
   }
 }

--- a/tests/src/test/scala/whisk/core/database/DbCommandTests.scala
+++ b/tests/src/test/scala/whisk/core/database/DbCommandTests.scala
@@ -162,7 +162,7 @@ class DbCommandTests
       val newAction = entityStore.get[WhiskAction](DocInfo(a.docid)).futureValue
       val oldAction = actionsWithAttachments.find(_.docid == newAction.docid).get
       newAction.exec match {
-        case _ @CodeExecAsAttachment(_, attached: Attached, _) =>
+        case _ @CodeExecAsAttachment(_, attached: Attached, _, _) =>
           val newBytes = getAttachmentBytes(newAction.docinfo, attached).futureValue.result().toArray
           val oldBytes = getAttachmentBytes(oldAction)
           newBytes shouldBe oldBytes

--- a/tests/src/test/scala/whisk/core/database/WhiskAdminCliTestBase.scala
+++ b/tests/src/test/scala/whisk/core/database/WhiskAdminCliTestBase.scala
@@ -24,7 +24,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FlatSpec, Matchers}
 import whisk.core.cli.{Conf, WhiskAdmin}
 import whisk.core.database.test.DbUtils
-import whisk.core.entity.WhiskAuthStore
+import whisk.core.entity.{WhiskAuthStore, WhiskEntityStore}
 
 import scala.util.Random
 
@@ -42,6 +42,7 @@ trait WhiskAdminCliTestBase
   //Bring in sync the timeout used by ScalaFutures and DBUtils
   implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = dbOpTimeout)
   protected val authStore = WhiskAuthStore.datastore()
+  protected val entityStore = WhiskEntityStore.datastore()
 
   //Ensure scalaop does not exit upon validation failure
   throwError.value = true
@@ -53,6 +54,7 @@ trait WhiskAdminCliTestBase
   override def afterAll(): Unit = {
     println("Shutting down store connections")
     authStore.shutdown()
+    entityStore.shutdown()
     super.afterAll()
   }
 

--- a/tests/src/test/scala/whisk/core/database/cosmosdb/CosmosDBArtifactStoreTests.scala
+++ b/tests/src/test/scala/whisk/core/database/cosmosdb/CosmosDBArtifactStoreTests.scala
@@ -20,11 +20,13 @@ package whisk.core.database.cosmosdb
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
+import whisk.core.database.StreamingArtifactStore
 import whisk.core.entity.size._
 import whisk.core.database.test.behavior.ArtifactStoreBehavior
 
 @RunWith(classOf[JUnitRunner])
 class CosmosDBArtifactStoreTests extends FlatSpec with CosmosDBStoreBehaviorBase with ArtifactStoreBehavior {
+  override lazy val entityStreamingStore = entityStore.asInstanceOf[StreamingArtifactStore]
   override protected def maxAttachmentSizeWithoutAttachmentStore = 1.MB
 
   behavior of "CosmosDB Setup"

--- a/tests/src/test/scala/whisk/core/database/memory/MemoryArtifactStoreTests.scala
+++ b/tests/src/test/scala/whisk/core/database/memory/MemoryArtifactStoreTests.scala
@@ -20,7 +20,10 @@ package whisk.core.database.memory
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
+import whisk.core.database.StreamingArtifactStore
 import whisk.core.database.test.behavior.ArtifactStoreBehavior
 
 @RunWith(classOf[JUnitRunner])
-class MemoryArtifactStoreTests extends FlatSpec with MemoryArtifactStoreBehaviorBase with ArtifactStoreBehavior
+class MemoryArtifactStoreTests extends FlatSpec with MemoryArtifactStoreBehaviorBase with ArtifactStoreBehavior {
+  override lazy val entityStreamingStore = entityStore.asInstanceOf[StreamingArtifactStore]
+}

--- a/tests/src/test/scala/whisk/core/database/test/behavior/ArtifactStoreBehavior.scala
+++ b/tests/src/test/scala/whisk/core/database/test/behavior/ArtifactStoreBehavior.scala
@@ -25,3 +25,4 @@ trait ArtifactStoreBehavior
     with ArtifactStoreWhisksQueryBehaviors
     with ArtifactStoreActivationsQueryBehaviors
     with ArtifactStoreAttachmentBehaviors
+    with StreamingArtifactStoreBehavior

--- a/tests/src/test/scala/whisk/core/database/test/behavior/StreamingArtifactStoreBehavior.scala
+++ b/tests/src/test/scala/whisk/core/database/test/behavior/StreamingArtifactStoreBehavior.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.database.test.behavior
+
+import akka.stream.scaladsl.{Flow, Keep, Sink}
+import spray.json.JsObject
+import whisk.common.TransactionId
+import whisk.core.database.test.behavior.ArtifactStoreTestUtil._
+import whisk.core.database.StreamingArtifactStore
+
+trait StreamingArtifactStoreBehavior extends ArtifactStoreBehaviorBase {
+
+  def entityStreamingStore: StreamingArtifactStore
+
+  behavior of s"${storeType}StreamingArtifactStore getAll"
+
+  it should "get all documents" in {
+    implicit val tid: TransactionId = transid()
+    val actions = List.tabulate(10)(_ => newAction(newNS()))
+    val actionJsons = actions.map(_.toDocumentRecord)
+    actions foreach (put(entityStore, _))
+
+    val actionIds = actions.map(_.docid.id).toSet
+    (collectedEntities(idFilter(actionIds)) should contain theSameElementsAs actionJsons)(
+      after being strippedOfRevision)
+
+  }
+
+  private def collectedEntities(filter: JsObject => Boolean)(implicit transid: TransactionId) = {
+    val sink = Flow[JsObject]
+      .filter(filter)
+      .toMat(Sink.seq[JsObject])(Keep.right)
+    entityStreamingStore.getAll(sink).futureValue._2
+  }
+}

--- a/tools/admin/src/main/scala/whisk/core/cli/CommandMessages.scala
+++ b/tools/admin/src/main/scala/whisk/core/cli/CommandMessages.scala
@@ -55,4 +55,7 @@ object CommandMessages {
   def putDocsFailed(success: Long, failed: Long, exists: Long) =
     s"Put result : Failed = $failed, Already Exists = $exists, Put Successful = $success"
 
+  def downloadAttachmentFailed(success: Long, failed: Long) =
+    s"Download result : Failed = $failed,  Successful = $success"
+
 }

--- a/tools/admin/src/main/scala/whisk/core/cli/CommandMessages.scala
+++ b/tools/admin/src/main/scala/whisk/core/cli/CommandMessages.scala
@@ -17,6 +17,10 @@
 
 package whisk.core.cli
 
+import java.io.File
+
+import scala.collection.immutable.Iterable
+
 object CommandMessages {
   val subjectBlocked = "The subject you want to edit is blocked"
   val namespaceExists = "Namespace already exists"
@@ -41,5 +45,9 @@ object CommandMessages {
 
   def limitsNotFound(namespace: String) = s"Limits not found for '$namespace'"
   val limitsDeleted = s"Limits deleted"
+
+  def dbContentToFile(count: Long, f: File) = s"Dumped $count documents to ${f.getAbsolutePath}"
+
+  def invalidDatabase(db: String, dbs: Iterable[String]) = s"Database type '$db' not found in $dbs"
 
 }

--- a/tools/admin/src/main/scala/whisk/core/cli/CommandMessages.scala
+++ b/tools/admin/src/main/scala/whisk/core/cli/CommandMessages.scala
@@ -50,4 +50,9 @@ object CommandMessages {
 
   def invalidDatabase(db: String, dbs: Iterable[String]) = s"Database type '$db' not found in $dbs"
 
+  def putDocs(count: Long) = s"Put $count docs"
+
+  def putDocsFailed(success: Long, failed: Long, exists: Long) =
+    s"Put result : Failed = $failed, Already Exists = $exists, Put Successful = $success"
+
 }

--- a/tools/admin/src/main/scala/whisk/core/cli/ConfSupport.scala
+++ b/tools/admin/src/main/scala/whisk/core/cli/ConfSupport.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.cli
+import java.io.File
+
+import org.rogach.scallop.singleArgConverter
+
+trait ConfSupport {
+  //Spring boot launch script changes the working directory to one where jar file is present
+  //So invocation like ./bin/wskadmin-next -c config.conf would fail to resolve file as it would
+  //be looked in directory where jar is present. This convertor makes use of `OLDPWD` to also
+  //do a fallback check in that directory
+  val relativeFileConverter = singleArgConverter[File] { f =>
+    val f1 = new File(f)
+    val oldpwd = System.getenv("OLDPWD")
+    if (f1.exists())
+      f1
+    else if (oldpwd != null) {
+      val f2 = new File(oldpwd, f)
+      if (f2.exists()) f2 else f1
+    } else {
+      f1
+    }
+  }
+}

--- a/tools/admin/src/main/scala/whisk/core/cli/Main.scala
+++ b/tools/admin/src/main/scala/whisk/core/cli/Main.scala
@@ -27,7 +27,7 @@ import org.rogach.scallop._
 import org.slf4j.LoggerFactory
 import pureconfig.error.ConfigReaderException
 import whisk.common.{AkkaLogging, Logging, TransactionId}
-import whisk.core.database.{LimitsCommand, UserCommand}
+import whisk.core.database.{DbCommand, LimitsCommand, UserCommand}
 
 import scala.concurrent.duration.{Duration, DurationInt}
 import scala.concurrent.{Await, Future}
@@ -63,6 +63,7 @@ class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
 
   addSubcommand(new UserCommand)
   addSubcommand(new LimitsCommand)
+  addSubcommand(new DbCommand)
   shortSubcommandsHelp()
 
   requireSubcommand()
@@ -189,6 +190,7 @@ case class WhiskAdmin(conf: Conf)(implicit val actorSystem: ActorSystem,
     conf.subcommands match {
       case List(cmd: UserCommand, x)   => cmd.exec(x)
       case List(cmd: LimitsCommand, x) => cmd.exec(x)
+      case List(cmd: DbCommand, x)     => cmd.exec(x)
     }
   }
 

--- a/tools/admin/src/main/scala/whisk/core/cli/Main.scala
+++ b/tools/admin/src/main/scala/whisk/core/cli/Main.scala
@@ -33,28 +33,12 @@ import scala.concurrent.duration.{Duration, DurationInt}
 import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success, Try}
 
-class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
+class Conf(arguments: Seq[String]) extends ScallopConf(arguments) with ConfSupport {
   banner("OpenWhisk admin command line tool")
   val durationConverter = singleArgConverter[Duration](Duration(_))
 
-  //Spring boot launch script changes the working directory to one where jar file is present
-  //So invocation like ./bin/wskadmin-next -c config.conf would fail to resolve file as it would
-  //be looked in directory where jar is present. This convertor makes use of `OLDPWD` to also
-  //do a fallback check in that directory
-  val fileConverter = singleArgConverter[File] { f =>
-    val f1 = new File(f)
-    val oldpwd = System.getenv("OLDPWD")
-    if (f1.exists())
-      f1
-    else if (oldpwd != null) {
-      val f2 = new File(oldpwd, f)
-      if (f2.exists()) f2 else f1
-    } else {
-      f1
-    }
-  }
   val verbose = tally()
-  val configFile = opt[File](descr = "application.conf which overwrites the default whisk.conf")(fileConverter)
+  val configFile = opt[File](descr = "application.conf which overwrites the default whisk.conf")(relativeFileConverter)
   val timeout =
     opt[Duration](descr = "time to wait for asynchronous task to finish", default = Some(30.seconds))(durationConverter)
   printedName = Main.printedName

--- a/tools/admin/src/main/scala/whisk/core/cli/Main.scala
+++ b/tools/admin/src/main/scala/whisk/core/cli/Main.scala
@@ -174,6 +174,7 @@ trait WhiskCommand {
   this: ScallopConfBase =>
 
   shortSubcommandsHelp()
+  appendDefaultToDescription = true
 
   def failNoSubCommand(): Unit = {
     val s = parentConfig.builder.findSubbuilder(commandNameAndAliases.head).get

--- a/tools/admin/src/main/scala/whisk/core/cli/Main.scala
+++ b/tools/admin/src/main/scala/whisk/core/cli/Main.scala
@@ -196,7 +196,8 @@ case class WhiskAdmin(conf: Conf)(implicit val actorSystem: ActorSystem,
 
   def timeout: Duration = {
     conf.subcommands match {
-      case _ => conf.timeout()
+      case List(_: DbCommand, _) => Duration.Inf
+      case _                     => conf.timeout()
     }
   }
 }

--- a/tools/admin/src/main/scala/whisk/core/cli/ProgressTicker.scala
+++ b/tools/admin/src/main/scala/whisk/core/cli/ProgressTicker.scala
@@ -17,6 +17,8 @@
 
 package whisk.core.cli
 
+import java.util.concurrent.TimeUnit
+
 import com.google.common.base.Stopwatch
 
 trait Ticker {
@@ -59,6 +61,8 @@ class ProgressTicker extends Ticker {
     s"${barBase * pos}$barCurrent${barBase * (width - pos)}"
   }
 
+  private def speed(): String = "%.0f/s".format(count * 1.0 / watch.elapsed(TimeUnit.SECONDS))
+
   private def move(): Unit = {
     if (count % nextDrawDelta == 0) {
       if (movingRight) pos += 1 else pos -= 1
@@ -68,5 +72,5 @@ class ProgressTicker extends Ticker {
     }
   }
 
-  private def status() = s"$count docs [$watch]"
+  private def status() = s"$count docs $speed [$watch]"
 }

--- a/tools/admin/src/main/scala/whisk/core/cli/ProgressTicker.scala
+++ b/tools/admin/src/main/scala/whisk/core/cli/ProgressTicker.scala
@@ -51,6 +51,7 @@ abstract class ProgressBarBase(val colored: Boolean = true) extends Ticker {
   protected var pos = 0
   private var lastDrawTime = 0L
   private var maxStatusLength = 0
+  private var closed = false
 
   override def tick(): Unit = {
     count += 1
@@ -58,7 +59,10 @@ abstract class ProgressBarBase(val colored: Boolean = true) extends Ticker {
   }
 
   override def close(): Unit = {
-    println(s"\r${statusPrefix()}${statusSuffix()}")
+    if (!closed) {
+      println(s"\r${statusPrefix()}${statusSuffix()}")
+      closed = true
+    }
   }
 
   protected def doMove(): Unit

--- a/tools/admin/src/main/scala/whisk/core/cli/ProgressTicker.scala
+++ b/tools/admin/src/main/scala/whisk/core/cli/ProgressTicker.scala
@@ -59,7 +59,13 @@ class ProgressTicker(val colored: Boolean = true) extends Ticker {
   private def draw() = {
     if (move()) {
       val msg = s"\r[${animation()}] ${status()}"
-      print(msg)
+      val msgToPrint = if (msg.length > maxStatusLength) {
+        maxStatusLength = msg.length
+        msg
+      } else {
+        msg + " " * (maxStatusLength - msg.length) //Add padding
+      }
+      print(msgToPrint)
     }
   }
 
@@ -81,15 +87,7 @@ class ProgressTicker(val colored: Boolean = true) extends Ticker {
     } else false
   }
 
-  private def status(): String = {
-    val s = s"$count docs ${speed()} [$watch]"
-    if (s.length > maxStatusLength) {
-      maxStatusLength = s.length
-      s
-    } else {
-      s + " " * (maxStatusLength - s.length)
-    } //Add padding
-  }
+  private def status() = s"$count docs ${speed()} [$watch]"
 
   private def color(code: String) = if (colored) code else ""
 }

--- a/tools/admin/src/main/scala/whisk/core/cli/ProgressTicker.scala
+++ b/tools/admin/src/main/scala/whisk/core/cli/ProgressTicker.scala
@@ -74,3 +74,7 @@ class ProgressTicker extends Ticker {
 
   private def status() = s"$count docs $speed [$watch]"
 }
+
+object ConsoleUtil {
+  def showProgressBar(): Boolean = System.console() != null
+}

--- a/tools/admin/src/main/scala/whisk/core/cli/ProgressTicker.scala
+++ b/tools/admin/src/main/scala/whisk/core/cli/ProgressTicker.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.cli
+
+import com.google.common.base.Stopwatch
+
+trait Ticker {
+
+  def tick(): Unit = {}
+
+  def close(): Unit = {}
+
+}
+
+object NoopTicker extends Ticker
+
+class ProgressTicker extends Ticker {
+  private var count = 0
+  private val anim = Array('|', '/', '-', '\\')
+  private val watch = Stopwatch.createStarted()
+
+  override def tick(): Unit = {
+    count += 1
+    draw()
+  }
+
+  override def close(): Unit = {
+    println("\r" + status())
+  }
+
+  private def draw() = {
+    val msg = s"\r[${anim(count % anim.size)}] ${status()}"
+    print(msg)
+  }
+
+  private def status() = s"$count docs [$watch]"
+}

--- a/tools/admin/src/main/scala/whisk/core/cli/ProgressTicker.scala
+++ b/tools/admin/src/main/scala/whisk/core/cli/ProgressTicker.scala
@@ -30,9 +30,15 @@ trait Ticker {
 object NoopTicker extends Ticker
 
 class ProgressTicker extends Ticker {
-  private var count = 0
-  private val anim = Array('|', '/', '-', '\\')
+  private val width = 10
+  private val nextDrawDelta = 10
   private val watch = Stopwatch.createStarted()
+  private val barBase = "-"
+  private val barCurrent = "*"
+
+  private var count = 0
+  private var pos = 0
+  private var movingRight = true
 
   override def tick(): Unit = {
     count += 1
@@ -44,8 +50,22 @@ class ProgressTicker extends Ticker {
   }
 
   private def draw() = {
-    val msg = s"\r[${anim(count % anim.size)}] ${status()}"
+    move()
+    val msg = s"\r[${animation()}] ${status()}"
     print(msg)
+  }
+
+  private def animation() = {
+    s"${barBase * pos}$barCurrent${barBase * (width - pos)}"
+  }
+
+  private def move(): Unit = {
+    if (count % nextDrawDelta == 0) {
+      if (movingRight) pos += 1 else pos -= 1
+
+      if (pos == 0) movingRight = true
+      if (pos == width) movingRight = false
+    }
   }
 
   private def status() = s"$count docs [$watch]"

--- a/tools/admin/src/main/scala/whisk/core/cli/ProgressTicker.scala
+++ b/tools/admin/src/main/scala/whisk/core/cli/ProgressTicker.scala
@@ -84,7 +84,13 @@ abstract class ProgressBarBase(val colored: Boolean = true) extends Ticker {
     s"$colStart${barCurrent * pos}$colCur$barCurrentN$colNorm${barRemain * (width - pos)}"
   }
 
-  protected def speed(): String = "%.0f/s".format(count * 1.0 / (watch.elapsed(TimeUnit.SECONDS) + 1))
+  protected def speed(): String = "%.0f/s".format(rate())
+
+  protected def rate(): Double = count * 1.0 / (watch.elapsed(TimeUnit.SECONDS) + 1)
+
+  protected def elapsedTime(): String = formatTime(watch.elapsed(TimeUnit.SECONDS))
+
+  protected def formatTime(s: Long) = "%d:%02d:%02d".format(s / 3600, (s % 3600) / 60, s % 60)
 
   private def move(): Boolean = {
     val elapsesMillis = watch.elapsed(TimeUnit.MILLISECONDS)
@@ -115,7 +121,7 @@ class InfiniteProgressBar(action: String, override val colored: Boolean = true) 
     if (pos == width) movingRight = false
   }
 
-  override protected def statusSuffix() = s"$count docs ${speed()} [$watch]"
+  override protected def statusSuffix() = s"$count docs ${speed()} (${elapsedTime()})"
   override protected def statusPrefix() = s"$action "
 }
 
@@ -132,11 +138,12 @@ class FiniteProgressBar(action: String, total: Long, override val colored: Boole
     pos = progress(width)
   }
 
-  override protected def statusSuffix() = s"$count/$total docs ${speed()} [$watch]"
+  override protected def statusSuffix() = s"$count/$total docs ${speed()} (${elapsedTime()} / ${eta()})"
   override protected def statusPrefix() = s"$action ${progressPercent()}% "
 
   private def progressPercent() = progress(100)
   private def progress(n: Int) = Math.ceil((count.toFloat / total) * n).toInt
+  private def eta() = formatTime(((total - count) / rate()).toLong)
 }
 
 object ConsoleUtil {

--- a/tools/admin/src/main/scala/whisk/core/cli/ProgressTicker.scala
+++ b/tools/admin/src/main/scala/whisk/core/cli/ProgressTicker.scala
@@ -31,12 +31,15 @@ trait Ticker {
 
 object NoopTicker extends Ticker
 
-class ProgressTicker extends Ticker {
+class ProgressTicker(val colored: Boolean = true) extends Ticker {
   private val width = 10
   private val nextDrawDelta = 200 //Redraw ever this millis
   private val watch = Stopwatch.createStarted()
   private val barBase = "-"
   private val barCurrent = "*"
+
+  private val colCur = color("\u001B[1;92m") //Green
+  private val colNorm = color("\u001B[0m") //Normal
 
   private var count = 0
   private var pos = 0
@@ -61,7 +64,7 @@ class ProgressTicker extends Ticker {
   }
 
   private def animation() = {
-    s"${barBase * pos}$barCurrent${barBase * (width - pos)}"
+    s"${barBase * pos}$colCur$barCurrent$colNorm${barBase * (width - pos)}"
   }
 
   private def speed(): String = "%.0f/s".format(count * 1.0 / (watch.elapsed(TimeUnit.SECONDS) + 1))
@@ -87,6 +90,8 @@ class ProgressTicker extends Ticker {
       s + " " * (maxStatusLength - s.length)
     } //Add padding
   }
+
+  private def color(code: String) = if (colored) code else ""
 }
 
 object ConsoleUtil {

--- a/tools/admin/src/main/scala/whisk/core/database/CouchDBStreamingStore.scala
+++ b/tools/admin/src/main/scala/whisk/core/database/CouchDBStreamingStore.scala
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.database
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.{HttpMethods, HttpRequest, StatusCode, Uri}
+import akka.stream.ActorMaterializer
+import akka.stream.alpakka.json.scaladsl.JsonReader
+import akka.stream.scaladsl.{Keep, Sink}
+import pureconfig.loadConfigOrThrow
+import spray.json.{JsObject, _}
+import whisk.common.{Logging, LoggingMarkers, TransactionId}
+import whisk.core.ConfigKeys
+import whisk.core.database.StoreUtils._
+
+import scala.concurrent.Future
+import scala.reflect.ClassTag
+
+object CouchDBStreamingStoreProvider extends StreamingArtifactStoreProvider {
+  def makeStore[D <: DocumentSerializer: ClassTag]()(implicit actorSystem: ActorSystem,
+                                                     logging: Logging,
+                                                     materializer: ActorMaterializer): StreamingArtifactStore = {
+    val dbConfig = loadConfigOrThrow[CouchDbConfig](ConfigKeys.couchdb)
+    new CouchDBStreamingStore(
+      dbConfig.protocol,
+      dbConfig.host,
+      dbConfig.port,
+      dbConfig.username,
+      dbConfig.password,
+      dbConfig.databaseFor[D])
+  }
+}
+
+class CouchDBStreamingStore(
+  protocol: String,
+  host: String,
+  port: Int,
+  username: String,
+  password: String,
+  dbName: String)(implicit system: ActorSystem, val logging: Logging, val materializer: ActorMaterializer)
+    extends StreamingArtifactStore {
+
+  private implicit val executionContext = system.dispatcher
+
+  private val client = new StreamingCouchDbRestClient(protocol, host, port, username, password, dbName)
+
+  override protected[database] def getAll[T](sink: Sink[JsObject, Future[T]])(
+    implicit transid: TransactionId): Future[(Long, T)] = {
+
+    val start = transid.started(this, LoggingMarkers.DATABASE_GET, s"[ATT_GET] '$dbName' reading all documents")
+
+    val f = client.getAllDocs(sink) map {
+      case Right((count, result)) =>
+        transid.finished(this, start, s"[GET_ALL] '$dbName' completed: read all $count docs")
+        (count, result)
+      case Left(code) =>
+        transid.failed(this, start, s"[GET_ALL] '$dbName' failed to get all documents; http status: '$code'")
+        throw new Exception("Unexpected http response code: " + code)
+    }
+
+    reportFailure(f, start, failure => s"[GET_ALL] '$dbName' internal error, failure: '${failure.getMessage}'")
+  }
+
+  override protected[database] def getCount()(implicit transid: TransactionId): Future[Option[Long]] = ???
+
+}
+
+class StreamingCouchDbRestClient(protocol: String,
+                                 host: String,
+                                 port: Int,
+                                 username: String,
+                                 password: String,
+                                 db: String)(implicit system: ActorSystem, logging: Logging)
+    extends CouchDbRestClient(protocol, host, port, username, password, db) {
+
+  def getAllDocs[T](sink: Sink[JsObject, Future[T]]): Future[Either[StatusCode, (Long, T)]] = {
+    val url = uri(db, "_all_docs").withQuery(Uri.Query(Map("include_docs" -> "true")))
+    val request = mkRequest(HttpMethods.GET, url, baseHeaders)
+    requestStream[T](request, sink)
+  }
+
+  def requestStream[T](futureRequest: Future[HttpRequest],
+                       sink: Sink[JsObject, Future[T]]): Future[Either[StatusCode, (Long, T)]] = {
+    request0(futureRequest) flatMap { response =>
+      if (response.status.isSuccess()) {
+        val counter = Sink.fold[Long, JsValue](0)((acc, _) => acc + 1)
+        val f = response.entity
+          .withoutSizeLimit()
+          .dataBytes
+          .via(JsonReader.select("$.rows[*].doc"))
+          .map(bs => JsonParser(ParserInput.apply(bs.toArray)).asJsObject) //Better to use SprayJsonByteStringParserInput ... its private :(
+          .alsoToMat(counter)(Keep.right)
+          .toMat(sink)(Keep.both)
+          .run()
+        for (count <- f._1; t <- f._2) yield Right((count, t))
+      } else {
+        // This is important, as it drains the entity stream.
+        // Otherwise the connection stays open and the pool dries up.
+        response.entity.withoutSizeLimit().dataBytes.runWith(Sink.ignore).map { _ =>
+          Left(response.status)
+        }
+      }
+    }
+  }
+}

--- a/tools/admin/src/main/scala/whisk/core/database/DbCommand.scala
+++ b/tools/admin/src/main/scala/whisk/core/database/DbCommand.scala
@@ -273,6 +273,8 @@ class DbCommand extends Subcommand("db") with WhiskCommand {
       val action = WhiskAction.serdes.read(js)
       action.exec match {
         case _ @CodeExecAsAttachment(_, Attached(_, contentType, _, _), _) =>
+          //If attachment was inlined at ArtifactStore level then downloadAttachments would have created attachment
+          //file on disk as part of download. So both inline and non inline case gets addressed
           val attachmentSource = getAttachmentSource(action, attachmentDir)
           entityStore
             .putAndAttach(action, WhiskAction.attachmentUpdater, contentType, attachmentSource, None)

--- a/tools/admin/src/main/scala/whisk/core/database/DbCommand.scala
+++ b/tools/admin/src/main/scala/whisk/core/database/DbCommand.scala
@@ -79,7 +79,6 @@ class DbCommand extends Subcommand("db") with WhiskCommand {
 
     val out = opt[File](descr = "file to dump the contents to")
 
-    //TODO Make use of this flag!
     val attachments =
       opt[Boolean](descr = "include attachments. Downloaded attachments would be stored under 'attachments' directory")
 
@@ -141,7 +140,7 @@ class DbCommand extends Subcommand("db") with WhiskCommand {
       .flatMap { rr =>
         ticker.close()
         //2. Now download attachments by reading output file
-        if (rr.attachmentCount > 0) {
+        if (rr.attachmentCount > 0 && get.attachments.getOrElse(false)) {
           val dump = get.out() //For attachment case out file is required
           downloadAttachments(dump, getOrCreateAttachmentDir(dump), rr.count, get.threads(), artifactStore)
             .map { sr =>

--- a/tools/admin/src/main/scala/whisk/core/database/DbCommand.scala
+++ b/tools/admin/src/main/scala/whisk/core/database/DbCommand.scala
@@ -136,7 +136,7 @@ class DbCommand extends Subcommand("db") with WhiskCommand {
           else throw r.io.getError
       }
       .flatMap { rr =>
-        //TODO Close ticker here and log
+        ticker.close()
         //2. Now download attachments by reading output file
         if (rr.attachmentCount > 0) {
           val dump = get.out() //For attachment case out file is required

--- a/tools/admin/src/main/scala/whisk/core/database/DbCommand.scala
+++ b/tools/admin/src/main/scala/whisk/core/database/DbCommand.scala
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.database
+
+import java.io.File
+
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.{FileIO, Flow, Keep, StreamConverters}
+import akka.stream.{ActorMaterializer, IOResult}
+import akka.util.ByteString
+import com.typesafe.config.ConfigFactory
+import org.rogach.scallop.{ScallopConfBase, Subcommand}
+import spray.json.JsObject
+import whisk.common.{Logging, TransactionId}
+import whisk.core.cli.{CommandError, CommandMessages, WhiskCommand}
+import whisk.core.entity.{WhiskActivation, WhiskAuth, WhiskEntity}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.reflect.{classTag, ClassTag}
+import scala.util.Properties
+
+class DbCommand extends Subcommand("db") with WhiskCommand {
+  descr("work with dbs")
+
+  val databases = Set("whisks", "activations", "subjects")
+
+  val get = new Subcommand("get") {
+    descr("get contents of database")
+
+    val dbTypeMapping: Map[String, ClassTag[_ <: DocumentSerializer]] =
+      Map(
+        "whisks" -> classTag[WhiskEntity],
+        "activations" -> classTag[WhiskActivation],
+        "subjects" -> classTag[WhiskAuth])
+
+    val database = trailArg[String](descr = s"database type. One of $databases")
+
+    validate(database) { db =>
+      if (databases.contains(db)) {
+        Right(Unit)
+      } else {
+        Left(CommandMessages.invalidDatabase(db, databases))
+      }
+    }
+
+    val docs = opt[Boolean](descr = "include document contents")
+
+    val view = opt[String](descr = "the view in the database to get", argName = "VIEW")
+
+    val out = opt[File](descr = "file to dump the contents to")
+
+    def dbType: ClassTag[_ <: DocumentSerializer] = dbTypeMapping(database())
+
+  }
+  addSubcommand(get)
+
+  def exec(cmd: ScallopConfBase)(implicit system: ActorSystem,
+                                 logging: Logging,
+                                 materializer: ActorMaterializer,
+                                 transid: TransactionId): Future[Either[CommandError, String]] = {
+    implicit val executionContext = system.dispatcher
+    val result = cmd match {
+      case `get` => getDBContents()
+    }
+    result
+  }
+
+  def getDBContents()(implicit system: ActorSystem,
+                      logging: Logging,
+                      materializer: ActorMaterializer,
+                      transid: TransactionId,
+                      ec: ExecutionContext): Future[Either[CommandError, String]] = {
+    val outputSink = Flow[JsObject]
+      .map(js => ByteString(js.compactPrint + Properties.lineSeparator))
+      .toMat(createSink())(Keep.right)
+    val store = DbCommand.createStore(get.dbType)
+
+    val f = store.getAll[IOResult](outputSink)
+    f.map {
+      case (count, r) =>
+        if (r.wasSuccessful)
+          Right(get.out.map(CommandMessages.dbContentToFile(count, _)).getOrElse(""))
+        else throw r.getError
+    }
+  }
+
+  private def createSink() =
+    get.out.map(f => FileIO.toPath(f.toPath)).getOrElse(StreamConverters.fromOutputStream(() => System.out))
+
+}
+
+object DbCommand {
+  def createStore[D <: DocumentSerializer](classTag: ClassTag[D])(
+    implicit system: ActorSystem,
+    logging: Logging,
+    materializer: ActorMaterializer): StreamingArtifactStore = {
+    implicit val tag = classTag
+    getStoreProvider().makeStore[D]()
+  }
+
+  def getStoreProvider(): StreamingArtifactStoreProvider = {
+    val storeClass = ConfigFactory.load().getString("whisk.spi.ArtifactStoreProvider") + "$"
+    if (storeClass == CouchDbStoreProvider.getClass.getName)
+      CouchDBStreamingStoreProvider
+    else
+      throw new IllegalArgumentException(s"Unsupported ArtifactStore $storeClass")
+  }
+}

--- a/tools/admin/src/main/scala/whisk/core/database/DbCommand.scala
+++ b/tools/admin/src/main/scala/whisk/core/database/DbCommand.scala
@@ -18,6 +18,7 @@
 package whisk.core.database
 
 import java.io.File
+import java.time.Instant
 
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{FileIO, Flow, Framing, Keep, Sink, Source, StreamConverters}
@@ -26,24 +27,26 @@ import akka.util.ByteString
 import com.typesafe.config.ConfigFactory
 import org.apache.commons.io.output.CloseShieldOutputStream
 import org.rogach.scallop.{ScallopConfBase, Subcommand}
+import org.slf4j.LoggerFactory
 import spray.json.{JsObject, JsonParser, ParserInput}
 import whisk.common.{Logging, TransactionId}
-import whisk.core.cli.{CommandError, CommandMessages, NoopTicker, ProgressTicker, Ticker, WhiskCommand}
-import whisk.core.entity.{ByteSize, WhiskActivation, WhiskAuth, WhiskEntity}
+import whisk.core.cli.{CommandError, CommandMessages, IllegalState, NoopTicker, ProgressTicker, Ticker, WhiskCommand}
+import whisk.core.database.DbCommand._
+import whisk.core.entity._
+import whisk.core.entity.size._
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.{classTag, ClassTag}
 import scala.util.Properties
-import whisk.core.entity.size._
 
 class DbCommand extends Subcommand("db") with WhiskCommand {
   descr("work with dbs")
 
+  private val log = LoggerFactory.getLogger(getClass.getName)
+
   val databases = Set("whisks", "activations", "subjects")
 
-  val get = new Subcommand("get") {
-    descr("get contents of database")
-
+  abstract class DbSubcommand(commandNameAndAliases: String*) extends Subcommand(commandNameAndAliases: _*) {
     val dbTypeMapping: Map[String, ClassTag[_ <: DocumentSerializer]] =
       Map(
         "whisks" -> classTag[WhiskEntity],
@@ -60,16 +63,28 @@ class DbCommand extends Subcommand("db") with WhiskCommand {
       }
     }
 
+    def dbType: ClassTag[_ <: DocumentSerializer] = dbTypeMapping(database())
+  }
+
+  val get = new DbSubcommand("get") {
+    descr("get contents of database")
+
     val docs = opt[Boolean](descr = "include document contents")
 
     val view = opt[String](descr = "the view in the database to get", argName = "VIEW")
 
     val out = opt[File](descr = "file to dump the contents to")
-
-    def dbType: ClassTag[_ <: DocumentSerializer] = dbTypeMapping(database())
-
   }
   addSubcommand(get)
+
+  val put = new DbSubcommand("put") {
+    descr("add content to database")
+
+    //TODO Support relative files also
+    val in = opt[File](descr = "file to read contents from", required = true)
+    validateFileExists(in)
+  }
+  addSubcommand(put)
 
   def exec(cmd: ScallopConfBase)(implicit system: ActorSystem,
                                  logging: Logging,
@@ -78,6 +93,7 @@ class DbCommand extends Subcommand("db") with WhiskCommand {
     implicit val executionContext = system.dispatcher
     val result = cmd match {
       case `get` => getDBContents()
+      case `put` => putDBContents()
     }
     result
   }
@@ -87,12 +103,12 @@ class DbCommand extends Subcommand("db") with WhiskCommand {
                       materializer: ActorMaterializer,
                       transid: TransactionId,
                       ec: ExecutionContext): Future[Either[CommandError, String]] = {
-    val ticker = createTicker()
+    val ticker = if (get.out.isDefined && showProgressBar()) new ProgressTicker else NoopTicker
     val outputSink = Flow[JsObject]
-      .map(js => ByteString(js.compactPrint + Properties.lineSeparator))
+      .map(jsToStringLine)
       .via(tick(ticker))
       .toMat(createSink())(Keep.right)
-    val store = DbCommand.createStore(get.dbType)
+    val store = DbCommand.createStreamingStore(get.dbType)
 
     val f = store.getAll[IOResult](outputSink)
     f.onComplete(_ => ticker.close())
@@ -101,6 +117,50 @@ class DbCommand extends Subcommand("db") with WhiskCommand {
         if (r.wasSuccessful)
           Right(get.out.map(CommandMessages.dbContentToFile(count, _)).getOrElse(""))
         else throw r.getError
+    }
+  }
+
+  def putDBContents()(implicit system: ActorSystem,
+                      logging: Logging,
+                      materializer: ActorMaterializer,
+                      transid: TransactionId,
+                      ec: ExecutionContext): Future[Either[CommandError, String]] = {
+    import spray.json.DefaultJsonProtocol._
+
+    val authStore = WhiskAuthStore.datastore()
+    val entityStore = WhiskEntityStore.datastore()
+    val activationStore = WhiskActivationStore.datastore()
+
+    val ticker = if (showProgressBar()) new ProgressTicker else NoopTicker
+    val source = createJSStream(put.in())
+    val f = source
+      .mapAsyncUnordered(4) { js =>
+        val id = js.fields("_id").convertTo[String]
+        val g = put.dbType.runtimeClass match {
+          case x if x == classOf[WhiskEntity]     => entityStore.put(AnyEntity(js))
+          case x if x == classOf[WhiskActivation] => activationStore.put(new AnyActivation(js))
+          case x if x == classOf[WhiskAuth]       => authStore.put(new AnyAuth(js))
+        }
+        g.map(_ => PutResultState.SUCCESS)
+          .recover {
+            case _: DocumentConflictException =>
+              log.warn("Document exists [{}]", id)
+              PutResultState.EXISTS
+            case e =>
+              log.warn(s"Error while adding [$id]", e)
+              PutResultState.ERROR
+          }
+      }
+      .via(tick(ticker))
+      .runWith(Sink.fold[PutResultAccumulator, PutResultState.PutResultState](new PutResultAccumulator) { (acc, s) =>
+        acc.update(s)
+      })
+
+    f.onComplete(_ => ticker.close())
+    f.map { acc =>
+      val r = acc.toResult()
+      if (r.ok) Right(CommandMessages.putDocs(r.success))
+      else Left(IllegalState(CommandMessages.putDocsFailed(success = r.success, failed = r.failed, exists = r.exists)))
     }
   }
 
@@ -113,19 +173,45 @@ class DbCommand extends Subcommand("db") with WhiskCommand {
     Flow[T].wireTap(Sink.foreach(_ => ticker.tick()))
   }
 
-  private def createTicker() = {
-    if (get.out.isDefined) new ProgressTicker else NoopTicker
+  private def showProgressBar(): Boolean = true
+
+  private object PutResultState extends Enumeration {
+    type PutResultState = Value
+    val SUCCESS, EXISTS, ERROR = Value
+  }
+
+  private class PutResultAccumulator(private var success: Long = 0,
+                                     private var failed: Long = 0,
+                                     private var exists: Long = 0) {
+    import PutResultState._
+    def update(r: PutResultState): PutResultAccumulator = {
+      r match {
+        case SUCCESS => success += 1
+        case EXISTS  => exists += 1
+        case ERROR   => failed += 1
+      }
+      this
+    }
+
+    def toResult(): PutResult = PutResult(success, failed, exists)
+  }
+
+  case class PutResult(success: Long, failed: Long, exists: Long) {
+    def ok: Boolean = failed == 0 && exists == 0
   }
 }
 
 object DbCommand {
-  def createStore[D <: DocumentSerializer](classTag: ClassTag[D])(
+  def createStreamingStore[D <: DocumentSerializer](classTag: ClassTag[D])(
     implicit system: ActorSystem,
     logging: Logging,
     materializer: ActorMaterializer): StreamingArtifactStore = {
     implicit val tag = classTag
     getStoreProvider().makeStore[D]()
   }
+
+  def retainProperFields(js: JsObject): JsObject =
+    JsObject(js.fields.filterKeys(key => key == "_id" || !key.startsWith("_")))
 
   def getStoreProvider(): StreamingArtifactStoreProvider = {
     val storeClass = ConfigFactory.load().getString("whisk.spi.ArtifactStoreProvider") + "$"
@@ -141,5 +227,38 @@ object DbCommand {
       .fromPath(file.toPath)
       .via(Framing.delimiter(ByteString("\n"), maxLineLength.toBytes.toInt))
       .map(bs => JsonParser(ParserInput.apply(bs.toArray)).asJsObject)
+  }
+
+  def jsToStringLine(js: JsObject): ByteString = ByteString(js.compactPrint + Properties.lineSeparator)
+
+  private val unusedSubject = Subject()
+  private val unusedParams = Parameters()
+  private val unusedPath = EntityPath("not used")
+  private val unusedName = EntityName("not used")
+  private val unusedActivationId = ActivationId.generate()
+  private val unusedInstant = Instant.now()
+  private val unusedVersion = SemVer()
+
+  //Need to use these proxy classes to enable passing in the js without
+  //needing to convert them to actual entity type. Later we should look
+  //into supporting ArtifactStore.putRaw kind of method to directly persist js
+  private class AnyAuth(js: JsObject) extends WhiskAuth(unusedSubject, Set.empty) {
+    override def toDocumentRecord: JsObject = retainProperFields(js)
+  }
+
+  private case class AnyEntity(js: JsObject,
+                               version: SemVer = unusedVersion,
+                               publish: Boolean = false,
+                               namespace: EntityPath = unusedPath,
+                               annotations: Parameters = unusedParams)
+      extends WhiskEntity(EntityName("not used"), "not used") {
+    override def toDocumentRecord: JsObject = retainProperFields(js)
+    override def toJson: JsObject = ???
+    //TODO entityType handling
+  }
+
+  private class AnyActivation(js: JsObject)
+      extends WhiskActivation(unusedPath, unusedName, unusedSubject, unusedActivationId, unusedInstant, unusedInstant) {
+    override def toDocumentRecord: JsObject = retainProperFields(js)
   }
 }

--- a/tools/admin/src/main/scala/whisk/core/database/DbCommand.scala
+++ b/tools/admin/src/main/scala/whisk/core/database/DbCommand.scala
@@ -45,7 +45,7 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.reflect.{classTag, ClassTag}
 import scala.util.{Failure, Properties, Success, Try}
 
-class DbCommand extends Subcommand("db") with WhiskCommand {
+class DbCommand extends Subcommand("db") with WhiskCommand with ConfSupport {
   descr("work with dbs")
 
   val databases = Set("whisks", "activations", "subjects")
@@ -77,7 +77,7 @@ class DbCommand extends Subcommand("db") with WhiskCommand {
 
     val view = opt[String](descr = "the view in the database to get", argName = "VIEW")
 
-    val out = opt[File](descr = "file to dump the contents to")
+    val out = opt[File](descr = "file to dump the contents to")(relativeFileConverter)
 
     val attachments =
       opt[Boolean](descr = "include attachments. Downloaded attachments would be stored under 'attachments' directory")
@@ -91,8 +91,7 @@ class DbCommand extends Subcommand("db") with WhiskCommand {
   val put = new DbSubcommand("put") {
     descr("add content to database")
 
-    //TODO Support relative files also
-    val in = opt[File](descr = "file to read contents from", required = true)
+    val in = opt[File](descr = "file to read contents from", required = true)(relativeFileConverter)
 
     val threads = opt[Int](descr = "Number of parallel puts to perform", default = Some(5))
     validateFileExists(in)

--- a/tools/admin/src/main/scala/whisk/core/database/DbCommand.scala
+++ b/tools/admin/src/main/scala/whisk/core/database/DbCommand.scala
@@ -24,6 +24,7 @@ import akka.stream.scaladsl.{FileIO, Flow, Keep, StreamConverters}
 import akka.stream.{ActorMaterializer, IOResult}
 import akka.util.ByteString
 import com.typesafe.config.ConfigFactory
+import org.apache.commons.io.output.CloseShieldOutputStream
 import org.rogach.scallop.{ScallopConfBase, Subcommand}
 import spray.json.JsObject
 import whisk.common.{Logging, TransactionId}
@@ -100,7 +101,9 @@ class DbCommand extends Subcommand("db") with WhiskCommand {
   }
 
   private def createSink() =
-    get.out.map(f => FileIO.toPath(f.toPath)).getOrElse(StreamConverters.fromOutputStream(() => System.out))
+    get.out
+      .map(f => FileIO.toPath(f.toPath))
+      .getOrElse(StreamConverters.fromOutputStream(() => new CloseShieldOutputStream(System.out)))
 
 }
 

--- a/tools/admin/src/main/scala/whisk/core/database/DbCommand.scala
+++ b/tools/admin/src/main/scala/whisk/core/database/DbCommand.scala
@@ -34,6 +34,7 @@ import whisk.core.cli.{CommandError, CommandMessages, IllegalState, NoopTicker, 
 import whisk.core.database.DbCommand._
 import whisk.core.entity._
 import whisk.core.entity.size._
+import whisk.core.cli.ConsoleUtil._
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.{classTag, ClassTag}
@@ -170,8 +171,6 @@ class DbCommand extends Subcommand("db") with WhiskCommand {
   private def tick[T](ticker: Ticker) = {
     Flow[T].wireTap(Sink.foreach(_ => ticker.tick()))
   }
-
-  private def showProgressBar(): Boolean = true
 
   private object PutResultState extends Enumeration {
     type PutResultState = Value

--- a/tools/admin/src/main/scala/whisk/core/database/StreamingArtifactStore.scala
+++ b/tools/admin/src/main/scala/whisk/core/database/StreamingArtifactStore.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.database
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Sink, Source}
+import spray.json.JsObject
+import whisk.common.{Logging, TransactionId}
+
+import scala.concurrent.Future
+import scala.reflect.ClassTag
+
+trait StreamingArtifactStore {
+
+  protected[database] def getAll[T](sink: Sink[JsObject, Future[T]])(implicit transid: TransactionId): Future[(Long, T)]
+
+  protected[database] def getCount()(implicit transid: TransactionId): Future[Option[Long]]
+}
+
+trait StreamingArtifactStoreProvider {
+
+  def makeStore[D <: DocumentSerializer: ClassTag]()(implicit actorSystem: ActorSystem,
+                                                     logging: Logging,
+                                                     materializer: ActorMaterializer): StreamingArtifactStore
+}


### PR DESCRIPTION
Adds `db` command support to export and import the db contents to scala based wskadmin impl (#3722)

## Description

Current `wskadmin` support dumping the db content for various collections, views etc to file via `db` command

```
$ wskadmin db get -h
usage: wskadmin db get [-h] [-v VIEW] [--docs] database

positional arguments:
  database              the database name

optional arguments:
  -h, --help            show this help message and exit
  -v VIEW, --view VIEW  the view in the database to get
  --docs                include document contents

```

This PR will support both `get` (export) and `put` (import) commands to admin tooling. 

### Streaming IO

The export and import support would make use of Akka Streams. 

For e.g. for exporting the json from CouchDB it would make use of [\_all_docs][1] endpoint which uses chunked transfer encoding. This logic is implemented in `CouchDBStreamingStore` which makes use of [Alpakka JSON Streaming][2] support to dump each json document as a single line

The JSON dump file created via `get` would have a one json record per line and thus can again be consumed in a streaming way

## TODO

- [ ] Export - Filter by view
- [ ] Export - Attachments
- [ ] Import 

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [x] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

[1]: http://docs.couchdb.org/en/2.0.0/api/database/bulk-api.html
[2]: https://developer.lightbend.com/docs/alpakka/current/data-transformations/json.html#streaming-of-nested-structures
