### PR TITLE
Don't use stubbed functions in InvokerSupervisionTests.

### DIFF
--- a/tests/src/test/scala/common/LoggedFunction.scala
+++ b/tests/src/test/scala/common/LoggedFunction.scala
@@ -83,10 +83,11 @@ class LoggedFunction6[A1, A2, A3, A4, A5, A6, B](body: (A1, A2, A3, A4, A5, A6) 
 }
 
 object LoggedFunction {
-  def apply[A1, B](body: (A1) => B) = new LoggedFunction1(body)
-  def apply[A1, A2, B](body: (A1, A2) => B) = new LoggedFunction2(body)
-  def apply[A1, A2, A3, B](body: (A1, A2, A3) => B) = new LoggedFunction3(body)
-  def apply[A1, A2, A3, A4, B](body: (A1, A2, A3, A4) => B) = new LoggedFunction4(body)
-  def apply[A1, A2, A3, A4, A5, B](body: (A1, A2, A3, A4, A5) => B) = new LoggedFunction5(body)
-  def apply[A1, A2, A3, A4, A5, A6, B](body: (A1, A2, A3, A4, A5, A6) => B) = new LoggedFunction6(body)
+  def apply[A1, B](body: (A1) => B) = new LoggedFunction1[A1, B](body)
+  def apply[A1, A2, B](body: (A1, A2) => B) = new LoggedFunction2[A1, A2, B](body)
+  def apply[A1, A2, A3, B](body: (A1, A2, A3) => B) = new LoggedFunction3[A1, A2, A3, B](body)
+  def apply[A1, A2, A3, A4, B](body: (A1, A2, A3, A4) => B) = new LoggedFunction4[A1, A2, A3, A4, B](body)
+  def apply[A1, A2, A3, A4, A5, B](body: (A1, A2, A3, A4, A5) => B) = new LoggedFunction5[A1, A2, A3, A4, A5, B](body)
+  def apply[A1, A2, A3, A4, A5, A6, B](body: (A1, A2, A3, A4, A5, A6) => B) =
+    new LoggedFunction6[A1, A2, A3, A4, A5, A6, B](body)
 }


### PR DESCRIPTION
`stubFunctions` don't seem to play nicely with retry logic because the `verify` handler will be attached more than once. Switching to a manual stub should help here.

Fixes #3809

## My changes affect the following components
- [X] Tests

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes.


