### PR TITLE
Use invoker id for metrics instead of the hostname.

### DIFF
--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -210,10 +210,7 @@ object LogMarkerToken {
 
 }
 
-object MetricEmitter {
-
-  val metrics = Kamon.metrics
-
+object MetricSupport {
   def initKamon(instanceName: String): Unit = {
     // Replace the hostname of the invoker to the assigned id of the invoker.
     val newKamonConfig = Kamon.config
@@ -222,6 +219,11 @@ object MetricEmitter {
         ConfigValueFactory.fromAnyRef(instanceName))
     Kamon.start(newKamonConfig)
   }
+}
+
+object MetricEmitter {
+
+  val metrics = Kamon.metrics
 
   def emitCounterMetric(token: LogMarkerToken): Unit = {
     if (TransactionId.metricsKamon) {

--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -18,12 +18,10 @@
 package whisk.common
 
 import java.io.PrintStream
-import java.time.format.DateTimeFormatter
 import java.time.{Clock, Instant, ZoneId}
-
+import java.time.format.DateTimeFormatter
 import akka.event.Logging._
 import akka.event.LoggingAdapter
-import com.typesafe.config.ConfigValueFactory
 import kamon.Kamon
 import whisk.core.entity.ControllerInstanceId
 
@@ -208,17 +206,6 @@ object LogMarkerToken {
     LogMarkerToken(component, generalAction, state, subAction)
   }
 
-}
-
-object MetricSupport {
-  def init(instanceName: String): Unit = {
-    // Replace the hostname of the invoker to the assigned id of the invoker.
-    val newKamonConfig = Kamon.config
-      .withValue(
-        "kamon.statsd.simple-metric-key-generator.hostname-override",
-        ConfigValueFactory.fromAnyRef(instanceName))
-    Kamon.start(newKamonConfig)
-  }
 }
 
 object MetricEmitter {

--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -18,10 +18,12 @@
 package whisk.common
 
 import java.io.PrintStream
-import java.time.{Clock, Instant, ZoneId}
 import java.time.format.DateTimeFormatter
+import java.time.{Clock, Instant, ZoneId}
+
 import akka.event.Logging._
 import akka.event.LoggingAdapter
+import com.typesafe.config.ConfigValueFactory
 import kamon.Kamon
 import whisk.core.entity.ControllerInstanceId
 
@@ -211,6 +213,15 @@ object LogMarkerToken {
 object MetricEmitter {
 
   val metrics = Kamon.metrics
+
+  def initKamon(instanceName: String): Unit = {
+    // Replace the hostname of the invoker to the assigned id of the invoker.
+    val newKamonConfig = Kamon.config
+      .withValue(
+        "kamon.statsd.simple-metric-key-generator.hostname-override",
+        ConfigValueFactory.fromAnyRef(instanceName))
+    Kamon.start(newKamonConfig)
+  }
 
   def emitCounterMetric(token: LogMarkerToken): Unit = {
     if (TransactionId.metricsKamon) {

--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -211,7 +211,7 @@ object LogMarkerToken {
 }
 
 object MetricSupport {
-  def initKamon(instanceName: String): Unit = {
+  def init(instanceName: String): Unit = {
     // Replace the hostname of the invoker to the assigned id of the invoker.
     val newKamonConfig = Kamon.config
       .withValue(

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -118,7 +118,7 @@ object Invoker {
         new InstanceIdAssigner(config.zookeeperHosts).getId(invokerUniqueName.get)
       }
 
-    MetricSupport.initKamon(s"invoker$assignedInvokerId")
+    MetricSupport.init(s"invoker$assignedInvokerId")
 
     val topicBaseName = "invoker"
     val topicName = topicBaseName + assignedInvokerId

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -21,7 +21,7 @@ import akka.Done
 import akka.actor.{ActorSystem, CoordinatedShutdown}
 import akka.stream.ActorMaterializer
 import kamon.Kamon
-import whisk.common.{AkkaLogging, MetricEmitter, Scheduler, TransactionId}
+import whisk.common._
 import whisk.core.WhiskConfig
 import whisk.core.WhiskConfig._
 import whisk.core.connector.{MessagingProvider, PingMessage}
@@ -30,8 +30,8 @@ import whisk.http.{BasicHttpService, BasicRasService}
 import whisk.spi.SpiLoader
 import whisk.utils.ExecutionContextFactory
 
-import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Try}
 
 case class CmdLineArgs(uniqueName: Option[String] = None, id: Option[Int] = None, displayedName: Option[String] = None)
@@ -118,7 +118,7 @@ object Invoker {
         new InstanceIdAssigner(config.zookeeperHosts).getId(invokerUniqueName.get)
       }
 
-    MetricEmitter.initKamon(s"invoker$assignedInvokerId")
+    MetricSupport.initKamon(s"invoker$assignedInvokerId")
 
     val topicBaseName = "invoker"
     val topicName = topicBaseName + assignedInvokerId


### PR DESCRIPTION
Today, the hostname of the invoker is used for the metrics, sent by kamon. This PR changes this behaviour to use the instance of the invoker instead.

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

