### PR TITLE
Fix max.poll.interval.ms setting of KafkaConsumer.

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -72,7 +72,7 @@ whisk {
             heartbeat-interval-ms = 10000
             enable-auto-commit = false
             auto-offset-reset = earliest
-            max-poll-interval = 360000
+            max-poll-interval-ms = 900000 // 20 minutes
             // This value controls the server-side wait time which affects polling latency.
             // A low value improves latency performance but it is important to not set it too low
             // as that will cause excessive busy-waiting.

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -72,7 +72,12 @@ whisk {
             heartbeat-interval-ms = 10000
             enable-auto-commit = false
             auto-offset-reset = earliest
-            max-poll-interval-ms = 900000 // 20 minutes
+
+            // request-timeout-ms always needs to be larger than max-poll-interval-ms per
+            // https://kafka.apache.org/documentation/#upgrade_1010_notable
+            max-poll-interval-ms = 1800000 // 30 minutes
+            request-timeout-ms = 1860000 // 31 minutes
+
             // This value controls the server-side wait time which affects polling latency.
             // A low value improves latency performance but it is important to not set it too low
             // as that will cause excessive busy-waiting.

--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaConsumerConnector.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaConsumerConnector.scala
@@ -127,6 +127,8 @@ class KafkaConsumerConnector(
       configMapToKafkaConfig(loadConfigOrThrow[Map[String, String]](ConfigKeys.kafkaCommon)) ++
       configMapToKafkaConfig(loadConfigOrThrow[Map[String, String]](ConfigKeys.kafkaConsumer))
 
+    verifyConfig(config, ConsumerConfig.configNames().asScala.toSet)
+
     val consumer = new KafkaConsumer(config, new ByteArrayDeserializer, new ByteArrayDeserializer)
     consumer.subscribe(Seq(topic).asJavaCollection)
     consumer

--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaMessagingProvider.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaMessagingProvider.scala
@@ -112,10 +112,10 @@ object KafkaConfiguration {
   def verifyConfig(config: Map[String, String], validKeys: Set[String])(implicit logging: Logging): Boolean = {
     val passedKeys = config.keySet
     val knownKeys = validKeys intersect passedKeys
-    val unknownSettings = config -- knownKeys
+    val unknownKeys = passedKeys -- knownKeys
 
-    if (unknownSettings.nonEmpty) {
-      logging.warn(this, s"potential misconfiguration, unknown settings: ${unknownSettings.mkString(",")}")
+    if (unknownKeys.nonEmpty) {
+      logging.warn(this, s"potential misconfiguration, unknown settings: ${unknownKeys.mkString(",")}")
       false
     } else {
       true

--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaMessagingProvider.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaMessagingProvider.scala
@@ -101,4 +101,24 @@ object KafkaConfiguration {
   def configMapToKafkaConfig(configMap: Map[String, String]): Map[String, String] = configMap.map {
     case (key, value) => configToKafkaKey(key) -> value
   }
+
+  /**
+   * Prints a warning for each unknown configuration item and returns false if at least one item is unknown.
+   *
+   * @param config the config to be checked
+   * @param validKeys known valid keys to configure
+   * @return true if all configuration keys are known, false if at least one is unknown
+   */
+  def verifyConfig(config: Map[String, String], validKeys: Set[String])(implicit logging: Logging): Boolean = {
+    val passedKeys = config.keySet
+    val knownKeys = validKeys intersect passedKeys
+    val unknownSettings = config -- knownKeys
+
+    if (unknownSettings.nonEmpty) {
+      logging.warn(this, s"potential misconfiguration, unknown settings: ${unknownSettings.mkString(",")}")
+      false
+    } else {
+      true
+    }
+  }
 }

--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaProducerConnector.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaProducerConnector.scala
@@ -29,6 +29,7 @@ import whisk.core.ConfigKeys
 import whisk.core.connector.{Message, MessageProducer}
 import whisk.core.entity.UUIDs
 
+import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.concurrent.{blocking, ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success}
@@ -95,6 +96,8 @@ class KafkaProducerConnector(kafkahosts: String, id: String = UUIDs.randomUUID()
     val config = Map(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> kafkahosts) ++
       configMapToKafkaConfig(loadConfigOrThrow[Map[String, String]](ConfigKeys.kafkaCommon)) ++
       configMapToKafkaConfig(loadConfigOrThrow[Map[String, String]](ConfigKeys.kafkaProducer))
+
+    verifyConfig(config, ProducerConfig.configNames().asScala.toSet)
 
     new KafkaProducer(config, new StringSerializer, new StringSerializer)
   }

--- a/tests/src/test/scala/services/KafkaConnectorTests.scala
+++ b/tests/src/test/scala/services/KafkaConnectorTests.scala
@@ -55,6 +55,7 @@ class KafkaConnectorTests
   val groupid = "kafkatest"
   val topic = "KafkaConnectorTestTopic"
   val maxPollInterval = 10.seconds
+  System.setProperty("whisk.kafka.consumer.max-poll-interval-ms", maxPollInterval.toMillis.toString)
 
   // Need to overwrite replication factor for tests that shut down and start
   // Kafka instances intentionally. These tests will fail if there is more than


### PR DESCRIPTION
The `max.poll.interval.ms` setting needs to be high enough to not be thrown off by all actions in the system consuming the maximum duration of their respective action timeout, ideally also adding enough slack to account for image pulls taking long, or docker runs being very slow.

The name of the setting was also misspelled so we've been running on the default.


<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [X] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).

