### PR TITLE
Always create users-database in couchdb, independently from the amoun…

### DIFF
--- a/ansible/roles/couchdb/tasks/deploy.yml
+++ b/ansible/roles/couchdb/tasks/deploy.yml
@@ -59,7 +59,7 @@
     user: "{{ db.credentials.admin.user }}"
     password: "{{ db.credentials.admin.pass }}"
     force_basic_auth: yes
-  when: (couchdb.version|version_compare('2.0','>=')) and (db.instances|int == 1)
+  when: (inventory_hostname == coordinator) and (couchdb.version|version_compare('2.0','>='))
 
 - name: enable the cluster setup mode
   uri:

--- a/ansible/tasks/db/grantPermissions.yml
+++ b/ansible/tasks/db/grantPermissions.yml
@@ -23,7 +23,7 @@
     body: |
       {
         "admins": {
-          "names": [ {{ adminList | join('", "') }} ],
+          "names": [ "{{ adminList | join('", "') }}" ],
           "roles": []
         },
         "members": {


### PR DESCRIPTION
…t of instances.

With the current statement, the users-database is only created, when you specify, that there is one instance of couchdb.
In my eyes this behaviour is wrong. You also want to have this database, if you are using several instances.
BUT you only want to have created it once (on the first instance). This is done with the following check instead.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

