### PR TITLE
Unify Entitlement SPI signatures

### DIFF
--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -162,7 +162,7 @@ protected[core] abstract class EntitlementProvider(
    * @param resource the resource to grant the subject access to
    * @return a promise that completes with true iff the subject is granted the right to access the requested resource
    */
-  protected[core] def grant(subject: Subject, right: Privilege, resource: Resource)(
+  protected[core] def grant(user: Identity, right: Privilege, resource: Resource)(
     implicit transid: TransactionId): Future[Boolean]
 
   /**
@@ -173,7 +173,7 @@ protected[core] abstract class EntitlementProvider(
    * @param resource the resource to revoke the subject access to
    * @return a promise that completes with true iff the subject is revoked the right to access the requested resource
    */
-  protected[core] def revoke(subject: Subject, right: Privilege, resource: Resource)(
+  protected[core] def revoke(user: Identity, right: Privilege, resource: Resource)(
     implicit transid: TransactionId): Future[Boolean]
 
   /**
@@ -184,7 +184,7 @@ protected[core] abstract class EntitlementProvider(
    * @param resource the resource the subject requests access to
    * @return a promise that completes with true iff the subject is permitted to access the request resource
    */
-  protected def entitled(subject: Subject, right: Privilege, resource: Resource)(
+  protected def entitled(user: Identity, right: Privilege, resource: Resource)(
     implicit transid: TransactionId): Future[Boolean]
 
   /**
@@ -305,7 +305,7 @@ protected[core] abstract class EntitlementProvider(
           case true => Future.successful(resource -> true)
           case false =>
             logging.debug(this, "checking explicit grants")
-            entitled(user.subject, right, resource).flatMap(b => Future.successful(resource -> b))
+            entitled(user, right, resource).flatMap(b => Future.successful(resource -> b))
         }
       }
     }

--- a/tests/src/test/scala/whisk/core/controller/test/EntitlementProviderTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/EntitlementProviderTests.scala
@@ -229,10 +229,10 @@ class EntitlementProviderTests extends ControllerTestCommon with ScalaFutures {
     val one = Resource(someUser.namespace.name.toPath, ACTIONS, Some("xyz"))
     Await.ready(entitlementProvider.check(adminUser, READ, all), requestTimeout).eitherValue.get should not be Right({})
     Await.ready(entitlementProvider.check(adminUser, READ, one), requestTimeout).eitherValue.get should not be Right({})
-    Await.result(entitlementProvider.grant(adminUser.subject, READ, all), requestTimeout) // granted
+    Await.result(entitlementProvider.grant(adminUser, READ, all), requestTimeout) // granted
     Await.ready(entitlementProvider.check(adminUser, READ, all), requestTimeout).eitherValue.get shouldBe Right({})
     Await.ready(entitlementProvider.check(adminUser, READ, one), requestTimeout).eitherValue.get shouldBe Right({})
-    Await.result(entitlementProvider.revoke(adminUser.subject, READ, all), requestTimeout) // revoked
+    Await.result(entitlementProvider.revoke(adminUser, READ, all), requestTimeout) // revoked
   }
 
   it should "grant access to specific resource to a user" in {
@@ -245,14 +245,14 @@ class EntitlementProviderTests extends ControllerTestCommon with ScalaFutures {
       .ready(entitlementProvider.check(adminUser, DELETE, one), requestTimeout)
       .eitherValue
       .get should not be Right({})
-    Await.result(entitlementProvider.grant(adminUser.subject, READ, one), requestTimeout) // granted
+    Await.result(entitlementProvider.grant(adminUser, READ, one), requestTimeout) // granted
     Await.ready(entitlementProvider.check(adminUser, READ, all), requestTimeout).eitherValue.get should not be Right({})
     Await.ready(entitlementProvider.check(adminUser, READ, one), requestTimeout).eitherValue.get shouldBe Right({})
     Await
       .ready(entitlementProvider.check(adminUser, DELETE, one), requestTimeout)
       .eitherValue
       .get should not be Right({})
-    Await.result(entitlementProvider.revoke(adminUser.subject, READ, one), requestTimeout) // revoked
+    Await.result(entitlementProvider.revoke(adminUser, READ, one), requestTimeout) // revoked
   }
 
   behavior of "Package Collection"

--- a/tests/src/test/scala/whisk/core/controller/test/PackageActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/PackageActionsApiTests.scala
@@ -348,7 +348,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     put(entityStore, binding)
     put(entityStore, action)
     val pkgaccess = Resource(provider.namespace, PACKAGES, Some(provider.name.asString))
-    Await.result(entitlementProvider.grant(auser.subject, READ, pkgaccess), 1 second)
+    Await.result(entitlementProvider.grant(auser, READ, pkgaccess), 1 second)
     Get(s"$collectionPath/${binding.name}/${action.name}") ~> Route.seal(routes(auser)) ~> check {
       status should be(OK)
       val response = responseAs[WhiskAction]
@@ -492,7 +492,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     put(entityStore, reference)
     put(entityStore, action)
     val pkgaccess = Resource(provider.namespace, PACKAGES, Some(provider.name.asString))
-    Await.result(entitlementProvider.grant(auser.subject, ACTIVATE, pkgaccess), 1 second)
+    Await.result(entitlementProvider.grant(auser, ACTIVATE, pkgaccess), 1 second)
     Post(s"$collectionPath/${reference.name}/${action.name}", content) ~> Route.seal(routes(auser)) ~> check {
       status should be(Accepted)
       val response = responseAs[JsObject]

--- a/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
@@ -1768,15 +1768,15 @@ trait WebActionsApiBaseTests extends ControllerTestCommon with BeforeAndAfterEac
       }
     }
 
-    protected[core] override def grant(subject: Subject, right: Privilege, resource: Resource)(
+    protected[core] override def grant(user: Identity, right: Privilege, resource: Resource)(
       implicit transid: TransactionId) = ???
 
     /** Revokes subject right to resource by removing them from the entitlement matrix. */
-    protected[core] override def revoke(subject: Subject, right: Privilege, resource: Resource)(
+    protected[core] override def revoke(user: Identity, right: Privilege, resource: Resource)(
       implicit transid: TransactionId) = ???
 
     /** Checks if subject has explicit grant for a resource. */
-    protected override def entitled(subject: Subject, right: Privilege, resource: Resource)(
+    protected override def entitled(user: Identity, right: Privilege, resource: Resource)(
       implicit transid: TransactionId) = ???
   }
 


### PR DESCRIPTION
Pass the user identity also to the `grant`, `revoke` and `entitled` methods of the entitlement provider.

## Description
This PR makes the method signatures of the entitlement providers uniform in the way that not only the user subject is passed to this method, but the whole user object.
This change makes it easier to implement entitlement providers that need more data about the user that the subject name.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

