### PR TITLE
Avoid regenerating auth key multiple times

### DIFF
--- a/tests/src/test/scala/whisk/core/database/UserCommandTests.scala
+++ b/tests/src/test/scala/whisk/core/database/UserCommandTests.scala
@@ -62,6 +62,12 @@ class UserCommandTests extends FlatSpec with WhiskAdminCliTestBase {
     admin.executeCommand().futureValue.right.get shouldBe key.compact
   }
 
+  it should "create a user with default key" in {
+    val subject = newSubject()
+    val generatedKey = resultOk("user", "create", subject)
+    resultOk("user", "get", subject) shouldBe generatedKey
+  }
+
   it should "add namespace to existing user" in {
     val subject = newSubject()
     val key = AuthKey()

--- a/tools/admin/src/main/scala/whisk/core/database/UserCommand.scala
+++ b/tools/admin/src/main/scala/whisk/core/database/UserCommand.scala
@@ -85,9 +85,7 @@ class UserCommand extends Subcommand("user") with WhiskCommand {
 
     def isUUID(u: String) = Try(UUID.fromString(u)).isSuccess
 
-    def desiredNamespace = Namespace(EntityName(namespace.getOrElse(subject()).trim), authKey.uuid)
-
-    def authKey: AuthKey = auth.map(AuthKey(_)).getOrElse(AuthKey())
+    def desiredNamespace(authKey: AuthKey) = Namespace(EntityName(namespace.getOrElse(subject()).trim), authKey.uuid)
   }
 
   val create = new CreateUserCmd
@@ -171,22 +169,26 @@ class UserCommand extends Subcommand("user") with WhiskCommand {
 
   def createUser(authStore: AuthStore)(implicit transid: TransactionId,
                                        ec: ExecutionContext): Future[Either[CommandError, String]] = {
-    authStore.get[ExtendedAuth](DocInfo(create.subject())).flatMap { auth =>
-      if (auth.isBlocked) {
-        Future.successful(Left(IllegalState(CommandMessages.subjectBlocked)))
-      } else if (auth.namespaces.exists(_.namespace.name == create.desiredNamespace.name)) {
-        Future.successful(Left(IllegalState(CommandMessages.namespaceExists)))
-      } else {
-        val newNS = auth.namespaces + WhiskNamespace(create.desiredNamespace, create.authKey)
-        val newAuth = WhiskAuth(auth.subject, newNS).revision[WhiskAuth](auth.rev)
-        authStore.put(newAuth).map(_ => Right(create.authKey.compact))
+    val authKey = create.auth.map(AuthKey(_)).getOrElse(AuthKey())
+    authStore
+      .get[ExtendedAuth](DocInfo(create.subject()))
+      .flatMap { auth =>
+        if (auth.isBlocked) {
+          Future.successful(Left(IllegalState(CommandMessages.subjectBlocked)))
+        } else if (auth.namespaces.exists(_.namespace.name == create.desiredNamespace(authKey).name)) {
+          Future.successful(Left(IllegalState(CommandMessages.namespaceExists)))
+        } else {
+          val newNS = auth.namespaces + WhiskNamespace(create.desiredNamespace(authKey), authKey)
+          val newAuth = WhiskAuth(auth.subject, newNS).revision[WhiskAuth](auth.rev)
+          authStore.put(newAuth).map(_ => Right(authKey.compact))
+        }
       }
-    }
-  }.recoverWith {
-    case _: NoDocumentException =>
-      val auth =
-        WhiskAuth(Subject(create.subject()), Set(WhiskNamespace(create.desiredNamespace, create.authKey)))
-      authStore.put(auth).map(_ => Right(create.authKey.compact))
+      .recoverWith {
+        case _: NoDocumentException =>
+          val auth =
+            WhiskAuth(Subject(create.subject()), Set(WhiskNamespace(create.desiredNamespace(authKey), authKey)))
+          authStore.put(auth).map(_ => Right(authKey.compact))
+      }
   }
 
   def deleteUser(authStore: AuthStore)(implicit transid: TransactionId,


### PR DESCRIPTION
Scala based `user create foo` command which sets a random auth key is printing wrong key in output.

## Description
This happens because in case authkey is not provided then current impl was generating the key multiple times. So they key which gets saved in db differs from one printed in output.

This PR fixes that by generating the key only once if none provided


<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [x] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

