### PR TITLE
Use the authz provider to retrieve the identity of the namespace

### DIFF
--- a/core/controller/src/main/scala/whisk/core/controller/BasicAuthenticationDirective.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/BasicAuthenticationDirective.scala
@@ -73,6 +73,10 @@ object BasicAuthenticationDirective extends AuthenticationDirectiveProvider {
     }
   }
 
+  def namespaceIdentity(namespace: EntityName)(implicit transid: TransactionId, authStore: AuthStore) = {
+    Identity.get(authStore, namespace)
+  }
+
   def authenticate(implicit transid: TransactionId,
                    authStore: AuthStore,
                    logging: Logging): AuthenticationDirective[Identity] = {

--- a/core/controller/src/main/scala/whisk/core/controller/BasicAuthenticationDirective.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/BasicAuthenticationDirective.scala
@@ -73,7 +73,7 @@ object BasicAuthenticationDirective extends AuthenticationDirectiveProvider {
     }
   }
 
-  def namespaceIdentity(namespace: EntityName)(implicit transid: TransactionId, authStore: AuthStore) = {
+  def identityByNamespace(namespace: EntityName)(implicit transid: TransactionId, authStore: AuthStore) = {
     Identity.get(authStore, namespace)
   }
 

--- a/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
@@ -320,9 +320,28 @@ class RestAPIVersion(config: WhiskConfig, apiPath: String, apiVersion: String)(
 }
 
 trait AuthenticationDirectiveProvider extends Spi {
+
+  /**
+   * Returns an authentication directive used to validate the
+   * passed user credentials.
+   * At runtime the directive returns an user identity
+   * which is passed to the following routes
+   *
+   * @return autehtication directive used to verify the user credentials
+   */
   def authenticate(implicit transid: TransactionId,
                    authStore: AuthStore,
                    logging: Logging): AuthenticationDirective[Identity]
 
-  def namespaceIdentity(namespace: EntityName)(implicit transid: TransactionId, authStore: AuthStore): Future[Identity]
+  /**
+   * Retrieves an Identity based on a given namespace name.
+   *
+   * For use-cases of anonymous invocation (i.e. WebActions),
+   * we need to an identity based on a given namespace-name to
+   * give the invocation all the context needed.
+   * @param namespace the namespace that the identity will be based on
+   * @return identity based on the given namespace
+   */
+  def identityByNamespace(namespace: EntityName)(implicit transid: TransactionId,
+                                                 authStore: AuthStore): Future[Identity]
 }

--- a/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
@@ -40,7 +40,7 @@ import whisk.core.{ConfigKeys, WhiskConfig}
 import whisk.http.Messages
 import whisk.spi.{Spi, SpiLoader}
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -323,4 +323,6 @@ trait AuthenticationDirectiveProvider extends Spi {
   def authenticate(implicit transid: TransactionId,
                    authStore: AuthStore,
                    logging: Logging): AuthenticationDirective[Identity]
+
+  def namespaceIdentity(namespace: EntityName)(implicit transid: TransactionId, authStore: AuthStore): Future[Identity]
 }

--- a/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
@@ -325,9 +325,9 @@ trait AuthenticationDirectiveProvider extends Spi {
    * Returns an authentication directive used to validate the
    * passed user credentials.
    * At runtime the directive returns an user identity
-   * which is passed to the following routes
+   * which is passed to the following routes.
    *
-   * @return autehtication directive used to verify the user credentials
+   * @return authentication directive used to verify the user credentials
    */
   def authenticate(implicit transid: TransactionId,
                    authStore: AuthStore,
@@ -339,6 +339,7 @@ trait AuthenticationDirectiveProvider extends Spi {
    * For use-cases of anonymous invocation (i.e. WebActions),
    * we need to an identity based on a given namespace-name to
    * give the invocation all the context needed.
+   *
    * @param namespace the namespace that the identity will be based on
    * @return identity based on the given namespace
    */

--- a/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
@@ -361,6 +361,9 @@ trait WhiskWebActionsApi extends Directives with ValidateRequestSize with PostAc
   /** Store for identities. */
   protected val authStore: AuthStore
 
+  /** Configured authentication provider. */
+  protected val authenticationProvider = SpiLoader.get[AuthenticationDirectiveProvider]
+
   /** The prefix for web invokes e.g., /web. */
   private lazy val webRoutePrefix = {
     pathPrefix(webInvokePathSegments.map(_segmentStringToPathMatcher(_)).reduceLeft(_ / _))
@@ -458,7 +461,8 @@ trait WhiskWebActionsApi extends Directives with ValidateRequestSize with PostAc
    * This method is factored out to allow mock testing.
    */
   protected def getIdentity(namespace: EntityName)(implicit transid: TransactionId): Future[Identity] = {
-    SpiLoader.get[AuthenticationDirectiveProvider].namespaceIdentity(namespace)(transid, authStore)
+
+    authenticationProvider.identityByNamespace(namespace)(transid, authStore)
   }
 
   private def handleMatch(namespaceSegment: String,

--- a/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
@@ -55,6 +55,7 @@ import whisk.core.entity.types._
 import whisk.http.ErrorResponse.terminate
 import whisk.http.Messages
 import whisk.http.LenientSprayJsonSupport._
+import whisk.spi.SpiLoader
 import whisk.utils.JsHelpers._
 
 protected[controller] sealed class WebApiDirectives(prefix: String = "__ow_") {
@@ -457,7 +458,7 @@ trait WhiskWebActionsApi extends Directives with ValidateRequestSize with PostAc
    * This method is factored out to allow mock testing.
    */
   protected def getIdentity(namespace: EntityName)(implicit transid: TransactionId): Future[Identity] = {
-    Identity.get(authStore, namespace)
+    SpiLoader.get[AuthenticationDirectiveProvider].namespaceIdentity(namespace)(transid, authStore)
   }
 
   private def handleMatch(namespaceSegment: String,


### PR DESCRIPTION
Unauthenticated web actions will use the authentication provider configured in the SPI to create the namespace based Identity

## Description
Unauthenticated web actions do create a namespace based identity that is used to entitle the call.
This change makes them use the configured authentication provider to construct this identity.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change

## My changes affect the following components
- [x] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

