### PR TITLE
Add implicit parameters when getting the namespace identity 

### DIFF
--- a/core/controller/src/main/scala/whisk/core/controller/BasicAuthenticationDirective.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/BasicAuthenticationDirective.scala
@@ -74,11 +74,8 @@ object BasicAuthenticationDirective extends AuthenticationDirectiveProvider {
     }
   }
 
-  def identityByNamespace(namespace: EntityName)(implicit transid: TransactionId,
-                                                 system: ActorSystem,
-                                                 ec: ExecutionContext,
-                                                 authStore: AuthStore,
-                                                 logging: Logging) = {
+  def identityByNamespace(
+    namespace: EntityName)(implicit transid: TransactionId, system: ActorSystem, authStore: AuthStore) = {
     Identity.get(authStore, namespace)
   }
 

--- a/core/controller/src/main/scala/whisk/core/controller/BasicAuthenticationDirective.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/BasicAuthenticationDirective.scala
@@ -17,6 +17,7 @@
 
 package whisk.core.controller
 
+import akka.actor.ActorSystem
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.directives.{AuthenticationDirective, AuthenticationResult}
@@ -73,7 +74,11 @@ object BasicAuthenticationDirective extends AuthenticationDirectiveProvider {
     }
   }
 
-  def identityByNamespace(namespace: EntityName)(implicit transid: TransactionId, authStore: AuthStore) = {
+  def identityByNamespace(namespace: EntityName)(implicit transid: TransactionId,
+                                                 system: ActorSystem,
+                                                 ec: ExecutionContext,
+                                                 authStore: AuthStore,
+                                                 logging: Logging) = {
     Identity.get(authStore, namespace)
   }
 

--- a/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
@@ -344,5 +344,8 @@ trait AuthenticationDirectiveProvider extends Spi {
    * @return identity based on the given namespace
    */
   def identityByNamespace(namespace: EntityName)(implicit transid: TransactionId,
-                                                 authStore: AuthStore): Future[Identity]
+                                                 system: ActorSystem,
+                                                 ec: ExecutionContext,
+                                                 authStore: AuthStore,
+                                                 logging: Logging): Future[Identity]
 }

--- a/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
@@ -343,9 +343,6 @@ trait AuthenticationDirectiveProvider extends Spi {
    * @param namespace the namespace that the identity will be based on
    * @return identity based on the given namespace
    */
-  def identityByNamespace(namespace: EntityName)(implicit transid: TransactionId,
-                                                 system: ActorSystem,
-                                                 ec: ExecutionContext,
-                                                 authStore: AuthStore,
-                                                 logging: Logging): Future[Identity]
+  def identityByNamespace(
+    namespace: EntityName)(implicit transid: TransactionId, system: ActorSystem, authStore: AuthStore): Future[Identity]
 }

--- a/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
@@ -461,7 +461,7 @@ trait WhiskWebActionsApi extends Directives with ValidateRequestSize with PostAc
    */
   protected def getIdentity(namespace: EntityName)(implicit transid: TransactionId): Future[Identity] = {
     // ask auth provider to create an identity for the given namespace
-    authenticationProvider.identityByNamespace(namespace)(transid, actorSystem, executionContext, authStore, logging)
+    authenticationProvider.identityByNamespace(namespace)(transid, actorSystem, authStore)
   }
 
   private def handleMatch(namespaceSegment: String,

--- a/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
@@ -460,8 +460,8 @@ trait WhiskWebActionsApi extends Directives with ValidateRequestSize with PostAc
    * This method is factored out to allow mock testing.
    */
   protected def getIdentity(namespace: EntityName)(implicit transid: TransactionId): Future[Identity] = {
-
-    authenticationProvider.identityByNamespace(namespace)(transid, authStore)
+    // ask auth provider to create an identity for the given namespace
+    authenticationProvider.identityByNamespace(namespace)(transid, actorSystem, executionContext, authStore, logging)
   }
 
   private def handleMatch(namespaceSegment: String,


### PR DESCRIPTION
Add implicit parameters to the authentication provider interface to allow datastore access

## Description
This PR add the actor system and the execution context as implicit parameters 
to the authentication provider interface to allow access to provider specific data sources.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

