### PR TITLE
Use ArtifactStore to manipulate data in NamespaceBlacklistTests

### DIFF
--- a/tests/src/test/scala/whisk/core/invoker/test/NamespaceBlacklistTests.scala
+++ b/tests/src/test/scala/whisk/core/invoker/test/NamespaceBlacklistTests.scala
@@ -23,13 +23,9 @@ import org.junit.runner.RunWith
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{FlatSpec, Matchers}
-import pureconfig.loadConfigOrThrow
-import spray.json.DefaultJsonProtocol._
 import spray.json._
 import whisk.common.TransactionId
-import whisk.core.database.CouchDbConfig
-import whisk.core.ConfigKeys
-import whisk.core.database.test.{DbUtils, ExtendedCouchDbRestClient}
+import whisk.core.database.test.DbUtils
 import whisk.core.entity._
 import whisk.core.invoker.NamespaceBlacklist
 import whisk.utils.{retry => testRetry}
@@ -51,38 +47,13 @@ class NamespaceBlacklistTests
   implicit val materializer = ActorMaterializer()
   implicit val tid = TransactionId.testing
 
-  val dbConfig = loadConfigOrThrow[CouchDbConfig](ConfigKeys.couchdb)
   val authStore = WhiskAuthStore.datastore()
-  val subjectsDb = new ExtendedCouchDbRestClient(
-    dbConfig.protocol,
-    dbConfig.host,
-    dbConfig.port,
-    dbConfig.username,
-    dbConfig.password,
-    dbConfig.databaseFor[WhiskAuth])
 
-  /* Identities needed for the first test */
-  val uuid1 = UUID()
-  val uuid2 = UUID()
-  val uuid3 = UUID()
-  val identities = Seq(
-    Identity(
-      Subject(),
-      Namespace(EntityName("testnamespace1"), uuid1),
-      BasicAuthenticationAuthKey(uuid1, Secret()),
-      Set.empty,
-      UserLimits(invocationsPerMinute = Some(0))),
-    Identity(
-      Subject(),
-      Namespace(EntityName("testnamespace2"), uuid2),
-      BasicAuthenticationAuthKey(uuid2, Secret()),
-      Set.empty,
-      UserLimits(concurrentInvocations = Some(0))),
-    Identity(
-      Subject(),
-      Namespace(EntityName("testnamespace3"), uuid3),
-      BasicAuthenticationAuthKey(uuid3, Secret()),
-      Set.empty,
+  val limitsAndAuths = Seq(
+    new LimitEntity(EntityName("testnamespace1"), UserLimits(invocationsPerMinute = Some(0))),
+    new LimitEntity(EntityName("testnamespace2"), UserLimits(concurrentInvocations = Some(0))),
+    new LimitEntity(
+      EntityName("testnamespace3"),
       UserLimits(invocationsPerMinute = Some(1), concurrentInvocations = Some(1))))
 
   /* Subject document needed for the second test */
@@ -92,49 +63,34 @@ class NamespaceBlacklistTests
   val ak5 = BasicAuthenticationAuthKey(uuid5, Secret())
   val ns4 = Namespace(EntityName("different1"), uuid4)
   val ns5 = Namespace(EntityName("different2"), uuid5)
-  val subject = WhiskAuth(Subject(), Set(WhiskNamespace(ns4, ak4), WhiskNamespace(ns5, ak5)))
-  val blockedSubject = JsObject(subject.toJson.fields + ("blocked" -> true.toJson))
+  val blockedSubject = new ExtendedAuth(Subject(), Set(WhiskNamespace(ns4, ak4), WhiskNamespace(ns5, ak5)), true)
 
-  val blockedNamespacesCount = 2 + subject.namespaces.size
+  val blockedNamespacesCount = 2 + blockedSubject.namespaces.size
 
-  def authToIdentities(auth: WhiskAuth): Set[Identity] = {
+  private def authToIdentities(auth: WhiskAuth): Set[Identity] = {
     auth.namespaces.map { ns =>
       Identity(auth.subject, ns.namespace, ns.authkey, Set(), UserLimits())
     }
   }
 
-  override protected def withFixture(test: NoArgTest) = {
-    assume(isCouchStore(authStore))
-    super.withFixture(test)
+  private def limitToIdentity(limit: LimitEntity): Identity = {
+    val namespace = limit.docid.id.dropRight("/limits".length)
+    Identity(
+      limit.subject,
+      Namespace(EntityName(namespace), UUID()),
+      BasicAuthenticationAuthKey(UUID(), Secret()),
+      Set(),
+      UserLimits())
   }
 
   override def beforeAll() = {
-    val documents = identities.map { i =>
-      (i.namespace.name + "/limits", i.limits.toJson.asJsObject)
-    } :+ (subject.subject.asString, blockedSubject)
-
-    // Add all documents to the database
-    documents.foreach { case (id, doc) => subjectsDb.putDoc(id, doc).futureValue }
-
-    // Waits for the 2 blocked identities + the namespaces of the blocked subject
-    waitOnView(subjectsDb, NamespaceBlacklist.view.ddoc, NamespaceBlacklist.view.view, blockedNamespacesCount)(
-      executionContext,
-      1.minute)
+    limitsAndAuths foreach (put(authStore, _))
+    put(authStore, blockedSubject)
+    waitOnView(authStore, blockedNamespacesCount, NamespaceBlacklist.view)
   }
 
   override def afterAll() = {
-    val ids = identities.map(_.namespace.name + "/limits") :+ subject.subject.asString
-
-    // Force remove all documents with those ids by first getting and then deleting the documents
-    ids.foreach { id =>
-      val docE = subjectsDb.getDoc(id).futureValue
-      docE shouldBe 'right
-      val doc = docE.right.get
-      subjectsDb
-        .deleteDoc(doc.fields("_id").convertTo[String], doc.fields("_rev").convertTo[String])
-        .futureValue
-    }
-
+    cleanup()
     super.afterAll()
   }
 
@@ -145,7 +101,18 @@ class NamespaceBlacklistTests
       blacklist.refreshBlacklist().futureValue should have size blockedNamespacesCount
     }, 60, Some(1.second))
 
-    identities.map(blacklist.isBlacklisted) shouldBe Seq(true, true, false)
-    authToIdentities(subject).toSeq.map(blacklist.isBlacklisted) shouldBe Seq(true, true)
+    limitsAndAuths.map(limitToIdentity).map(blacklist.isBlacklisted) shouldBe Seq(true, true, false)
+    authToIdentities(blockedSubject).toSeq.map(blacklist.isBlacklisted) shouldBe Seq(true, true)
+  }
+
+  class LimitEntity(name: EntityName, limits: UserLimits) extends WhiskAuth(Subject(), namespaces = Set.empty) {
+    override def docid = DocId(s"${name.name}/limits")
+
+    override def toJson = UserLimits.serdes.write(limits).asJsObject
+  }
+
+  class ExtendedAuth(subject: Subject, namespaces: Set[WhiskNamespace], blocked: Boolean)
+      extends WhiskAuth(subject, namespaces) {
+    override def toJson = JsObject(super.toJson.fields + ("blocked" -> JsBoolean(blocked)))
   }
 }


### PR DESCRIPTION
It's better to use the ArtifactStore than a specified DB client in `whisk.core.invoker.test.NamespaceBlacklistTests`,
now we can test this piece of codes with a different database backend other than CouchDB

## Description

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

