### PR TITLE
Allow Elasticsearch client to skip query result hits

### DIFF
--- a/common/scala/src/main/scala/whisk/core/containerpool/logging/ElasticSearchRestClient.scala
+++ b/common/scala/src/main/scala/whisk/core/containerpool/logging/ElasticSearchRestClient.scala
@@ -58,6 +58,7 @@ case class EsQueryRange(key: String, range: EsRange, value: String)
 case class EsQueryBoolMatch(key: String, value: String)
 case class EsQueryOrder(field: String, kind: EsOrder)
 case class EsQuerySize(size: Integer)
+case class EsQueryFrom(from: Integer)
 case class EsQueryAll() extends EsQueryMethod
 case class EsQueryMust(matches: Vector[EsQueryBoolMatch], range: Vector[EsQueryRange] = Vector.empty)
     extends EsQueryMethod
@@ -67,6 +68,7 @@ case class EsQueryString(queryString: String) extends EsQueryMethod
 case class EsQuery(query: EsQueryMethod,
                    sort: Option[EsQueryOrder] = None,
                    size: Option[EsQuerySize] = None,
+                   from: Option[EsQueryFrom] = None,
                    aggs: Option[EsQueryAggs] = None)
 
 // Schema of ES query results
@@ -126,6 +128,11 @@ object ElasticSearchJsonProtocol extends DefaultJsonProtocol {
     def write(query: EsQuerySize) = JsNumber(query.size)
   }
 
+  implicit object EsQueryFromJsonFormat extends RootJsonFormat[EsQueryFrom] {
+    def read(query: JsValue) = ???
+    def write(query: EsQueryFrom) = JsNumber(query.from)
+  }
+
   implicit object EsQueryAggsJsonFormat extends RootJsonFormat[EsQueryAggs] {
     def read(query: JsValue) = ???
     def write(query: EsQueryAggs) =
@@ -148,7 +155,7 @@ object ElasticSearchJsonProtocol extends DefaultJsonProtocol {
     }
   }
 
-  implicit val esQueryFormat = jsonFormat4(EsQuery.apply)
+  implicit val esQueryFormat = jsonFormat5(EsQuery.apply)
   implicit val esSearchHitFormat = jsonFormat(EsSearchHit.apply _, "_source")
   implicit val esSearchHitsFormat = jsonFormat2(EsSearchHits.apply)
   implicit val esSearchResultFormat = jsonFormat1(EsSearchResult.apply)

--- a/common/scala/src/main/scala/whisk/core/containerpool/logging/ElasticSearchRestClient.scala
+++ b/common/scala/src/main/scala/whisk/core/containerpool/logging/ElasticSearchRestClient.scala
@@ -57,7 +57,6 @@ case class EsQueryAggs(aggField: String, agg: EsAgg, field: String)
 case class EsQueryRange(key: String, range: EsRange, value: String)
 case class EsQueryBoolMatch(key: String, value: String)
 case class EsQueryOrder(field: String, kind: EsOrder)
-case class EsQuerySize(size: Int)
 case class EsQueryAll() extends EsQueryMethod
 case class EsQueryMust(matches: Vector[EsQueryBoolMatch], range: Vector[EsQueryRange] = Vector.empty)
     extends EsQueryMethod
@@ -66,7 +65,7 @@ case class EsQueryTerm(key: String, value: String) extends EsQueryMethod
 case class EsQueryString(queryString: String) extends EsQueryMethod
 case class EsQuery(query: EsQueryMethod,
                    sort: Option[EsQueryOrder] = None,
-                   size: Option[EsQuerySize] = None,
+                   size: Option[Int] = None,
                    from: Int = 0,
                    aggs: Option[EsQueryAggs] = None)
 
