### PR TITLE
Fix for exception being thrown during api creation

### DIFF
--- a/core/routemgmt/common/apigw-utils.js
+++ b/core/routemgmt/common/apigw-utils.js
@@ -41,7 +41,7 @@ function generateTargetUrlMap(ibmConfig) {
         var execs = element['execute'];
         //each nth element of execs and operations go together, so lets add those to the map.
         for (var i = 0; i < operations.length ; ++i) {
-          if(i < execs.length && execs[i] && execs[i]['invoke']['target-url']) {
+          if(i < execs.length && execs[i] && execs[i]['invoke'] && execs[i]['invoke']['target-url']) {
             targetUrls[operations[i]] = execs[i]['invoke']['target-url'];
           }
         }

--- a/tests/dat/apigw/testswaggerdoc1
+++ b/tests/dat/apigw/testswaggerdoc1
@@ -21,6 +21,38 @@
                     "url": "https://172.17.0.1/api/v1/web/whisk.system/default/CLI_APIGWTEST7_action.http"
                 }
             }
+        },
+        "/pathSecure1": {
+            "get": {
+                "operationId": "get_/pathSecure1",
+                "responses": {
+                    "default": {
+                        "description": "Default response"
+                    }
+                },
+                "x-openwhisk": {
+                    "action": "CLI_APIGWTEST7_action",
+                    "namespace": "whisk.system",
+                    "package": "",
+                    "url": "https://172.17.0.1/api/v1/web/whisk.system/default/CLI_APIGWTEST7_action.http"
+                }
+            }
+        },
+        "/pathSecure2": {
+            "get": {
+                "operationId": "get_/pathSecure2",
+                "responses": {
+                    "default": {
+                        "description": "Default response"
+                    }
+                },
+                "x-openwhisk": {
+                    "action": "CLI_APIGWTEST7_action",
+                    "namespace": "whisk.system",
+                    "package": "",
+                    "url": "https://172.17.0.1/api/v1/web/whisk.system/default/CLI_APIGWTEST7_action.http"
+                }
+            }
         }
     },
     "x-ibm-configuration": {
@@ -50,6 +82,52 @@
                                 ],
                                 "operations": [
                                     "get_/path"
+                                ]
+                            },
+                            {
+                                "execute": [
+                                    {
+                                        "invoke": {
+                                            "target-url": "https://172.17.0.1/api/v1/web/whisk.system/default/CLI_APIGWTEST7_action.http",
+                                            "verb": "keep"
+                                        }
+                                    },
+                                    {
+                                        "set-variable": {
+                                            "actions": [
+                                                {
+                                                    "set": "message.headers.X-Require-Whisk-Auth",
+                                                    "value": "my-secret"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "operations": [
+                                    "get_/pathSecure1"
+                                ]
+                            },
+                            {
+                                "execute": [
+                                    {
+                                        "set-variable": {
+                                            "actions": [
+                                                {
+                                                    "set": "message.headers.X-Require-Whisk-Auth",
+                                                    "value": "my-secret"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "invoke": {
+                                            "target-url": "https://172.17.0.1/api/v1/web/whisk.system/default/CLI_APIGWTEST7_action.http",
+                                            "verb": "keep"
+                                        }
+                                    }
+                                ],
+                                "operations": [
+                                    "get_/pathSecure2"
                                 ]
                             }
                         ]

--- a/tests/src/test/scala/whisk/core/cli/test/ApiGwRestBasicTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/ApiGwRestBasicTests.scala
@@ -521,6 +521,8 @@ abstract class ApiGwRestBasicTests extends BaseApiGwTests {
     val testName = "CLI_APIGWTEST7"
     val testbasepath = "/" + testName + "_bp"
     val testrelpath = "/path"
+    val testrelpath1 = "/pathSecure1"
+    val testrelpath2 = "/pathSecure2"
     val testurlop = "get"
     val testapiname = testName + " API Name"
     val actionName = testName + "_action"
@@ -530,7 +532,8 @@ abstract class ApiGwRestBasicTests extends BaseApiGwTests {
       verifyApiCreated(rr)
       rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
       verifyApiFullList(rr, "", actionName, testurlop, testbasepath, testrelpath, testapiname)
-
+      verifyApiFullList(rr, "", actionName, testurlop, testbasepath, testrelpath1, testapiname)
+      verifyApiFullList(rr, "", actionName, testurlop, testbasepath, testrelpath2, testapiname)
     } finally {
       apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
     }


### PR DESCRIPTION

## Description
Fixes #3888
An exception is thrown when an managing an existing API that has the `set-variable` object appearing prior to the `invoke` stanza.  This `set-variable` stanza is set when the target web action has been secured with the `require-whisk-auth` annotation, and this stanza typically follows the `invoke` stanza; however, when reversed an exception was thrown.

## Related issue and scope
- [x] I opened an issue to propose and discuss this change (#3888 )

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [x] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

