### PR TITLE
Treat blackbox action code as attachment

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/Attachments.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Attachments.scala
@@ -54,6 +54,13 @@ object Attachments {
     }
   }
 
+  implicit class OptionSizeAttachment[T <% SizeConversion](a: Option[Attachment[T]]) extends SizeConversion {
+    def sizeIn(unit: SizeUnits.Unit): ByteSize = a match {
+      case Some(Inline(v)) => (v: SizeConversion).sizeIn(unit)
+      case _               => 0.bytes
+    }
+  }
+
   object Attached {
     implicit val serdes = {
       implicit val contentTypeSerdes = new RootJsonFormat[ContentType] {

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -330,49 +330,31 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
     implicit transid: TransactionId,
     notifier: Option[CacheChangeNotification]): Future[DocInfo] = {
 
+    def putWithAttachment(code: String, binary: Boolean, exec: AttachedCode) = {
+      implicit val logger = db.logging
+      implicit val ec = db.executionContext
+
+      val oldAttachment = old.flatMap(getAttachment)
+      val (bytes, attachmentType) = if (binary) {
+        (Base64.getDecoder.decode(code), ContentTypes.`application/octet-stream`)
+      } else {
+        (code.getBytes(UTF_8), ContentTypes.`text/plain(UTF-8)`)
+      }
+      val stream = new ByteArrayInputStream(bytes)
+      super.putAndAttach(db, doc, attachmentUpdater, attachmentType, stream, oldAttachment, Some { a: WhiskAction =>
+        a.copy(exec = exec.inline(code.getBytes(UTF_8)))
+      })
+    }
+
     Try {
       require(db != null, "db undefined")
       require(doc != null, "doc undefined")
     } map { _ =>
       doc.exec match {
         case exec @ CodeExecAsAttachment(_, Inline(code), _, binary) =>
-          implicit val logger = db.logging
-          implicit val ec = db.executionContext
-
-          val (bytes, attachmentType) = if (binary) {
-            (Base64.getDecoder.decode(code), ContentTypes.`application/octet-stream`)
-          } else {
-            (code.getBytes(UTF_8), ContentTypes.`text/plain(UTF-8)`)
-          }
-          val stream = new ByteArrayInputStream(bytes)
-          val oldAttachment = old
-            .flatMap(_.exec match {
-              case CodeExecAsAttachment(_, a: Attached, _, _) => Some(a)
-              case _                                          => None
-            })
-
-          super.putAndAttach(db, doc, attachmentUpdater, attachmentType, stream, oldAttachment, Some { a: WhiskAction =>
-            a.copy(exec = exec.inline(code.getBytes(UTF_8)))
-          })
+          putWithAttachment(code, binary, exec)
         case exec @ BlackBoxExec(_, Some(Inline(code)), _, _, binary) =>
-          implicit val logger = db.logging
-          implicit val ec = db.executionContext
-
-          val (bytes, attachmentType) = if (binary) {
-            (Base64.getDecoder.decode(code), ContentTypes.`application/octet-stream`)
-          } else {
-            (code.getBytes(UTF_8), ContentTypes.`text/plain(UTF-8)`)
-          }
-          val stream = new ByteArrayInputStream(bytes)
-          val oldAttachment = old
-            .flatMap(_.exec match {
-              case BlackBoxExec(_, Some(a: Attached), _, _, _) => Some(a)
-              case _                                           => None
-            })
-
-          super.putAndAttach(db, doc, attachmentUpdater, attachmentType, stream, oldAttachment, Some { a: WhiskAction =>
-            a.copy(exec = exec.inline(code.getBytes(UTF_8)))
-          })
+          putWithAttachment(code, binary, exec)
         case _ =>
           super.put(db, doc, old)
       }
@@ -394,28 +376,23 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
     val fa = super.getWithAttachment(db, doc, rev, fromCache, Some(attachmentHandler _))
 
     fa.flatMap { action =>
+      def getWithAttachment(attached: Attached, binary: Boolean, exec: AttachedCode) = {
+        val boas = new ByteArrayOutputStream()
+        val wrapped = if (binary) Base64.getEncoder().wrap(boas) else boas
+
+        getAttachment[A](db, action, attached, wrapped, Some { a: WhiskAction =>
+          wrapped.close()
+          val newAction = a.copy(exec = exec.inline(boas.toByteArray))
+          newAction.revision(a.rev)
+          newAction
+        })
+      }
+
       action.exec match {
         case exec @ CodeExecAsAttachment(_, attached: Attached, _, binary) =>
-          val boas = new ByteArrayOutputStream()
-          val wrapped = if (binary) Base64.getEncoder().wrap(boas) else boas
-
-          getAttachment[A](db, action, attached, wrapped, Some { a: WhiskAction =>
-            wrapped.close()
-            val newAction = a.copy(exec = exec.inline(boas.toByteArray))
-            newAction.revision(a.rev)
-            newAction
-          })
+          getWithAttachment(attached, binary, exec)
         case exec @ BlackBoxExec(_, Some(attached: Attached), _, _, binary) =>
-          val boas = new ByteArrayOutputStream()
-          val wrapped = if (binary) Base64.getEncoder().wrap(boas) else boas
-
-          getAttachment[A](db, action, attached, wrapped, Some { a: WhiskAction =>
-            wrapped.close()
-            val newAction = a.copy(exec = exec.inline(boas.toByteArray))
-            newAction.revision(a.rev)
-            newAction
-          })
-
+          getWithAttachment(attached, binary, exec)
         case _ =>
           Future.successful(action)
       }
@@ -423,16 +400,17 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
   }
 
   def attachmentHandler(action: WhiskAction, attached: Attached): WhiskAction = {
+    def checkName(name: String) = {
+      require(
+        name == attached.attachmentName,
+        s"Attachment name '${attached.attachmentName}' does not match the expected name '$name'")
+    }
     val eu = action.exec match {
       case exec @ CodeExecAsAttachment(_, Attached(attachmentName, _, _, _), _, _) =>
-        require(
-          attachmentName == attached.attachmentName,
-          s"Attachment name '${attached.attachmentName}' does not match the expected name '$attachmentName'")
+        checkName(attachmentName)
         exec.attach(attached)
       case exec @ BlackBoxExec(_, Some(Attached(attachmentName, _, _, _)), _, _, _) =>
-        require(
-          attachmentName == attached.attachmentName,
-          s"Attachment name '${attached.attachmentName}' does not match the expected name '$attachmentName'")
+        checkName(attachmentName)
         exec.attach(attached)
       case exec => exec
     }
@@ -444,6 +422,14 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
       case exec: AttachedCode =>
         action.copy(exec = exec.attach(updatedAttachment)).revision[WhiskAction](action.rev)
       case _ => action
+    }
+  }
+
+  def getAttachment(action: WhiskAction): Option[Attached] = {
+    action.exec match {
+      case CodeExecAsAttachment(_, a: Attached, _, _)  => Some(a)
+      case BlackBoxExec(_, Some(a: Attached), _, _, _) => Some(a)
+      case _                                           => None
     }
   }
 

--- a/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
@@ -38,7 +38,6 @@ import whisk.http.Messages
 import whisk.core.database.UserContext
 
 import akka.http.scaladsl.model.headers.RawHeader
-import akka.stream.scaladsl._
 import whisk.core.entity.Attachments.Inline
 
 /**

--- a/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
@@ -41,6 +41,7 @@ import java.util.Base64
 
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.stream.scaladsl._
+import whisk.core.entity.Attachments.Inline
 
 /**
  * Tests Actions API.
@@ -591,7 +592,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           action.annotations ++ Parameters(WhiskAction.execFieldName, Exec.BLACKBOX)))
       response.exec shouldBe an[BlackBoxExec]
       val bb = response.exec.asInstanceOf[BlackBoxExec]
-      bb.code shouldBe Some("cc")
+      bb.code shouldBe Some(Inline("cc"))
       bb.binary shouldBe false
     }
   }

--- a/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
@@ -36,8 +36,6 @@ import whisk.core.entitlement.Collection
 import whisk.http.ErrorResponse
 import whisk.http.Messages
 import whisk.core.database.UserContext
-import java.io.ByteArrayInputStream
-import java.util.Base64
 
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.stream.scaladsl._
@@ -802,7 +800,8 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         annotations = Parameters("exec", "java"))
     val nodeAction = WhiskAction(namespace, aname(), jsDefault(nonInlinedCode(entityStore)), Parameters("x", "b"))
     val swiftAction = WhiskAction(namespace, aname(), swift3(nonInlinedCode(entityStore)), Parameters("x", "b"))
-    val actions = Seq((javaAction, JAVA_DEFAULT), (nodeAction, NODEJS6), (swiftAction, SWIFT3))
+    val bbAction = WhiskAction(namespace, aname(), bb("bb", nonInlinedCode(entityStore), Some("bbMain")))
+    val actions = Seq((javaAction, JAVA_DEFAULT), (nodeAction, NODEJS6), (swiftAction, SWIFT3), (bbAction, BLACKBOX))
 
     actions.foreach {
       case (action, kind) =>
@@ -960,121 +959,112 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
 
   it should "get an action with attachment that is not cached" in {
     implicit val tid = transid()
-    val code = nonInlinedCode(entityStore)
-    val action =
-      WhiskAction(namespace, aname(), javaDefault(code, Some("hello")), annotations = Parameters("exec", "java"))
-    val content = WhiskActionPut(
-      Some(action.exec),
-      Some(action.parameters),
-      Some(ActionLimitsOption(Some(action.limits.timeout), Some(action.limits.memory), Some(action.limits.logs))))
-    val name = action.name
-    val cacheKey = s"${CacheKey(action)}".replace("(", "\\(").replace(")", "\\)")
-    val expectedGetLog = Seq(
-      s"finding document: 'id: ${action.namespace}/${action.name}",
-      s"finding attachment '[\\w-/:]+' of document 'id: ${action.namespace}/${action.name}").mkString("(?s).*")
+    val nodeAction = WhiskAction(namespace, aname(), jsDefault(nonInlinedCode(entityStore)), Parameters("x", "b"))
+    val swiftAction = WhiskAction(namespace, aname(), swift3(nonInlinedCode(entityStore)), Parameters("x", "b"))
+    val bbAction = WhiskAction(namespace, aname(), bb("bb", nonInlinedCode(entityStore), Some("bbMain")))
+    val actions = Seq((nodeAction, NODEJS6), (swiftAction, SWIFT3), (bbAction, BLACKBOX))
 
-    action.exec match {
-      case exec @ CodeExecAsAttachment(_, _, _, binary) =>
-        val bytes = if (binary) Base64.getDecoder().decode(code) else code.getBytes("UTF-8")
-        val stream = new ByteArrayInputStream(bytes)
-        val manifest = exec.manifest.attached.get
-        val src = StreamConverters.fromInputStream(() => stream)
-        putAndAttach[WhiskAction, WhiskEntity](
-          entityStore,
-          action,
-          (d, a) => d.copy(exec = exec.attach(a)).revision[WhiskAction](d.rev),
-          manifest.attachmentType,
-          src,
-          None)
+    actions.foreach {
+      case (action, kind) =>
+        val content = WhiskActionPut(
+          Some(action.exec),
+          Some(action.parameters),
+          Some(ActionLimitsOption(Some(action.limits.timeout), Some(action.limits.memory), Some(action.limits.logs))))
+        val name = action.name
+        val cacheKey = s"${CacheKey(action)}".replace("(", "\\(").replace(")", "\\)")
+        val expectedGetLog = Seq(
+          s"finding document: 'id: ${action.namespace}/${action.name}",
+          s"finding attachment '[\\w-/:]+' of document 'id: ${action.namespace}/${action.name}").mkString("(?s).*")
 
-      case _ =>
+        Put(s"$collectionPath/$name", content) ~> Route.seal(routes(creds)(transid())) ~> check {
+          status should be(OK)
+        }
+
+        removeFromCache(action, WhiskAction)
+
+        // second request should not fetch from cache
+        Get(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
+          status should be(OK)
+          val response = responseAs[WhiskAction]
+          response should be(
+            WhiskAction(
+              action.namespace,
+              action.name,
+              action.exec,
+              action.parameters,
+              action.limits,
+              action.version,
+              action.publish,
+              action.annotations ++ Parameters(WhiskAction.execFieldName, kind)))
+        }
+
+        stream.toString should include regex (expectedGetLog)
+        stream.reset()
     }
-
-    // second request should fetch from cache
-    Get(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
-      status should be(OK)
-      val response = responseAs[WhiskAction]
-      response should be(
-        WhiskAction(
-          action.namespace,
-          action.name,
-          action.exec,
-          action.parameters,
-          action.limits,
-          action.version,
-          action.publish,
-          action.annotations ++ Parameters(WhiskAction.execFieldName, JAVA_DEFAULT)))
-    }
-
-    stream.toString should include regex (expectedGetLog)
-    stream.reset()
   }
 
   it should "update an existing action with attachment that is not cached" in {
     implicit val tid = transid()
-    val code = nonInlinedCode(entityStore)
-    val action =
-      WhiskAction(namespace, aname(), javaDefault(code, Some("hello")), annotations = Parameters("exec", "java"))
-    val content = WhiskActionPut(
-      Some(action.exec),
-      Some(action.parameters),
-      Some(ActionLimitsOption(Some(action.limits.timeout), Some(action.limits.memory), Some(action.limits.logs))))
-    val name = action.name
-    val cacheKey = s"${CacheKey(action)}".replace("(", "\\(").replace(")", "\\)")
-    val expectedPutLog =
-      Seq(s"uploading attachment '[\\w-/:]+' of document 'id: ${action.namespace}/${action.name}", s"caching $cacheKey")
-        .mkString("(?s).*")
+    val nodeAction = WhiskAction(namespace, aname(), jsDefault(nonInlinedCode(entityStore)), Parameters("x", "b"))
+    val swiftAction = WhiskAction(namespace, aname(), swift3(nonInlinedCode(entityStore)), Parameters("x", "b"))
+    val bbAction = WhiskAction(namespace, aname(), bb("bb", nonInlinedCode(entityStore), Some("bbMain")))
+    val actions = Seq((nodeAction, NODEJS6), (swiftAction, SWIFT3), (bbAction, BLACKBOX))
 
-    action.exec match {
-      case exec @ CodeExecAsAttachment(_, _, _, _) =>
-        val stream = new ByteArrayInputStream(code.getBytes)
-        val manifest = exec.manifest.attached.get
-        val src = StreamConverters.fromInputStream(() => stream)
-        putAndAttach[WhiskAction, WhiskEntity](
-          entityStore,
-          action,
-          (d, a) => d.copy(exec = exec.attach(a)).revision[WhiskAction](d.rev),
-          manifest.attachmentType,
-          src,
-          None)
+    actions.foreach {
+      case (action, kind) =>
+        val content = WhiskActionPut(
+          Some(action.exec),
+          Some(action.parameters),
+          Some(ActionLimitsOption(Some(action.limits.timeout), Some(action.limits.memory), Some(action.limits.logs))))
+        val name = action.name
+        val cacheKey = s"${CacheKey(action)}".replace("(", "\\(").replace(")", "\\)")
+        val expectedPutLog =
+          Seq(
+            s"uploading attachment '[\\w-/:]+' of document 'id: ${action.namespace}/${action.name}",
+            s"caching $cacheKey")
+            .mkString("(?s).*")
 
-      case _ =>
+        Put(s"$collectionPath/$name", content) ~> Route.seal(routes(creds)(transid())) ~> check {
+          status should be(OK)
+        }
+
+        removeFromCache(action, WhiskAction)
+
+        Put(s"$collectionPath/$name?overwrite=true", content) ~> Route.seal(routes(creds)(transid())) ~> check {
+          status should be(OK)
+          val response = responseAs[WhiskAction]
+          response should be(
+            WhiskAction(
+              action.namespace,
+              action.name,
+              action.exec,
+              action.parameters,
+              action.limits,
+              action.version.upPatch,
+              action.publish,
+              action.annotations ++ Parameters(WhiskAction.execFieldName, kind)))
+        }
+        stream.toString should include regex (expectedPutLog)
+        stream.reset()
+
+        // delete should invalidate cache
+        Delete(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
+          status should be(OK)
+          val response = responseAs[WhiskAction]
+          response should be(
+            WhiskAction(
+              action.namespace,
+              action.name,
+              action.exec,
+              action.parameters,
+              action.limits,
+              action.version.upPatch,
+              action.publish,
+              action.annotations ++ Parameters(WhiskAction.execFieldName, kind)))
+        }
+        stream.toString should include(s"invalidating ${CacheKey(action)}")
+        stream.reset()
     }
-
-    Put(s"$collectionPath/$name?overwrite=true", content) ~> Route.seal(routes(creds)(transid())) ~> check {
-      status should be(OK)
-      val response = responseAs[WhiskAction]
-      response should be(
-        WhiskAction(
-          action.namespace,
-          action.name,
-          action.exec,
-          action.parameters,
-          action.limits,
-          action.version.upPatch,
-          action.publish,
-          action.annotations ++ Parameters(WhiskAction.execFieldName, JAVA_DEFAULT)))
-    }
-    stream.toString should include regex (expectedPutLog)
-    stream.reset()
-
-    // delete should invalidate cache
-    Delete(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
-      status should be(OK)
-      val response = responseAs[WhiskAction]
-      response should be(
-        WhiskAction(
-          action.namespace,
-          action.name,
-          action.exec,
-          action.parameters,
-          action.limits,
-          action.version.upPatch,
-          action.publish,
-          action.annotations ++ Parameters(WhiskAction.execFieldName, JAVA_DEFAULT)))
-    }
-    stream.toString should include(s"invalidating ${CacheKey(action)}")
-    stream.reset()
   }
 
   it should "ensure old and new action schemas are supported" in {

--- a/tests/src/test/scala/whisk/core/database/test/AttachmentCompatibilityTests.scala
+++ b/tests/src/test/scala/whisk/core/database/test/AttachmentCompatibilityTests.scala
@@ -138,6 +138,21 @@ class AttachmentCompatibilityTests
     codeExec(action2).codeAsJson shouldBe JsString("while (true)")
   }
 
+  it should "read existing simple code string for blackbox action" in {
+    implicit val tid: TransactionId = transid()
+    val exec = """{
+                 |  "kind": "blackbox",
+                 |  "image": "docker-custom.com/openwhisk-runtime/magic/nodejs:0.0.1",
+                 |  "code":  "while (true)",
+                 |  "binary": false
+                 |}""".stripMargin.parseJson.asJsObject
+    val (id, action) = makeActionJson(namespace, aname(), exec)
+    val info = putDoc(id, action)
+
+    val action2 = WhiskAction.get(entityStore, info.id).futureValue
+    codeExec(action2).codeAsJson shouldBe JsString("while (true)")
+  }
+
   private def codeExec(a: WhiskAction) = a.exec.asInstanceOf[CodeExec[_]]
 
   private def makeActionJson(namespace: EntityPath, name: EntityName, exec: JsObject): (String, JsObject) = {

--- a/tests/src/test/scala/whisk/core/database/test/DbUtils.scala
+++ b/tests/src/test/scala/whisk/core/database/test/DbUtils.scala
@@ -350,6 +350,11 @@ trait DbUtils extends Assertions {
   def isMemoryStore(store: ArtifactStore[_]): Boolean = store.isInstanceOf[MemoryArtifactStore[_]]
   def isCouchStore(store: ArtifactStore[_]): Boolean = store.isInstanceOf[CouchDbRestStore[_]]
 
+  protected def removeFromCache[A <: DocumentRevisionProvider](entity: WhiskEntity, factory: DocumentFactory[A])(
+    implicit ec: ExecutionContext): Unit = {
+    factory.removeId(CacheKey(entity))
+  }
+
   protected def randomBytes(size: Int): Array[Byte] = {
     val arr = new Array[Byte](size)
     Random.nextBytes(arr)

--- a/tests/src/test/scala/whisk/core/database/test/behavior/ArtifactStoreBehaviorBase.scala
+++ b/tests/src/test/scala/whisk/core/database/test/behavior/ArtifactStoreBehaviorBase.scala
@@ -125,7 +125,7 @@ trait ArtifactStoreBehaviorBase
     WhiskNamespace(Namespace(EntityName(name), uuid), BasicAuthenticationAuthKey(uuid, Secret()))
   }
 
-  private val exec = BlackBoxExec(ExecManifest.ImageName("image"), None, None, native = false)
+  private val exec = BlackBoxExec(ExecManifest.ImageName("image"), None, None, native = false, binary = false)
 
   protected def newAction(ns: EntityPath): WhiskAction = {
     WhiskAction(ns, aname(), exec)

--- a/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
@@ -19,7 +19,6 @@ package whisk.core.entity.test
 
 import org.scalatest.Matchers
 import org.scalatest.Suite
-
 import common.StreamLogging
 import common.WskActorSystem
 import whisk.core.WhiskConfig
@@ -27,7 +26,6 @@ import whisk.core.entity._
 import whisk.core.entity.ArgNormalizer.trim
 import whisk.core.entity.ExecManifest._
 import whisk.core.entity.size._
-
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
@@ -136,10 +134,13 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
 
   protected def sequenceMetaData(components: Vector[FullyQualifiedEntityName]) = SequenceExecMetaData(components)
 
-  protected def bb(image: String) = BlackBoxExec(ExecManifest.ImageName(trim(image)), None, None, false)
+  protected def bb(image: String) = BlackBoxExec(ExecManifest.ImageName(trim(image)), None, None, false, false)
 
   protected def bb(image: String, code: String, main: Option[String] = None) = {
-    BlackBoxExec(ExecManifest.ImageName(trim(image)), Some(trim(code)).filter(_.nonEmpty), main, false)
+    val (codeOpt, binary) =
+      if (code.trim.nonEmpty) (Some(attFmt[String].read(code.toJson)), Exec.isBinaryCode(code))
+      else (None, false)
+    BlackBoxExec(ExecManifest.ImageName(trim(image)), codeOpt, main, false, binary)
   }
 
   protected def blackBoxMetaData(image: String, main: Option[String] = None, binary: Boolean) = {

--- a/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecHelpers.scala
@@ -39,6 +39,7 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
   protected val NODEJS6 = "nodejs:6"
   protected val SWIFT = "swift"
   protected val SWIFT3 = "swift:3.1.1"
+  protected val BLACKBOX = "blackbox"
   protected val SWIFT3_IMAGE = "action-swift-v3.1.1"
   protected val JAVA_DEFAULT = "java"
 

--- a/tests/src/test/scala/whisk/core/entity/test/ExecTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecTests.scala
@@ -17,6 +17,7 @@
 
 package whisk.core.entity.test
 
+import akka.http.scaladsl.model.ContentTypes
 import common.StreamLogging
 import spray.json._
 import org.junit.runner.RunWith
@@ -24,7 +25,8 @@ import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 import whisk.core.WhiskConfig
 import whisk.core.entity.Attachments.{Attached, Inline}
-import whisk.core.entity.{CodeExecAsAttachment, CodeExecAsString, Exec, ExecManifest, WhiskAction}
+import whisk.core.entity.ExecManifest.ImageName
+import whisk.core.entity.{BlackBoxExec, CodeExecAsAttachment, CodeExecAsString, Exec, ExecManifest, WhiskAction}
 
 import scala.collection.mutable
 
@@ -166,6 +168,132 @@ class ExecTests extends FlatSpec with Matchers with StreamLogging with BeforeAnd
 
     //Reset config back
     ExecManifest.initialize(config)
+  }
+
+  behavior of "blackbox exec deserialization"
+
+  it should "read existing code string as attachment" in {
+    val json = """{
+                 |  "name": "action_tests_name2",
+                 |  "_id": "anon-Yzycx8QnIYDp3Tby0Fnj23KcMtH/action_tests_name2",
+                 |  "publish": false,
+                 |  "annotations": [],
+                 |  "version": "0.0.1",
+                 |  "updated": 1533623651650,
+                 |  "entityType": "action",
+                 |  "exec": {
+                 |    "kind": "blackbox",
+                 |    "image": "docker-custom.com/openwhisk-runtime/magic/nodejs:0.0.1",
+                 |    "code": "foo",
+                 |    "binary": false
+                 |  },
+                 |  "parameters": [
+                 |    {
+                 |      "key": "x",
+                 |      "value": "b"
+                 |    }
+                 |  ],
+                 |  "limits": {
+                 |    "timeout": 60000,
+                 |    "memory": 256,
+                 |    "logs": 10
+                 |  },
+                 |  "namespace": "anon-Yzycx8QnIYDp3Tby0Fnj23KcMtH"
+                 |}""".stripMargin.parseJson.asJsObject
+    val action = WhiskAction.serdes.read(json)
+    action.exec should matchPattern { case BlackBoxExec(_, Some(Inline("foo")), None, false, false) => }
+  }
+
+  it should "properly determine binary property" in {
+    val j1 = """{
+               |    "kind": "blackbox",
+               |    "image": "docker-custom.com/openwhisk-runtime/magic/nodejs:0.0.1",
+               |    "code": "SGVsbG8gT3BlbldoaXNr",
+               |    "binary": false
+               |}""".stripMargin.parseJson.asJsObject
+    Exec.serdes.read(j1) should matchPattern {
+      case BlackBoxExec(_, Some(Inline("SGVsbG8gT3BlbldoaXNr")), None, false, true) =>
+    }
+
+    val j2 = """{
+               |  "kind": "blackbox",
+               |  "image": "docker-custom.com/openwhisk-runtime/magic/nodejs:0.0.1",
+               |  "code":  "while (true)",
+               |  "binary": false
+               |}""".stripMargin.parseJson.asJsObject
+    Exec.serdes.read(j2) should matchPattern {
+      case BlackBoxExec(_, Some(Inline("while (true)")), None, false, false) =>
+    }
+
+    //Empty code should resolve as None
+    val j3 = """{
+               |  "kind": "blackbox",
+               |  "image": "docker-custom.com/openwhisk-runtime/magic/nodejs:0.0.1",
+               |  "code": " "
+               |}""".stripMargin.parseJson.asJsObject
+    Exec.serdes.read(j3) should matchPattern {
+      case BlackBoxExec(_, None, None, false, false) =>
+    }
+
+    val j4 = """{
+                 |  "kind": "blackbox",
+                 |  "image": "docker-custom.com/openwhisk-runtime/magic/nodejs:0.0.1",
+                 |  "code": {
+                 |    "attachmentName": "foo:bar",
+                 |    "attachmentType": "application/octet-stream",
+                 |    "length": 32768,
+                 |    "digest": "sha256-foo"
+                 |  },
+                 |  "binary": true,
+                 |  "main": "hello"
+                 |}""".stripMargin.parseJson.asJsObject
+    Exec.serdes.read(j4) should matchPattern {
+      case BlackBoxExec(_, Some(Attached("foo:bar", _, Some(32768), Some("sha256-foo"))), Some("hello"), false, true) =>
+    }
+  }
+
+  behavior of "blackbox exec serialization"
+
+  it should "serialize with inline attachment" in {
+    val bb = BlackBoxExec(
+      ImageName.fromString("docker-custom.com/openwhisk-runtime/magic/nodejs:0.0.1").get,
+      Some(Inline("foo")),
+      None,
+      false,
+      false)
+    val js = Exec.serdes.write(bb)
+
+    val js2 = """{
+                |  "kind": "blackbox",
+                |  "image": "docker-custom.com/openwhisk-runtime/magic/nodejs:0.0.1",
+                |  "binary": false,
+                |  "code": "foo"
+                |}""".stripMargin.parseJson.asJsObject
+    js shouldBe js2
+  }
+
+  it should "serialize with attached attachment" in {
+    val bb = BlackBoxExec(
+      ImageName.fromString("docker-custom.com/openwhisk-runtime/magic/nodejs:0.0.1").get,
+      Some(Attached("foo", ContentTypes.`application/octet-stream`, Some(42), Some("sha1-42"))),
+      None,
+      false,
+      true)
+    val js = Exec.serdes.write(bb)
+    println(js)
+
+    val js2 = """{
+                |  "kind": "blackbox",
+                |  "image": "docker-custom.com/openwhisk-runtime/magic/nodejs:0.0.1",
+                |  "binary": true,
+                |  "code": {
+                |    "attachmentName": "foo",
+                |    "attachmentType": "application/octet-stream",
+                |    "length": 42,
+                |    "digest": "sha1-42"
+                |  }
+                |}""".stripMargin.parseJson.asJsObject
+    js shouldBe js2
   }
 
   private class TestConfig(val props: Map[String, String], requiredProperties: Map[String, String])

--- a/tests/src/test/scala/whisk/core/entity/test/ExecTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecTests.scala
@@ -280,7 +280,6 @@ class ExecTests extends FlatSpec with Matchers with StreamLogging with BeforeAnd
       false,
       true)
     val js = Exec.serdes.write(bb)
-    println(js)
 
     val js2 = """{
                 |  "kind": "blackbox",


### PR DESCRIPTION
Treats blackbox action code as attachment

## Description

This is next installment in the [attachment saga](#3944) (previous in this series #3945). With this change code related to blackbox action would also be stored as attachment.

1. Change is backward compatible in reading code
2. Upon update or new action being created the code would be stored as attachment

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#3944)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