@@ -120,11 +119,6 @@ object ElasticSearchJsonProtocol extends DefaultJsonProtocol {
     def read(query: JsValue) = ???
     def write(query: EsQueryOrder) =
       JsArray(JsObject(query.field -> JsObject("order" -> query.kind.toString.toJson)))
-  }
-
-  implicit object EsQuerySizeJsonFormat extends RootJsonFormat[EsQuerySize] {
-    def read(query: JsValue) = ???
-    def write(query: EsQuerySize) = JsNumber(query.size)
   }
 
   implicit object EsQueryAggsJsonFormat extends RootJsonFormat[EsQueryAggs] {

--- a/common/scala/src/main/scala/whisk/core/containerpool/logging/ElasticSearchRestClient.scala
+++ b/common/scala/src/main/scala/whisk/core/containerpool/logging/ElasticSearchRestClient.scala
@@ -58,7 +58,6 @@ case class EsQueryRange(key: String, range: EsRange, value: String)
 case class EsQueryBoolMatch(key: String, value: String)
 case class EsQueryOrder(field: String, kind: EsOrder)
 case class EsQuerySize(size: Int)
-case class EsQueryFrom(from: Int)
 case class EsQueryAll() extends EsQueryMethod
 case class EsQueryMust(matches: Vector[EsQueryBoolMatch], range: Vector[EsQueryRange] = Vector.empty)
     extends EsQueryMethod
@@ -68,7 +67,7 @@ case class EsQueryString(queryString: String) extends EsQueryMethod
 case class EsQuery(query: EsQueryMethod,
                    sort: Option[EsQueryOrder] = None,
                    size: Option[EsQuerySize] = None,
-                   from: Option[EsQueryFrom] = None,
+                   from: Int = 0,
                    aggs: Option[EsQueryAggs] = None)
 
 // Schema of ES query results
@@ -126,11 +125,6 @@ object ElasticSearchJsonProtocol extends DefaultJsonProtocol {
   implicit object EsQuerySizeJsonFormat extends RootJsonFormat[EsQuerySize] {
     def read(query: JsValue) = ???
     def write(query: EsQuerySize) = JsNumber(query.size)
-  }
-
-  implicit object EsQueryFromJsonFormat extends RootJsonFormat[EsQueryFrom] {
-    def read(query: JsValue) = ???
-    def write(query: EsQueryFrom) = JsNumber(query.from)
   }
 
   implicit object EsQueryAggsJsonFormat extends RootJsonFormat[EsQueryAggs] {

--- a/common/scala/src/main/scala/whisk/core/containerpool/logging/ElasticSearchRestClient.scala
+++ b/common/scala/src/main/scala/whisk/core/containerpool/logging/ElasticSearchRestClient.scala
@@ -57,8 +57,8 @@ case class EsQueryAggs(aggField: String, agg: EsAgg, field: String)
 case class EsQueryRange(key: String, range: EsRange, value: String)
 case class EsQueryBoolMatch(key: String, value: String)
 case class EsQueryOrder(field: String, kind: EsOrder)
-case class EsQuerySize(size: Integer)
-case class EsQueryFrom(from: Integer)
+case class EsQuerySize(size: Int)
+case class EsQueryFrom(from: Int)
 case class EsQueryAll() extends EsQueryMethod
 case class EsQueryMust(matches: Vector[EsQueryBoolMatch], range: Vector[EsQueryRange] = Vector.empty)
     extends EsQueryMethod

--- a/tests/src/test/scala/whisk/core/containerpool/logging/ElasticSearchLogStoreTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/logging/ElasticSearchLogStoreTests.scala
@@ -79,7 +79,8 @@ class ElasticSearchLogStoreTests
     "query" -> JsObject(
       "query_string" -> JsObject("query" -> JsString(
         s"_type: ${defaultConfig.logSchema.userLogs} AND ${defaultConfig.logSchema.activationId}: $activationId"))),
-    "sort" -> JsArray(JsObject(defaultConfig.logSchema.time -> JsObject("order" -> JsString("asc"))))).compactPrint
+    "sort" -> JsArray(JsObject(defaultConfig.logSchema.time -> JsObject("order" -> JsString("asc")))),
+    "from" -> JsNumber(0)).compactPrint
   private val defaultHttpRequest = HttpRequest(
     POST,
     Uri(s"/whisk_user_logs/_search"),

--- a/tests/src/test/scala/whisk/core/containerpool/logging/ElasticSearchRestClientTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/logging/ElasticSearchRestClientTests.scala
@@ -175,9 +175,7 @@ class ElasticSearchRestClientTests
   }
 
   it should "construct query with size" in {
-    val querySize = EsQuerySize(1)
-
-    EsQuery(EsQueryAll(), size = Some(querySize)).toJson shouldBe JsObject(
+    EsQuery(EsQueryAll(), size = Some(1)).toJson shouldBe JsObject(
       "query" -> JsObject("match_all" -> JsObject.empty),
       "size" -> 1.toJson,
       "from" -> 0.toJson)

--- a/tests/src/test/scala/whisk/core/containerpool/logging/ElasticSearchRestClientTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/logging/ElasticSearchRestClientTests.scala
@@ -87,7 +87,8 @@ class ElasticSearchRestClientTests
               "must" ->
                 JsArray(
                   JsObject("match" -> JsObject("someKey1" -> JsString("someValue1"))),
-                  JsObject("match" -> JsObject("someKey2" -> JsString("someValue2")))))))
+                  JsObject("match" -> JsObject("someKey2" -> JsString("someValue2")))))),
+      "from" -> 0.toJson)
 
     // Test must with ranges
     Seq((EsRangeGte, "gte"), (EsRangeGt, "gt"), (EsRangeLte, "lte"), (EsRangeLt, "lt")).foreach {
@@ -109,7 +110,8 @@ class ElasticSearchRestClientTests
                   "filter" ->
                     JsArray(
                       JsObject("range" -> JsObject("someKey1" -> JsObject(rangeValue -> "someValue1".toJson))),
-                      JsObject("range" -> JsObject("someKey2" -> JsObject(rangeValue -> "someValue2".toJson)))))))
+                      JsObject("range" -> JsObject("someKey2" -> JsObject(rangeValue -> "someValue2".toJson)))))),
+          "from" -> 0.toJson)
     }
   }
 
