### PR TITLE
Adding enforceEmptyErrorStream check to testEcho

### DIFF
--- a/tests/src/test/scala/actionContainers/BasicActionRunnerTests.scala
+++ b/tests/src/test/scala/actionContainers/BasicActionRunnerTests.scala
@@ -238,7 +238,8 @@ trait BasicActionRunnerTests extends ActionProxyContainerTestUtils {
     checkStreams(out, err, {
       case (o, e) =>
         o should include("hello stdout")
-        e should include("hello stderr")
+        // some languages may not support printing to stderr
+        if (config.enforceEmptyErrorStream) e should include("hello stderr")
     }, argss.length)
   }
 

--- a/tests/src/test/scala/actionContainers/BasicActionRunnerTests.scala
+++ b/tests/src/test/scala/actionContainers/BasicActionRunnerTests.scala
@@ -239,7 +239,7 @@ trait BasicActionRunnerTests extends ActionProxyContainerTestUtils {
       case (o, e) =>
         o should include("hello stdout")
         // some languages may not support printing to stderr
-        if (config.enforceEmptyErrorStream) e should include("hello stderr")
+        if (!config.skipTest) e should include("hello stderr")
     }, argss.length)
   }
 


### PR DESCRIPTION
Some language runtimes doesn't write to standard error. Hence testEcho should be able to avoid checking for standard error. 

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [x] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

