### PR TITLE
close connections and reset pool on Container.pause

### DIFF
--- a/common/scala/src/main/scala/whisk/core/containerpool/AkkaContainerClient.scala
+++ b/common/scala/src/main/scala/whisk/core/containerpool/AkkaContainerClient.scala
@@ -71,7 +71,7 @@ protected class AkkaContainerClient(
   maxResponse: ByteSize,
   queueSize: Int,
   retryInterval: FiniteDuration = 100.milliseconds)(implicit logging: Logging, as: ActorSystem)
-    extends PoolingRestClient("http", hostname, port, queueSize, timeout = Some(timeout), keepAlive = Some(false))
+    extends PoolingRestClient("http", hostname, port, queueSize, timeout = Some(timeout))
     with ContainerClient {
 
   def close() = Await.result(shutdown(), 30.seconds)

--- a/common/scala/src/main/scala/whisk/core/containerpool/AkkaContainerClient.scala
+++ b/common/scala/src/main/scala/whisk/core/containerpool/AkkaContainerClient.scala
@@ -74,7 +74,7 @@ protected class AkkaContainerClient(
     extends PoolingRestClient("http", hostname, port, queueSize, timeout = Some(timeout))
     with ContainerClient {
 
-  def close() = Await.result(shutdown(), 30.seconds)
+  def close() = shutdown()
 
   /**
    * Posts to hostname/endpoint the given JSON object.

--- a/common/scala/src/main/scala/whisk/core/containerpool/ApacheBlockingContainerClient.scala
+++ b/common/scala/src/main/scala/whisk/core/containerpool/ApacheBlockingContainerClient.scala
@@ -72,7 +72,7 @@ protected class ApacheBlockingContainerClient(hostname: String,
    * This will close the HttpClient that is generated for this instance of ApacheBlockingContainerClient. That will also cause the
    * ConnectionManager to be closed alongside.
    */
-  def close(): Unit = HttpClientUtils.closeQuietly(connection)
+  def close(): Future[Unit] = Future.successful(HttpClientUtils.closeQuietly(connection))
 
   /**
    * Posts to hostname/endpoint the given JSON object.

--- a/common/scala/src/main/scala/whisk/core/containerpool/Container.scala
+++ b/common/scala/src/main/scala/whisk/core/containerpool/Container.scala
@@ -196,10 +196,7 @@ trait Container {
       }
   }
   private def closeConnections(toClose: Option[ContainerClient]): Future[Unit] = {
-    toClose match {
-      case Some(conn) => conn.close()
-      case None       => Future.successful(Unit)
-    }
+    toClose.map(_.close()).getOrElse(Future.successful(()))
   }
 }
 

--- a/common/scala/src/main/scala/whisk/core/containerpool/ContainerClient.scala
+++ b/common/scala/src/main/scala/whisk/core/containerpool/ContainerClient.scala
@@ -23,8 +23,8 @@ import whisk.common.TransactionId
 import whisk.core.entity.ActivationResponse.ContainerHttpError
 import whisk.core.entity.ActivationResponse._
 
-trait ContainerClient extends AutoCloseable {
+trait ContainerClient {
   def post(endpoint: String, body: JsValue, retry: Boolean)(
     implicit tid: TransactionId): Future[Either[ContainerHttpError, ContainerResponse]]
-
+  def close(): Future[Unit]
 }

--- a/common/scala/src/main/scala/whisk/core/mesos/MesosTask.scala
+++ b/common/scala/src/main/scala/whisk/core/mesos/MesosTask.scala
@@ -142,8 +142,8 @@ class MesosTask(override protected val id: ContainerId,
 
   /** Stops the container from consuming CPU cycles. */
   override def suspend()(implicit transid: TransactionId): Future[Unit] = {
-    // suspend not supported
-    Future.successful(Unit)
+    super.suspend()
+    // suspend not supported (just return result from super)
   }
 
   /** Dual of halt. */

--- a/common/scala/src/main/scala/whisk/http/PoolingRestClient.scala
+++ b/common/scala/src/main/scala/whisk/http/PoolingRestClient.scala
@@ -24,7 +24,6 @@ import akka.http.scaladsl.marshalling._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.settings.ConnectionPoolSettings
 import akka.http.scaladsl.unmarshalling._
-import akka.io.Tcp.SO
 import akka.stream.{ActorMaterializer, OverflowStrategy, QueueOfferResult}
 import akka.stream.scaladsl.{Flow, _}
 import spray.json._
@@ -46,8 +45,7 @@ class PoolingRestClient(
   port: Int,
   queueSize: Int,
   httpFlow: Option[Flow[(HttpRequest, Promise[HttpResponse]), (Try[HttpResponse], Promise[HttpResponse]), Any]] = None,
-  timeout: Option[FiniteDuration] = None,
-  keepAlive: Option[Boolean] = None)(implicit system: ActorSystem) {
+  timeout: Option[FiniteDuration] = None)(implicit system: ActorSystem) {
   require(protocol == "http" || protocol == "https", "Protocol must be one of { http, https }.")
 
   protected implicit val context: ExecutionContext = system.dispatcher
@@ -56,8 +54,7 @@ class PoolingRestClient(
   //if specified, override the ClientConnection idle-timeout and keepalive socket option value
   private val timeoutSettings = {
     ConnectionPoolSettings(system.settings.config).withUpdatedConnectionSettings { s =>
-      val t = timeout.map(t => s.withIdleTimeout(t)).getOrElse(s)
-      keepAlive.map(k => t.withSocketOptions(SO.KeepAlive(k) :: Nil)).getOrElse(t)
+      timeout.map(t => s.withIdleTimeout(t)).getOrElse(s)
     }
   }
 

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
@@ -177,9 +177,7 @@ class DockerContainer(protected val id: ContainerId,
   protected val filePollInterval: FiniteDuration = 5.milliseconds
 
   override def suspend()(implicit transid: TransactionId): Future[Unit] = {
-    super.suspend().andThen {
-      case _ => if (useRunc) { runc.pause(id) } else { docker.pause(id) }
-    }
+    super.suspend().flatMap(_ => if (useRunc) runc.pause(id) else docker.pause(id))
   }
   def resume()(implicit transid: TransactionId): Future[Unit] =
     if (useRunc) { runc.resume(id) } else { docker.unpause(id) }

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
@@ -176,8 +176,11 @@ class DockerContainer(protected val id: ContainerId,
   protected val waitForOomState: FiniteDuration = 2.seconds
   protected val filePollInterval: FiniteDuration = 5.milliseconds
 
-  def suspend()(implicit transid: TransactionId): Future[Unit] =
-    if (useRunc) { runc.pause(id) } else { docker.pause(id) }
+  override def suspend()(implicit transid: TransactionId): Future[Unit] = {
+    super.suspend().andThen {
+      case _ => if (useRunc) { runc.pause(id) } else { docker.pause(id) }
+    }
+  }
   def resume()(implicit transid: TransactionId): Future[Unit] =
     if (useRunc) { runc.resume(id) } else { docker.unpause(id) }
   override def destroy()(implicit transid: TransactionId): Future[Unit] = {

--- a/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesContainer.scala
@@ -104,9 +104,7 @@ class KubernetesContainer(protected[core] val id: ContainerId,
   protected val waitForLogs: FiniteDuration = 2.seconds
 
   override def suspend()(implicit transid: TransactionId): Future[Unit] = {
-    super.suspend().andThen {
-      case _ => kubernetes.suspend(this)
-    }
+    super.suspend().flatMap(_ => kubernetes.suspend(this))
   }
 
   def resume()(implicit transid: TransactionId): Future[Unit] = kubernetes.resume(this)

--- a/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesContainer.scala
@@ -103,7 +103,11 @@ class KubernetesContainer(protected[core] val id: ContainerId,
 
   protected val waitForLogs: FiniteDuration = 2.seconds
 
-  def suspend()(implicit transid: TransactionId): Future[Unit] = kubernetes.suspend(this)
+  override def suspend()(implicit transid: TransactionId): Future[Unit] = {
+    super.suspend().andThen {
+      case _ => kubernetes.suspend(this)
+    }
+  }
 
   def resume()(implicit transid: TransactionId): Future[Unit] = kubernetes.resume(this)
 

--- a/tests/src/test/scala/whisk/core/containerpool/logging/test/DockerToActivationLogStoreTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/logging/test/DockerToActivationLogStoreTests.scala
@@ -102,7 +102,7 @@ class DockerToActivationLogStoreTests extends FlatSpec with Matchers with WskAct
                       val addr: ContainerAddress = ContainerAddress("test", 1234))(implicit val ec: ExecutionContext,
                                                                                    val logging: Logging)
       extends Container {
-    def suspend()(implicit transid: TransactionId): Future[Unit] = ???
+    override def suspend()(implicit transid: TransactionId): Future[Unit] = ???
     def resume()(implicit transid: TransactionId): Future[Unit] = ???
 
     def logs(limit: ByteSize, waitForSentinel: Boolean)(implicit transid: TransactionId) = lines

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
@@ -740,7 +740,7 @@ class ContainerProxyTests
     var runCount = 0
     var logsCount = 0
 
-    def suspend()(implicit transid: TransactionId): Future[Unit] = {
+    override def suspend()(implicit transid: TransactionId): Future[Unit] = {
       suspendCount += 1
       Future.successful(())
     }

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
@@ -742,7 +742,7 @@ class ContainerProxyTests
 
     override def suspend()(implicit transid: TransactionId): Future[Unit] = {
       suspendCount += 1
-      Future.successful(())
+      super.suspend()
     }
     def resume()(implicit transid: TransactionId): Future[Unit] = {
       resumeCount += 1


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
Instead of restricting connection reuse, destroy connection pool on Container.pause.
Partly from discussion at https://github.com/apache/incubator-openwhisk/pull/3969#issuecomment-413590542
and partly to enable connection reuse to prep for concurrent activations (#2795)
we should not constraint connection handling at the client, but rather dispose the connection pool at time of pause (since it may leave the client pool in a bad state if the container is paused then resumed) 

(replaces the fix added in #3969 )

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

