### PR TITLE
Adjust Kafka's config to not contain any more warnings.

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -58,6 +58,10 @@ whisk {
     kafka {
         replication-factor = 1
 
+        // Used to control the cadence of the consumer lag check interval
+        consumer-lag-check-interval = 60 seconds
+
+        // The following settings are passed "raw" to the respective Kafka client. Dashes are replaced by dots.
         common {
             security-protocol = PLAINTEXT
             ssl-endpoint-identification-algorithm = "" // restores pre-kafka 2.0.0 default
@@ -81,9 +85,6 @@ whisk {
             // A low value improves latency performance but it is important to not set it too low
             // as that will cause excessive busy-waiting.
             fetch-max-wait-ms = 20
-
-            // Used to control the window size of kafka metric reporting and cadence of consumer lag checking
-            metrics-sample-window-ms = 60000 // 60 seconds
         }
 
         topics {

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -81,7 +81,9 @@ whisk {
             // A low value improves latency performance but it is important to not set it too low
             // as that will cause excessive busy-waiting.
             fetch-max-wait-ms = 20
-            metric-flush-interval-s = 60
+
+            // Used to control the window size of kafka metric reporting and cadence of consumer lag checking
+            metrics-sample-window-ms = 60000 // 60 seconds
         }
 
         topics {

--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaConsumerConnector.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaConsumerConnector.scala
@@ -34,7 +34,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{blocking, ExecutionContext, Future}
 import scala.util.Failure
 
-case class KafkaConsumerConfig(sessionTimeoutMs: Long, metricsSampleWindowMs: Long)
+case class KafkaConsumerConfig(sessionTimeoutMs: Long)
 
 class KafkaConsumerConnector(
   kafkahost: String,
@@ -175,7 +175,7 @@ class KafkaConsumerConnector(
   // Read current lag of the consumed topic, e.g. invoker queue
   // Since we use only one partition in kafka, it is defined 0
   Scheduler.scheduleWaitAtMost(
-    interval = cfg.metricsSampleWindowMs.milliseconds,
+    interval = loadConfigOrThrow[KafkaConfig](ConfigKeys.kafka).consumerLagCheckInterval,
     initialDelay = 10.seconds,
     name = "kafka-lag-monitor") { () =>
     Future {

--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaConsumerConnector.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaConsumerConnector.scala
@@ -34,7 +34,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{blocking, ExecutionContext, Future}
 import scala.util.Failure
 
-case class KafkaConsumerConfig(sessionTimeoutMs: Long, metricFlushIntervalS: Int)
+case class KafkaConsumerConfig(sessionTimeoutMs: Long, metricsSampleWindowMs: Long)
 
 class KafkaConsumerConnector(
   kafkahost: String,
@@ -174,7 +174,10 @@ class KafkaConsumerConnector(
 
   // Read current lag of the consumed topic, e.g. invoker queue
   // Since we use only one partition in kafka, it is defined 0
-  Scheduler.scheduleWaitAtMost(cfg.metricFlushIntervalS.seconds, 10.seconds, "kafka-lag-monitor") { () =>
+  Scheduler.scheduleWaitAtMost(
+    interval = cfg.metricsSampleWindowMs.milliseconds,
+    initialDelay = 10.seconds,
+    name = "kafka-lag-monitor") { () =>
     Future {
       blocking {
         if (offset > 0) {

--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaMessagingProvider.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaMessagingProvider.scala
@@ -31,7 +31,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
-case class KafkaConfig(replicationFactor: Short)
+case class KafkaConfig(replicationFactor: Short, consumerLagCheckInterval: FiniteDuration)
 
 /**
  * A Kafka based implementation of MessagingProvider


### PR DESCRIPTION
Currently, the KafkaConsumer warns about a misconfiguration because we added a fantasy value to the kafka config itself. There is a value to control the window size of metrics reporting which roughly fits the needs of the value we need, thus switching to that value also gets rid of the warning in the log.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [X] Message Bus (e.g., Kafka)

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).

