### PR TITLE
Fix warnings in python scripts.

### DIFF
--- a/tools/build/citool
+++ b/tools/build/citool
@@ -38,10 +38,10 @@ import time
 import traceback
 import argparse
 if sys.version_info.major >= 3:
-    from http.client import HTTPConnection, HTTPSConnection, IncompleteRead, TEMPORARY_REDIRECT, OK
+    from http.client import HTTPConnection, HTTPSConnection, TEMPORARY_REDIRECT, OK
     from urllib.parse import urlparse
 else:
-    from httplib import HTTPConnection, HTTPSConnection, IncompleteRead, TEMPORARY_REDIRECT, OK
+    from httplib import HTTPConnection, HTTPSConnection, TEMPORARY_REDIRECT, OK
     from urlparse import urlparse
 import re
 import threading

--- a/tools/build/redo
+++ b/tools/build/redo
@@ -278,12 +278,12 @@ Components = [
                   'build a runtime action container, matching name using the regex; NOTE: must use --dir for path to runtime directory',
                   yaml = False,
                   gradle = 'core:$1:distDocker'),
-    
-    makeComponent('actionproxy',	
-                  'build action proxy container',	
-                  yaml = False,	
+
+    makeComponent('actionproxy',
+                  'build action proxy container',
+                  yaml = False,
                   gradle = 'tools:actionProxy'),
-    
+
     # required for tests
     makeComponent('props',
                   'build whisk.properties file (required for tests)',

--- a/tools/travis/flake8.sh
+++ b/tools/travis/flake8.sh
@@ -30,13 +30,13 @@ do
     flake8 "$i" --select=E999,F821 --statistics
     RETURN_CODE=$?
     if [ $RETURN_CODE != 0 ]; then
-        echo 'Flake8 found Python 3 syntax errors above.  See: https://docs.python.org/3/howto/pyporting.html'
+        echo 'Flake8 found Python 3 syntax errors above. See: https://docs.python.org/3/howto/pyporting.html'
         exit $RETURN_CODE
     fi
 done
 
-echo 'Flake8: second round uses the --exit-zero flag to treat _every_ message as a warning...'
+echo 'Flake8: second round to find any other stylistic issues...'
 for i in "${PYTHON_FILES[@]}"
 do
-    flake8 "$i" --ignore=E --max-line-length=127 --statistics --exit-zero
+    flake8 "$i" --ignore=E --max-line-length=127 --statistics
 done


### PR DESCRIPTION
See title.

Also enabled Flake8 to exit non-zero if there are warnings, seems like there is no harm to that right now. We can always disable that again if it really gets in the way.