### PR TITLE
Add an action runner test to ensure /init is only called once.

### DIFF
--- a/tests/src/test/scala/actionContainers/BasicActionRunnerTests.scala
+++ b/tests/src/test/scala/actionContainers/BasicActionRunnerTests.scala
@@ -174,10 +174,10 @@ trait BasicActionRunnerTests extends ActionProxyContainerTestUtils {
     it should "fail to initialize a second time" in {
       val (out, err) = withActionContainer() { c =>
         val (initCode1, _) = c.init(initPayload(code))
-        initCode1 should be (200)
+        initCode1 should be(200)
 
         val (initCode2, error2) = c.init(initPayload(code))
-        initCode2 should be (403)
+        initCode2 should be(403)
         error2 shouldBe a[Some[_]]
         error2.get shouldBe a[JsObject]
         error2.get.fields("error").toString should include("Cannot initialize the action more than once.")
@@ -185,9 +185,8 @@ trait BasicActionRunnerTests extends ActionProxyContainerTestUtils {
 
       checkStreams(out, err, {
         case (o, e) =>
-            (o + e) should include("Cannot initialize the action more than once")
+          (o + e) should include("Cannot initialize the action more than once")
       })
     }
   }
-
 }

--- a/tests/src/test/scala/actionContainers/BasicActionRunnerTests.scala
+++ b/tests/src/test/scala/actionContainers/BasicActionRunnerTests.scala
@@ -166,4 +166,28 @@ trait BasicActionRunnerTests extends ActionProxyContainerTestUtils {
     }
   }
 
+  /**
+   * Runs tests for actions which do not allow more than one initialisation and confirms expected error messages.
+   * @param code the code to execute, should be valid
+   */
+  def testInitCannotBeCalledMoreThanOnce(code: String) = {
+    it should "fail to initialize a second time" in {
+      val (out, err) = withActionContainer() { c =>
+        val (initCode1, _) = c.init(initPayload(code))
+        initCode1 should be (200)
+
+        val (initCode2, error2) = c.init(initPayload(code))
+        initCode2 should be (403)
+        error2 shouldBe a[Some[_]]
+        error2.get shouldBe a[JsObject]
+        error2.get.fields("error").toString should include("Cannot initialize the action more than once.")
+      }
+
+      checkStreams(out, err, {
+        case (o, e) =>
+            (o + e) should include("Cannot initialize the action more than once")
+      })
+    }
+  }
+
 }


### PR DESCRIPTION
## Description

We need to enforce that /init is only called once for a given instance of a runtime. Adding to `BasicActionRunnerTests` means that all the action runtimes can be consistent.

## Related issue and scope
- [X ] Rodric opened an issue to propose and discuss this change (#3839)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [X] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.
