### PR TITLE
Throttle the system based on active-ack timeouts.

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -348,12 +348,10 @@ The default system throttling limits are configured in this file [./group_vars/a
 limits:
   invocationsPerMinute: "{{ limit_invocations_per_minute | default(60) }}"
   concurrentInvocations: "{{ limit_invocations_concurrent | default(30) }}"
-  concurrentInvocationsSystem:  "{{ limit_invocations_concurrent_system | default(5000) }}"
   firesPerMinute: "{{ limit_fires_per_minute | default(60) }}"
   sequenceMaxLength: "{{ limit_sequence_max_length | default(50) }}"
 ```
 - The `limits.invocationsPerMinute` represents the allowed namespace action invocations per minute.
 - The `limits.concurrentInvocations` represents the maximum concurrent invocations allowed per namespace.
-- The `limits.concurrentInvocationsSystem` represents the maximum concurrent invocations the system will allow across all namespaces.
 - The `limits.firesPerMinute` represents the allowed namespace trigger firings per minute.
 - The `limits.sequenceMaxLength` represents the maximum length of a sequence action.

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -53,7 +53,6 @@ runtimesManifest: "{{ runtimes_manifest | default(lookup('file', openwhisk_home 
 limits:
   invocationsPerMinute: "{{ limit_invocations_per_minute | default(60) }}"
   concurrentInvocations: "{{ limit_invocations_concurrent | default(30) }}"
-  concurrentInvocationsSystem:  "{{ limit_invocations_concurrent_system | default(5000) }}"
   firesPerMinute: "{{ limit_fires_per_minute | default(60) }}"
   sequenceMaxLength: "{{ limit_sequence_max_length | default(50) }}"
 

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -178,8 +178,6 @@
 
       "LIMITS_ACTIONS_INVOKES_PERMINUTE": "{{ limits.invocationsPerMinute }}"
       "LIMITS_ACTIONS_INVOKES_CONCURRENT": "{{ limits.concurrentInvocations }}"
-      "LIMITS_ACTIONS_INVOKES_CONCURRENTINSYSTEM":
-        "{{ limits.concurrentInvocationsSystem }}"
       "LIMITS_TRIGGERS_FIRES_PERMINUTE": "{{ limits.firesPerMinute }}"
       "LIMITS_ACTIONS_SEQUENCE_MAXLENGTH": "{{ limits.sequenceMaxLength }}"
 

--- a/ansible/templates/whisk.properties.j2
+++ b/ansible/templates/whisk.properties.j2
@@ -35,7 +35,6 @@ runtimes.manifest={{ runtimesManifest | to_json }}
 
 limits.actions.invokes.perMinute={{ limits.invocationsPerMinute }}
 limits.actions.invokes.concurrent={{ limits.concurrentInvocations }}
-limits.actions.invokes.concurrentInSystem={{ limits.concurrentInvocationsSystem }}
 limits.triggers.fires.perMinute={{ limits.firesPerMinute }}
 limits.actions.sequence.maxLength={{ limits.sequenceMaxLength }}
 

--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -272,8 +272,8 @@ object LoggingMarkers {
   def INVOKER_STARTUP(i: Int) = LogMarkerToken(invoker, s"startup$i", count)
 
   // Check invoker healthy state from loadbalancer
-  val LOADBALANCER_INVOKER_OFFLINE = LogMarkerToken(loadbalancer, "invokerOffline", count)
-  val LOADBALANCER_INVOKER_UNHEALTHY = LogMarkerToken(loadbalancer, "invokerUnhealthy", count)
+  def LOADBALANCER_INVOKER_STATUS_CHANGE(state: String) =
+    LogMarkerToken(loadbalancer, "invokerState", count, Some(state))
   val LOADBALANCER_ACTIVATION_START = LogMarkerToken(loadbalancer, "activations", count)
 
   def LOADBALANCER_ACTIVATIONS_INFLIGHT(controllerInstance: ControllerInstanceId) =

--- a/common/scala/src/main/scala/whisk/common/RingBuffer.scala
+++ b/common/scala/src/main/scala/whisk/common/RingBuffer.scala
@@ -28,5 +28,5 @@ class RingBuffer[T](size: Int) {
 
   def add(el: T) = inner.add(el)
 
-  def toList() = inner.toArray().asInstanceOf[Array[T]].toList
+  def toList = inner.toArray().asInstanceOf[Array[T]].toList
 }

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -78,7 +78,6 @@ class WhiskConfig(requiredProperties: Map[String, String],
   val actionInvokePerMinuteLimit = this(WhiskConfig.actionInvokePerMinuteLimit)
   val actionInvokeConcurrentLimit = this(WhiskConfig.actionInvokeConcurrentLimit)
   val triggerFirePerMinuteLimit = this(WhiskConfig.triggerFirePerMinuteLimit)
-  val actionInvokeSystemOverloadLimit = this(WhiskConfig.actionInvokeSystemOverloadLimit)
   val actionSequenceLimit = this(WhiskConfig.actionSequenceMaxLimit)
   val controllerSeedNodes = this(WhiskConfig.controllerSeedNodes)
 }
@@ -189,7 +188,6 @@ object WhiskConfig {
   val actionSequenceMaxLimit = "limits.actions.sequence.maxLength"
   val actionInvokePerMinuteLimit = "limits.actions.invokes.perMinute"
   val actionInvokeConcurrentLimit = "limits.actions.invokes.concurrent"
-  val actionInvokeSystemOverloadLimit = "limits.actions.invokes.concurrentInSystem"
   val triggerFirePerMinuteLimit = "limits.triggers.fires.perMinute"
   val controllerSeedNodes = "akka.cluster.seed.nodes"
 }

--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -45,6 +45,7 @@ import whisk.http.Messages
 import whisk.http.Messages._
 import whisk.core.entitlement.Resource
 import whisk.core.entitlement.Collection
+import whisk.core.loadBalancer.LoadBalancerException
 
 /**
  * A singleton object which defines the properties that must be present in a configuration
@@ -280,6 +281,9 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
       case Failure(RejectRequest(code, message)) =>
         logging.debug(this, s"[POST] action rejected with code $code: $message")
         terminate(code, message)
+      case Failure(t: LoadBalancerException) =>
+        logging.error(this, s"[POST] failed in loadbalancer: ${t.getMessage}")
+        terminate(ServiceUnavailable)
       case Failure(t: Throwable) =>
         logging.error(this, s"[POST] action activation failed: ${t.getMessage}")
         terminate(InternalServerError)

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -42,7 +42,7 @@ import whisk.core.entitlement._
 import whisk.core.entity._
 import whisk.core.entity.ActivationId.ActivationIdGenerator
 import whisk.core.entity.ExecManifest.Runtimes
-import whisk.core.loadBalancer.{Healthy, LoadBalancerProvider}
+import whisk.core.loadBalancer.{InvokerState, LoadBalancerProvider}
 import whisk.http.BasicHttpService
 import whisk.http.BasicRasService
 import whisk.spi.SpiLoader
@@ -151,7 +151,7 @@ class Controller(val instance: ControllerInstanceId,
         complete {
           loadBalancer
             .invokerHealth()
-            .map(_.count(_.status == Healthy).toJson)
+            .map(_.count(_.status == InvokerState.Healthy).toJson)
         }
       }
     }

--- a/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
@@ -52,6 +52,7 @@ import whisk.core.controller.actions.PostActionActivation
 import whisk.core.database._
 import whisk.core.entity._
 import whisk.core.entity.types._
+import whisk.core.loadBalancer.LoadBalancerException
 import whisk.http.ErrorResponse.terminate
 import whisk.http.Messages
 import whisk.http.LenientSprayJsonSupport._
@@ -672,6 +673,10 @@ trait WhiskWebActionsApi extends Directives with ValidateRequestSize with PostAc
         terminate(Accepted, Messages.responseNotReady)
 
       case Failure(t: RejectRequest) => terminate(t.code, t.message)
+
+      case Failure(t: LoadBalancerException) =>
+        logging.error(this, s"failed in loadbalancer: $t")
+        terminate(ServiceUnavailable)
 
       case Failure(t) =>
         logging.error(this, s"exception in completeRequest: $t")

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -73,8 +73,7 @@ protected[core] object EntitlementProvider {
   val requiredProperties = Map(
     WhiskConfig.actionInvokePerMinuteLimit -> null,
     WhiskConfig.actionInvokeConcurrentLimit -> null,
-    WhiskConfig.triggerFirePerMinuteLimit -> null,
-    WhiskConfig.actionInvokeSystemOverloadLimit -> null)
+    WhiskConfig.triggerFirePerMinuteLimit -> null)
 }
 
 /**

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -35,7 +35,6 @@ import whisk.core.entity._
 import whisk.core.loadBalancer.{LoadBalancer, ShardingContainerPoolBalancer}
 import whisk.http.ErrorResponse
 import whisk.http.Messages
-import whisk.http.Messages._
 import whisk.core.connector.MessagingProvider
 import whisk.spi.SpiLoader
 import whisk.spi.Spi
@@ -148,8 +147,7 @@ protected[core] abstract class EntitlementProvider(
   private val concurrentInvokeThrottler =
     new ActivationThrottler(
       loadBalancer,
-      activationThrottleCalculator(config.actionInvokeConcurrentLimit.toInt, _.limits.concurrentInvocations),
-      config.actionInvokeSystemOverloadLimit.toInt)
+      activationThrottleCalculator(config.actionInvokeConcurrentLimit.toInt, _.limits.concurrentInvocations))
 
   private val messagingProvider = SpiLoader.get[MessagingProvider]
   private val eventProducer = messagingProvider.getProducer(this.config)
@@ -196,8 +194,7 @@ protected[core] abstract class EntitlementProvider(
   protected[core] def checkThrottles(user: Identity)(implicit transid: TransactionId): Future[Unit] = {
 
     logging.debug(this, s"checking user '${user.subject}' has not exceeded activation quota")
-    checkSystemOverload(ACTIVATE)
-      .flatMap(_ => checkThrottleOverload(Future.successful(invokeRateThrottler.check(user)), user))
+    checkThrottleOverload(Future.successful(invokeRateThrottler.check(user)), user)
       .flatMap(_ => checkThrottleOverload(concurrentInvokeThrottler.check(user), user))
   }
 
@@ -257,8 +254,7 @@ protected[core] abstract class EntitlementProvider(
         val throttleCheck =
           if (noThrottle) Future.successful(())
           else
-            checkSystemOverload(right)
-              .flatMap(_ => checkUserThrottle(user, right, resources))
+            checkUserThrottle(user, right, resources)
               .flatMap(_ => checkConcurrentUserThrottle(user, right, resources))
         throttleCheck
           .flatMap(_ => checkPrivilege(user, right, resources))
@@ -308,22 +304,6 @@ protected[core] abstract class EntitlementProvider(
             entitled(user, right, resource).flatMap(b => Future.successful(resource -> b))
         }
       }
-    }
-  }
-
-  /**
-   * Limits activations if the system is overloaded.
-   *
-   * @param right the privilege, if ACTIVATE then check quota else return None
-   * @return future completing successfully if system is not overloaded else failing with a rejection
-   */
-  protected def checkSystemOverload(right: Privilege)(implicit transid: TransactionId): Future[Unit] = {
-    concurrentInvokeThrottler.isOverloaded.flatMap { isOverloaded =>
-      val systemOverload = right == ACTIVATE && isOverloaded
-      if (systemOverload) {
-        logging.error(this, "system is overloaded")
-        Future.failed(RejectRequest(TooManyRequests, systemOverloaded))
-      } else Future.successful(())
     }
   }
 

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
@@ -20,7 +20,7 @@ package whisk.core.loadBalancer
 import java.nio.charset.StandardCharsets
 
 import scala.collection.immutable
-import scala.concurrent.{Await, Future}
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Success
@@ -45,19 +45,47 @@ case object GetStatus
 case object Tick
 
 // States an Invoker can be in
-sealed trait InvokerState { val asString: String }
-case object Offline extends InvokerState { val asString = "down" }
-case object Healthy extends InvokerState { val asString = "up" }
-case object UnHealthy extends InvokerState { val asString = "unhealthy" }
+sealed trait InvokerState {
+  val asString: String
+  val isUsable: Boolean
+}
+
+object InvokerState {
+  // Invokers in this state can be used to schedule workload to
+  sealed trait Usable extends InvokerState { val isUsable = true }
+  // No workload should be scheduled to invokers in this state
+  sealed trait Unusable extends InvokerState { val isUsable = false }
+
+  // A completely healthy invoker, pings arriving fine, no system errors
+  case object Healthy extends Usable { val asString = "up" }
+  // Pings are arriving fine, the invoker returns system errors though
+  case object Unhealthy extends Unusable { val asString = "unhealthy" }
+  // Pings are arriving fine, the invoker does not respond with active-acks in the expected time though
+  case object Overloaded extends Unusable { val asString = "overloaded" }
+  // Pings are not arriving for this invoker
+  case object Offline extends Unusable { val asString = "down" }
+}
+
+// Possible answers of an activation
+sealed trait InvocationFinishedResult
+object InvocationFinishedResult {
+  // The activation could be successfully executed from the system's point of view. That includes user- and application
+  // errors
+  case object Success extends InvocationFinishedResult
+  // The activation could not be executed because of a system error
+  case object SystemError extends InvocationFinishedResult
+  // The active-ack did not arrive before it timed out
+  case object Timeout extends InvocationFinishedResult
+}
 
 case class ActivationRequest(msg: ActivationMessage, invoker: InvokerInstanceId)
-case class InvocationFinishedMessage(invokerInstance: InvokerInstanceId, successful: Boolean)
+case class InvocationFinishedMessage(invokerInstance: InvokerInstanceId, result: InvocationFinishedResult)
 
 // Sent to a monitor if the state changed
 case class CurrentInvokerPoolState(newState: IndexedSeq[InvokerHealth])
 
 // Data stored in the Invoker
-final case class InvokerInfo(buffer: RingBuffer[Boolean])
+final case class InvokerInfo(buffer: RingBuffer[InvocationFinishedResult])
 
 /**
  * Actor representing a pool of invokers
@@ -76,10 +104,12 @@ class InvokerPool(childFactory: (ActorRefFactory, InvokerInstanceId) => ActorRef
                   monitor: Option[ActorRef])
     extends Actor {
 
-  implicit val transid = TransactionId.invokerHealth
-  implicit val logging = new AkkaLogging(context.system.log)
-  implicit val timeout = Timeout(5.seconds)
-  implicit val ec = context.dispatcher
+  import InvokerState._
+
+  implicit val transid: TransactionId = TransactionId.invokerHealth
+  implicit val logging: Logging = new AkkaLogging(context.system.log)
+  implicit val timeout: Timeout = Timeout(5.seconds)
+  implicit val ec: ExecutionContext = context.dispatcher
 
   // State of the actor. Mutable vars with immutable collections prevents closures or messages
   // from leaking the state for external mutation
@@ -87,7 +117,7 @@ class InvokerPool(childFactory: (ActorRefFactory, InvokerInstanceId) => ActorRef
   var refToInstance = immutable.Map.empty[ActorRef, InvokerInstanceId]
   var status = IndexedSeq[InvokerHealth]()
 
-  def receive = {
+  def receive: Receive = {
     case p: PingMessage =>
       val invoker = instanceToRef.getOrElse(p.instance, registerInvoker(p.instance))
       instanceToRef = instanceToRef.updated(p.instance, invoker)
@@ -116,15 +146,15 @@ class InvokerPool(childFactory: (ActorRefFactory, InvokerInstanceId) => ActorRef
     case msg: ActivationRequest => sendActivationToInvoker(msg.msg, msg.invoker).pipeTo(sender)
   }
 
-  def logStatus() = {
+  def logStatus(): Unit = {
     monitor.foreach(_ ! CurrentInvokerPoolState(status))
     val pretty = status.map(i => s"${i.id.toInt} -> ${i.status}")
     logging.info(this, s"invoker status changed to ${pretty.mkString(", ")}")
   }
 
   /** Receive Ping messages from invokers. */
-  val pingPollDuration = 1.second
-  val invokerPingFeed = context.system.actorOf(Props {
+  val pingPollDuration: FiniteDuration = 1.second
+  val invokerPingFeed: ActorRef = context.system.actorOf(Props {
     new MessageFeed(
       "ping",
       logging,
@@ -149,7 +179,7 @@ class InvokerPool(childFactory: (ActorRefFactory, InvokerInstanceId) => ActorRef
   }
 
   /** Pads a list to a given length using the given function to compute entries */
-  def padToIndexed[A](list: IndexedSeq[A], n: Int, f: (Int) => A) = list ++ (list.size until n).map(f)
+  def padToIndexed[A](list: IndexedSeq[A], n: Int, f: (Int) => A): IndexedSeq[A] = list ++ (list.size until n).map(f)
 
   // Register a new invoker
   def registerInvoker(instanceId: InvokerInstanceId): ActorRef = {
@@ -170,9 +200,9 @@ class InvokerPool(childFactory: (ActorRefFactory, InvokerInstanceId) => ActorRef
 
 object InvokerPool {
   private def createTestActionForInvokerHealth(db: EntityStore, action: WhiskAction): Future[Unit] = {
-    implicit val tid = TransactionId.loadbalancer
-    implicit val ec = db.executionContext
-    implicit val logging = db.logging
+    implicit val tid: TransactionId = TransactionId.loadbalancer
+    implicit val ec: ExecutionContext = db.executionContext
+    implicit val logging: Logging = db.logging
 
     WhiskAction
       .get(db, action.docid)
@@ -214,12 +244,12 @@ object InvokerPool {
   def props(f: (ActorRefFactory, InvokerInstanceId) => ActorRef,
             p: (ActivationMessage, InvokerInstanceId) => Future[RecordMetadata],
             pc: MessageConsumer,
-            m: Option[ActorRef] = None) = {
+            m: Option[ActorRef] = None): Props = {
     Props(new InvokerPool(f, p, pc, m))
   }
 
   /** A stub identity for invoking the test action. This does not need to be a valid identity. */
-  val healthActionIdentity = {
+  val healthActionIdentity: Identity = {
     val whiskSystem = "whisk.system"
     val uuid = UUID()
     Identity(
@@ -230,13 +260,13 @@ object InvokerPool {
   }
 
   /** An action to use for monitoring invoker health. */
-  def healthAction(i: ControllerInstanceId) = ExecManifest.runtimesManifest.resolveDefaultRuntime("nodejs:6").map {
-    manifest =>
+  def healthAction(i: ControllerInstanceId): Option[WhiskAction] =
+    ExecManifest.runtimesManifest.resolveDefaultRuntime("nodejs:6").map { manifest =>
       new WhiskAction(
         namespace = healthActionIdentity.namespace.name.toPath,
         name = EntityName(s"invokerHealthTestAction${i.asString}"),
         exec = CodeExecAsString(manifest, """function main(params) { return params; }""", None))
-  }
+    }
 }
 
 /**
@@ -247,47 +277,47 @@ object InvokerPool {
  */
 class InvokerActor(invokerInstance: InvokerInstanceId, controllerInstance: ControllerInstanceId)
     extends FSM[InvokerState, InvokerInfo] {
-  implicit val transid = TransactionId.invokerHealth
-  implicit val logging = new AkkaLogging(context.system.log)
+
+  import InvokerState._
+
+  implicit val transid: TransactionId = TransactionId.invokerHealth
+  implicit val logging: Logging = new AkkaLogging(context.system.log)
   val name = s"invoker${invokerInstance.toInt}"
 
-  val healthyTimeout = 10.seconds
+  val healthyTimeout: FiniteDuration = 10.seconds
 
   // This is done at this point to not intermingle with the state-machine
   // especially their timeouts.
   def customReceive: Receive = {
     case _: RecordMetadata => // The response of putting testactions to the MessageProducer. We don't have to do anything with them.
   }
-  override def receive = customReceive.orElse(super.receive)
+  override def receive: Receive = customReceive.orElse(super.receive)
 
-  /**
-   *  Always start UnHealthy. Then the invoker receives some test activations and becomes Healthy.
-   */
-  startWith(UnHealthy, InvokerInfo(new RingBuffer[Boolean](InvokerActor.bufferSize)))
+  /** Always start UnHealthy. Then the invoker receives some test activations and becomes Healthy. */
+  startWith(Unhealthy, InvokerInfo(new RingBuffer[InvocationFinishedResult](InvokerActor.bufferSize)))
 
-  /**
-   * An Offline invoker represents an existing but broken
-   * invoker. This means, that it does not send pings anymore.
-   */
+  /** An Offline invoker represents an existing but broken invoker. This means, that it does not send pings anymore. */
   when(Offline) {
-    case Event(_: PingMessage, _) => goto(UnHealthy)
+    case Event(_: PingMessage, _) => goto(Unhealthy)
   }
 
-  /**
-   * An UnHealthy invoker represents an invoker that was not able to handle actions successfully.
-   */
-  when(UnHealthy, stateTimeout = healthyTimeout) {
+  // To be used for all states that should send test actions to reverify the invoker
+  val healthPingingState: StateFunction = {
     case Event(_: PingMessage, _) => stay
     case Event(StateTimeout, _)   => goto(Offline)
-    case Event(Tick, info) => {
+    case Event(Tick, _) =>
       invokeTestAction()
       stay
-    }
   }
 
+  /** An Unhealthy invoker represents an invoker that was not able to handle actions successfully. */
+  when(Unhealthy, stateTimeout = healthyTimeout)(healthPingingState)
+
+  /** An Overloaded invoker represents an invoker that is not responding with active acks in a timely manner */
+  when(Overloaded, stateTimeout = healthyTimeout)(healthPingingState)
+
   /**
-   * A Healthy invoker is characterized by continuously getting
-   * pings. It will go offline if that state is not confirmed
+   * A Healthy invoker is characterized by continuously getting pings. It will go offline if that state is not confirmed
    * for 20 seconds.
    */
   when(Healthy, stateTimeout = healthyTimeout) {
@@ -295,38 +325,32 @@ class InvokerActor(invokerInstance: InvokerInstanceId, controllerInstance: Contr
     case Event(StateTimeout, _)   => goto(Offline)
   }
 
-  /**
-   * Handle the completion of an Activation in every state.
-   */
+  /** Handle the completion of an Activation in every state. */
   whenUnhandled {
-    case Event(cm: InvocationFinishedMessage, info) => handleCompletionMessage(cm.successful, info.buffer)
+    case Event(cm: InvocationFinishedMessage, info) => handleCompletionMessage(cm.result, info.buffer)
   }
 
   /** Logging on Transition change */
   onTransition {
-    case _ -> Offline =>
+    case _ -> newState if !newState.isUsable =>
       transid.mark(
         this,
-        LoggingMarkers.LOADBALANCER_INVOKER_OFFLINE,
-        s"$name is offline",
+        LoggingMarkers.LOADBALANCER_INVOKER_STATUS_CHANGE(newState.asString),
+        s"$name is ${newState.asString}",
         akka.event.Logging.WarningLevel)
-    case _ -> UnHealthy =>
-      transid.mark(
-        this,
-        LoggingMarkers.LOADBALANCER_INVOKER_UNHEALTHY,
-        s"$name is unhealthy",
-        akka.event.Logging.WarningLevel)
-    case _ -> Healthy => logging.info(this, s"$name is healthy")
+    case _ -> newState if newState.isUsable => logging.info(this, s"$name is ${newState.asString}")
   }
 
-  /** Scheduler to send test activations when the invoker is unhealthy. */
-  onTransition {
-    case _ -> UnHealthy => {
+  // To be used for all states that should send test actions to reverify the invoker
+  def healthPingingTransitionHandler(state: InvokerState): TransitionHandler = {
+    case _ -> `state` =>
       invokeTestAction()
-      setTimer(InvokerActor.timerName, Tick, 1.minute, true)
-    }
-    case UnHealthy -> _ => cancelTimer(InvokerActor.timerName)
+      setTimer(InvokerActor.timerName, Tick, 1.minute, repeat = true)
+    case `state` -> _ => cancelTimer(InvokerActor.timerName)
   }
+
+  onTransition(healthPingingTransitionHandler(Unhealthy))
+  onTransition(healthPingingTransitionHandler(Overloaded))
 
   initialize()
 
@@ -334,31 +358,35 @@ class InvokerActor(invokerInstance: InvokerInstanceId, controllerInstance: Contr
    * Handling for active acks. This method saves the result (successful or unsuccessful)
    * into an RingBuffer and checks, if the InvokerActor has to be changed to UnHealthy.
    *
-   * @param wasActivationSuccessful: result of Activation
+   * @param result: result of Activation
    * @param buffer to be used
    */
-  private def handleCompletionMessage(wasActivationSuccessful: Boolean, buffer: RingBuffer[Boolean]) = {
-    buffer.add(wasActivationSuccessful)
+  private def handleCompletionMessage(result: InvocationFinishedResult,
+                                      buffer: RingBuffer[InvocationFinishedResult]) = {
+    buffer.add(result)
 
     // If the action is successful it seems like the Invoker is Healthy again. So we execute immediately
     // a new test action to remove the errors out of the RingBuffer as fast as possible.
     // The actions that arrive while the invoker is unhealthy are most likely health actions.
     // It is possible they are normal user actions as well. This can happen if such actions were in the
     // invoker queue or in progress while the invoker's status flipped to Unhealthy.
-    if (wasActivationSuccessful && stateName == UnHealthy) {
+    if (result == InvocationFinishedResult.Success && stateName == Unhealthy) {
       invokeTestAction()
     }
 
     // Stay in online if the activations was successful.
     // Stay in offline, if an activeAck reaches the controller.
-    if ((stateName == Healthy && wasActivationSuccessful) || stateName == Offline) {
+    if ((stateName == Healthy && result == InvocationFinishedResult.Success) || stateName == Offline) {
       stay
     } else {
-      // Goto UnHealthy if there are more errors than accepted in buffer, else goto Healthy
-      if (buffer.toList.count(_ == true) >= InvokerActor.bufferSize - InvokerActor.bufferErrorTolerance) {
-        gotoIfNotThere(Healthy)
+      val entries = buffer.toList
+      // Goto Unhealthy or Overloaded respectively if there are more errors than accepted in buffer, else goto Healthy
+      if (entries.count(_ == InvocationFinishedResult.SystemError) > InvokerActor.bufferErrorTolerance) {
+        gotoIfNotThere(Unhealthy)
+      } else if (entries.count(_ == InvocationFinishedResult.Timeout) > InvokerActor.bufferErrorTolerance) {
+        gotoIfNotThere(Overloaded)
       } else {
-        gotoIfNotThere(UnHealthy)
+        gotoIfNotThere(Healthy)
       }
     }
   }

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
@@ -61,7 +61,7 @@ object InvokerState {
   // Pings are arriving fine, the invoker returns system errors though
   case object Unhealthy extends Unusable { val asString = "unhealthy" }
   // Pings are arriving fine, the invoker does not respond with active-acks in the expected time though
-  case object Overloaded extends Unusable { val asString = "overloaded" }
+  case object Unresponsible extends Unusable { val asString = "unresponsible" }
   // Pings are not arriving for this invoker
   case object Offline extends Unusable { val asString = "down" }
 }
@@ -313,8 +313,8 @@ class InvokerActor(invokerInstance: InvokerInstanceId, controllerInstance: Contr
   /** An Unhealthy invoker represents an invoker that was not able to handle actions successfully. */
   when(Unhealthy, stateTimeout = healthyTimeout)(healthPingingState)
 
-  /** An Overloaded invoker represents an invoker that is not responding with active acks in a timely manner */
-  when(Overloaded, stateTimeout = healthyTimeout)(healthPingingState)
+  /** An Unresponsible invoker represents an invoker that is not responding with active acks in a timely manner */
+  when(Unresponsible, stateTimeout = healthyTimeout)(healthPingingState)
 
   /**
    * A Healthy invoker is characterized by continuously getting pings. It will go offline if that state is not confirmed
@@ -350,7 +350,7 @@ class InvokerActor(invokerInstance: InvokerInstanceId, controllerInstance: Contr
   }
 
   onTransition(healthPingingTransitionHandler(Unhealthy))
-  onTransition(healthPingingTransitionHandler(Overloaded))
+  onTransition(healthPingingTransitionHandler(Unresponsible))
 
   initialize()
 
@@ -380,11 +380,11 @@ class InvokerActor(invokerInstance: InvokerInstanceId, controllerInstance: Contr
       stay
     } else {
       val entries = buffer.toList
-      // Goto Unhealthy or Overloaded respectively if there are more errors than accepted in buffer, else goto Healthy
+      // Goto Unhealthy or Unresponsible respectively if there are more errors than accepted in buffer, else goto Healthy
       if (entries.count(_ == InvocationFinishedResult.SystemError) > InvokerActor.bufferErrorTolerance) {
         gotoIfNotThere(Unhealthy)
       } else if (entries.count(_ == InvocationFinishedResult.Timeout) > InvokerActor.bufferErrorTolerance) {
-        gotoIfNotThere(Overloaded)
+        gotoIfNotThere(Unresponsible)
       } else {
         gotoIfNotThere(Healthy)
       }

--- a/tests/performance/preparation/deploy.sh
+++ b/tests/performance/preparation/deploy.sh
@@ -25,7 +25,7 @@ TERM=dumb ./gradlew distDocker -PdockerImagePrefix=testing $GRADLE_PROJS_SKIP
 
 # Deploy Openwhisk
 cd $ROOTDIR/ansible
-ANSIBLE_CMD="$ANSIBLE_CMD -e limit_invocations_per_minute=999999 -e limit_invocations_concurrent=999999 -e limit_invocations_concurrent_system=999999 -e controller_client_auth=false"
+ANSIBLE_CMD="$ANSIBLE_CMD -e limit_invocations_per_minute=999999 -e limit_invocations_concurrent=999999 -e controller_client_auth=false"
 
 $ANSIBLE_CMD setup.yml
 $ANSIBLE_CMD prereq.yml

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/InvokerSupervisionTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/InvokerSupervisionTests.scala
@@ -264,17 +264,17 @@ class InvokerSupervisionTests
       }
       pool.expectMsg(Transition(invoker, Unhealthy, Healthy))
 
-      // Fill buffer with errors
+      // Fill buffer with timeouts
       (1 to InvokerActor.bufferSize).foreach { _ =>
         invoker ! InvocationFinishedMessage(InvokerInstanceId(0), InvocationFinishedResult.Timeout)
       }
-      pool.expectMsg(Transition(invoker, Healthy, Overloaded))
+      pool.expectMsg(Transition(invoker, Healthy, Unresponsible))
 
       // Fill buffer with successful invocations to become healthy again (one below errorTolerance)
       (1 to InvokerActor.bufferSize - InvokerActor.bufferErrorTolerance).foreach { _ =>
         invoker ! InvocationFinishedMessage(InvokerInstanceId(0), InvocationFinishedResult.Success)
       }
-      pool.expectMsg(Transition(invoker, Overloaded, Healthy))
+      pool.expectMsg(Transition(invoker, Unresponsible, Healthy))
     }
   }
 

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
@@ -24,6 +24,7 @@ import org.scalatest.junit.JUnitRunner
 import whisk.common.{ForcableSemaphore, TransactionId}
 import whisk.core.entity.InvokerInstanceId
 import whisk.core.loadBalancer._
+import whisk.core.loadBalancer.InvokerState._
 
 /**
  * Unit tests for the ContainerPool object.
@@ -36,7 +37,7 @@ class ShardingContainerPoolBalancerTests extends FlatSpec with Matchers with Str
   behavior of "ShardingContainerPoolBalancerState"
 
   def healthy(i: Int) = new InvokerHealth(InvokerInstanceId(i), Healthy)
-  def unhealthy(i: Int) = new InvokerHealth(InvokerInstanceId(i), UnHealthy)
+  def unhealthy(i: Int) = new InvokerHealth(InvokerInstanceId(i), Unhealthy)
   def offline(i: Int) = new InvokerHealth(InvokerInstanceId(i), Offline)
 
   def semaphores(count: Int, max: Int): IndexedSeq[ForcableSemaphore] =


### PR DESCRIPTION
This is a fairly big change but bear with me!

Today, we have an arbitrary system-wide limit of maximum concurrent connections. In general that is fine, but it doesn't have a direct correlation to what's actually happening in the system.

This adds a new state to each monitored invoker: Overloaded. An invoker will go into overloaded state if active-acks are starting to timeout. Eventually, if the system is really overloaded, all Invokers will be in overloaded state which will cause the loadbalancer to return a failure. This failure now results in a `503 - System overloaded` message back to the user.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [X] Controller
- [ ] Message Bus (e.g., Kafka)
- [X] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [X] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [X] I updated the documentation where necessary.

