### PR TITLE
make error count and percentage configurable for gatling tests

### DIFF
--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -114,7 +114,7 @@ MAX_ERRORS_ALLOWED_PERCENTAGE (default: 0)
 ```
 
 It is possible to override the `MEAN_RESPONSE_TIME`, `MAX_MEAN_RESPONSE_TIME`, `MAX_ERRORS_ALLOWED` and `MAX_ERRORS_ALLOWED_PERCENTAGE`
-for each kind by adding the kind as perfix in upper case, like `JAVA_MEAN_RESPONSE_TIME`.
+for each kind by adding the kind as prefix in upper case, like `JAVA_MEAN_RESPONSE_TIME`.
 
 
 You can run the simulation with (in OPENWHISK_HOME)

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -70,11 +70,13 @@ The test is doing as many requests as possible for the given amount of time (`SE
 Available environment variables:
 
 ```
-OPENWHISK_HOST          (required)
-CONNECTIONS             (required)
-SECONDS                 (default: 10)
-REQUESTS_PER_SEC        (required)
-MIN_REQUESTS_PER_SEC    (default: REQUESTS_PER_SEC)
+OPENWHISK_HOST                (required)
+CONNECTIONS                   (required)
+SECONDS                       (default: 10)
+REQUESTS_PER_SEC              (required)
+MIN_REQUESTS_PER_SEC          (default: REQUESTS_PER_SEC)
+MAX_ERRORS_ALLOWED            (default: 0)
+MAX_ERRORS_ALLOWED_PERCENTAGE (default: 0)
 ```
 
 You can run the simulation with (in OPENWHISK_HOME)
@@ -101,13 +103,19 @@ The comparison of the thresholds is against the mean response times of the warm 
 Available environment variables:
 
 ```
-OPENWHISK_HOST          (required)
-API_KEY                 (required, format: UUID:KEY)
-PAUSE_BETWEEN_INVOKES   (default: 0)
-MEAN_RESPONSE_TIME      (required)
-MAX_MEAN_RESPONSE_TIME  (default: MEAN_RESPONSE_TIME)
-EXCLUDED_KINDS          (default: "", format: "python:default,java:default,swift:default")
+OPENWHISK_HOST                (required)
+API_KEY                       (required, format: UUID:KEY)
+PAUSE_BETWEEN_INVOKES         (default: 0)
+MEAN_RESPONSE_TIME            (required)
+MAX_MEAN_RESPONSE_TIME        (default: MEAN_RESPONSE_TIME)
+EXCLUDED_KINDS                (default: "", format: "python:default,java:default,swift:default")
+MAX_ERRORS_ALLOWED            (default: 0)
+MAX_ERRORS_ALLOWED_PERCENTAGE (default: 0)
 ```