@@ -120,7 +122,8 @@ class ElasticSearchRestClientTests
 
         EsQuery(EsQueryAll(), aggs = Some(queryAgg)).toJson shouldBe JsObject(
           "query" -> JsObject("match_all" -> JsObject.empty),
-          "aggs" -> JsObject("someAgg" -> JsObject(aggValue -> JsObject("field" -> "someField".toJson))))
+          "aggs" -> JsObject("someAgg" -> JsObject(aggValue -> JsObject("field" -> "someField".toJson))),
+          "from" -> 0.toJson)
     }
   }
 
@@ -128,7 +131,8 @@ class ElasticSearchRestClientTests
     val queryMatch = EsQueryMatch("someField", "someValue")
 
     EsQuery(queryMatch).toJson shouldBe JsObject(
-      "query" -> JsObject("match" -> JsObject("someField" -> JsObject("query" -> "someValue".toJson))))
+      "query" -> JsObject("match" -> JsObject("someField" -> JsObject("query" -> "someValue".toJson))),
+      "from" -> 0.toJson)
 
     // Test match with types
     Seq((EsMatchPhrase, "phrase"), (EsMatchPhrasePrefix, "phrase_prefix")).foreach {
@@ -137,21 +141,25 @@ class ElasticSearchRestClientTests
 
         EsQuery(queryMatch).toJson shouldBe JsObject(
           "query" -> JsObject(
-            "match" -> JsObject("someField" -> JsObject("query" -> "someValue".toJson, "type" -> typeValue.toJson))))
+            "match" -> JsObject("someField" -> JsObject("query" -> "someValue".toJson, "type" -> typeValue.toJson))),
+          "from" -> 0.toJson)
     }
   }
 
   it should "construct a query with term" in {
     val queryTerm = EsQueryTerm("user", "someUser")
 
-    EsQuery(queryTerm).toJson shouldBe JsObject("query" -> JsObject("term" -> JsObject("user" -> JsString("someUser"))))
+    EsQuery(queryTerm).toJson shouldBe JsObject(
+      "query" -> JsObject("term" -> JsObject("user" -> JsString("someUser"))),
+      "from" -> 0.toJson)
   }
 
   it should "construct a query with query string" in {
     val queryString = EsQueryString("_type: someType")
 
     EsQuery(queryString).toJson shouldBe JsObject(
-      "query" -> JsObject("query_string" -> JsObject("query" -> JsString("_type: someType"))))
+      "query" -> JsObject("query_string" -> JsObject("query" -> JsString("_type: someType"))),
+      "from" -> 0.toJson)
   }
 
   it should "construct a query with order" in {
@@ -161,7 +169,8 @@ class ElasticSearchRestClientTests
 
         EsQuery(EsQueryAll(), Some(queryOrder)).toJson shouldBe JsObject(
           "query" -> JsObject("match_all" -> JsObject.empty),
-          "sort" -> JsArray(JsObject("someField" -> JsObject("order" -> orderValue.toJson))))
+          "sort" -> JsArray(JsObject("someField" -> JsObject("order" -> orderValue.toJson))),
+          "from" -> 0.toJson)
     }
   }
 
@@ -170,13 +179,12 @@ class ElasticSearchRestClientTests
 
     EsQuery(EsQueryAll(), size = Some(querySize)).toJson shouldBe JsObject(
       "query" -> JsObject("match_all" -> JsObject.empty),
-      "size" -> 1.toJson)
+      "size" -> 1.toJson,
+      "from" -> 0.toJson)
   }
 
   it should "construct query with from" in {
-    val queryFrom = EsQueryFrom(1)
-
-    EsQuery(EsQueryAll(), from = Some(queryFrom)).toJson shouldBe JsObject(
+    EsQuery(EsQueryAll(), from = 1).toJson shouldBe JsObject(
       "query" -> JsObject("match_all" -> JsObject.empty),
       "from" -> 1.toJson)
   }

--- a/tests/src/test/scala/whisk/core/containerpool/logging/ElasticSearchRestClientTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/logging/ElasticSearchRestClientTests.scala
@@ -170,7 +170,15 @@ class ElasticSearchRestClientTests
 
     EsQuery(EsQueryAll(), size = Some(querySize)).toJson shouldBe JsObject(
       "query" -> JsObject("match_all" -> JsObject.empty),
-      "size" -> JsNumber(1))
+      "size" -> 1.toJson)
+  }
+
+  it should "construct query with from" in {
+    val queryFrom = EsQueryFrom(1)
+
+    EsQuery(EsQueryAll(), from = Some(queryFrom)).toJson shouldBe JsObject(
+      "query" -> JsObject("match_all" -> JsObject.empty),
+      "from" -> 1.toJson)
   }
 
   it should "error when search response does not match expected type" in {


### PR DESCRIPTION
## Description
<!--- Provide a concise summary of your changes in the Title -->
Using the `from` parameter, Elasticsearch can paginate query results. Such functionality is needed for an Elasticsearch activation store in order to implement the `skip` logic that currently exists in the activation list REST APIs.


<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [x] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

