### PR TITLE
Bump fetch.max.wait of Kafka-consumers to lower the load on Kafka in large systems.

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -81,10 +81,14 @@ whisk {
 
             max-poll-interval-ms = 1800000 // 30 minutes
 
-            // This value controls the server-side wait time which affects polling latency.
-            // A low value improves latency performance but it is important to not set it too low
-            // as that will cause excessive busy-waiting.
-            fetch-max-wait-ms = 20
+            // The maximum amount of time the server will block before answering
+            // the fetch request if there isn't sufficient data to immediately
+            // satisfy the requirement given by fetch.min.bytes.
+            // (default is 500, default of fetch.min.bytes is 1)
+            // On changing fetch.min.bytes, a high value for fetch.max.wait.ms,
+            // could increase latency of activations.
+            // A low value will cause excessive busy-waiting.
+            fetch-max-wait-ms = 500
         }
 
         topics {

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
@@ -108,7 +108,7 @@ class InvokerReactive(
     maxPollInterval = TimeLimit.MAX_DURATION + 1.minute)
 
   private val activationFeed = actorSystem.actorOf(Props {
-    new MessageFeed("activation", logging, consumer, maximumContainers, 500.milliseconds, processActivationMessage)
+    new MessageFeed("activation", logging, consumer, maximumContainers, 1.second, processActivationMessage)
   })
 
   /** Sends an active-ack. */


### PR DESCRIPTION
## Description

In systems with a lot of invokers, all Kafka-consumers are slowing down Kafka if they are ideling.

I did some tests with the fetch.max.wait.ms-parameter.
I produce messages to one topic. Each consumer has it’s own topic. So if there are 100 consumers, 99 of them are idling.
I used the command kafka-producer-perf-test.sh --topic invoker0 --num-records 100000 --throughput 999999999 --record-size 600 --producer-props bootstrap.servers=localhost:9072 for the test.

|               |           20ms           |           100ms          |           500ms          |          1000ms          |
|:-------------:|:------------------------:|:------------------------:|:------------------------:|:------------------------:|
|  1 consumers  | 39698.292973 records/sec | 40225.261464 records/sec | 39047.247169 records/sec |                          |
|  10 consumers | 39936.102236 records/sec | 39729.837108 records/sec | 42625.745951 records/sec |                          |
|  50 consumers | 25144.581343 records/sec | 36324.010171 records/sec | 39603.960396 records/sec |                          |
| 100 consumers | 16860.563143 records/sec | 28425.241615 records/sec | 35435.861091 records/sec | 36616.623947 records/sec |

On the test-machine, a got these numbers. The only changes were made in the amount of consumers and topics and the parameter `fetch.max.wait`.

As you can see, the procuder can write much more messages to Kafka, if the idling consumers are having a higher `fetch.max.wait`.

As `fetch.min.bytes` is set to 1, there should be no latency-impact on executing activations.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [x] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

