### PR TITLE
Use separate db users for deployed components.

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -237,6 +237,12 @@ db:
     admin:
       user: "{{ db_username | default(lookup('ini', 'db_username section=db_creds file={{ playbook_dir }}/db_local.ini')) }}"
       pass: "{{ db_password | default(lookup('ini', 'db_password section=db_creds file={{ playbook_dir }}/db_local.ini')) }}"
+    controller:
+      user: "{{ db_controller_user | default(lookup('ini', 'db_username section=controller file={{ playbook_dir }}/db_local.ini')) }}"
+      pass: "{{ db_controller_pass | default(lookup('ini', 'db_password section=controller file={{ playbook_dir }}/db_local.ini')) }}"
+    invoker:
+      user: "{{ db_invoker_user | default(lookup('ini', 'db_username section=invoker file={{ playbook_dir }}/db_local.ini')) }}"
+      pass: "{{ db_invoker_pass | default(lookup('ini', 'db_password section=invoker file={{ playbook_dir }}/db_local.ini')) }}"
 
 apigateway:
   port:

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -78,6 +78,8 @@
   include_tasks: "{{ openwhisk_home }}/ansible/tasks/db/checkDb.yml"
   vars:
     dbName: "{{ item }}"
+    dbUser: "{{ db.credentials.controller.user }}"
+    dbPass: "{{ db.credentials.controller.pass }}"
   with_items:
     - "{{ db.whisk.actions }}"
     - "{{ db.whisk.auth }}"
@@ -162,8 +164,8 @@
       "CONFIG_whisk_couchdb_protocol": "{{ db.protocol }}"
       "CONFIG_whisk_couchdb_host": "{{ db.host }}"
       "CONFIG_whisk_couchdb_port": "{{ db.port }}"
-      "CONFIG_whisk_couchdb_username": "{{ db.credentials.admin.user }}"
-      "CONFIG_whisk_couchdb_password": "{{ db.credentials.admin.pass }}"
+      "CONFIG_whisk_couchdb_username": "{{ db.credentials.controller.user }}"
+      "CONFIG_whisk_couchdb_password": "{{ db.credentials.controller.pass }}"
       "CONFIG_whisk_couchdb_provider": "{{ db.provider }}"
       "CONFIG_whisk_couchdb_databases_WhiskAuth": "{{ db.whisk.auth }}"
       "CONFIG_whisk_couchdb_databases_WhiskEntity": "{{ db.whisk.actions }}"

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -90,6 +90,8 @@
   include_tasks: "{{ openwhisk_home }}/ansible/tasks/db/checkDb.yml"
   vars:
     dbName: "{{ item }}"
+    dbUser: "{{ db.credentials.invoker.user }}"
+    dbPass: "{{ db.credentials.invoker.pass }}"
   with_items:
   - "{{ db.whisk.actions }}"
   - "{{ db.whisk.activations }}"
@@ -182,8 +184,8 @@
       "CONFIG_whisk_couchdb_protocol": "{{ db.protocol }}"
       "CONFIG_whisk_couchdb_host": "{{ db.host }}"
       "CONFIG_whisk_couchdb_port": "{{ db.port }}"
-      "CONFIG_whisk_couchdb_username": "{{ db.credentials.admin.user }}"
-      "CONFIG_whisk_couchdb_password": "{{ db.credentials.admin.pass }}"
+      "CONFIG_whisk_couchdb_username": "{{ db.credentials.invoker.user }}"
+      "CONFIG_whisk_couchdb_password": "{{ db.credentials.invoker.pass }}"
       "CONFIG_whisk_couchdb_provider": "{{ db.provider }}"
       "CONFIG_whisk_couchdb_databases_WhiskAuth": "{{ db.whisk.auth }}"
       "CONFIG_whisk_couchdb_databases_WhiskEntity": "{{ db.whisk.actions }}"

--- a/ansible/tasks/db/checkDb.yml
+++ b/ansible/tasks/db/checkDb.yml
@@ -3,12 +3,14 @@
 ---
 # Checks, that the Database exists
 # dbName - name of the database to check
