### PR TITLE
Use only scoverage related artifcats in modified classpath

### DIFF
--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -234,7 +234,8 @@ def getScoverageClasspath(Project project) {
         ':tools:admin'
     ]
     def combinedClasspath = projectNames.inject(project.files([])) { result, name ->
-        result + project.project(name).sourceSets.scoverage.runtimeClasspath
+        def cp = project.project(name).sourceSets.scoverage.runtimeClasspath
+        result + cp.filter {it.name.contains('scoverage')}
     }
 
     combinedClasspath + sourceSets.test.runtimeClasspath


### PR DESCRIPTION
Fixes #3819 by only using scoverage related artifacts.

## Description

Post this change the modified classpath looks like. This ensures **only** scoverage instrumented classes come first in the classpath and rest of the classpath is normal testRuntimeClasspath

```
/Users/travis/openwhisk/common/scala/build/classes/java/scoverage
/Users/travis/openwhisk/common/scala/build/classes/scala/scoverage
/Users/travis/openwhisk/common/scala/build/resources/scoverage
/Users/travis/.gradle/caches/modules-2/files-2.1/org.scoverage/scalac-scoverage-plugin_2.11/1.3.1/9b5637564eec011cac1aceab345c8de6b5a4e336/scalac-scoverage-plugin_2.11-1.3.1.jar
/Users/travis/.gradle/caches/modules-2/files-2.1/org.scoverage/scalac-scoverage-runtime_2.11/1.3.1/6f98957ae5ade845d20ac31e34f4142ddbb268a9/scalac-scoverage-runtime_2.11-1.3.1.jar
/Users/travis/openwhisk/core/controller/build/classes/java/scoverage
/Users/travis/openwhisk/core/controller/build/classes/scala/scoverage
/Users/travis/openwhisk/core/controller/build/resources/scoverage
/Users/travis/openwhisk/core/invoker/build/classes/java/scoverage
/Users/travis/openwhisk/core/invoker/build/classes/scala/scoverage
/Users/travis/openwhisk/core/invoker/build/resources/scoverage
/Users/travis/openwhisk/tools/admin/build/classes/java/scoverage
/Users/travis/openwhisk/tools/admin/build/classes/scala/scoverage
/Users/travis/openwhisk/tools/admin/build/resources/scoverage
/Users/travis/openwhisk/tests/build/classes/java/test
/Users/travis/openwhisk/tests/build/classes/scala/test
/Users/travis/openwhisk/tests/build/resources/test
/Users/travis/openwhisk/tests/build/classes/java/main
/Users/travis/openwhisk/tests/build/classes/scala/main
/Users/travis/openwhisk/tests/build/resources/main
/Users/travis/openwhisk/core/controller/build/libs/openwhisk-controller-1.0.0-SNAPSHOT.jar
/Users/travis/openwhisk/core/invoker/build/libs/openwhisk-invoker-1.0.0-SNAPSHOT.jar
/Users/travis/openwhisk/tools/admin/build/libs/openwhisk-admin-tools-1.0.0-SNAPSHOT.jar
/Users/travis/openwhisk/common/scala/build/libs/openwhisk-common-1.0.0-SNAPSHOT.jar
/Users/travis/.gradle/caches/modules-2/files-2.1/org.scalamock/scalamock-scalatest-support_2.11/3.4.2/3bb1ee48b2715279f44edce457ef568d6ea75f2d/scalamock-scalatest-support_2.11-3.4.2.jar
/Users/travis/.gradle/caches/modules-2/files-2.1/org.scalatest/scalatest_2.11/3.0.1/40a1842e7f0b915d87de1cb69f9c6962a65ee1fd/scalatest_2.11-3.0.1.jar
/Users/travis/.gradle/caches/modules-2/files-2.1/com.typesafe.akka/akka-http-testkit_2.11/10.1.1/83e187401da61eaedf54e8538fdcccd515d21c36/akka-http-testkit_2.11-10.1.1.jar
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#3819)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

