### PR TITLE
Shutdown AttachmentStore in CosmosDBArtifactStore

### DIFF
--- a/common/scala/src/main/scala/whisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
@@ -401,7 +401,10 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
       .map(as => as.deleteAttachments(doc.id))
       .getOrElse(Future.successful(true)) // For CosmosDB it is expected that the entire document is deleted.
 
-  override def shutdown(): Unit = clientRef.close()
+  override def shutdown(): Unit = {
+    attachmentStore.foreach(_.shutdown())
+    clientRef.close()
+  }
 
   private def isNotFound[A <: DocumentAbstraction](e: DocumentClientException) =
     e.getStatusCode == StatusCodes.NotFound.intValue


### PR DESCRIPTION
`CosmosDBArtifactStore` should close the configured `AttachmentStore` instance upon shutdown

## Description
Due to this currently testcases are not cleaning up the db created in Cosmos

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

