### PR TITLE
eliminate setting of COMPONENT_NAME

### DIFF
--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -123,7 +123,6 @@
       "CONTROLLER_INSTANCES": "{{ controller.instances }}"
       "JMX_REMOTE": "{{ jmx.enabled }}"
 
-      "COMPONENT_NAME": "{{ controller_name }}"
       "PORT": 8080
 
       "CONFIG_whisk_info_date": "{{ whisk.version.date }}"

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -167,7 +167,6 @@
       "JAVA_OPTS": "-Xmx{{ invoker.heap }} -XX:+CrashOnOutOfMemoryError -XX:+UseGCOverheadLimit -XX:ErrorFile=/logs/java_error.log"
       "INVOKER_OPTS": "{{ invoker_args | default(invoker.arguments) }}"
       "JMX_REMOTE": "{{ jmx.enabled }}"
-      "COMPONENT_NAME": "{{ invoker_name }}"
       "PORT": 8080
       "KAFKA_HOSTS": "{{ kafka_connect_string }}"
       "CONFIG_whisk_kafka_replicationFactor": "{{ kafka.replicationFactor | default() }}"


### PR DESCRIPTION
Small cleanup: As best as I can tell, this envvar is set when deploying the
invoker/controller but the value is never actually used.
