### PR TITLE
k8s: implement invoker-node affinity and eliminate usage of kubectl

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     }
     compile 'com.github.ben-manes.caffeine:caffeine:2.4.0'
     compile 'com.google.code.findbugs:jsr305:3.0.2'
-    compile 'io.fabric8:kubernetes-client:2.5.7'
+    compile 'io.fabric8:kubernetes-client:4.0.3'
     compile 'io.kamon:kamon-core_2.11:0.6.7'
     compile 'io.kamon:kamon-statsd_2.11:0.6.7'
     //for mesos

--- a/core/invoker/Dockerfile
+++ b/core/invoker/Dockerfile
@@ -4,7 +4,6 @@
 FROM scala
 
 ENV DOCKER_VERSION 1.12.0
-ENV KUBERNETES_VERSION 1.6.4
 
 RUN apk add --update openssl
 
@@ -16,11 +15,6 @@ tar --strip-components 1 -xvzf docker-${DOCKER_VERSION}.tgz -C /usr/bin docker/d
 rm -f docker-${DOCKER_VERSION}.tgz && \
 chmod +x /usr/bin/docker && \
 chmod +x /usr/bin/docker-runc
-
-# Install kubernetes client
-RUN wget --no-verbose https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_VERSION}/bin/linux/amd64/kubectl && \
-chmod +x kubectl && \
-mv kubectl /usr/bin/kubectl
 
 ADD build/distributions/invoker.tar ./
 

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -46,13 +46,16 @@ whisk {
     # Timeouts for k8s commands. Set to "Inf" to disable timeout.
     timeouts {
       run: 1 minute
-      rm: 1 minute
-      inspect: 1 minute
       logs: 1 minute
     }
     invoker-agent {
       enabled: false
       port: 3233
+    }
+    user-pod-node-affinity {
+      enabled: true
+      key: "openwhisk-role"
+      value: "invoker"
     }
   }
 

--- a/tests/src/test/scala/whisk/core/containerpool/kubernetes/test/KubernetesClientTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/kubernetes/test/KubernetesClientTests.scala
@@ -76,13 +76,9 @@ class KubernetesClientTests
   val id = ContainerId("55db56ee082239428b27d3728b4dd324c09068458aad9825727d5bfc1bba6d52")
   val container = kubernetesContainer(id)
 
-  val kubectlCommand = "kubectl"
-
   /** Returns a KubernetesClient with a mocked result for 'executeProcess' */
   def kubernetesClient(fixture: => Future[String]) = {
     new KubernetesClient()(global) {
-      override def findKubectlCmd() = kubectlCommand
-
       override def executeProcess(args: Seq[String], timeout: Duration)(implicit ec: ExecutionContext,
                                                                         as: ActorSystem) =
         fixture


### PR DESCRIPTION
    
    1. Upgrade to latest released version of the fabric8 Kubernetes client
       to get access to an implementation of node affinity. Use that implementation
       to optionally add a scheduling affinity to the pods created for actions
       to bind them to worker nodes labeled as invoker nodes.
    
    2. implement the container removal operation via the kube rest client
       instead of via an exec to the kubectl cli.  This eliminates the last
       usage of kubectl in the KubernetesClient and allows the kubectl
       executable to be removed from the invoker Docker image.