### PR TITLE
Fix CacheConcurrencyTest cleanup.

### DIFF
--- a/tests/src/test/scala/whisk/core/database/test/CacheConcurrencyTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/CacheConcurrencyTests.scala
@@ -33,7 +33,7 @@ import whisk.common.TransactionId
 import whisk.utils.retry
 
 @RunWith(classOf[JUnitRunner])
-class CacheConcurrencyTests extends FlatSpec with WskTestHelpers with WskActorSystem with BeforeAndAfterEach {
+class CacheConcurrencyTests extends FlatSpec with WskTestHelpers with BeforeAndAfterEach with WskActorSystem {
 
   println(s"Running tests on # proc: ${Runtime.getRuntime.availableProcessors()}")
 


### PR DESCRIPTION
This test prints the usual `Abrupt termination` messages known due to an unsafe shutdown of the ActorSystem. `afterAll` of `WskActorSystem` should provide a stable cleanup mechanism but to do so `BeforeAndAfterAll` needs to be the last entry in the extension-list to make `super` do the right thing.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [X] Tests

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes. (hrhr)

