### PR TITLE
Bypass system test for runtime kind if test file is not found.

### DIFF
--- a/tests/src/test/scala/system/rest/RestUtil.scala
+++ b/tests/src/test/scala/system/rest/RestUtil.scala
@@ -31,11 +31,16 @@ import spray.json._
  */
 trait RestUtil {
 
+  private val skipKeyStore = false // set this to true for convenient local testing
   private val trustStorePassword = WhiskProperties.getSslCertificateChallenge
 
   // force RestAssured to allow all hosts in SSL certificates
   protected val sslconfig = {
-    new RestAssuredConfig().sslConfig(new SSLConfig().keystore("keystore", trustStorePassword).allowAllHostnames())
+    new RestAssuredConfig().sslConfig(if (!skipKeyStore) {
+      new SSLConfig().keystore("keystore", trustStorePassword).allowAllHostnames()
+    } else {
+      new SSLConfig().relaxedHTTPSValidation().allowAllHostnames()
+    })
   }
 
   /**


### PR DESCRIPTION
Some deployments which add kinds that are not part of the openwhisk manifest will have a dependence on this repo because of the way the sniff tests looks for a test function. Instead of failing the test if a file is missing, skip it instead. It would still be possible to test the kinds by extending the class and overriding `getFileLocation`.

<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

