### PR TITLE
Do not abort conductor action execution when component action is invalid, not found, not accessible or when composition is too long

### DIFF
--- a/tests/src/test/scala/system/basic/WskConductorTests.scala
+++ b/tests/src/test/scala/system/basic/WskConductorTests.scala
@@ -105,7 +105,7 @@ class WskConductorTests extends TestHelpers with WskTestHelpers with JsHelpers w
         activation.response.status shouldBe "application error"
         activation.response.result.get.fields.get("error") shouldBe Some(
           JsString(compositionComponentInvalid(JsString(invalid))))
-        checkConductorLogsAndAnnotations(activation, 1) // echo
+        checkConductorLogsAndAnnotations(activation, 2) // echo
       }
 
       // an undefined action
@@ -116,7 +116,7 @@ class WskConductorTests extends TestHelpers with WskTestHelpers with JsHelpers w
         activation.response.status shouldBe "application error"
         activation.response.result.get.fields.get("error") shouldBe Some(
           JsString(compositionComponentNotFound(s"$namespace/$missing")))
-        checkConductorLogsAndAnnotations(activation, 1) // echo
+        checkConductorLogsAndAnnotations(activation, 2) // echo
       }
   }
 

--- a/tests/src/test/scala/whisk/core/controller/test/ConductorsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ConductorsApiTests.scala
@@ -117,7 +117,7 @@ class ConductorsApiTests extends ControllerTestCommon with WhiskActionsApi {
       response.fields("response").asJsObject.fields("status") shouldBe "application error".toJson
       response.fields("response").asJsObject.fields("result") shouldBe JsObject(
         "error" -> compositionComponentInvalid(invalid.toJson).toJson)
-      response.fields("logs").convertTo[JsArray].elements.size shouldBe 1
+      response.fields("logs").convertTo[JsArray].elements.size shouldBe 2
     }
 
     // an undefined action
@@ -128,7 +128,7 @@ class ConductorsApiTests extends ControllerTestCommon with WhiskActionsApi {
       response.fields("response").asJsObject.fields("status") shouldBe "application error".toJson
       response.fields("response").asJsObject.fields("result") shouldBe JsObject(
         "error" -> compositionComponentNotFound(s"$namespace/$missing").toJson)
-      response.fields("logs").convertTo[JsArray].elements.size shouldBe 1
+      response.fields("logs").convertTo[JsArray].elements.size shouldBe 2
     }
   }
 
@@ -180,7 +180,7 @@ class ConductorsApiTests extends ControllerTestCommon with WhiskActionsApi {
       response.fields("response").asJsObject.fields("status") shouldBe "application error".toJson
       response.fields("response").asJsObject.fields("result") shouldBe JsObject(
         "error" -> compositionComponentNotAccessible(forbidden.drop(1)).toJson)
-      response.fields("logs").convertTo[JsArray].elements.size shouldBe 1
+      response.fields("logs").convertTo[JsArray].elements.size shouldBe 2
     }
 
     // dynamically invoke step action twice, forwarding state


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

Conductor actions currently abort when they fail to execute a component action with no possibility to catch the error and recover. This PR makes it possible to handle several failure scenarios.

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

With this PR, the following failure scenarios can now be handled by the conductor action code:
- parsing failure,
- resolution failure,
- entitlement check failure,
- excessive number of component action activations.

With this PR, a conductor action can reliably invoke a callback upon completion, whereas currently a simple typo in the name of a component action aborts the execution and prevents the callback to run.

The unit and system tests for conductor actions have been updated to confirm that the conductor action invocation does not abort in these scenarios.

The documentation of conductor actions has been updated to reflect this new behavior.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [x] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [x] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [x] Breaking change (a bug fix or enhancement which changes existing behavior).

While this change breaks the existing behavior for these failure scenarios, this current behavior is undesirable.

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [x] I updated the documentation where necessary.
