### PR TITLE
Log activation retrieval from activation store for block invocations

### DIFF
--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -260,6 +260,7 @@ object LoggingMarkers {
   // Time of the activation in controller until it is delivered to Kafka
   val CONTROLLER_ACTIVATION = LogMarkerToken(controller, activation, start)
   val CONTROLLER_ACTIVATION_BLOCKING = LogMarkerToken(controller, "blockingActivation", start)
+  val CONTROLLER_ACTIVATION_BLOCKING_FROM_DB_POLL = LogMarkerToken(controller, "blockingActivationPoll", count)
 
   // Time that is needed load balance the activation
   val CONTROLLER_LOADBALANCER = LogMarkerToken(controller, loadbalancer, start)

--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -260,7 +260,8 @@ object LoggingMarkers {
   // Time of the activation in controller until it is delivered to Kafka
   val CONTROLLER_ACTIVATION = LogMarkerToken(controller, activation, start)
   val CONTROLLER_ACTIVATION_BLOCKING = LogMarkerToken(controller, "blockingActivation", start)
-  val CONTROLLER_ACTIVATION_BLOCKING_FROM_DB_POLL = LogMarkerToken(controller, "blockingActivationPoll", count)
+  val CONTROLLER_ACTIVATION_BLOCKING_DATABASE_RETRIEVAL =
+    LogMarkerToken(controller, "blockingActivationDatabaseRetrieval", count)
 
   // Time that is needed load balance the activation
   val CONTROLLER_LOADBALANCER = LogMarkerToken(controller, loadbalancer, start)

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
@@ -614,7 +614,11 @@ protected[actions] trait PrimitiveActions {
       val schedule = actorSystem.scheduler.scheduleOnce(wait(retries)) {
         activationStore.get(ActivationId(docid.asString), context).onComplete {
           case Success(activation) =>
-            logging.info(this, "retrieved activation for blocking invocation from ActivationStore")
+            transid.mark(
+              this,
+              LoggingMarkers.CONTROLLER_ACTIVATION_BLOCKING_FROM_DB_POLL,
+              s"retrieved activation for blocking invocation via DB polling",
+              logLevel = InfoLevel)
             result.trySuccess(Right(activation))
           case Failure(_: NoDocumentException) => pollActivation(docid, context, result, wait, retries + 1, maxRetries)
           case Failure(t: Throwable)           => result.tryFailure(t)

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
@@ -616,7 +616,7 @@ protected[actions] trait PrimitiveActions {
           case Success(activation) =>
             transid.mark(
               this,
-              LoggingMarkers.CONTROLLER_ACTIVATION_BLOCKING_FROM_DB_POLL,
+              LoggingMarkers.CONTROLLER_ACTIVATION_BLOCKING_DATABASE_RETRIEVAL,
               s"retrieved activation for blocking invocation via DB polling",
               logLevel = InfoLevel)
             result.trySuccess(Right(activation))

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
@@ -613,7 +613,9 @@ protected[actions] trait PrimitiveActions {
     if (!result.isCompleted && retries < maxRetries) {
       val schedule = actorSystem.scheduler.scheduleOnce(wait(retries)) {
         activationStore.get(ActivationId(docid.asString), context).onComplete {
-          case Success(activation)             => result.trySuccess(Right(activation))
+          case Success(activation) =>
+            logging.info(this, "retrieved activation for blocking invocation from ActivationStore")
+            result.trySuccess(Right(activation))
           case Failure(_: NoDocumentException) => pollActivation(docid, context, result, wait, retries + 1, maxRetries)
           case Failure(t: Throwable)           => result.tryFailure(t)
         }

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -110,6 +110,10 @@ Metrics below are emitted from within a Controller instance.
   * Example _openwhisk.counter.controller_startup0_count_
   * Records count of controller instance startup
 
+##### Controller Activation Retrieval During Blocking Invocations
+
+* `openwhisk.counter.controller_blockingActivationPoll_count` (counter) - Records the count of activations the controller has retrieved from the activation store during blocking invocations
+
 ##### Activation Submission
 
 Following metrics record stats around activation handling within Controller

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -112,7 +112,7 @@ Metrics below are emitted from within a Controller instance.
 
 ##### Controller Activation Retrieval During Blocking Invocations
 
-* `openwhisk.counter.controller_blockingActivationPoll_count` (counter) - Records the count of activations the controller has retrieved from the activation store during blocking invocations
+* `openwhisk.counter.controller_blockingActivationDatabaseRetrieval_count` (counter) - Records the count of activations the controller has retrieved from the activation store during blocking invocations
 
 ##### Activation Submission
 


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
Adds a log message when an activation record is retrieved from the activation store for blocking invocations. This will help us determine how often the DB polling flow is used to retrieve blocking invocation activations.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

