### PR TITLE
Limit of binary actions is too low.

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -56,7 +56,10 @@ limits:
   concurrentInvocationsSystem:  "{{ limit_invocations_concurrent_system | default(5000) }}"
   firesPerMinute: "{{ limit_fires_per_minute | default(60) }}"
   sequenceMaxLength: "{{ limit_sequence_max_length | default(50) }}"
+  # The parameter limits.actionCodeMb is the net action code. It might to be increased in some places to allow base64 overhead.
   actionCodeMb: "{{ limit_action_code_mb | default(48) }}"
+  # The parameter limits.parametersMb are applied for parameters and annotations. As no encoding is used on sending the
+  # annotations, it can be taken everywhere as it is.
   parametersMb: "{{ limit_parameters_mb | default(1) }}"
 
 # port means outer port

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -56,6 +56,8 @@ limits:
   concurrentInvocationsSystem:  "{{ limit_invocations_concurrent_system | default(5000) }}"
   firesPerMinute: "{{ limit_fires_per_minute | default(60) }}"
   sequenceMaxLength: "{{ limit_sequence_max_length | default(50) }}"
+  actionCodeMb: "{{ limit_action_code_mb | default(48) }}"
+  parametersMb: "{{ limit_parameters_mb | default(1) }}"
 
 # port means outer port
 controller:

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -126,7 +126,10 @@
       "COMPONENT_NAME": "{{ controller_name }}"
       "PORT": 8080
 
-      # Allow base64 overhead of action-code, parameters and annotations.
+      # Allow parameters, annotations and base64 overhead of action-code.
+      # We calculate the limit out of the maximum size of annotations, the maximum size of paramters and the maximum size of action code (including base64 overhead).
+      # A valid message might still be too large, e.g. on choosing a very long name. But we are only considering the parameters, the annotations and the code here,
+      # as these are the largest parts of the message.
       "CONFIG_akka_http_server_parsing_maxContentLength": "{{ (limits.actionCodeMb | int * 4 / 3 + limits.parametersMb | int * 2) | round(0, 'ceil') | int }}m"
       "CONFIG_akka_http_client_parsing_maxChunkSize": "{{ (limits.actionCodeMb | int * 4 / 3 + limits.parametersMb | int * 2) | round(0, 'ceil') | int }}m"
 

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -128,6 +128,7 @@
 
       # Allow base64 overhead of action-code, parameters and annotations.
       "CONFIG_akka_http_server_parsing_maxContentLength": "{{ (limits.actionCodeMb | int * 4 / 3 + limits.parametersMb | int * 2) | round(0, 'ceil') | int }}m"
+      "CONFIG_akka_http_client_parsing_maxChunkSize": "{{ (limits.actionCodeMb | int * 4 / 3 + limits.parametersMb | int * 2) | round(0, 'ceil') | int }}m"
 
       "CONFIG_whisk_info_date": "{{ whisk.version.date }}"
       "CONFIG_whisk_info_buildNo": "{{ docker.image.tag }}"

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -126,6 +126,9 @@
       "COMPONENT_NAME": "{{ controller_name }}"
       "PORT": 8080
 
+      # Allow base64 overhead of action-code, parameters and annotations.
+      "CONFIG_akka_http_server_parsing_maxContentLength": "{{ (limits.actionCodeMb | int * 4 / 3 + limits.parametersMb | int * 2) | round(0, 'ceil') | int }}m"
+
       "CONFIG_whisk_info_date": "{{ whisk.version.date }}"
       "CONFIG_whisk_info_buildNo": "{{ docker.image.tag }}"
 
@@ -190,6 +193,9 @@
       "CONFIG_whisk_timeLimit_min": "{{ limit_action_time_min | default() }}"
       "CONFIG_whisk_timeLimit_max": "{{ limit_action_time_max | default() }}"
       "CONFIG_whisk_timeLimit_std": "{{ limit_action_time_std | default() }}"
+
+      "CONFIG_whisk_limits_actionCodeSize": "{{ limits.actionCodeMb }} m"
+      "CONFIG_whisk_limits_parameterSize": "{{ limits.parametersMb }} m"
 
       "CONFIG_whisk_activation_payload_max":
         "{{ limit_activation_payload | default() }}"

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -223,6 +223,8 @@
       "CONFIG_whisk_timeLimit_min": "{{ limit_action_time_min | default() }}"
       "CONFIG_whisk_timeLimit_max": "{{ limit_action_time_max | default() }}"
       "CONFIG_whisk_timeLimit_std": "{{ limit_action_time_std | default() }}"
