### PR TITLE
Add length of podName checking code for K8s

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesContainer.scala
@@ -63,7 +63,9 @@ object KubernetesContainer {
                                                       log: Logging): Future[KubernetesContainer] = {
     implicit val tid = transid
 
-    val podName = name.replace("_", "-").replaceAll("[()]", "").toLowerCase()
+    // Kubernetes naming rule allows maximum length of 63 character.
+    val origName = name.replace("_", "-").replaceAll("[()]", "").toLowerCase()
+    val podName = if (origName.length() > 63) origName.substring(0, 63) else origName
 
     for {
       container <- kubernetes.run(podName, image, memory, environment, labels).recoverWith {

--- a/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesContainer.scala
@@ -63,8 +63,9 @@ object KubernetesContainer {
                                                       log: Logging): Future[KubernetesContainer] = {
     implicit val tid = transid
 
-    // Kubernetes naming rule allows maximum length of 63 character.
-    val podName = name.replace("_", "-").replaceAll("[()]", "").toLowerCase.take(63)
+    // Kubernetes naming rule allows maximum length of 63 character and ended with character only.
+    val origName = name.replace("_", "-").replaceAll("[()]", "").toLowerCase.take(63)
+    val podName = if (origName.endsWith("-")) origName.reverse.dropWhile(_ == '-').reverse else origName
 
     for {
       container <- kubernetes.run(podName, image, memory, environment, labels).recoverWith {

--- a/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesContainer.scala
@@ -64,8 +64,7 @@ object KubernetesContainer {
     implicit val tid = transid
 
     // Kubernetes naming rule allows maximum length of 63 character.
-    val origName = name.replace("_", "-").replaceAll("[()]", "").toLowerCase()
-    val podName = if (origName.length() > 63) origName.substring(0, 63) else origName
+    val podName = name.replace("_", "-").replaceAll("[()]", "").toLowerCase.take(63)
 
     for {
       container <- kubernetes.run(podName, image, memory, environment, labels).recoverWith {


### PR DESCRIPTION
Add maximum length of  pod name checking and fixing code.

<!--- Provide a concise summary of your changes in the Title -->
## Description
In case of kubenetes deployment environment, invokers make container and pool using kubernetes api.
thus action containers are created as a pod.
so naming rule for action container have to follow K8s policy.
the name of pod must be no more than 63 characters in kubernetes.
however there is no checking code for maximum length of pod name.
This problem causes significant problems that actions are not invoked.

<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

