### PR TITLE
make request id header name comparison case insensitive

### DIFF
--- a/common/scala/src/main/scala/whisk/common/TransactionId.scala
+++ b/common/scala/src/main/scala/whisk/common/TransactionId.scala
@@ -245,4 +245,6 @@ object TransactionId {
   }
 }
 
-case class TransactionGeneratorConfig(header: String)
+case class TransactionGeneratorConfig(header: String) {
+  val lowerCaseHeader = header.toLowerCase //to cache the lowercase version of the header name
+}

--- a/common/scala/src/main/scala/whisk/http/BasicHttpService.scala
+++ b/common/scala/src/main/scala/whisk/http/BasicHttpService.scala
@@ -108,7 +108,7 @@ trait BasicHttpService extends Directives {
     extract { req =>
       val tid =
         req.request.headers
-          .find(_.name.toLowerCase == TransactionId.generatorConfig.header.toLowerCase)
+          .find(_.is(TransactionId.generatorConfig.lowerCaseHeader))
           .map(_.value)
           .filterNot(_.startsWith(TransactionId.systemPrefix))
           .getOrElse {

--- a/common/scala/src/main/scala/whisk/http/BasicHttpService.scala
+++ b/common/scala/src/main/scala/whisk/http/BasicHttpService.scala
@@ -108,7 +108,7 @@ trait BasicHttpService extends Directives {
     extract { req =>
       val tid =
         req.request.headers
-          .find(_.name == TransactionId.generatorConfig.header)
+          .find(_.name.toLowerCase == TransactionId.generatorConfig.header.toLowerCase)
           .map(_.value)
           .filterNot(_.startsWith(TransactionId.systemPrefix))
           .getOrElse {


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
Request headers should be compared case insensitive. We noticed X-Request-Id was being ignored at controller, due to the configured header being X-Request-ID
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