+# dbUser - name of the user which should have access rights
+# dbPass - password of the user which should have access
 
 - name: check if {{ dbName }} with {{ db.provider }} exists
   uri:
     url: "{{ db.protocol }}://{{ db.host }}:{{ db.port }}/{{ dbName }}"
     method: HEAD
     status_code: 200
-    user: "{{ db.credentials.admin.user }}"
-    password: "{{ db.credentials.admin.pass }}"
+    user: "{{ dbUser }}"
+    password: "{{ dbPass }}"
     force_basic_auth: yes

--- a/ansible/tasks/db/createUsers.yml
+++ b/ansible/tasks/db/createUsers.yml
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+---
+# Create all required users in _users-database
+# http://docs.couchdb.org/en/2.0.0/intro/security.html#users-documents
+
+- name: create required users
+  uri:
+    url: "{{ db.protocol }}://{{ db.host }}:{{ db.port }}/_users/org.couchdb.user:{{ item.value.user }}"
+    method: PUT
+    status_code: 201,409
+    body_format: json
+    body: |
+      {
+        "name": "{{ item.value.user }}",
+        "password": "{{ item.value.pass }}",
+        "roles": [],
+        "type": "user"
+      }
+    user: "{{ db.credentials.admin.user }}"
+    password: "{{ db.credentials.admin.pass }}"
+    force_basic_auth: yes
+  with_dict: "{{ db.credentials }}"
+  # Don't create the admin user again, if a component is using admin access.
+  when: item.value.user != db.credentials.admin.user

--- a/ansible/tasks/db/grantPermissions.yml
+++ b/ansible/tasks/db/grantPermissions.yml
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+---
+# Grant the specified users permissions to the specified database.
+# dbName - name of the database
+# admins - all users with admin access
+# readers - all users that have read access on the database
+# writers - all users that have write access on the database
+
+# If a component uses admin credentials, the admin user will not be added to the list (as it already has all access rights).
+- set_fact:
+    readerList: "{{ readers | default([]) | difference([db.credentials.admin.user]) }}"
+    writerList: "{{ writers | default([]) | difference([db.credentials.admin.user]) }}"
+    adminList: "{{ admins | default([]) | difference([db.credentials.admin.user]) }}"
+
+# http://docs.couchdb.org/en/2.0.0/api/database/security.html
+- name: grant permissions for CouchDB
+  uri:
+    url: "{{ db.protocol }}://{{ db.host }}:{{ db.port }}/{{ dbName }}/_security"
+    method: PUT
+    status_code: 200
+    body_format: json
+    body: |
+      {
+        "admins": {
+          "names": [ {{ adminList | join('", "') }} ],
+          "roles": []
+        },
+        "members": {
+          "names": [ "{{ readerList | union(writerList) | join('", "') }}" ],
+          "roles": []
+        }
+      }
+    user: "{{ db.credentials.admin.user }}"
+    password: "{{ db.credentials.admin.pass }}"
+    force_basic_auth: yes
+  when: db.provider == 'CouchDB'
+
+# https://console.bluemix.net/docs/services/Cloudant/api/authorization.html#authorization
+- name: grant permissions for Cloudant
+  uri:
+    url: "{{ db.protocol }}://{{ db.host }}:{{ db.port }}/{{ dbName }}/_security"
+    method: PUT
+    status_code: 200
+    body_format: json
+    body: |
+      {
+        "cloudant": {
+          {% for item in readerList | union(writerList) | union(adminList) %}"{{ item }}": [ {% if item in readerList %}"_reader"{% if item in writerList %}, "_writer"{% if item in adminList %}, "_admin"{% endif %}{% endif %}{% endif %} ], {% endfor %}
+        }
+      }
+    user: "{{ db.credentials.admin.user }}"
+    password: "{{ db.credentials.admin.pass }}"
+    force_basic_auth: yes
+  when: db.provider == 'Cloudant'

