### PR TITLE
Treat action code as attachments

### DIFF
--- a/ansible/files/runtimes.json
+++ b/ansible/files/runtimes.json
@@ -170,6 +170,10 @@
                     "prefix": "openwhisk",
                     "name": "action-php-v7.1",
                     "tag": "latest"
+                },
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
                 }
             },
             {
@@ -180,6 +184,10 @@
                     "prefix": "openwhisk",
                     "name": "action-php-v7.2",
                     "tag": "latest"
+                },
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
                 }
             }
         ],

--- a/ansible/files/runtimes.json
+++ b/ansible/files/runtimes.json
@@ -8,7 +8,11 @@
                     "name": "nodejsaction",
                     "tag": "latest"
                 },
-                "deprecated": true
+                "deprecated": true,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
             },
             {
                 "kind": "nodejs:6",
@@ -19,6 +23,10 @@
                     "tag": "latest"
                 },
                 "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                },
                 "stemCells": [{
                     "count": 2,
                     "memory": "256 MB"
@@ -32,7 +40,11 @@
                     "name": "action-nodejs-v8",
                     "tag": "latest"
                 },
-                "deprecated": false
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
             }
         ],
         "python": [
@@ -43,7 +55,11 @@
                     "name": "python2action",
                     "tag": "latest"
                 },
-                "deprecated": false
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
             },
             {
                 "kind": "python:2",
@@ -53,7 +69,11 @@
                     "name": "python2action",
                     "tag": "latest"
                 },
-                "deprecated": false
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
             },
             {
                 "kind": "python:3",
@@ -62,7 +82,11 @@
                     "name": "python3action",
                     "tag": "latest"
                 },
-                "deprecated": false
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
             }
         ],
         "swift": [
@@ -73,7 +97,11 @@
                     "name": "swiftaction",
                     "tag": "latest"
                 },
-                "deprecated": true
+                "deprecated": true,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
             },
             {
                 "kind": "swift:3",
@@ -82,7 +110,11 @@
                     "name": "swift3action",
                     "tag": "latest"
                 },
-                "deprecated": true
+                "deprecated": true,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
             },
             {
                 "kind": "swift:3.1.1",
@@ -91,7 +123,11 @@
                     "name": "action-swift-v3.1.1",
                     "tag": "latest"
                 },
-                "deprecated": false
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
             },
             {
                 "kind": "swift:4.1",
@@ -101,7 +137,11 @@
                     "name": "action-swift-v4.1",
                     "tag": "latest"
                 },
-                "deprecated": false
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
             }
         ],
         "java": [
@@ -115,8 +155,8 @@
                 },
                 "deprecated": false,
                 "attached": {
-                    "attachmentName": "jarfile",
-                    "attachmentType": "application/java-archive"
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
                 },
                 "requireMain": true
             }
@@ -148,6 +188,10 @@
                 "kind": "ruby:2.5",
                 "default": true,
                 "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                },
                 "image": {
                     "prefix": "openwhisk",
                     "name": "action-ruby-v2.5",

--- a/common/scala/src/main/scala/whisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Exec.scala
@@ -308,8 +308,9 @@ protected[core] object Exec extends ArgNormalizer[Exec] with DefaultJsonProtocol
           }
 
           manifest.attached
