### PR TITLE
Make gradle and dependency downloads more stable.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,17 @@ notifications:
       # travis2slack webhook to enable DMs on openwhisk-team.slack.com to PR authors with TravisCI results
       secure: "tYJIDAKtHp+yLw53yB6+TQnNfyNwZDAZyG7QmHbNP5Mf1HR0GLhpe02AjV99NkjAgaGYxngUELMhNOyB8eiyMdxpemwny4oOeyOUQzVmiry/804JnjK2YvHyAGFVGuhV0LZVfCPsPh5x91yKcDPLSqRSTKhZOiJFmDpBy4qzxM4W7IXxAM+yHKrm8cznBRdR5rGxT5IjV58xMB1p69jJy1rxnjtEWmB2z7j/SiKa6IQlVYgr+BgaJxBhy9WYYczvceU+qyrTWpVYy5P3o5+b0MZ/UkyB5CZT9N5LzLGjLRDqNaNYCT3U8ow1H6w+zY7/9KrAf6szT6raN606vN7uv7TqGEugG949JQfRSQNe3Y7IvTAHatI9VAc3opWgy0jm7eBu9pzSECamGGSGGHl18m7oWZypiwB+ooKg7k545XQCoVwlRulBvwnVO8w2HOjkKSds/JnNhdXLtNKRaBaZxhBkk+5b43k59vaYsHDXaYFUob/nG/K3JoPRkcLtFe3JfNsCABJYC0VbRE3AizHr8CYMhBUrgElPFwPmIJwwLOORq6y3zIRxTOIz4b/x2q9Oa17vK0IwAjgHi8y9RXc6lG0mCyVFScdpxoGF3d9xF8Edwc8WN22pYaZ8r71UF4AWOVxJs1Cnp8gcAn14gONVVvkaVCUwNCCElbJkjdVhhnI="
 
+# specific cache configuration for gradle based builds
+# see: https://docs.travis-ci.com/user/languages/java/#caching
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+
 before_install:
   - pip install --upgrade pip setuptools six
   - pip3 install --upgrade pip setuptools six

--- a/tools/travis/distDocker.sh
+++ b/tools/travis/distDocker.sh
@@ -26,10 +26,6 @@ ROOTDIR="$SCRIPTDIR/../.."
 
 cd $ROOTDIR
 
-# Downloads the gradle wrapper, dependencies and tries to compile the code
-# Retried 5 times in case there are network hiccups.
-for i in {1..5}; do TERM=dumb ./gradlew compileScala && break || sleep 5; done
-
 TERM=dumb ./gradlew distDocker -PdockerImagePrefix=testing $GRADLE_PROJS_SKIP
 
 TERM=dumb ./gradlew :core:controller:distDockerCoverage -PdockerImagePrefix=testing

--- a/tools/travis/distDocker.sh
+++ b/tools/travis/distDocker.sh
@@ -25,7 +25,6 @@ SCRIPTDIR=$(cd $(dirname "$0") && pwd)
 ROOTDIR="$SCRIPTDIR/../.."
 
 cd $ROOTDIR
-
 TERM=dumb ./gradlew distDocker -PdockerImagePrefix=testing $GRADLE_PROJS_SKIP
 
 TERM=dumb ./gradlew :core:controller:distDockerCoverage -PdockerImagePrefix=testing

--- a/tools/travis/distDocker.sh
+++ b/tools/travis/distDocker.sh
@@ -28,7 +28,7 @@ cd $ROOTDIR
 
 # Downloads the gradle wrapper, dependencies and tries to compile the code
 # Retried 5 times in case there are network hiccups.
-TERM=dumb for i in {1..5}; do ./gradlew compileScala && break || sleep 15; done
+for i in {1..5}; do TERM=dumb ./gradlew compileScala && break || sleep 5; done
 
 TERM=dumb ./gradlew distDocker -PdockerImagePrefix=testing $GRADLE_PROJS_SKIP
 

--- a/tools/travis/distDocker.sh
+++ b/tools/travis/distDocker.sh
@@ -25,6 +25,11 @@ SCRIPTDIR=$(cd $(dirname "$0") && pwd)
 ROOTDIR="$SCRIPTDIR/../.."
 
 cd $ROOTDIR
+
+# Downloads the gradle wrapper, dependencies and tries to compile the code
+# Retried 5 times in case there are network hiccups.
+TERM=dumb for i in {1..5}; do ./gradlew compileScala && break || sleep 15; done
+
 TERM=dumb ./gradlew distDocker -PdockerImagePrefix=testing $GRADLE_PROJS_SKIP
 
 TERM=dumb ./gradlew :core:controller:distDockerCoverage -PdockerImagePrefix=testing

--- a/tools/travis/setup.sh
+++ b/tools/travis/setup.sh
@@ -36,3 +36,10 @@ pip install --user ansible==2.5.2
 
 # Azure CosmosDB
 pip install --user pydocumentdb
+
+# Basic check that all code compiles and depdendencies are downloaded correctly.
+# Compiling the tests will compile all components as well.
+#
+# Downloads the gradle wrapper, dependencies and tries to compile the code.
+# Retried 5 times in case there are network hiccups.
+for i in {1..5}; do TERM=dumb ./gradlew :tests:compileTestScala && break || sleep 5; done

--- a/tools/travis/setup.sh
+++ b/tools/travis/setup.sh
@@ -56,4 +56,4 @@ pip install --user pydocumentdb
 #
 # Downloads the gradle wrapper, dependencies and tries to compile the code.
 # Retried 5 times in case there are network hiccups.
-retry TERM=dumb ./gradlew :tests:compileTestScala
+TERM=dumb retry ./gradlew :tests:compileTestScala


### PR DESCRIPTION
Gradle wrapper and dependency downloads are subject to intermittent failures, which can get annoying when you want to test your branches reliably. This adds the travis caching feature to cache the wrapper and caches. Moreover, it retries those downloads to be resilient against hiccups.


## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [X] General tooling

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).

