### PR TITLE
Properly consume and optimize reading of http entities, drop connection reuse.

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     compile 'commons-io:commons-io:2.6'
     compile 'commons-collections:commons-collections:3.2.2'
     compile 'org.apache.kafka:kafka-clients:0.11.0.1'
-    compile ('org.apache.httpcomponents:httpclient:4.4.1') {
+    compile ('org.apache.httpcomponents:httpclient:4.5.5') {
         exclude group: 'commons-logging'
     }
     compile ('com.fasterxml.uuid:java-uuid-generator:3.1.3') {


### PR DESCRIPTION
**Notice:** This has been quite an odyssey to fix and we needed to roll back the change the last time. Please consider trying the changes out in an environment where you can assert latency and stability for different runtimes etc.

I myself have run:
- 3x Latency simulation (important, caught a regression last time) => **no regression**
- 3x Warm action simulation => **no regression**
- 1x Cold action simulation => **no regression**

## Description

- Explicitly consume and close the response's entity in any case (even if ignored) to make sure the connections get released properly and are not leaked.
- Use optimized path for consuming the entire entity into a string if its length is within bounds.
- Don't reuse connections.

To the last point: Reusing connections when a runtime doesn't support it adds a significant latency overhead when closing the response's entity. That's likely due to some sort of mismatched behavior (client wants to keep the connection open, the server doesn't even know the concept). The latency overhead in those cases (10-20ms of latency added in latency tests) seem far higher than the latency overhead of establishing a new connection (not measurable in latency tests).
Dropping connection reuse also solves any issues that might be encountered due to the pause/resume cycles of the container, in which sockets don't react to any event at all.


## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [X] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).

