### PR TITLE
Java runtime now has log sentinels

### DIFF
--- a/ansible/files/runtimes.json
+++ b/ansible/files/runtimes.json
@@ -118,7 +118,6 @@
                     "attachmentName": "jarfile",
                     "attachmentType": "application/java-archive"
                 },
-                "sentinelledLogs": false,
                 "requireMain": true
             }
         ],


### PR DESCRIPTION
PR 63 in runtime-java added log sentinels, so we can now
update runtime.json accordingly.

