### PR TITLE
Improve robustness of KafkaConsumerConnector

### DIFF
--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaConsumerConnector.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaConsumerConnector.scala
@@ -155,8 +155,7 @@ class KafkaConsumerConnector(
   private def recreateConsumer(): Unit = {
     logging.info(this, s"recreating consumer for '$topic'")
     try {
-      val oldConsumer = consumer
-      oldConsumer.close()
+      consumer.close()
     } catch {
       // According to documentation, the consumer is force closed if it cannot be closed gracefully.
       // See https://kafka.apache.org/11/javadoc/index.html?org/apache/kafka/clients/consumer/KafkaConsumer.html

--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaConsumerConnector.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaConsumerConnector.scala
@@ -31,6 +31,7 @@ import whisk.core.connector.MessageConsumer
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.concurrent.{blocking, ExecutionContext, Future}
+import scala.util.Failure
 
 case class KafkaConsumerConfig(sessionTimeoutMs: Long, metricFlushIntervalS: Int)
 
@@ -66,11 +67,16 @@ class KafkaConsumerConnector(
                     retry: Int = 3): Iterable[(String, Int, Long, Array[Byte])] = {
 
     // poll can be infinitely blocked in edge-cases, so we need to wakeup explicitly.
-    val wakeUpTask = actorSystem.scheduler.scheduleOnce(cfg.sessionTimeoutMs.milliseconds + 1.second)(consumer.wakeup())
+    val wakeUpTask = actorSystem.scheduler.scheduleOnce(cfg.sessionTimeoutMs.milliseconds + 1.second) {
+      consumer.wakeup()
+      logging.info(this, s"woke up consumer for topic '${topic}'")
+    }
 
     try {
       val response = consumer.poll(duration.toMillis).asScala
       val now = System.currentTimeMillis
+
+      wakeUpTask.cancel()
 
       response.lastOption.foreach(record => offset = record.offset + 1)
       response.map { r =>
@@ -79,21 +85,31 @@ class KafkaConsumerConnector(
         (r.topic, r.partition, r.offset, r.value)
       }
     } catch {
-      // Happens if the peek hangs.
       case _: WakeupException if retry > 0 =>
+        // Happens if the 'poll()' takes too long.
+        // This exception should occur iff 'poll()' has been woken up by the scheduled task.
+        // For this reason, it should not necessary to cancel the task. We cancel the task
+        // to be on the safe side because an ineffective `wakeup()` applies to the next
+        // consumer call that can be woken up.
+        // The scheduler is expected to safely ignore the cancellation of a task that already
+        // has been cancelled or is already complete.
+        wakeUpTask.cancel()
         logging.error(this, s"poll timeout occurred. Retrying $retry more times.")
         Thread.sleep(gracefulWaitTime.toMillis) // using Thread.sleep is okay, since `poll` is blocking anyway
         peek(duration, retry - 1)
       case e: RetriableException if retry > 0 =>
-        logging.error(this, s"$e: Retrying $retry more times")
+        // Happens if something goes wrong with 'poll()' and 'poll()' can be retried.
         wakeUpTask.cancel()
+        logging.error(this, s"poll returned with failure. Retrying $retry more times. Exception: ${e}")
         Thread.sleep(gracefulWaitTime.toMillis) // using Thread.sleep is okay, since `poll` is blocking anyway
         peek(duration, retry - 1)
-      // Every other error results in a restart of the consumer
       case e: Throwable =>
+        // Every other error results in a restart of the consumer
+        wakeUpTask.cancel()
+        logging.error(this, s"poll returned with failure. Retrying $retry more times. Exception: ${e}")
         recreateConsumer()
         throw e
-    } finally wakeUpTask.cancel()
+    }
   }
 
   /**
@@ -114,8 +130,8 @@ class KafkaConsumerConnector(
     }
 
   override def close(): Unit = {
+    logging.info(this, s"closing consumer for '$topic'")
     consumer.close()
-    logging.info(this, s"closing '$topic' consumer")
   }
 
   /** Creates a new kafka consumer and subscribes to topic list if given. */
@@ -135,9 +151,21 @@ class KafkaConsumerConnector(
   }
 
   private def recreateConsumer(): Unit = {
-    val oldConsumer = consumer
-    oldConsumer.close()
-    logging.info(this, s"old consumer closed")
+    logging.info(this, s"recreating consumer for '$topic'")
+    try {
+      val oldConsumer = consumer
+      oldConsumer.close()
+    } catch {
+      // According to documentation, the consumer is force closed if it cannot be closed gracefully.
+      // See https://kafka.apache.org/11/javadoc/index.html?org/apache/kafka/clients/consumer/KafkaConsumer.html
+      //
+      // For the moment, we are ignoring 'InterruptException' which indicates that the thread has been
+      // interrupted while running 'close()'.
+      //
+      case t: Throwable =>
+        logging.error(this, s"failed to close old consumer while recreating: ${t}")
+    }
+    logging.info(this, s"old consumer closed for '$topic'")
     consumer = createConsumer(topic)
   }
 
@@ -157,6 +185,10 @@ class KafkaConsumerConnector(
           }
         }
       }
+    }.andThen {
+      case Failure(e) =>
+        // Only log level info because failed metric reporting is not critical
+        logging.info(this, s"lag metric reporting failed for topic '${topic}': ${e}")
     }
   }
 }


### PR DESCRIPTION
* We schedule a wake-up thread once to wake up the long `poll()` call if it takes too long. Make sure that this wake-up thread is cancelled as soon as possible once the `poll()` has returned - no matter whether it was successful or not. Otherwise the wake-up will be remembered by the consumer and applied on the next `poll()`. See https://kafka.apache.org/11/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html#endOffsets-java.util.Collection-
* Catch failures when closing the old consumer during re-creation. In the past, re-creation was interrupted when closing failed and no new consumer was created.
* Add more logging such that unexpected or error conditions no more happen unnoticed.


<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [x] Message Bus (e.g., Kafka)

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