+      "CONFIG_whisk_limits_actionCodeSize": "{{ limits.actionCodeMb }} m"
+      "CONFIG_whisk_limits_parameterSize": "{{ limits.parametersMb }} m"
       "CONFIG_whisk_activation_payload_max": "{{ limit_activation_payload | default() }}"
       "CONFIG_whisk_transactions_header": "{{ transactions.header }}"
 

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -169,6 +169,7 @@
       "JMX_REMOTE": "{{ jmx.enabled }}"
       "COMPONENT_NAME": "{{ invoker_name }}"
       "PORT": 8080
+      "CONFIG_akka_http_client_parsing_maxChunkSize": "{{ (limits.actionCodeMb | int * 4 / 3 + limits.parametersMb | int * 2) | round(0, 'ceil') | int }}m"
       "KAFKA_HOSTS": "{{ kafka_connect_string }}"
       "CONFIG_whisk_kafka_replicationFactor": "{{ kafka.replicationFactor | default() }}"
       "CONFIG_whisk_kafka_topics_invoker_retentionBytes": "{{ kafka_topics_invoker_retentionBytes | default() }}"

--- a/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/ansible/roles/nginx/templates/nginx.conf.j2
@@ -10,7 +10,7 @@ events {
 
 http {
 {# allow large uploads, need to thread proper limit into here #}
-    client_max_body_size 50M;
+    client_max_body_size 66M;
 
     rewrite_log on;
 {# change log format to display the upstream information #}

--- a/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/ansible/roles/nginx/templates/nginx.conf.j2
@@ -10,7 +10,8 @@ events {
 
 http {
 {# allow large uploads, need to thread proper limit into here #}
-    client_max_body_size 66M;
+    # Allow base64 overhead of action-code, parameters and annotations.
+    client_max_body_size {{ (limits.actionCodeMb | int * 4 / 3 + limits.parametersMb | int * 2) | round(0, 'ceil') | int }}M;
 
     rewrite_log on;
 {# change log format to display the upstream information #}

--- a/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/ansible/roles/nginx/templates/nginx.conf.j2
@@ -10,7 +10,7 @@ events {
 
 http {
 {# allow large uploads, need to thread proper limit into here #}
-    # Allow base64 overhead of action-code, parameters and annotations.
+    # Allow parameters, annotations and base64 overhead of action-code.
     client_max_body_size {{ (limits.actionCodeMb | int * 4 / 3 + limits.parametersMb | int * 2) | round(0, 'ceil') | int }}M;
 
     rewrite_log on;

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -7,7 +7,6 @@ include "logging"
 akka.http {
     client {
         parsing.illegal-header-warnings = off
-        parsing.max-chunk-size = 50m
     }
 
     host-connection-pool {

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -214,6 +214,8 @@ object ConfigKeys {
   val activationPayload = s"$activation.payload"
   val userEvents = "whisk.user-events"
 
+  val limits = "whisk.limits"
+
   val runtimes = "whisk.runtimes"
 
   val db = "whisk.db"

--- a/common/scala/src/main/scala/whisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Exec.scala
@@ -90,7 +90,10 @@ sealed abstract class CodeExec[+T <% SizeConversion] extends Exec {
    */
   val binary: Boolean
 
-  override def size = code.sizeInBytes + entryPoint.map(_.sizeInBytes).getOrElse(0.B)
+  private val rawCodeSize = code.sizeInBytes
+  // The overhead of the base64-encoding is 1/3. To allow the full limit for decoded actions, the overhead has to be
+  // removed in calculation of size.
+  override def size = (if (binary) rawCodeSize / 4 * 3 else rawCodeSize) + entryPoint.map(_.sizeInBytes).getOrElse(0.B)
 }
 
 sealed abstract class ExecMetaData extends ExecMetaDataBase {

--- a/common/scala/src/main/scala/whisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Exec.scala
@@ -19,16 +19,15 @@ package whisk.core.entity
 
 import java.nio.charset.StandardCharsets
 
-import scala.language.postfixOps
-import scala.util.matching.Regex
-
-import spray.json._
+import pureconfig.loadConfigOrThrow
 import spray.json.DefaultJsonProtocol._
+import spray.json._
+import whisk.core.ConfigKeys
 import whisk.core.entity.Attachments._
 import whisk.core.entity.ExecManifest._
-import whisk.core.entity.size.SizeInt
-import whisk.core.entity.size.SizeOptionString
-import whisk.core.entity.size.SizeString
+import whisk.core.entity.size._
+
+import scala.util.matching.Regex
 
 /**
  * Exec encodes the executable details of an action. For black
@@ -215,7 +214,7 @@ protected[core] case class SequenceExecMetaData(components: Vector[FullyQualifie
 
 protected[core] object Exec extends ArgNormalizer[Exec] with DefaultJsonProtocol {
 
-  val sizeLimit = 48 MB
+  val sizeLimit = loadConfigOrThrow[EntityLimits](ConfigKeys.limits).actionCodeSize
 
   // The possible values of the JSON 'kind' field for certain runtimes:
   // - Sequence because it is an intrinsic
@@ -345,7 +344,7 @@ protected[core] object Exec extends ArgNormalizer[Exec] with DefaultJsonProtocol
 
 protected[core] object ExecMetaDataBase extends ArgNormalizer[ExecMetaDataBase] with DefaultJsonProtocol {
 
-  val sizeLimit = 48 MB
+  val sizeLimit = loadConfigOrThrow[EntityLimits](ConfigKeys.limits).actionCodeSize
 
   // The possible values of the JSON 'kind' field for certain runtimes:
   // - Sequence because it is an intrinsic

--- a/common/scala/src/main/scala/whisk/core/entity/Parameter.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Parameter.scala
@@ -17,12 +17,14 @@
 
 package whisk.core.entity
 
-import scala.util.Try
+import pureconfig.loadConfigOrThrow
 import spray.json.DefaultJsonProtocol._
 import spray.json._
+import whisk.core.ConfigKeys
+import whisk.core.entity.size._
+
 import scala.language.postfixOps
-import whisk.core.entity.size.SizeInt
-import whisk.core.entity.size.SizeString
+import scala.util.Try
 
 /**
  * Parameters is a key-value map from parameter names to parameter values. The value of a
@@ -159,7 +161,7 @@ protected[core] object Parameters extends ArgNormalizer[Parameters] {
 
   /** Name of parameter that indicates if action is a feed. */
   protected[core] val Feed = "feed"
-  protected[core] val sizeLimit = 1 MB
+  protected[core] val sizeLimit = loadConfigOrThrow[EntityLimits](ConfigKeys.limits).parameterSize
 
   protected[core] def apply(): Parameters = new Parameters(Map.empty)
 

--- a/common/scala/src/main/scala/whisk/core/entity/Size.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Size.scala
@@ -69,6 +69,14 @@ case class ByteSize(size: Long, unit: SizeUnits.Unit) extends Ordered[ByteSize] 
     ByteSize(commonSize, commonUnit)
   }
 
+  def *(other: Int): ByteSize = {
+    ByteSize(toBytes * other, SizeUnits.BYTE)
+  }
+
+  def /(other: Int): ByteSize = {
+    ByteSize((toBytes / other).toInt, SizeUnits.BYTE)
+  }
+
   def compare(other: ByteSize) = toBytes compare other.toBytes
 
   override def equals(that: Any): Boolean = that match {

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskEntity.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskEntity.scala
@@ -209,3 +209,5 @@ case class LimitedWhiskEntityPut(exec: Option[Exec] = None,
     }
   }
 }
+
+case class EntityLimits(actionCodeSize: ByteSize, parameterSize: ByteSize)

--- a/core/controller/src/main/resources/application.conf
+++ b/core/controller/src/main/resources/application.conf
@@ -52,9 +52,6 @@ akka.http {
       # This indirectly puts a bound on the name of entities
       # 8k matches nginx default
       max-uri-length = 8k
-
-      # This is 50MB to allow action attachments
-      max-content-length = 66m
     }
   }
 }

--- a/core/controller/src/main/resources/application.conf
+++ b/core/controller/src/main/resources/application.conf
@@ -54,7 +54,7 @@ akka.http {
       max-uri-length = 8k
 
       # This is 50MB to allow action attachments
-      max-content-length = 50m
+      max-content-length = 66m
     }
   }
 }

--- a/tests/src/test/resources/application.conf.j2
+++ b/tests/src/test/resources/application.conf.j2
@@ -9,6 +9,7 @@ akka.http.client.idle-timeout = 90 s
 akka.http.host-connection-pool.idle-timeout = 90 s
 akka.http.host-connection-pool.client.idle-timeout = 90 s
 akka.http.client.parsing.max-content-length = "{{ (limits.actionCodeMb | int * 4 / 3 + limits.parametersMb | int * 2) | round(0, 'ceil') | int }}m"
+akka.http.client.parsing.max-chunk-size = "{{ (limits.actionCodeMb | int * 4 / 3 + limits.parametersMb | int * 2) | round(0, 'ceil') | int }}m"
 
 whisk {
     # kafka related configuration

--- a/tests/src/test/resources/application.conf.j2
+++ b/tests/src/test/resources/application.conf.j2
@@ -8,6 +8,7 @@ whisk.spi {
 akka.http.client.idle-timeout = 90 s
 akka.http.host-connection-pool.idle-timeout = 90 s
 akka.http.host-connection-pool.client.idle-timeout = 90 s
+akka.http.client.parsing.max-content-length = "{{ (limits.actionCodeMb | int * 4 / 3 + limits.parametersMb | int * 2) | round(0, 'ceil') | int }}m"
 
 whisk {
     # kafka related configuration
@@ -66,5 +67,10 @@ whisk {
     }
     user-events {
         enabled = {{ user_events }}
+    }
+
+    limits {
+        action-code-size = "{{ limits.actionCodeMb }} m"
+        parameter-size = "{{ limits.parametersMb }} m"
     }
 }

--- a/tests/src/test/scala/whisk/core/database/test/DbUtils.scala
+++ b/tests/src/test/scala/whisk/core/database/test/DbUtils.scala
@@ -262,7 +262,7 @@ trait DbUtils extends Assertions {
                                                           gc: Boolean = true)(implicit transid: TransactionId,
                                                                               timeout: Duration = 10 seconds,
                                                                               ma: Manifest[A]): (DocInfo, A) = {
-    val doc = put(db, entity, gc)
+    val doc = put(db, entity, gc)(transid, timeout)
     assert(doc != null && doc.id.asString != null && doc.rev.asString != null)
     val future = factory.get(db, doc.id, doc.rev)
     val dbEntity = Await.result(future, timeout)

--- a/tests/src/test/scala/whisk/core/entity/test/SizeTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/SizeTests.scala
@@ -102,6 +102,10 @@ class SizeTests extends FlatSpec with Matchers {
     40.MB * 2 should be(80.MB)
   }
 
+  it should "56 MB * 0 = 0 MB" in {
+    56.MB * 0 should be(0.B)
+  }
+
   // Division
   it should "5 Byte / 2 = 2 Byte" in {
     5.B / 2 should be(2 B)
@@ -111,7 +115,7 @@ class SizeTests extends FlatSpec with Matchers {
     1.MB / 512 should be(2 KB)
   }
 
-  it should "throw an exception if division is through 0" in {
+  it should "throw an exception if division is by 0" in {
     an[ArithmeticException] should be thrownBy {
       1.MB / 0
     }

--- a/tests/src/test/scala/whisk/core/entity/test/SizeTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/SizeTests.scala
@@ -93,6 +93,30 @@ class SizeTests extends FlatSpec with Matchers {
     }
   }
 
+  // Multiplication
+  it should "2 B * 10 = 20 B" in {
+    2.B * 10 should be(20.B)
+  }
+
+  it should "40 MB * 2 = 80 MB" in {
+    40.MB * 2 should be(80.MB)
+  }
+
+  // Division
+  it should "5 Byte / 2 = 2 Byte" in {
+    5.B / 2 should be(2 B)
+  }
+
+  it should "1 MB / 512 = 2 Byte" in {
+    1.MB / 512 should be(2 KB)
+  }
+
+  it should "throw an exception if division is through 0" in {
+    an[ArithmeticException] should be thrownBy {
+      1.MB / 0
+    }
+  }
+
   // Conversions
   it should "1024 B to KB = 1" in {
     (1024 B).toKB should be(1)

--- a/tests/src/test/scala/whisk/core/limits/ActionLimitsTests.scala
+++ b/tests/src/test/scala/whisk/core/limits/ActionLimitsTests.scala
@@ -338,7 +338,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers with WskActorSys
     // Create a file, that has 5/6 of the allowed size.
     // Due to the overhead of base64, the encoded request will be bigger than the allowed limit.
     pw.write("a" * (actionCodeLimit.toBytes * 5 / 6).toInt)
-    pw close ()
+    pw.close()
 
     assetHelper.withCleaner(wsk.action, name, confirmDelete = false) { (action, _) =>
       action.create(name, Some(actionCode.getAbsolutePath), kind = Some("nodejs:default"))


### PR DESCRIPTION
On creating an action, the code is sent to the controller. Afterwards the controller checks, that the code is not too big. If the code itself is sent directly (e.g. uploading a single `.js` file), the limit is 48MB (today).
If an archive is uploaded, it will be encoded with base64. The problem here is, that base64 has an overhead of 1/3. This means, if you have an archive, that has a size of e.g. 45MB, 60MB will be sent to the controller. So the request will be rejected. This is not expected for the user, as a limit of 48MB was proposed to him.

This PR fixes that bug.

## Related issue and scope
- [x] I opened an issue to propose and discuss this change (apache-mailing-list)

## My changes affect the following components
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

