### PR TITLE
utility Docker images to run ansible playbooks and bash scripts

### DIFF
--- a/tools/ansibleRunner/Dockerfile
+++ b/tools/ansibleRunner/Dockerfile
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
+from alpine
+
+ENV DOCKER_VERSION 1.12.0
+
+RUN apk --no-cache add \
+  bash \
+  curl \
+  git \
+  libc6-compat \
+  libffi \
+  openssl \
+  python \
+  py-pip \
+  wget \
+  zip
+
+RUN apk --no-cache add --virtual build-dependencies \
+  python-dev \
+  build-base \
+  libffi-dev \
+  openssl-dev
+
+# Install docker client
+RUN wget --no-verbose https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz && \
+tar --strip-components 1 -xvzf docker-${DOCKER_VERSION}.tgz -C /usr/bin docker/docker && \
+rm -f docker-${DOCKER_VERSION}.tgz && \
+chmod +x /usr/bin/docker
+
+RUN pip install --upgrade setuptools
+RUN pip install ansible==2.5.2
+RUN pip install jinja2==2.9.6
+
+RUN apk del build-dependencies
+
+CMD ["/usr/bin/ansible-playbook", "/task/playbook.yml"]

--- a/tools/ansibleRunner/README.md
+++ b/tools/ansibleRunner/README.md
@@ -1,0 +1,27 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
+Utility image for executing ansible playbooks
+================
+
+The `ansible-runner` base image is intended to be used to execute
+utility tasks defined as ansible playbooks. The playbook to be
+executed should be mounted in the container as /task/playbook.yml by
+Kubernetes/Docker/Mesos.
+

--- a/tools/ansibleRunner/build.gradle
+++ b/tools/ansibleRunner/build.gradle
@@ -15,38 +15,5 @@
  * limitations under the License.
  */
 
-include 'common:scala'
-
-include 'core:controller'
-include 'core:invoker'
-
-include 'tests'
-include 'tests:performance:gatling_tests'
-
-include 'tools:actionProxy'
-include 'tools:ansibleRunner'
-include 'tools:scriptRunner'
-include 'tools:dev'
-
-include 'tools:admin'
-
-rootProject.name = 'openwhisk'
-
-gradle.ext.scala = [
-    version: '2.11.11',
-    compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
-]
-
-gradle.ext.scalafmt = [
-    version: '1.5.0',
-    config: new File(rootProject.projectDir, '.scalafmt.conf')
-]
-
-gradle.ext.scoverage = [
-    deps: [
-        'org.scoverage:scalac-scoverage-plugin_2.11:1.3.1',
-        'org.scoverage:scalac-scoverage-runtime_2.11:1.3.1'
-    ]
-]
-
-gradle.ext.curator = [version:'4.0.0']
+ext.dockerImageName = 'ansible-runner'
+apply from: '../../gradle/docker.gradle'

--- a/tools/scriptRunner/Dockerfile
+++ b/tools/scriptRunner/Dockerfile
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
+from alpine
+
+RUN apk --no-cache add \
+  bash \
+  git \
+  libc6-compat \
+  wget \
+  zip
+
+# Install `wsk` cli in /usr/local/bin
+ENV WHISK_CLI_VERSION latest
+RUN wget -q https://github.com/apache/incubator-openwhisk-cli/releases/download/$WHISK_CLI_VERSION/OpenWhisk_CLI-$WHISK_CLI_VERSION-linux-amd64.tgz && \
+    tar xzf OpenWhisk_CLI-$WHISK_CLI_VERSION-linux-amd64.tgz -C /usr/local/bin wsk && \
+    rm OpenWhisk_CLI-$WHISK_CLI_VERSION-linux-amd64.tgz
+
+COPY init.sh /init.sh
+RUN chmod +X /init.sh
+
+CMD ["/init.sh"]

--- a/tools/scriptRunner/README.md
+++ b/tools/scriptRunner/README.md
@@ -1,0 +1,28 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
+Utility image for executing bash scripts
+================
+
+The `script-runner` base image is intended to be used to execute
+utility tasks defined as bash scripts. The script to be executed
+should be mounted in the container as /task/myTask.sh by
+Kubernetes/Docker/Mesos.  The `wsk` cli is installed in /usr/local/bin
+to make it easily available to the scripts.
+

--- a/tools/scriptRunner/build.gradle
+++ b/tools/scriptRunner/build.gradle
@@ -15,38 +15,5 @@
  * limitations under the License.
  */
 
-include 'common:scala'
-
-include 'core:controller'
-include 'core:invoker'
-
-include 'tests'
-include 'tests:performance:gatling_tests'
-
-include 'tools:actionProxy'
-include 'tools:ansibleRunner'
-include 'tools:scriptRunner'
-include 'tools:dev'
-
-include 'tools:admin'
-
-rootProject.name = 'openwhisk'
-
-gradle.ext.scala = [
-    version: '2.11.11',
-    compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
-]
-
-gradle.ext.scalafmt = [
-    version: '1.5.0',
-    config: new File(rootProject.projectDir, '.scalafmt.conf')
-]
-
-gradle.ext.scoverage = [
-    deps: [
-        'org.scoverage:scalac-scoverage-plugin_2.11:1.3.1',
-        'org.scoverage:scalac-scoverage-runtime_2.11:1.3.1'
-    ]
-]
-
-gradle.ext.curator = [version:'4.0.0']
+ext.dockerImageName = 'script-runner'
+apply from: '../../gradle/docker.gradle'

--- a/tools/scriptRunner/init.sh
+++ b/tools/scriptRunner/init.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
+set -ex
+
+# Run the custom task mounted into /task by kube/docker
+if [ -f /task/myTask.sh ]; then
+    . /task/myTask.sh
+else
+    echo "I was not given a task to execute.  Exiting with error"
+    exit 1
+fi


### PR DESCRIPTION
Define alpine based utility images that execute bash scripts and ansible
playbooks mounted into /task by Kubernetes/Dockers/Mesos/OpenShift.
By defining these images as part of the OpenWhisk core project, we can
reduce the number of bespoke Docker images in downstream deployment projects.

