### PR TITLE
Log possible errors around creation of kafka clients.

### DIFF
--- a/common/scala/src/main/scala/whisk/utils/Exceptions.scala
+++ b/common/scala/src/main/scala/whisk/utils/Exceptions.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.utils
+
+import whisk.common.Logging
+
+import scala.util.control.NonFatal
+
+trait Exceptions {
+
+  /**
+   * Executes the block, catches and logs a NonFatal exception and swallows it.
+   *
+   * @param task description of the task that's being executed
+   * @param block the block to execute
+   */
+  def tryAndSwallow(task: String)(block: => Any)(implicit logging: Logging): Unit = {
+    try block
+    catch {
+      case NonFatal(t) => logging.error(this, s"$task failed: $t")
+    }
+  }
+
+  /**
+   * Executes the block, catches and logs a NonFatal exception and rethrows it.
+   *
+   * @param task description of the task that's being executed
+   * @param block the block to execute
+   */
+  def tryAndThrow[T](task: String)(block: => T)(implicit logging: Logging): T = {
+    try block
+    catch {
+      case NonFatal(t) =>
+        logging.error(this, s"$task failed: $t")
+        throw t
+    }
+  }
+
+}


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description

When we have general failures in our Kafka clients, we try to recreate them. If that recreation fails for some reason, the component might be broken forever, but it doesn't contain enough debug information now to fix this. This adds that debug information.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [X] Message Bus (e.g., Kafka)

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).

