### PR TITLE
Implement full specification of docker image names.

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 
     compile 'com.github.pureconfig:pureconfig_2.11:0.9.0'
     compile 'io.spray:spray-json_2.11:1.3.4'
+    compile 'com.lihaoyi:fastparse_2.11:1.0.0'
 
     compile 'com.typesafe.akka:akka-actor_2.11:2.5.12'
     compile 'com.typesafe.akka:akka-stream_2.11:2.5.12'

--- a/common/scala/src/main/scala/whisk/core/entity/ExecManifest.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ExecManifest.scala
@@ -216,7 +216,7 @@ protected[core] object ExecManifest {
     private val alphaNumericWithUpper = P(letters | digits)
     private val word = P(alphaNumericWithUpper | "_")
 
-    private val digestHex = P((digits | CharIn(('a' to 'f') ++ ('A' to 'F'))).rep(min = 32))
+    private val digestHex = P(digits | CharIn(('a' to 'f') ++ ('A' to 'F'))).rep(min = 32)
     private val digestAlgorithmComponent = P(letters ~ alphaNumericWithUpper.rep)
     private val digestAlgorithmSeperator = P("+" | "." | "-" | "_")
     private val digestAlgorithm = P(digestAlgorithmComponent.rep(min = 1, sep = digestAlgorithmSeperator))

--- a/common/scala/src/main/scala/whisk/core/entity/ExecManifest.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ExecManifest.scala
@@ -226,7 +226,7 @@ protected[core] object ExecManifest {
 
     private val separator = P("_" | "." | "__" | "-".rep)
     private val pathComponent = P(alphaNumeric.rep(min = 1, sep = separator))
-    private val portNumber = P(CharIn('0' to '9').rep(min = 1))
+    private val portNumber = P(digits.rep(min = 1))
     // FIXME: this is not correct yet. It accepts "-" as the beginning and end of a domain
     private val domainComponent = P((alphaNumericWithUpper | "-").rep(min = 1))
     private val domain = P(domainComponent.rep(min = 1, sep = ".") ~ (":" ~ portNumber).?)

--- a/common/scala/src/main/scala/whisk/core/entity/ExecManifest.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ExecManifest.scala
@@ -19,12 +19,13 @@ package whisk.core.entity
 
 import pureconfig.loadConfigOrThrow
 
-import scala.util.{Failure, Try}
+import scala.util.{Failure, Success, Try}
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import whisk.core.{ConfigKeys, WhiskConfig}
 import whisk.core.entity.Attachments._
 import whisk.core.entity.Attachments.Attached._
+import fastparse.all._
 
 /**
  * Reads manifest of supported runtimes from configuration file and stores
@@ -185,8 +186,53 @@ protected[core] object ExecManifest {
 
   protected[core] object ImageName {
     private val defaultImageTag = "latest"
-    private val componentRegex = """([a-z0-9._-]+)""".r
-    private val tagRegex = """([\w.-]{0,128})""".r
+
+    // docker image name grammar, taken from: https://github.com/docker/distribution/blob/master/reference/reference.go
+    //
+    // Grammar
+    //
+    // reference                       := name [ ":" tag ] [ "@" digest ]
+    // name                            := [domain '/'] path-component ['/' path-component]*
+    // domain                          := domain-component ['.' domain-component]* [':' port-number]
+    // domain-component                := /([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])/
+    // port-number                     := /[0-9]+/
+    // path-component                  := alpha-numeric [separator alpha-numeric]*
+    // alpha-numeric                   := /[a-z0-9]+/
+    // separator                       := /[_.]|__|[-]*/
+    //
+    // tag                             := /[\w][\w.-]{0,127}/
+    //
+    // digest                          := digest-algorithm ":" digest-hex
+    // digest-algorithm                := digest-algorithm-component [ digest-algorithm-separator digest-algorithm-component ]*
+    // digest-algorithm-separator      := /[+.-_]/
+    // digest-algorithm-component      := /[A-Za-z][A-Za-z0-9]*/
+    // digest-hex                      := /[0-9a-fA-F]{32,}/ ; At least 128 bit digest value
+
+    private val lowercaseLetters = P(CharIn('a' to 'z'))
+    private val uppercaseLetters = P(CharIn('A' to 'Z'))
+    private val digits = P(CharIn('0' to '9'))
+
+    private val alphaNumeric = P(lowercaseLetters | digits)
+    private val alphaNumericWithUpper = P(alphaNumeric | uppercaseLetters)
+    private val word = P(alphaNumericWithUpper | "_")
+
+    private val digestHex = P((digits | CharIn(('a' to 'f') ++ ('A' to 'F'))).rep(min = 32))
+    private val digestAlgorithmComponent = P((uppercaseLetters | lowercaseLetters) ~ alphaNumericWithUpper.rep)
+    private val digestAlgorithmSeperator = P("+" | "." | "-" | "+")
+    private val digestAlgorithm = P(digestAlgorithmComponent.rep(min = 1, sep = digestAlgorithmSeperator))
+    private val digest = P(digestAlgorithm ~ ":" ~ digestHex)
+
+    private val tag = P(word ~ (word | "." | "-").rep(max = 127))
+
+    private val separator = P("_" | "." | "__" | "-".rep)
+    private val pathComponent = P(alphaNumeric.rep(min = 1, sep = separator))
+    private val portNumber = P(CharIn('0' to '9').rep(min = 1))
+    // FIXME: this is not correct yet. It accepts "-" as the beginning and end of a domain
+    private val domainComponent = P((alphaNumericWithUpper | "-").rep(min = 1))
+    private val domain = P(domainComponent.rep(min = 1, sep = ".") ~ (":" ~ portNumber).?)
+    private val name = P((domain.! ~ "/").? ~ pathComponent.!.rep(min = 1, sep = "/"))
+
+    private val reference = P(Start ~ name ~ (":" ~ tag.!).? ~ ("@" ~ digest.!).? ~ End)
 
     /**
      * Constructs an ImageName from a string. This method checks that the image name conforms
@@ -194,27 +240,17 @@ protected[core] object ExecManifest {
      * which fails the Try. Callers could use this to short-circuit operations (CRUD or activation).
      * Internal container names use the proper constructor directly.
      */
-    def fromString(s: String): Try[ImageName] =
-      Try {
-        val parts = s.split("/")
+    def fromString(s: String): Try[ImageName] = {
+      reference.parse(s) match {
+        case Parsed.Success((registry, imagePathParts, imageTag, _), _) =>
+          // imagePathParts has at least one element per the parser above
+          val prefix = (registry ++ imagePathParts.dropRight(1)).mkString("/")
+          val imageName = imagePathParts.last
 
-        val (name, tag) = parts.last.split(":") match {
-          case Array(componentRegex(s))              => (s, None)
-          case Array(componentRegex(s), tagRegex(t)) => (s, Some(t))
-          case _                                     => throw DeserializationException("image name is not valid")
-        }
-
-        val prefixParts = parts.dropRight(1)
-        if (!prefixParts.forall(componentRegex.pattern.matcher(_).matches)) {
-          throw DeserializationException("image prefix not is not valid")
-        }
-        val prefix = if (prefixParts.nonEmpty) Some(prefixParts.mkString("/")) else None
-
-        ImageName(name, prefix, tag)
-      } recoverWith {
-        case t: DeserializationException => Failure(t)
-        case t                           => Failure(DeserializationException("could not parse image name"))
+          Success(ImageName(imageName, if (prefix.nonEmpty) Some(prefix) else None, imageTag))
+        case _ => Failure(DeserializationException("could not parse image name"))
       }
+    }
   }
 
   /**

--- a/common/scala/src/main/scala/whisk/core/entity/ExecManifest.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ExecManifest.scala
@@ -218,7 +218,7 @@ protected[core] object ExecManifest {
 
     private val digestHex = P((digits | CharIn(('a' to 'f') ++ ('A' to 'F'))).rep(min = 32))
     private val digestAlgorithmComponent = P((uppercaseLetters | lowercaseLetters) ~ alphaNumericWithUpper.rep)
-    private val digestAlgorithmSeperator = P("+" | "." | "-" | "+")
+    private val digestAlgorithmSeperator = P("+" | "." | "-" | "_")
     private val digestAlgorithm = P(digestAlgorithmComponent.rep(min = 1, sep = digestAlgorithmSeperator))
     private val digest = P(digestAlgorithm ~ ":" ~ digestHex)
 

--- a/tests/src/test/scala/whisk/core/entity/test/ExecManifestTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecManifestTests.scala
@@ -51,12 +51,15 @@ class ExecManifestTests extends FlatSpec with WskActorSystem with StreamLogging 
       "pre/img" -> ImageName("img", Some("pre")),
       "pre/img:t" -> ImageName("img", Some("pre"), Some("t")),
       "pre1/pre2/img:t" -> ImageName("img", Some("pre1/pre2"), Some("t")),
-      "pre1/pre2/img" -> ImageName("img", Some("pre1/pre2")))
+      "pre1/pre2/img" -> ImageName("img", Some("pre1/pre2")),
+      "hostname.com:3121/pre1/pre2/img:t" -> ImageName("img", Some("hostname.com:3121/pre1/pre2"), Some("t")),
+      "hostname.com:3121/pre1/pre2/img:t@sha256:77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182" ->
+        ImageName("img", Some("hostname.com:3121/pre1/pre2"), Some("t")))
       .foreach {
         case (s, v) => ImageName.fromString(s) shouldBe Success(v)
       }
 
-    Seq("ABC", "x:8080/abc", "p/a:x:y").foreach { s =>
+    Seq("ABC", "x:8080:10/abc", "p/a:x:y", "p/a:t@sha256:77af4d6b9").foreach { s =>
       a[DeserializationException] should be thrownBy ImageName.fromString(s).get
     }
   }


### PR DESCRIPTION
Today we have a very basic way of parsing docker image names, which even prohibit the use of ports in the domain names and/or providing a fully-qualified digest to pull.

This parser implements the full specification of docker image names to allow OpenWhisk to take all kinds of image references possible.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [X] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