-            .map { a =>
-              val code = obj.fields.get("code")
+            .map { _ =>
+              // java actions once stored the attachment in "jar" instead of "code"
+              val code = obj.fields.get("code").orElse(obj.fields.get("jar"))
               val binary: Boolean = code match {
                 case Some(JsString(c)) => isBinaryCode(c)
                 case _ =>

--- a/common/scala/src/main/scala/whisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Exec.scala
@@ -300,9 +300,6 @@ protected[core] object Exec extends ArgNormalizer[Exec] with DefaultJsonProtocol
             case None    => throw new DeserializationException(s"kind '$kind' not in $runtimes")
           }
 
-          manifest.attached.map { _ =>
-            }
-
           manifest.attached
             .map { _ =>
               // java actions once stored the attachment in "jar" instead of "code"

--- a/common/scala/src/main/scala/whisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Exec.scala
@@ -30,8 +30,6 @@ import whisk.core.entity.size.SizeInt
 import whisk.core.entity.size.SizeOptionString
 import whisk.core.entity.size.SizeString
 
-import java.util.Base64
-
 /**
  * Exec encodes the executable details of an action. For black
  * box container, an image name is required. For Javascript and Python
@@ -153,13 +151,8 @@ protected[core] case class CodeExecAsAttachment(manifest: RuntimeManifest,
   override def codeAsJson = code.toJson
 
   def inline(bytes: Array[Byte]): CodeExecAsAttachment = {
-    val code = new String(bytes, StandardCharsets.UTF_8)
-
-    if (kind == "java" && !Exec.isBinaryCode(code)) {
-      val encoded = Base64.getEncoder.encodeToString(bytes)
-      copy(code = Inline(encoded))
-    } else
-      copy(code = Inline(code))
+    val encoded = new String(bytes, StandardCharsets.UTF_8)
+    copy(code = Inline(encoded))
   }
 
   def attach(attached: Attached): CodeExecAsAttachment = {

--- a/common/scala/src/main/scala/whisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Exec.scala
@@ -324,7 +324,8 @@ protected[core] object Exec extends ArgNormalizer[Exec] with DefaultJsonProtocol
               } map {
                 attFmt[String].read(_)
               } getOrElse {
-                throw new DeserializationException(s"'code' must be a string defined in 'exec' for '$kind' actions")
+                throw new DeserializationException(
+                  s"'code' must be a string or attachment object defined in 'exec' for '$kind' actions")
               }
               val main = optMainField.orElse {
                 if (manifest.requireMain.exists(identity)) {

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -19,6 +19,7 @@ package whisk.core.entity
 
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
 import java.util.Base64
 
 import akka.http.scaladsl.model.ContentTypes
@@ -340,9 +341,9 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
           implicit val ec = db.executionContext
 
           val (bytes, attachmentType) = if (binary) {
-            (Base64.getDecoder().decode(code), ContentTypes.`application/octet-stream`)
+            (Base64.getDecoder.decode(code), ContentTypes.`application/octet-stream`)
           } else {
-            (code.getBytes("UTF-8"), ContentTypes.`text/plain(UTF-8)`)
+            (code.getBytes(StandardCharsets.UTF_8), ContentTypes.`text/plain(UTF-8)`)
           }
           val stream = new ByteArrayInputStream(bytes)
           val oldAttachment = old

--- a/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
@@ -790,82 +790,91 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
   }
 
   it should "put and then get an action with attachment from cache" in {
-    val action =
+    val javaAction =
       WhiskAction(
         namespace,
         aname(),
         javaDefault(nonInlinedCode(entityStore), Some("hello")),
         annotations = Parameters("exec", "java"))
-    val content = WhiskActionPut(
-      Some(action.exec),
-      Some(action.parameters),
-      Some(ActionLimitsOption(Some(action.limits.timeout), Some(action.limits.memory), Some(action.limits.logs))))
-    val name = action.name
-    val cacheKey = s"${CacheKey(action)}".replace("(", "\\(").replace(")", "\\)")
-    val expectedPutLog =
-      Seq(s"uploading attachment '[\\w-]+' of document 'id: ${action.namespace}/${action.name}", s"caching $cacheKey")
-        .mkString("(?s).*")
-    val notExpectedGetLog = Seq(
-      s"finding document: 'id: ${action.namespace}/${action.name}",
-      s"finding attachment '[\\w-/:]+' of document 'id: ${action.namespace}/${action.name}").mkString("(?s).*")
+    val nodeAction = WhiskAction(namespace, aname(), jsDefault(nonInlinedCode(entityStore)), Parameters("x", "b"))
+    val swiftAction = WhiskAction(namespace, aname(), swift3(nonInlinedCode(entityStore)), Parameters("x", "b"))
+    val actions = Seq((javaAction, JAVA_DEFAULT), (nodeAction, NODEJS6), (swiftAction, SWIFT3))
 
-    // first request invalidates any previous entries and caches new result
-    Put(s"$collectionPath/$name", content) ~> Route.seal(routes(creds)(transid())) ~> check {
-      status should be(OK)
-      val response = responseAs[WhiskAction]
-      response should be(
-        WhiskAction(
-          action.namespace,
-          action.name,
-          action.exec,
-          action.parameters,
-          action.limits,
-          action.version,
-          action.publish,
-          action.annotations ++ Parameters(WhiskAction.execFieldName, JAVA_DEFAULT)))
+    actions.foreach {
+      case (action, kind) =>
+        val content = WhiskActionPut(
+          Some(action.exec),
+          Some(action.parameters),
+          Some(ActionLimitsOption(Some(action.limits.timeout), Some(action.limits.memory), Some(action.limits.logs))))
+        val cacheKey = s"${CacheKey(action)}".replace("(", "\\(").replace(")", "\\)")
+
+        val expectedPutLog =
+          Seq(
+            s"uploading attachment '[\\w-]+' of document 'id: ${action.namespace}/${action.name}",
+            s"caching $cacheKey")
+            .mkString("(?s).*")
+        val notExpectedGetLog = Seq(
+          s"finding document: 'id: ${action.namespace}/${action.name}",
+          s"finding attachment '[\\w-/:]+' of document 'id: ${action.namespace}/${action.name}").mkString("(?s).*")
+
+        // first request invalidates any previous entries and caches new result
+        Put(s"$collectionPath/${action.name}", content) ~> Route.seal(routes(creds)(transid())) ~> check {
+          status should be(OK)
+          val response = responseAs[WhiskAction]
+          response should be(
+            WhiskAction(
+              action.namespace,
+              action.name,
+              action.exec,
+              action.parameters,
+              action.limits,
+              action.version,
+              action.publish,
+              action.annotations ++ Parameters(WhiskAction.execFieldName, kind)))
+        }
+
+        stream.toString should not include (s"invalidating ${CacheKey(action)} on delete")
+        stream.toString should include regex (expectedPutLog)
+        stream.reset()
+
+        // second request should fetch from cache
+        Get(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)(transid())) ~> check {
+          status should be(OK)
+          val response = responseAs[WhiskAction]
+          response should be(
+            WhiskAction(
+              action.namespace,
+              action.name,
+              action.exec,
+              action.parameters,
+              action.limits,
+              action.version,
+              action.publish,
+              action.annotations ++ Parameters(WhiskAction.execFieldName, kind)))
+        }
+        stream.toString should include(s"serving from cache: ${CacheKey(action)}")
+        stream.toString should not include regex(notExpectedGetLog)
+        stream.reset()
+
+        // delete should invalidate cache
+        Delete(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)(transid())) ~> check {
+          status should be(OK)
+          val response = responseAs[WhiskAction]
+          response should be(
+            WhiskAction(
+              action.namespace,
+              action.name,
+              action.exec,
+              action.parameters,
+              action.limits,
+              action.version,
+              action.publish,
+              action.annotations ++ Parameters(WhiskAction.execFieldName, kind)))
+        }
+
+        stream.toString should include(s"invalidating ${CacheKey(action)}")
+        stream.reset()
     }
-
-    stream.toString should not include (s"invalidating ${CacheKey(action)} on delete")
-    stream.toString should include regex (expectedPutLog)
-    stream.reset()
-
-    // second request should fetch from cache
-    Get(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
-      status should be(OK)
-      val response = responseAs[WhiskAction]
-      response should be(
-        WhiskAction(
-          action.namespace,
-          action.name,
-          action.exec,
-          action.parameters,
-          action.limits,
-          action.version,
-          action.publish,
-          action.annotations ++ Parameters(WhiskAction.execFieldName, JAVA_DEFAULT)))
-    }
-
-    stream.toString should include(s"serving from cache: ${CacheKey(action)}")
-    stream.toString should not include regex(notExpectedGetLog)
-    stream.reset()
-
-    // delete should invalidate cache
-    Delete(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
-      status should be(OK)
-      val response = responseAs[WhiskAction]
-      response should be(
-        WhiskAction(
-          action.namespace,
-          action.name,
-          action.exec,
-          action.parameters,
-          action.limits,
-          action.version,
-          action.publish,
-          action.annotations ++ Parameters(WhiskAction.execFieldName, JAVA_DEFAULT)))
-    }
-    stream.toString should include(s"invalidating ${CacheKey(action)}")
-    stream.reset()
   }
 
   it should "put and then get an action with inlined attachment" in {
@@ -961,8 +970,8 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
       s"finding attachment '[\\w-/:]+' of document 'id: ${action.namespace}/${action.name}").mkString("(?s).*")
 
     action.exec match {
-      case exec @ CodeExecAsAttachment(_, _, _) =>
-        val stream = new ByteArrayInputStream(Base64.getDecoder().decode(code))
+      case exec @ CodeExecAsAttachment(_, _, _, _) =>
+        val stream = new ByteArrayInputStream(code.getBytes)
         val manifest = exec.manifest.attached.get
         val src = StreamConverters.fromInputStream(() => stream)
         putAndAttach[WhiskAction, WhiskEntity](
@@ -1012,8 +1021,8 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         .mkString("(?s).*")
 
     action.exec match {
-      case exec @ CodeExecAsAttachment(_, _, _) =>
-        val stream = new ByteArrayInputStream(Base64.getDecoder().decode(code))
+      case exec @ CodeExecAsAttachment(_, _, _, _) =>
+        val stream = new ByteArrayInputStream(code.getBytes)
         val manifest = exec.manifest.attached.get
         val src = StreamConverters.fromInputStream(() => stream)
         putAndAttach[WhiskAction, WhiskEntity](
@@ -1061,6 +1070,72 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     }
     stream.toString should include(s"invalidating ${CacheKey(action)}")
     stream.reset()
+  }
+
+  it should "ensure old and new action schemas are supported" in {
+    implicit val tid = transid()
+    val actionOldSchema = WhiskAction(namespace, aname(), js6Old(nonInlinedCode(entityStore)))
+    val actionNewSchema = WhiskAction(namespace, aname(), jsDefault(nonInlinedCode(entityStore)))
+    val content = WhiskActionPut(
+      Some(actionOldSchema.exec),
+      Some(actionOldSchema.parameters),
+      Some(
+        ActionLimitsOption(
+          Some(actionOldSchema.limits.timeout),
+          Some(actionOldSchema.limits.memory),
+          Some(actionOldSchema.limits.logs))))
+    val expectedPutLog =
+      Seq(s"uploading attachment '[\\w-/:]+' of document 'id: ${actionOldSchema.namespace}/${actionOldSchema.name}")
+        .mkString("(?s).*")
+
+    put(entityStore, actionOldSchema)
+
+    stream.toString should not include regex(expectedPutLog)
+    stream.reset()
+
+    Post(s"$collectionPath/${actionOldSchema.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(Accepted)
+      val response = responseAs[JsObject]
+      response.fields("activationId") should not be None
+    }
+
+    Put(s"$collectionPath/${actionOldSchema.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      val response = responseAs[WhiskAction]
+      response should be(
+        WhiskAction(
+          actionOldSchema.namespace,
+          actionOldSchema.name,
+          actionNewSchema.exec,
+          actionOldSchema.parameters,
+          actionOldSchema.limits,
+          actionOldSchema.version.upPatch,
+          actionOldSchema.publish,
+          actionOldSchema.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6)))
+    }
+
+    stream.toString should include regex (expectedPutLog)
+    stream.reset()
+
+    Post(s"$collectionPath/${actionOldSchema.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(Accepted)
+      val response = responseAs[JsObject]
+      response.fields("activationId") should not be None
+    }
+
+    Delete(s"$collectionPath/${actionOldSchema.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskAction]
+      response should be(
+        WhiskAction(
+          actionOldSchema.namespace,
+          actionOldSchema.name,
+          actionNewSchema.exec,
+          actionOldSchema.parameters,
+          actionOldSchema.limits,
+          actionOldSchema.version.upPatch,
+          actionOldSchema.publish,
+          actionOldSchema.annotations ++ Parameters(WhiskAction.execFieldName, NODEJS6)))
+    }
   }
 
   it should "reject put with conflict for pre-existing action" in {

--- a/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
@@ -36,7 +36,6 @@ import whisk.core.entitlement.Collection
 import whisk.http.ErrorResponse
 import whisk.http.Messages
 import java.io.ByteArrayInputStream
-import java.util.Base64
 
 import akka.stream.scaladsl._
 

--- a/tests/src/test/scala/whisk/core/database/test/AttachmentCompatibilityTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/AttachmentCompatibilityTests.scala
@@ -120,7 +120,7 @@ class AttachmentCompatibilityTests
   private def createAction(doc: WhiskAction) = {
     implicit val tid: TransactionId = transid()
     doc.exec match {
-      case exec @ CodeExecAsAttachment(_, Inline(code), _) =>
+      case exec @ CodeExecAsAttachment(_, Inline(code), _, _) =>
         val attached = exec.manifest.attached.get
 
         val newDoc = doc.copy(exec = exec.copy(code = attached))

--- a/tests/src/test/scala/whisk/core/database/test/AttachmentCompatibilityTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/AttachmentCompatibilityTests.scala
@@ -30,24 +30,15 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FlatSpec, Matchers}
 import pureconfig.loadConfigOrThrow
-import spray.json.DefaultJsonProtocol
+import spray.json._
 import whisk.common.TransactionId
 import whisk.core.ConfigKeys
+import whisk.core.controller.test.WhiskAuthHelpers
 import whisk.core.database.memory.MemoryAttachmentStoreProvider
 import whisk.core.database.{CouchDbConfig, CouchDbRestClient, CouchDbStoreProvider, NoDocumentException}
 import whisk.core.entity.Attachments.Inline
 import whisk.core.entity.test.ExecHelpers
-import whisk.core.entity.{
-  CodeExecAsAttachment,
-  DocInfo,
-  EntityName,
-  EntityPath,
-  WhiskAction,
-  WhiskDocumentReader,
-  WhiskEntity,
-  WhiskEntityJsonFormat,
-  WhiskEntityStore
-}
+import whisk.core.entity._
 
 import scala.concurrent.Future
 import scala.reflect.classTag
@@ -68,6 +59,10 @@ class AttachmentCompatibilityTests
   //Bring in sync the timeout used by ScalaFutures and DBUtils
   implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = dbOpTimeout)
   implicit val materializer = ActorMaterializer()
+
+  val creds = WhiskAuthHelpers.newIdentity()
+  val namespace = EntityPath(creds.subject.asString)
+  def aname() = MakeName.next("action_tests")
   val config = loadConfigOrThrow[CouchDbConfig](ConfigKeys.couchdb)
   val entityStore = WhiskEntityStore.datastore()
   val client =
@@ -117,6 +112,71 @@ class AttachmentCompatibilityTests
     doc2.exec shouldBe exec
   }
 
+  it should "read existing base64 encoded code string" in {
+    implicit val tid: TransactionId = transid()
+    val exec = """{
+               |  "kind": "nodejs:6",
+               |  "code": "SGVsbG8gT3BlbldoaXNr"
+               |}""".stripMargin.parseJson.asJsObject
+    val (id, action) = makeActionJson(namespace, aname(), exec)
+    val info = putDoc(id, action)
+
+    val action2 = WhiskAction.get(entityStore, info.id).futureValue
+    codeExec(action2).codeAsJson shouldBe JsString("SGVsbG8gT3BlbldoaXNr")
+  }
+
+  it should "read existing simple code string" in {
+    implicit val tid: TransactionId = transid()
+    val exec = """{
+                 |  "kind": "nodejs:6",
+                 |  "code": "while (true)"
+                 |}""".stripMargin.parseJson.asJsObject
+    val (id, action) = makeActionJson(namespace, aname(), exec)
+    val info = putDoc(id, action)
+
+    val action2 = WhiskAction.get(entityStore, info.id).futureValue
+    codeExec(action2).codeAsJson shouldBe JsString("while (true)")
+  }
+
+  private def codeExec(a: WhiskAction) = a.exec.asInstanceOf[CodeExec[_]]
+
+  private def makeActionJson(namespace: EntityPath, name: EntityName, exec: JsObject): (String, JsObject) = {
+    val id = namespace.addPath(name).asString
+    val base = s"""{
+                 |  "name": "${name.asString}",
+                 |  "_id": "$id",
+                 |  "publish": false,
+                 |  "annotations": [],
+                 |  "version": "0.0.1",
+                 |  "updated": 1533623651650,
+                 |  "entityType": "action",
+                 |  "parameters": [
+                 |    {
+                 |      "key": "x",
+                 |      "value": "b"
+                 |    }
+                 |  ],
+                 |  "limits": {
+                 |    "timeout": 60000,
+                 |    "memory": 256,
+                 |    "logs": 10
+                 |  },
+                 |  "namespace": "${namespace.asString}"
+                 |}""".stripMargin.parseJson.asJsObject
+    (id, JsObject(base.fields + ("exec" -> exec)))
+  }
+
+  private def putDoc(id: String, js: JsObject): DocInfo = {
+    val r = client.putDoc(id, js).futureValue
+    r match {
+      case Right(response) =>
+        val info = response.convertTo[DocInfo]
+        docsToDelete += ((entityStore, info))
+        info
+      case _ => fail()
+    }
+  }
+
   private def createAction(doc: WhiskAction) = {
     implicit val tid: TransactionId = transid()
     doc.exec match {
@@ -134,6 +194,14 @@ class AttachmentCompatibilityTests
         docsToDelete += ((entityStore, info2))
       case _ =>
         fail("Exec must be code attachment")
+    }
+  }
+
+  object MakeName {
+    @volatile var counter = 1
+    def next(prefix: String = "test")(): EntityName = {
+      counter = counter + 1
+      EntityName(s"${prefix}_name$counter")
     }
   }
 

--- a/tests/src/test/scala/whisk/core/database/test/CacheConcurrencyTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/CacheConcurrencyTests.scala
@@ -121,7 +121,11 @@ class CacheConcurrencyTests extends FlatSpec with WskTestHelpers with WskActorSy
         para.tasksupport = new ForkJoinTaskSupport(new ForkJoinPool(nThreads))
         para.map { i =>
           if (i != 16) {
-            wsk.action.get(name)
+            val rr = wsk.action.get(name, expectedExitCode = DONTCARE_EXIT)
+            withClue(s"expecting get to either succeed or fail with not found: $rr") {
+              // some will succeed and some should fail with not found
+              rr.exitCode should (be(SUCCESS_EXIT) or be(NOT_FOUND))
+            }
           } else {
             wsk.action.create(name, None, parameters = Map("color" -> JsString("blue")), update = true)
           }

--- a/tests/src/test/scala/whisk/core/database/test/behavior/ArtifactStoreAttachmentBehaviors.scala
+++ b/tests/src/test/scala/whisk/core/database/test/behavior/ArtifactStoreAttachmentBehaviors.scala
@@ -22,14 +22,15 @@ import java.util.Base64
 
 import akka.http.scaladsl.model.{ContentTypes, Uri}
 import akka.stream.IOResult
-import scala.concurrent.duration.DurationInt
 import akka.stream.scaladsl.{Sink, StreamConverters}
 import akka.util.{ByteString, ByteStringBuilder}
 import whisk.common.TransactionId
 import whisk.core.database.{AttachmentSupport, CacheChangeNotification, NoDocumentException}
 import whisk.core.entity.Attachments.{Attached, Attachment, Inline}
 import whisk.core.entity.test.ExecHelpers
-import whisk.core.entity.{CodeExec, DocInfo, EntityName, ExecManifest, WhiskAction}
+import whisk.core.entity.{CodeExec, DocInfo, EntityName, WhiskAction}
+
+import scala.concurrent.duration.DurationInt
 
 trait ArtifactStoreAttachmentBehaviors extends ArtifactStoreBehaviorBase with ExecHelpers {
   behavior of s"${storeType}ArtifactStore attachments"
@@ -133,12 +134,7 @@ trait ArtifactStoreAttachmentBehaviors extends ArtifactStoreBehaviorBase with Ex
 
     docsToDelete += ((entityStore, i1))
 
-    attached(action2).attachmentType shouldBe ExecManifest.runtimesManifest
-      .resolveDefaultRuntime(JAVA_DEFAULT)
-      .get
-      .attached
-      .get
-      .attachmentType
+    attached(action2).attachmentType shouldBe ContentTypes.`application/octet-stream`
     attached(action2).length shouldBe Some(size)
     attached(action2).digest should not be empty
 

--- a/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
@@ -50,11 +50,18 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
     ExecManifest.runtimesManifest.runtimes.flatMap(_.versions).find(_.kind == name).get.image
   }
 
-  protected def js(code: String, main: Option[String] = None) = {
+  protected def jsOld(code: String, main: Option[String] = None) = {
     CodeExecAsString(RuntimeManifest(NODEJS, imagename(NODEJS), deprecated = Some(true)), trim(code), main.map(_.trim))
   }
 
-  protected def js6(code: String, main: Option[String] = None) = {
+  protected def js(code: String, main: Option[String] = None) = {
+    val attachment = attFmt[String].read(code.trim.toJson)
+    val manifest = ExecManifest.runtimesManifest.resolveDefaultRuntime(NODEJS).get
+
+    CodeExecAsAttachment(manifest, attachment, main.map(_.trim), Exec.isBinaryCode(code))
+  }
+
+  protected def js6Old(code: String, main: Option[String] = None) = {
     CodeExecAsString(
       RuntimeManifest(
         NODEJS6,
@@ -65,12 +72,18 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
       trim(code),
       main.map(_.trim))
   }
+  protected def js6(code: String, main: Option[String] = None) = {
+    val attachment = attFmt[String].read(code.trim.toJson)
+    val manifest = ExecManifest.runtimesManifest.resolveDefaultRuntime(NODEJS6).get
+
+    CodeExecAsAttachment(manifest, attachment, main.map(_.trim), Exec.isBinaryCode(code))
+  }
 
   protected def jsDefault(code: String, main: Option[String] = None) = {
     js6(code, main)
   }
 
-  protected def js6MetaData(main: Option[String] = None, binary: Boolean) = {
+  protected def js6MetaDataOld(main: Option[String] = None, binary: Boolean) = {
     CodeExecMetaDataAsString(
       RuntimeManifest(
         NODEJS6,
@@ -82,11 +95,17 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
       main.map(_.trim))
   }
 
+  protected def js6MetaData(main: Option[String] = None, binary: Boolean) = {
+    val manifest = ExecManifest.runtimesManifest.resolveDefaultRuntime(NODEJS6).get
+
+    CodeExecMetaDataAsAttachment(manifest, binary, main.map(_.trim))
+  }
+
   protected def javaDefault(code: String, main: Option[String] = None) = {
     val attachment = attFmt[String].read(code.trim.toJson)
     val manifest = ExecManifest.runtimesManifest.resolveDefaultRuntime(JAVA_DEFAULT).get
 
-    CodeExecAsAttachment(manifest, attachment, main.map(_.trim))
+    CodeExecAsAttachment(manifest, attachment, main.map(_.trim), Exec.isBinaryCode(code))
   }
 
   protected def javaMetaData(main: Option[String] = None, binary: Boolean) = {
@@ -95,16 +114,22 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
     CodeExecMetaDataAsAttachment(manifest, binary, main.map(_.trim))
   }
 
-  protected def swift(code: String, main: Option[String] = None) = {
+  protected def swiftOld(code: String, main: Option[String] = None) = {
     CodeExecAsString(RuntimeManifest(SWIFT, imagename(SWIFT), deprecated = Some(true)), trim(code), main.map(_.trim))
   }
 
+  protected def swift(code: String, main: Option[String] = None) = {
+    val attachment = attFmt[String].read(code.trim.toJson)
+    val manifest = ExecManifest.runtimesManifest.resolveDefaultRuntime(SWIFT).get
+
+    CodeExecAsAttachment(manifest, attachment, main.map(_.trim), Exec.isBinaryCode(code))
+  }
+
   protected def swift3(code: String, main: Option[String] = None) = {
-    val default = ExecManifest.runtimesManifest.resolveDefaultRuntime(SWIFT3).flatMap(_.default)
-    CodeExecAsString(
-      RuntimeManifest(SWIFT3, imagename(SWIFT3), default = default, deprecated = Some(false)),
-      trim(code),
-      main.map(_.trim))
+    val attachment = attFmt[String].read(code.trim.toJson)
+    val manifest = ExecManifest.runtimesManifest.resolveDefaultRuntime(SWIFT3).get
+
+    CodeExecAsAttachment(manifest, attachment, main.map(_.trim), Exec.isBinaryCode(code))
   }
 
   protected def sequence(components: Vector[FullyQualifiedEntityName]) = SequenceExec(components)

--- a/tests/src/test/scala/whisk/core/entity/test/ExecTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecTests.scala
@@ -117,6 +117,17 @@ class ExecTests extends FlatSpec with Matchers with StreamLogging with BeforeAnd
     }
   }
 
+  it should "read code stored as jar property" in {
+    val j1 = """{
+               |  "kind": "nodejs:6",
+               |  "jar": "SGVsbG8gT3BlbldoaXNr",
+               |  "binary": false
+               |}""".stripMargin.parseJson.asJsObject
+    Exec.serdes.read(j1) should matchPattern {
+      case CodeExecAsAttachment(_, Inline("SGVsbG8gT3BlbldoaXNr"), None, true) =>
+    }
+  }
+
   it should "read existing code string as string with old manifest" in {
     val oldManifestJson =
       """{

--- a/tests/src/test/scala/whisk/core/entity/test/ExecTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecTests.scala
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.entity.test
+
+import common.StreamLogging
+import spray.json._
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import whisk.core.WhiskConfig
+import whisk.core.entity.Attachments.{Attached, Inline}
+import whisk.core.entity.{CodeExecAsAttachment, CodeExecAsString, Exec, ExecManifest, WhiskAction}
+
+import scala.collection.mutable
+
+@RunWith(classOf[JUnitRunner])
+class ExecTests extends FlatSpec with Matchers with StreamLogging with BeforeAndAfterAll {
+  behavior of "exec deserialization"
+
+  val config = new WhiskConfig(ExecManifest.requiredProperties)
+  ExecManifest.initialize(config)
+
+  override protected def afterAll(): Unit = {
+    ExecManifest.initialize(config)
+    super.afterAll()
+  }
+
+  it should "read existing code string as attachment" in {
+    val json = """{
+                 |  "name": "action_tests_name2",
+                 |  "_id": "anon-Yzycx8QnIYDp3Tby0Fnj23KcMtH/action_tests_name2",
+                 |  "publish": false,
+                 |  "annotations": [],
+                 |  "version": "0.0.1",
+                 |  "updated": 1533623651650,
+                 |  "entityType": "action",
+                 |  "exec": {
+                 |    "kind": "nodejs:6",
+                 |    "code": "foo",
+                 |    "binary": false
+                 |  },
+                 |  "parameters": [
+                 |    {
+                 |      "key": "x",
+                 |      "value": "b"
+                 |    }
+                 |  ],
+                 |  "limits": {
+                 |    "timeout": 60000,
+                 |    "memory": 256,
+                 |    "logs": 10
+                 |  },
+                 |  "namespace": "anon-Yzycx8QnIYDp3Tby0Fnj23KcMtH"
+                 |}""".stripMargin.parseJson.asJsObject
+    val action = WhiskAction.serdes.read(json)
+    action.exec should matchPattern { case CodeExecAsAttachment(_, Inline("foo"), None, false) => }
+  }
+
+  it should "properly determine binary property" in {
+    val j1 = """{
+               |  "kind": "nodejs:6",
+               |  "code": "SGVsbG8gT3BlbldoaXNr",
+               |  "binary": false
+               |}""".stripMargin.parseJson.asJsObject
+    Exec.serdes.read(j1) should matchPattern {
+      case CodeExecAsAttachment(_, Inline("SGVsbG8gT3BlbldoaXNr"), None, true) =>
+    }
+
+    val j2 = """{
+               |  "kind": "nodejs:6",
+               |  "code": "while (true)",
+               |  "binary": false
+               |}""".stripMargin.parseJson.asJsObject
+    Exec.serdes.read(j2) should matchPattern {
+      case CodeExecAsAttachment(_, Inline("while (true)"), None, false) =>
+    }
+
+    //Defaults to binary
+    val j3 = """{
+               |  "kind": "nodejs:6",
+               |  "code": "while (true)"
+               |}""".stripMargin.parseJson.asJsObject
+    Exec.serdes.read(j3) should matchPattern {
+      case CodeExecAsAttachment(_, Inline("while (true)"), None, false) =>
+    }
+  }
+
+  it should "read code stored as attachment" in {
+    val json = """{
+                 |  "kind": "java",
+                 |  "code": {
+                 |    "attachmentName": "foo:bar",
+                 |    "attachmentType": "application/java-archive",
+                 |    "length": 32768,
+                 |    "digest": "sha256-foo"
+                 |  },
+                 |  "binary": true,
+                 |  "main": "hello"
+                 |}""".stripMargin.parseJson.asJsObject
+    Exec.serdes.read(json) should matchPattern {
+      case CodeExecAsAttachment(_, Attached("foo:bar", _, Some(32768), Some("sha256-foo")), Some("hello"), true) =>
+    }
+  }
+
+  it should "read existing code string as string with old manifest" in {
+    val oldManifestJson =
+      """{
+        |  "runtimes": {
+        |    "nodejs": [
+        |      {
+        |        "kind": "nodejs:6",
+        |        "default": true,
+        |        "image": {
+        |          "prefix": "openwhisk",
+        |          "name": "nodejs6action",
+        |          "tag": "latest"
+        |        },
+        |        "deprecated": false,
+        |        "stemCells": [{
+        |          "count": 2,
+        |          "memory": "256 MB"
+        |        }]
+        |      }
+        |    ]
+        |  }
+        |}""".stripMargin.parseJson.compactPrint
+
+    val oldConfig =
+      new TestConfig(Map(WhiskConfig.runtimesManifest -> oldManifestJson), ExecManifest.requiredProperties)
+    ExecManifest.initialize(oldConfig)
+    val j1 = """{
+               |  "kind": "nodejs:6",
+               |  "code": "SGVsbG8gT3BlbldoaXNr",
+               |  "binary": false
+             |}""".stripMargin.parseJson.asJsObject
+
+    val a = Exec.serdes.read(j1)
+    Exec.serdes.read(j1) should matchPattern {
+      case CodeExecAsString(_, "SGVsbG8gT3BlbldoaXNr", None) =>
+    }
+
+    //Reset config back
+    ExecManifest.initialize(config)
+  }
+
+  private class TestConfig(val props: Map[String, String], requiredProperties: Map[String, String])
+      extends WhiskConfig(requiredProperties) {
+    override protected def getProperties() = mutable.Map(props.toSeq: _*)
+  }
+}

--- a/tests/src/test/scala/whisk/core/entity/test/ExecTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecTests.scala
@@ -160,7 +160,6 @@ class ExecTests extends FlatSpec with Matchers with StreamLogging with BeforeAnd
                |  "binary": false
              |}""".stripMargin.parseJson.asJsObject
 
-    val a = Exec.serdes.read(j1)
     Exec.serdes.read(j1) should matchPattern {
       case CodeExecAsString(_, "SGVsbG8gT3BlbldoaXNr", None) =>
     }

--- a/tools/db/moveCodeToAttachment.py
+++ b/tools/db/moveCodeToAttachment.py
@@ -21,28 +21,7 @@
 import argparse
 import couchdb.client
 import time
-import base64
 from couchdb import ResourceNotFound
-
-def updateJavaAction(db, doc, id):
-    updated = False
-    attachment = db.get_attachment(doc, 'jarfile')
-
-    if attachment != None:
-        encodedAttachment = base64.b64encode(attachment.getvalue())
-        db.put_attachment(doc, encodedAttachment, 'codefile', 'text/plain')
-        doc = db.get(id)
-        doc['exec']['code'] = {
-            'attachmentName': 'codefile',
-            'attachmentType': 'text/plain'
-        }
-        if 'jar' in doc['exec']:
-            del doc['exec']['jar']
-        db.save(doc)
-        db.delete_attachment(doc, 'jarfile')
-        updated = True
-
-    return updated
 
 def updateNonJavaAction(db, doc, id):
     updated = False
@@ -96,7 +75,7 @@ def main(args):
             if doc['exec']['kind'] != 'java':
                 updated = updateNonJavaAction(db, doc, id)
             else:
-                updated = updateJavaAction(db, doc, id)
+                updated = False
 
             if updated:
                 print('Updated action: "{0}"'.format(id))


### PR DESCRIPTION
Treats action code as attachment for all kinds in default runtime.

Supersedes #3286. 

## Description

This PR builds on #3286 and enables use of attachment mode for all kinds. Some key aspects are

1. Binary code (like zip/jar) is stored in raw form (NOT Base64 encoded) in attachment
2. Change is backward compatible in reading code
3. Upon update or new action being created the code would be stored as attachment
4. `attachmentType` property of runtime.json is now not used. Instead one of the below is used
    - `text/plain(UTF-8)` - For plain string which are not base64 encoded
    - `application/octet-stream` - For codes which are Base64 string. Such codes are stored in raw form in persistent store

Note that with support for attachment inlining (#3709) it may happen that small code is still stored as part of same document (but in attachment object format)

### Forms of code

Code related to an action can be stored in following forms

#### String property

```json
{
  "exec": {
    "kind": "java",
    "code": "ZHViZWU=",
    "binary": true,
    "main": "hello"
  }
}
```

For Blackbox action also the code is stored as string property

```json
 {
 "exec": {
    "kind": "blackbox",
    "image": "docker-custom.com/openwhisk-runtime/magic/nodejs:0.0.1",
    "binary": false,
    "code": "\"use strict\";\n\nvar fs = require('fs');..."
  }
  }
```

#### Attachment

```json
{
  "exec": {
    "kind": "java",
    "code": {
      "attachmentName": "couch:f41be90d-5656-47f5-9be9-0d5656f7f555",
      "attachmentType": "application/java-archive",
      "length": 32768,
      "digest": "sha256-5a373715b8cdcd608059debe9dae2ad95087eb5322321d1d0b862f8330a0e54d"
    },
    "binary": true,
    "main": "hello"
  }
}
```

### Potential Performance Impact

Currently for non java kinds the code is stored as part of same document. With this change the code may be (if size > `max-inline-size`) stored as attachment. Due to this in case of action invocation if there is a cache miss then it would require 2 remote calls to load the whole action compared to 1 remote call currently.

Note that post #2855 the attachments are now also cached. So if more new containers need to be spinned then they would not incur any further performance impact till action is cached.

### Benefits

With this change it would be possible to store larger codes for setups using store which place restriction on maximum document size.

Further it also improves the heap usage for normal cases where the code is not required to be loaded. See #2847

### TODO

- [x] Review `moveCodeToAttachment.py`
- [x] Add more compatability tests
- [ ] Review default inline size
- [x] Restore support for `jar` property name
- [x] Use `application/octet-stream` for binary code. Even for jars and `text/plain` for non binary code

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#3944)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

