### PR TITLE
Add an variable to set the timezone for all of components

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -368,3 +368,6 @@ limits:
 - The `limits.concurrentInvocations` represents the maximum concurrent invocations allowed per namespace.
 - The `limits.firesPerMinute` represents the allowed namespace trigger firings per minute.
 - The `limits.sequenceMaxLength` represents the maximum length of a sequence action.
+
+#### Set the timezone for containers
+The default timezone for all system containers is UTC. The timezone may differ from your servers which could make it difficult to inspect logs. The timezone is configured globally in [group_vars/all](./group_vars/all#L280) or by passing an extra variable `-e docker_timezone=xxx` when you run an ansible-playbook.

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -275,6 +275,7 @@ docker:
   pull:
     retries: 10
     delay: 10
+  timezone: "{{ docker_timezone | default('UTC') }}"
 
 sdk:
   dir:

--- a/ansible/roles/apigateway/tasks/deploy.yml
+++ b/ansible/roles/apigateway/tasks/deploy.yml
@@ -16,6 +16,7 @@
       "REDIS_PORT": "{{ redis.port }}"
       "PUBLIC_MANAGEDURL_HOST": "{{ ansible_host }}"
       "PUBLIC_MANAGEDURL_PORT": "{{ apigateway.port.mgmt }}"
+      "TZ": "{{ docker.timezone }}"
     ports:
       - "{{ apigateway.port.mgmt }}:8080"
       - "{{ apigateway.port.api }}:9000"

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -124,6 +124,7 @@
       "JMX_REMOTE": "{{ jmx.enabled }}"
 
       "PORT": 8080
+      "TZ": "{{ docker.timezone }}"
 
       "CONFIG_whisk_info_date": "{{ whisk.version.date }}"
       "CONFIG_whisk_info_buildNo": "{{ docker.image.tag }}"

--- a/ansible/roles/couchdb/tasks/deploy.yml
+++ b/ansible/roles/couchdb/tasks/deploy.yml
@@ -53,6 +53,7 @@
       COUCHDB_USER: "{{ db.credentials.admin.user }}"
       COUCHDB_PASSWORD: "{{ db.credentials.admin.pass }}"
       NODENAME: "{{ ansible_host }}"
+      TZ: "{{ docker.timezone }}"
     pull: "{{ couchdb.pull_couchdb | default(true) }}"
 
 - name: wait until CouchDB in this host is up and running

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -168,6 +168,7 @@
       "INVOKER_OPTS": "{{ invoker_args | default(invoker.arguments) }}"
       "JMX_REMOTE": "{{ jmx.enabled }}"
       "PORT": 8080
+      "TZ": "{{ docker.timezone }}"
       "KAFKA_HOSTS": "{{ kafka_connect_string }}"
       "CONFIG_whisk_kafka_replicationFactor": "{{ kafka.replicationFactor | default() }}"
       "CONFIG_whisk_kafka_topics_invoker_retentionBytes": "{{ kafka_topics_invoker_retentionBytes | default() }}"

--- a/ansible/roles/kafka/tasks/deploy.yml
+++ b/ansible/roles/kafka/tasks/deploy.yml
@@ -25,6 +25,7 @@
       "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR": "{{ kafka.offsetsTopicReplicationFactor }}"
       "KAFKA_AUTO_CREATE_TOPICS_ENABLE": "false"
       "KAFKA_NUM_NETWORK_THREADS": "{{ kafka.networkThreads }}"
+      "TZ": "{{ docker.timezone }}"
 
 - name: add kafka non-ssl vars
   when: kafka.protocol != 'SSL'

--- a/ansible/roles/nginx/tasks/deploy.yml
+++ b/ansible/roles/nginx/tasks/deploy.yml
@@ -69,3 +69,5 @@
       - "{{ nginx.port.http }}:80"
       - "{{ nginx.port.api }}:443"
       - "{{ nginx.port.adminportal }}:8443"
+    env:
+      TZ: "{{ docker.timezone }}"

--- a/ansible/roles/redis/tasks/deploy.yml
+++ b/ansible/roles/redis/tasks/deploy.yml
@@ -19,6 +19,8 @@
     restart_policy: "{{ docker.restart.policy }}"
     ports:
       - "{{ redis.port }}:6379"
+    env:
+      TZ: "{{ docker.timezone }}"
 
 - name: wait until redis is up and running
   action: shell (echo PING; sleep 1) | nc {{ ansible_host }} {{ redis.port }}

--- a/ansible/roles/zookeeper/tasks/deploy.yml
+++ b/ansible/roles/zookeeper/tasks/deploy.yml
@@ -18,6 +18,7 @@
     recreate: true
     restart_policy: "{{ docker.restart.policy }}"
     env:
+        TZ: "{{ docker.timezone }}"
         ZOO_MY_ID: "{{ groups['zookeepers'].index(inventory_hostname) + 1 }}"
         ZOO_SERVERS: "{% set zhosts = [] %}
                       {% for host in groups['zookeepers'] %}


### PR DESCRIPTION
This makes it easy to analyze when errors were happened from logs

## Description
All components except CouchDB will print local datetime in their logs, so I think it's better to add an variable in ansible to set the timezone for these components

For CouchDB, seems it's not possible to make it use local time in its logs: https://serverfault.com/questions/335232/how-to-change-couchdb-time-zone-setting-in-log-file

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [x] I updated the documentation where necessary.

