### PR TITLE
Allow providers to fall back to the original entilement

### DIFF
--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -184,7 +184,7 @@ protected[core] abstract class EntitlementProvider(
    * @param resource the resource the subject requests access to
    * @return a promise that completes with true iff the subject is permitted to access the request resource
    */
-  protected def entitled(user: Identity, right: Privilege, resource: Resource)(
+  protected[core] def entitled(user: Identity, right: Privilege, resource: Resource)(
     implicit transid: TransactionId): Future[Boolean]
 
   /**
@@ -293,7 +293,7 @@ protected[core] abstract class EntitlementProvider(
    * implicitly or explicitly granted. Instead, the given resource set should include both the binding
    * and the referenced package.
    */
-  protected def checkPrivilege(user: Identity, right: Privilege, resources: Set[Resource])(
+  protected[core] def checkPrivilege(user: Identity, right: Privilege, resources: Set[Resource])(
     implicit transid: TransactionId): Future[Set[(Resource, Boolean)]] = {
     // check the default namespace first, bypassing additional checks if permitted
     val defaultNamespaces = Set(user.namespace.name.asString)

--- a/core/controller/src/main/scala/whisk/core/entitlement/LocalEntitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/LocalEntitlement.scala
@@ -61,7 +61,7 @@ protected[core] class LocalEntitlementProvider(
   }
 
   /** Checks if subject has explicit grant for a resource. */
-  protected override def entitled(user: Identity, right: Privilege, resource: Resource)(
+  protected[core] override def entitled(user: Identity, right: Privilege, resource: Resource)(
     implicit transid: TransactionId) = Future.successful {
     val subject = user.subject
     lazy val one = matrix.get((subject, resource.id)) map { _ contains right } getOrElse false

--- a/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
@@ -1776,7 +1776,7 @@ trait WebActionsApiBaseTests extends ControllerTestCommon with BeforeAndAfterEac
       implicit transid: TransactionId) = ???
 
     /** Checks if subject has explicit grant for a resource. */
-    protected override def entitled(user: Identity, right: Privilege, resource: Resource)(
+    protected[core] override def entitled(user: Identity, right: Privilege, resource: Resource)(
       implicit transid: TransactionId) = ???
   }
 


### PR DESCRIPTION
Change method protection to allow providers to fall back to the original entitlement implementation

## Description
With these changes new providers are allowed to fall back to the original entitlement implementation if necessary

## My changes affect the following components
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

