### PR TITLE
Bump Kafka's fetch.max.wait duration and adjust poll's timeout.

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -81,7 +81,7 @@ whisk {
             // This value controls the server-side wait time which affects polling latency.
             // A low value improves latency performance but it is important to not set it too low
             // as that will cause excessive busy-waiting.
-            fetch-max-wait-ms = 20
+            fetch-max-wait-ms = 500
             metric-flush-interval-s = 60
         }
 

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
@@ -108,7 +108,7 @@ class InvokerReactive(
     maxPollInterval = TimeLimit.MAX_DURATION + 1.minute)
 
   private val activationFeed = actorSystem.actorOf(Props {
-    new MessageFeed("activation", logging, consumer, maximumContainers, 500.milliseconds, processActivationMessage)
+    new MessageFeed("activation", logging, consumer, maximumContainers, 1.second, processActivationMessage)
   })
 
   /** Sends an active-ack. */


### PR DESCRIPTION
Kafka's `fetch.max.wait` duration determines how long the server will wait to send a response if *no record is present*.
The timeout set on `poll` determines how long the client blocks if *no record is present*.

Note that both of these only block if no records are present. Latency should not be impacted, if records are arriving quickly, as both of these timeouts will not apply if records are already there.

The `fetch.max.wait` duration determines how often Kafka is queried though. Big systems can slow down Kafka even by the amount of polling that is happening, even if all the topics are empty.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [X] Message Bus (e.g., Kafka)

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).

