### PR TITLE
Support storing attachment in a sub folder in S3 bucket

### DIFF
--- a/common/scala/src/main/resources/s3-reference.conf
+++ b/common/scala/src/main/resources/s3-reference.conf
@@ -3,6 +3,13 @@
 
 whisk {
   s3 {
+
+    # Name of S3 bucket
+    # bucket =
+
+    # Folder path within the bucket (optional)
+    # prefix =
+
     # See https://developer.lightbend.com/docs/alpakka/current/s3.html#usage
     alpakka {
       # whether the buffer request chunks (up to 5MB each) to "memory" or "disk"

--- a/common/scala/src/main/scala/whisk/core/database/s3/S3AttachmentStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/s3/S3AttachmentStore.scala
@@ -38,9 +38,10 @@ import scala.reflect.ClassTag
 
 object S3AttachmentStoreProvider extends AttachmentStoreProvider {
   val alpakkaConfigKey = s"${ConfigKeys.s3}.alpakka"
-  case class S3Config(bucket: String) {
+  case class S3Config(bucket: String, prefix: Option[String]) {
     def prefixFor[D](implicit tag: ClassTag[D]): String = {
-      tag.runtimeClass.getSimpleName.toLowerCase
+      val className = tag.runtimeClass.getSimpleName.toLowerCase
+      prefix.map(p => s"$p/$className").getOrElse(className)
     }
   }
 
@@ -68,6 +69,8 @@ class S3AttachmentStore(client: S3Client, bucket: String, prefix: String)(implic
   override val scheme = "s3"
 
   override protected[core] implicit val executionContext: ExecutionContext = system.dispatcher
+
+  logging.info(this, s"Initializing S3AttachmentStore with bucket=[$bucket], prefix=[$prefix]")
 
   override protected[core] def attach(
     docId: DocId,

--- a/tests/src/test/scala/whisk/core/database/s3/S3Minio.scala
+++ b/tests/src/test/scala/whisk/core/database/s3/S3Minio.scala
@@ -56,7 +56,7 @@ trait S3Minio extends FlatSpec with BeforeAndAfterAll with StreamLogging {
       |         endpoint-url = "http://localhost:$port"
       |      }
       |      bucket = "$bucket"
-      |      prefix = $bucketPrefix
+      |      $prefixConfig
       |     }
       |}
       """.stripMargin).withFallback(ConfigFactory.load())
@@ -67,6 +67,10 @@ trait S3Minio extends FlatSpec with BeforeAndAfterAll with StreamLogging {
   private val secretAccessKey = "TESTSECRET"
   private val port = freePort()
   private val bucket = "test-ow-travis"
+
+  private def prefixConfig = {
+    if (bucketPrefix.nonEmpty) s"prefix = $bucketPrefix" else ""
+  }
 
   protected def bucketPrefix: String = ""
 

--- a/tests/src/test/scala/whisk/core/database/s3/S3Minio.scala
+++ b/tests/src/test/scala/whisk/core/database/s3/S3Minio.scala
@@ -56,6 +56,7 @@ trait S3Minio extends FlatSpec with BeforeAndAfterAll with StreamLogging {
       |         endpoint-url = "http://localhost:$port"
       |      }
       |      bucket = "$bucket"
+      |      prefix = $bucketPrefix
       |     }
       |}
       """.stripMargin).withFallback(ConfigFactory.load())
@@ -66,6 +67,8 @@ trait S3Minio extends FlatSpec with BeforeAndAfterAll with StreamLogging {
   private val secretAccessKey = "TESTSECRET"
   private val port = freePort()
   private val bucket = "test-ow-travis"
+
+  protected def bucketPrefix: String = ""
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()

--- a/tests/src/test/scala/whisk/core/database/s3/S3WithPrefixTests.scala
+++ b/tests/src/test/scala/whisk/core/database/s3/S3WithPrefixTests.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.database.s3
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import whisk.core.database.s3.S3AttachmentStoreProvider.S3Config
+import whisk.core.entity.WhiskEntity
+
+@RunWith(classOf[JUnitRunner])
+class S3WithPrefixTests extends S3AttachmentStoreMinioTests {
+  override protected val bucketPrefix: String = "master"
+
+  behavior of "S3Config"
+
+  it should "work with none prefix" in {
+    val config = S3Config("foo", None)
+    config.prefixFor[WhiskEntity] shouldBe "whiskentity"
+  }
+
+  it should "work with optional prefix" in {
+    val config = S3Config("foo", Some("bar"))
+    config.prefixFor[WhiskEntity] shouldBe "bar/whiskentity"
+  }
+}


### PR DESCRIPTION
Enable configuring a common parent folder under which all attachments stored. This enables sharing same bucket with multiple clusters

## Description

Currently the attachments are stored with path structure `whiskentity/<namespace>/<docId>/<name>`. With this PR it would be possible to also specify a parent path under which this path would be created. So path structure would be like `<prefix>/whiskentity/<namespace>/<docId>/<name>`

### Config

The prefix can be specified via `prefix` setting (optional)

```
whisk {
     s3 {
      alpakka {
         aws {
           credentials {
             provider = static
             access-key-id = "$accessKey"
             secret-access-key = "$secretAccessKey"
           }
           region {
             provider = static
             default-region = us-west-2
           }
         }
         endpoint-url = "http://localhost:$port"
      }
      bucket = "openwhisk"
      prefix = "dev-cluster"
     }
}
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