--- a/ansible/tasks/initdb.yml
+++ b/ansible/tasks/initdb.yml
@@ -9,6 +9,13 @@
     dbName: "{{ db.whisk.auth }}"
     forceRecreation: False
 
+- include_tasks: db/grantPermissions.yml
+  vars:
+    dbName: "{{ db.whisk.auth }}"
+    readers:
+    - "{{ db.credentials.controller.user }}"
+    - "{{ db.credentials.invoker.user }}"
+
 - include_tasks: db/recreateDoc.yml
   vars:
     dbName: "{{ db.whisk.auth }}"

--- a/ansible/tasks/recreateViews.yml
+++ b/ansible/tasks/recreateViews.yml
@@ -21,4 +21,3 @@
     - "{{ openwhisk_home }}/ansible/files/filter_design_document.json"
     - "{{ openwhisk_home }}/ansible/files/activations_design_document_for_activations_db.json"
     - "{{ openwhisk_home }}/ansible/files/logCleanup_design_document_for_activations_db.json"
-  when: db.whisk.activations != db.whisk.actions

--- a/ansible/tasks/wipeDatabase.yml
+++ b/ansible/tasks/wipeDatabase.yml
@@ -4,15 +4,34 @@
 # Wipe transient databases. You should know what you are doing here.
 # withViews: True or False. Says, if the views have to be recreated.
 
+- include_tasks: db/createUsers.yml
+
 - include_tasks: db/recreateDb.yml
   vars:
     dbName: "{{ db.whisk.actions }}"
     forceRecreation: True
+- include_tasks: db/grantPermissions.yml
+  vars:
+    dbName: "{{ db.whisk.actions }}"
+    readers:
+    - "{{ db.credentials.controller.user }}"
+    - "{{ db.credentials.invoker.user }}"
+    writers:
+    - "{{ db.credentials.controller.user }}"
+
 - include_tasks: db/recreateDb.yml
   vars:
     dbName: "{{ db.whisk.activations }}"
     forceRecreation: True
-  when: db.whisk.activations != db.whisk.actions
+- include_tasks: db/grantPermissions.yml
+  vars:
+    dbName: "{{ db.whisk.activations }}"
+    readers:
+    - "{{ db.credentials.controller.user }}"
+    - "{{ db.credentials.invoker.user }}"
+    writers:
+    - "{{ db.credentials.controller.user }}"
+    - "{{ db.credentials.invoker.user }}"
 
 - include_tasks: recreateViews.yml
   when: withViews == True

--- a/ansible/templates/db_local.ini.j2
+++ b/ansible/templates/db_local.ini.j2
@@ -5,3 +5,11 @@ db_password={{ lookup('env', 'OW_DB_PASSWORD')|default('some_passw0rd', true) }}
 db_protocol={{ lookup('env', 'OW_DB_PROTOCOL')|default('http', true) }}
 db_host={{ lookup('env', 'OW_DB_HOST')|default(groups['db']|first, true) }}
 db_port={{ lookup('env', 'OW_DB_PORT')|default('5984', true) }}
+
+[controller]
+db_username={{ lookup('env', 'OW_DB_CONTROLLER_USERNAME') | default(db_prefix + 'controller0', true) }}
+db_password={{ lookup('env', 'OW_DB_CONTROLLER_PASSWORD') | default('some_controller_passw0rd', true) }}
+
+[invoker]
+db_username={{ lookup('env', 'OW_DB_INVOKER_USERNAME') | default(db_prefix + 'invoker0', true) }}
+db_password={{ lookup('env', 'OW_DB_INVOKER_PASSWORD') | default('some_invoker_passw0rd', true) }}


### PR DESCRIPTION
With this PR, each deployed component will get it's own database credentials. On doing this, we are able to set the permissions for each component.
E.g. the invoker does not need write access to the subjects- and the whisks db.

The database users and the permission handling is done on wipedb and initdb.

The db-prefix is part of the usernames. This is to avoid clashes if several Openwhisk instances use the same couchdb/cloudant instance.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