+
+It is possible to override the `MEAN_RESPONSE_TIME`, `MAX_MEAN_RESPONSE_TIME`, `MAX_ERRORS_ALLOWED` and `MAX_ERRORS_ALLOWED_PERCENTAGE`
+for each kind by adding the kind as perfix in upper case, like `JAVA_MEAN_RESPONSE_TIME`.
+
 
 You can run the simulation with (in OPENWHISK_HOME)
 ```
@@ -130,12 +138,14 @@ The test is doing as many requests as possible for the given amount of time (`SE
 
 Available environment variables:
 ```
-OPENWHISK_HOST          (required)
-API_KEY                 (required, format: UUID:KEY)
-CONNECTIONS             (required)
-SECONDS                 (default: 10)
-REQUESTS_PER_SEC        (required)
-MIN_REQUESTS_PER_SEC    (default: REQUESTS_PER_SEC)
+OPENWHISK_HOST                (required)
+API_KEY                       (required, format: UUID:KEY)
+CONNECTIONS                   (required)
+SECONDS                       (default: 10)
+REQUESTS_PER_SEC              (required)
+MIN_REQUESTS_PER_SEC          (default: REQUESTS_PER_SEC)
+MAX_ERRORS_ALLOWED            (default: 0)
+MAX_ERRORS_ALLOWED_PERCENTAGE (default: 0)
 ```
 
 You can run the simulation with

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -160,11 +160,13 @@ The test is doing as many requests as possible for the given amount of time (`SE
 
 Available environment variables:
 ```
-OPENWHISK_HOST          (required)
-USERS                   (required)
-SECONDS                 (default: 10)
-REQUESTS_PER_SEC        (required)
-MIN_REQUESTS_PER_SEC    (default: REQUESTS_PER_SEC)
+OPENWHISK_HOST                (required)
+USERS                         (required)
+SECONDS                       (default: 10)
+REQUESTS_PER_SEC              (required)
+MIN_REQUESTS_PER_SEC          (default: REQUESTS_PER_SEC)
+MAX_ERRORS_ALLOWED            (default: 0)
+MAX_ERRORS_ALLOWED_PERCENTAGE (default: 0)
 ```
 
 You can run the simulation with

--- a/tests/performance/gatling_tests/src/gatling/scala/ApiV1Simulation.scala
+++ b/tests/performance/gatling_tests/src/gatling/scala/ApiV1Simulation.scala
@@ -30,6 +30,8 @@ class ApiV1Simulation extends Simulation {
   // Specify thresholds
   val requestsPerSec = sys.env("REQUESTS_PER_SEC").toInt
   val minimalRequestsPerSec = sys.env.getOrElse("MIN_REQUESTS_PER_SEC", requestsPerSec.toString).toInt
+  val maxErrorsAllowed: Int = sys.env.getOrElse("MAX_ERRORS_ALLOWED", "0").toInt
+  val maxErrorsAllowedPercentage: Double = sys.env.getOrElse("MAX_ERRORS_ALLOWED_PERCENTAGE", "0.1").toDouble
 
   // Generate the OpenWhiskProtocol
   val openWhiskProtocol = openWhisk.apiHost(host)
@@ -46,6 +48,6 @@ class ApiV1Simulation extends Simulation {
     .assertions(details("Call api/v1 endpoint").requestsPerSec.gt(minimalRequestsPerSec))
     .assertions(details("Call api/v1 endpoint").requestsPerSec.gt(requestsPerSec))
     // Mark the build yellow, if there are failed requests. And red if both conditions fail.
-    .assertions(details("Call api/v1 endpoint").failedRequests.count.is(0))
-    .assertions(details("Call api/v1 endpoint").failedRequests.percent.lte(0.1))
+    .assertions(details("Call api/v1 endpoint").failedRequests.count.lte(maxErrorsAllowed))
+    .assertions(details("Call api/v1 endpoint").failedRequests.percent.lte(maxErrorsAllowedPercentage))
 }

--- a/tests/performance/gatling_tests/src/gatling/scala/BlockingInvokeOneActionSimulation.scala
+++ b/tests/performance/gatling_tests/src/gatling/scala/BlockingInvokeOneActionSimulation.scala
@@ -39,6 +39,8 @@ class BlockingInvokeOneActionSimulation extends Simulation {
   // Specify thresholds
   val requestsPerSec: Int = sys.env("REQUESTS_PER_SEC").toInt
   val minimalRequestsPerSec: Int = sys.env.getOrElse("MIN_REQUESTS_PER_SEC", requestsPerSec.toString).toInt
+  val maxErrorsAllowed: Int = sys.env.getOrElse("MAX_ERRORS_ALLOWED", "0").toInt
+  val maxErrorsAllowedPercentage: Double = sys.env.getOrElse("MAX_ERRORS_ALLOWED_PERCENTAGE", "0.1").toDouble
 
   // Generate the OpenWhiskProtocol
   val openWhiskProtocol: OpenWhiskProtocolBuilder = openWhisk.apiHost(host)
@@ -74,6 +76,6 @@ class BlockingInvokeOneActionSimulation extends Simulation {
     .assertions(details("Invoke action").requestsPerSec.gt(minimalRequestsPerSec))
     .assertions(details("Invoke action").requestsPerSec.gt(requestsPerSec))
     // Mark the build yellow, if there are failed requests. And red if both conditions fail.
-    .assertions(details("Invoke action").failedRequests.count.is(0))
-    .assertions(details("Invoke action").failedRequests.percent.lte(0.1))
+    .assertions(details("Invoke action").failedRequests.count.lte(maxErrorsAllowed))
+    .assertions(details("Invoke action").failedRequests.percent.lte(maxErrorsAllowedPercentage))
 }

--- a/tests/performance/gatling_tests/src/gatling/scala/ColdBlockingInvokeSimulation.scala
+++ b/tests/performance/gatling_tests/src/gatling/scala/ColdBlockingInvokeSimulation.scala
@@ -38,6 +38,9 @@ class ColdBlockingInvokeSimulation extends Simulation {
   // Specify thresholds
   val requestsPerSec: Int = sys.env("REQUESTS_PER_SEC").toInt
   val minimalRequestsPerSec: Int = sys.env.getOrElse("MIN_REQUESTS_PER_SEC", requestsPerSec.toString).toInt
+  val maxErrorsAllowed: Int = sys.env.getOrElse("MAX_ERRORS_ALLOWED", "0").toInt
+  val maxErrorsAllowedPercentage: Double = sys.env.getOrElse("MAX_ERRORS_ALLOWED_PERCENTAGE", "0").toDouble
+
 
   // Generate the OpenWhiskProtocol
   val openWhiskProtocol: OpenWhiskProtocolBuilder = openWhisk.apiHost(host)
@@ -85,6 +88,6 @@ class ColdBlockingInvokeSimulation extends Simulation {
     .assertions(details("Invoke action").requestsPerSec.gt(minimalRequestsPerSec))
     .assertions(details("Invoke action").requestsPerSec.gt(requestsPerSec))
     // Mark the build yellow, if there are failed requests. And red if both conditions fail.
-    .assertions(details("Invoke action").failedRequests.count.is(0))
-    .assertions(details("Invoke action").failedRequests.percent.lte(0.1))
+    .assertions(details("Invoke action").failedRequests.count.lte(maxErrorsAllowed))
+    .assertions(details("Invoke action").failedRequests.percent.lte(maxErrorsAllowedPercentage))
 }

--- a/tests/performance/gatling_tests/src/gatling/scala/ColdBlockingInvokeSimulation.scala
+++ b/tests/performance/gatling_tests/src/gatling/scala/ColdBlockingInvokeSimulation.scala
@@ -39,7 +39,7 @@ class ColdBlockingInvokeSimulation extends Simulation {
   val requestsPerSec: Int = sys.env("REQUESTS_PER_SEC").toInt
   val minimalRequestsPerSec: Int = sys.env.getOrElse("MIN_REQUESTS_PER_SEC", requestsPerSec.toString).toInt
   val maxErrorsAllowed: Int = sys.env.getOrElse("MAX_ERRORS_ALLOWED", "0").toInt
-  val maxErrorsAllowedPercentage: Double = sys.env.getOrElse("MAX_ERRORS_ALLOWED_PERCENTAGE", "0").toDouble
+  val maxErrorsAllowedPercentage: Double = sys.env.getOrElse("MAX_ERRORS_ALLOWED_PERCENTAGE", "0.1").toDouble
 
 
   // Generate the OpenWhiskProtocol

--- a/tests/performance/gatling_tests/src/gatling/scala/ColdBlockingInvokeSimulation.scala
+++ b/tests/performance/gatling_tests/src/gatling/scala/ColdBlockingInvokeSimulation.scala
@@ -41,7 +41,6 @@ class ColdBlockingInvokeSimulation extends Simulation {
   val maxErrorsAllowed: Int = sys.env.getOrElse("MAX_ERRORS_ALLOWED", "0").toInt
   val maxErrorsAllowedPercentage: Double = sys.env.getOrElse("MAX_ERRORS_ALLOWED_PERCENTAGE", "0.1").toDouble
 
-
   // Generate the OpenWhiskProtocol
   val openWhiskProtocol: OpenWhiskProtocolBuilder = openWhisk.apiHost(host)
 

--- a/tests/performance/gatling_tests/src/gatling/scala/LatencySimulation.scala
+++ b/tests/performance/gatling_tests/src/gatling/scala/LatencySimulation.scala
@@ -35,9 +35,17 @@ class LatencySimulation extends Simulation {
 
   val pauseBetweenInvokes: Int = sys.env.getOrElse("PAUSE_BETWEEN_INVOKES", "0").toInt
 
+  val MEAN_RESPONSE_TIME = "MEAN_RESPONSE_TIME"
+  val MAX_MEAN_RESPONSE_TIME = "MAX_MEAN_RESPONSE_TIME"
+  val MAX_ERRORS_ALLOWED = "MAX_ERRORS_ALLOWED"
+  val MAX_ERRORS_ALLOWED_PERCENTAGE = "MAX_ERRORS_ALLOWED_PERCENTAGE"
+
   // Specify thresholds
-  val meanResponseTime: Int = sys.env("MEAN_RESPONSE_TIME").toInt
-  val maximalMeanResponseTime: Int = sys.env.getOrElse("MAX_MEAN_RESPONSE_TIME", meanResponseTime.toString).toInt
+  val meanResponseTime: Int = sys.env(MEAN_RESPONSE_TIME).toInt
+  val maximalMeanResponseTime: Int = sys.env.getOrElse(MAX_MEAN_RESPONSE_TIME, meanResponseTime.toString).toInt
+
+  val maxErrorsAllowed: Int = sys.env.getOrElse(MAX_ERRORS_ALLOWED, "0").toInt
+  val maxErrorsAllowedPercentage: Double = sys.env.getOrElse(MAX_ERRORS_ALLOWED_PERCENTAGE, "0.1").toDouble
 
   // Exclude runtimes
   val excludedKinds: Seq[String] = sys.env.getOrElse("EXCLUDED_KINDS", "").split(",")
@@ -91,14 +99,20 @@ class LatencySimulation extends Simulation {
     .protocols(openWhiskProtocol)
 
   actions
-    .map { case (kind, _, _, _) => s"Warm $kind invocation" }
-    .foldLeft(testSetup) { (agg, cur) =>
+    .map { case (kind, _, _, _) => kind }
+    .foldLeft(testSetup) { (agg, kind) =>
+      val cur = s"Warm $kind invocation"
       // One failure will make the build yellow
+      val mrt : Int = sys.env.getOrElse(kind.split(":").head.toUpperCase + "_" + MEAN_RESPONSE_TIME, meanResponseTime.toString).toInt
+      val maxrt = sys.env.getOrElse(kind.split(":").head.toUpperCase + "_" + MAX_MEAN_RESPONSE_TIME, maximalMeanResponseTime.toString).toInt
+      val maxerr = sys.env.getOrElse(kind.split(":").head.toUpperCase + "_" + MAX_ERRORS_ALLOWED, maxErrorsAllowed.toString).toInt
+      val maxerrp = sys.env.getOrElse(kind.split(":").head.toUpperCase + "_" + MAX_ERRORS_ALLOWED_PERCENTAGE, maxErrorsAllowedPercentage.toString).toDouble
+
       agg
-        .assertions(details(cur).responseTime.mean.lte(meanResponseTime))
-        .assertions(details(cur).responseTime.mean.lt(maximalMeanResponseTime))
+        .assertions(details(cur).responseTime.mean.lte(mrt))
+        .assertions(details(cur).responseTime.mean.lt(maxrt))
         // Mark the build yellow, if there are failed requests. And red if both conditions fail.
-        .assertions(details(cur).failedRequests.count.is(0))
-        .assertions(details(cur).failedRequests.percent.lte(0.1))
+        .assertions(details(cur).failedRequests.count.lte(maxerr))
+        .assertions(details(cur).failedRequests.percent.lte(maxerrp))
     }
 }

--- a/tests/performance/gatling_tests/src/gatling/scala/LatencySimulation.scala
+++ b/tests/performance/gatling_tests/src/gatling/scala/LatencySimulation.scala
@@ -55,7 +55,6 @@ class LatencySimulation extends Simulation {
   // Generate the OpenWhiskProtocol
   val openWhiskProtocol = openWhisk.apiHost(host)
 
-
   /**
    * Generate a list of actions to execute. The list is a tuple of (kind, code, actionName, main)
    * `kind` is needed to create the action
@@ -101,16 +100,20 @@ class LatencySimulation extends Simulation {
   val testSetup = setUp(test.inject(atOnceUsers(1)))
     .protocols(openWhiskProtocol)
 
-
   actions
     .map { case (kind, _, _, _) => kind }
     .foldLeft(testSetup) { (agg, kind) =>
       val cur = s"Warm $kind invocation"
       // One failure will make the build yellow
-      val specificMeanResponseTime : Int = sys.env.getOrElse(toKindSpecificKey(kind,MEAN_RESPONSE_TIME), meanResponseTime.toString).toInt
-      val specificMaxMeanResponseTime = sys.env.getOrElse(toKindSpecificKey(kind,MAX_MEAN_RESPONSE_TIME), maximalMeanResponseTime.toString).toInt
-      val specificMaxErrorsAllowed = sys.env.getOrElse(toKindSpecificKey(kind,MAX_ERRORS_ALLOWED), maxErrorsAllowed.toString).toInt
-      val specificMaxErrorsAllowedPercentage = sys.env.getOrElse(toKindSpecificKey(kind,MAX_ERRORS_ALLOWED_PERCENTAGE), maxErrorsAllowedPercentage.toString).toDouble
+      val specificMeanResponseTime: Int =
+        sys.env.getOrElse(toKindSpecificKey(kind, MEAN_RESPONSE_TIME), meanResponseTime.toString).toInt
+      val specificMaxMeanResponseTime =
+        sys.env.getOrElse(toKindSpecificKey(kind, MAX_MEAN_RESPONSE_TIME), maximalMeanResponseTime.toString).toInt
+      val specificMaxErrorsAllowed =
+        sys.env.getOrElse(toKindSpecificKey(kind, MAX_ERRORS_ALLOWED), maxErrorsAllowed.toString).toInt
+      val specificMaxErrorsAllowedPercentage = sys.env
+        .getOrElse(toKindSpecificKey(kind, MAX_ERRORS_ALLOWED_PERCENTAGE), maxErrorsAllowedPercentage.toString)
+        .toDouble
 
       agg
         .assertions(details(cur).responseTime.mean.lte(specificMeanResponseTime))


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
Today the gatling tests hard code the amount and percentage of errors, like:
https://github.com/apache/incubator-openwhisk/blob/master/tests/performance/gatling_tests/src/gatling/scala/ColdBlockingInvokeSimulation.scala#L88

The PR is making the number of errors and percentage configurable per environment variable. For example during long running tests with lot of requests a certain amount of failure rate is acceptable.

I can extend this to other tests once first review is ok. Give me a ping...

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [x] I updated the documentation where necessary.

I've run a test that the parameters are recognised as expected.
```
OPENWHISK_HOST="xxxxxx" USERS="10" REQUESTS_PER_SEC="10" MAX_ERRORS_ALLOWED="1" MAX_ERRORS_ALLOWED_PERCENTAGE="0.1" ./gradlew gatlingRun-ColdBlockingInvokeSimulation
```

Result
```
Invoke action: mean requests per second is greater than 10.0 : true
Invoke action: count of failed requests is less than or equal to 1.0 : true
Invoke action: percentage of failed requests is less than or equal to 0.1 : true
```