### PR TITLE
Set erlang magic cookie for couchdb

### DIFF
--- a/ansible/roles/couchdb/tasks/deploy.yml
+++ b/ansible/roles/couchdb/tasks/deploy.yml
@@ -7,6 +7,10 @@
   set_fact:
     coordinator: "{{ groups['db'][0] }}"
 
+- name: "Set the volumes"
+  set_fact:
+    volumes: []
+
 - name: check if db credentials are valid for CouchDB
   fail: msg="The db provider in your {{ hosts_dir }}/group_vars/all is {{ db.provider }}, it has to be CouchDB, pls double check"
   when: db.provider != "CouchDB"
@@ -20,8 +24,16 @@
   vars:
     instance: "{{instances | selectattr('name', 'equalto', 'db') | list | first}}"
   set_fact:
-    volume_dir: "{{ instance.volume.fsmount | default( '/mnt/' + group_names|first, true ) }}:/usr/local/var/lib/couchdb"
+    volumes: "{{ volumes }} + [ '{{ instance.volume.fsmount | default( '/mnt/' + group_names|first, true ) }}:/usr/local/var/lib/couchdb' ]"
   when: (block_device is defined) and (block_device in disk_status.stdout)
+
+- include_tasks: gen_erl_cookie.yml
+  when: (db.instances|int >= 2)
+
+- name: "set the erlang cookie volume"
+  set_fact:
+    volumes: "{{ volumes }} + [ '{{ config_root_dir }}/erlang.cookie:/opt/couchdb/.erlang.cookie' ]"
+  when: (db.instances|int >= 2)
 
 - name: "(re)start CouchDB from '{{ couchdb_image }} ' "
   vars:
@@ -32,7 +44,7 @@
     state: started
     recreate: true
     restart_policy: "{{ docker.restart.policy }}"
-    volumes: "{{volume_dir | default([])}}"
+    volumes: "{{ volumes }}"
     ports:
       - "{{ db.port }}:5984"
       - "4369:4369"

--- a/ansible/tasks/gen_erl_cookie.yml
+++ b/ansible/tasks/gen_erl_cookie.yml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+---
+
+# generate erlang cookie for CouchDB
+
+- name: "generate erlang cookie"
+  local_action: command openssl rand -base64 32op
+  register: random_stdout
+  run_once: true
+  when: erlang_cookie is not defined
+
+- set_fact:
+    erlang_cookie: "{{ random_stdout.stdout }}"
+  when: erlang_cookie is not defined
+
+- name: "ensure config root dir exists"
+  file:
+    path: "{{ config_root_dir }}"
+    state: directory
+
+# when enable uid namespace mode, couchdb container doesn't have permission to change the owner of files which mounted
+# from host, so the container will be failed to start. Use a temporary container here to create the file erlang.cookie
+# with the correct user 'couchdb' as its owner
+- name: "create the erlang cookie file on remote"
+  vars:
+    couchdb_image: "{{ couchdb.docker_image | default('apache/couchdb:' ~ couchdb.version ) }}"
+  command: "docker run --rm -v /tmp:/tmp -u couchdb {{ couchdb_image }} sh -c 'echo {{ erlang_cookie }} >> /tmp/erlang.cookie'"
+  become: true
+
+- name: "move erlang.cookie from /tmp to {{ config_root_dir }}"
+  shell: "chmod 400 /tmp/erlang.cookie && mv /tmp/erlang.cookie {{ config_root_dir }}/erlang.cookie"
+  args:
+    warn: false
+  become: true


### PR DESCRIPTION
Set identical erlang magic cookie for couchdb

## Description
This commit try to set an identical erlang magic cookie for each couchdb container, so that they  can rejoin the cluster after being restarted

## Related issue and scope
- [x] I opened an issue to propose and discuss this change (#3852)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

