### PR TITLE
Fix macOS bash update instructions in docs/cli.md

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -59,12 +59,15 @@ To verify your CLI setup, try [creating and running an action](./samples.md).
 ### Configure command completion for Openwhisk CLI
 
 For bash command completion to work, bash 4.1 or newer is required. The most recent Linux distributions should have the correct version of bash but Mac users will most likely have an older version.
+
 Mac users can check their bash version and update it by running the following commands:
 
 ```
 bash --version
-brew install bash-completion
+brew install bash
 ```
+
+This requires [Homebrew](https://brew.sh/) to be installed. The updated bash will be installed in `/usr/local/bin`.
 
 To write the bash command completion to your local directory, run the following command:
 


### PR DESCRIPTION
## Description

The existing description of updating bash on macOS tells users to install an updated bash by installing `bash-completion` via brew. The `bash-completion` package is not bash itself; it is a set of completion definitions for various programs. To actually get a newer bash, users should do `brew install bash` instead.

This PR also adds a line to clarify that the updated bash is installed in `/usr/local/bin` (as opposed to updating the system default bash).


## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [X] Documentation

## Types of changes
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes. *This is a doco-only change; no relevant tests to add.*
- [ ] My changes require further changes to the documentation.
- [X] I updated the documentation where necessary.

