### PR TITLE
Allow raw JSON string as response for webaction without base64 encoding.

### DIFF
--- a/tests/dat/actions/echo-web-http.js
+++ b/tests/dat/actions/echo-web-http.js
@@ -2,11 +2,9 @@
 // license agreements; and to You under the Apache License, Version 2.0.
 
 function main(params) {
-    var bodyobj = params || {};
-    bodystr = JSON.stringify(bodyobj);
     return {
         statusCode: 200,
         headers: { 'Content-Type': 'application/json' },
-        body: new Buffer(bodystr).toString('base64')
+        body: params
     };
 }

--- a/tests/dat/actions/jsonStringWebAction.js
+++ b/tests/dat/actions/jsonStringWebAction.js
@@ -7,6 +7,6 @@ function main() {
             "content-type": "application/json"
         },
         statusCode: 200,
-        body: new Buffer(JSON.stringify({'status': 'success'})).toString('base64')
+        body: '{"status": "success"}'
     }
 }

--- a/tests/src/test/scala/whisk/core/cli/test/ApiGwRestBasicTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/ApiGwRestBasicTests.scala
@@ -97,7 +97,7 @@ abstract class ApiGwRestBasicTests extends BaseApiGwTests {
   }
 
   def verifyApiGet(rr: RunResult): Unit = {
-    rr.stdout should include regex (s""""operationId":\\s+"getPathWithSub_pathsInIt"""")
+    rr.stdout should include regex (s""""operationId":\\s*"getPathWithSub_pathsInIt"""")
   }
 
   def verifyApiFullList(rr: RunResult,

--- a/tests/src/test/scala/whisk/core/cli/test/ApiGwRestTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/ApiGwRestTests.scala
@@ -142,7 +142,7 @@ class ApiGwRestTests extends ApiGwRestBasicTests with RestUtil with WskActorSyst
   }
 
   override def verifyApiGet(rr: RunResult): Unit = {
-    rr.stdout should include(s""""operationId":"getPathWithSub_pathsInIt"""")
+    rr.stdout should include regex (s""""operationId":\\s*"getPathWithSub_pathsInIt"""")
   }
 
   override def verifyApiFullList(rr: RunResult,
@@ -202,7 +202,7 @@ class ApiGwRestTests extends ApiGwRestBasicTests with RestUtil with WskActorSyst
     val openwhisk = RestResult.getFieldJsObject(urlop, "x-openwhisk")
     val actionN = RestResult.getField(openwhisk, "action")
     actionN shouldBe actionName
-    rr.stdout should include regex (s""""target-url":".*${actionName}.${responseType}"""")
+    rr.stdout should include regex (s""""target-url":\\s*".*${actionName}.${responseType}"""")
   }
 
   override def verifyInvalidSwagger(rr: RunResult): Unit = {

--- a/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
@@ -265,9 +265,9 @@ class WskWebActionsTests extends TestHelpers with WskTestHelpers with RestUtil w
     new Header("Set-Cookie", "c=d"))
   }
 
-  it should "handle http web action with base64 encoded response" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "base64Web"
-    val file = Some(TestUtils.getTestActionFilename("base64Web.js"))
+  it should "handle http web action returning JSON as string" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "jsonStringWebAction"
+    val file = Some(TestUtils.getTestActionFilename("jsonStringWebAction.js"))
     val host = getServiceURL
     val url = host + s"$testRoutePath/$namespace/default/$name.http"
 


### PR DESCRIPTION
For legacy reasons, we required web actions to return a base 64 encoded string when returning JSON. This PR removes the requirement to base64 encode JSON if returning the result as string. This is based on a slack discussion with @csantanapr (as reported from an end-user).

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [x] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

