### PR TITLE
Allow non-json skip_pull_runtimes to be passed as True.

### DIFF
--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -28,7 +28,7 @@
 - name: "pull runtime action images per manifest"
   shell: "docker pull {{runtimes_registry | default()}}{{item.prefix}}/{{item.name}}:{{item.tag | default()}}"
   loop: "{{ runtimesManifest.runtimes.values() | sum(start=[]) | selectattr('deprecated', 'equalto',false)  | map(attribute='image') | list | unique }}"
-  when: skip_pull_runtimes is not defined or skip_pull_runtimes != True
+  when: skip_pull_runtimes is not defined or not (skip_pull_runtimes == True or skip_pull_runtimes.lower() == "true")
   register: result
   until: (result.rc == 0)
   retries: "{{ docker.pull.retries }}"
@@ -40,7 +40,7 @@
 - name: "pull blackboxes action images per manifest"
   shell: "docker pull {{runtimes_registry | default()}}{{item.prefix}}/{{item.name}}:{{item.tag | default()}}"
   loop: "{{ runtimesManifest.blackboxes }}"
-  when: skip_pull_runtimes is not defined or skip_pull_runtimes != True
+  when: skip_pull_runtimes is not defined or not (skip_pull_runtimes == True or skip_pull_runtimes.lower() == "true")
   register: result
   until: (result.rc == 0)
   retries: "{{ docker.pull.retries }}"

--- a/docs/actions-ruby.md
+++ b/docs/actions-ruby.md
@@ -34,7 +34,7 @@ with the following source code:
 def main(args)
   name = args["name"] || "stranger"
   greeting = "Hello #{name}!"
-  print greeting
+  puts greeting
   { "greeting" => greeting }
 end
 ```

--- a/tests/src/test/resources/application.conf.j2
+++ b/tests/src/test/resources/application.conf.j2
@@ -1,3 +1,6 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
 whisk.spi {
   SimpleSpi = whisk.spi.SimpleSpiImpl
   MissingSpi = whisk.spi.MissingImpl

--- a/tools/travis/README.md
+++ b/tools/travis/README.md
@@ -33,4 +33,4 @@ These jobs make use of following scripts
 4. `setupSystem.sh` - Runs the various containers which are part of an OpenWhisk setup like Controller, Invoker etc.
 5. `runTests.sh` - Runs the tests. It make use of `ORG_GRADLE_PROJECT_testSetName` env setting to determine which test
    suite to run.
-6. `checkAndUploadLogs.sh` -  Collect the logs, check them and then upload them https://app.box.com/v/openwhisk-travis-logs
+6. `checkAndUploadLogs.sh` -  Collects the logs, checks them and uploads them to https://openwhisk.box.com/v/travis-logs.


### PR DESCRIPTION
This change is to allow for a small convenience: `redo invoker -e skip_pull_runtimes=true` and `redo invoker -xd -e "{skip_pull_runtimes: True}"` will now be accepted (this is because passing boolean variables through ansible requires using JSON.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [x] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

