### PR TITLE
Simplify configuring OpenWhisk

### DIFF
--- a/common/scala/transformEnvironment.sh
+++ b/common/scala/transformEnvironment.sh
@@ -36,8 +36,9 @@ props=()
 
 if [ -n "$OPENWHISK_CONFIG" ]
 then
-   printf "%s" "$OPENWHISK_CONFIG" > "/openwhisk.conf"
-   props+=("-Dconfig.file='/openwhisk.conf'")
+    location="/config.conf"
+    printf "%s" "$OPENWHISK_CONFIG" > "$location"
+    props+=("-Dconfig.file='$location'")
 fi
 
 for var in $configVariables

--- a/common/scala/transformEnvironment.sh
+++ b/common/scala/transformEnvironment.sh
@@ -34,6 +34,12 @@ configVariables=$(compgen -v | grep $prefix)
 
 props=()
 
+if [ -n "$OPENWHISK_CONFIG" ]
+then
+   printf "%s" "$OPENWHISK_CONFIG" > "/openwhisk.conf"
+   props+=("-Dconfig.file='/openwhisk.conf'")
+fi
+
 for var in $configVariables
 do
     value=$(printenv "$var")


### PR DESCRIPTION
Enables support for passing typesafe config string as part of environment variables. 

## Description

Currently to configure OpenWhisk settings in Controller and Invoker one needs to reverse map the typesafe config to environment variable following specific convention. For example setting `whisk.loadbalancer.invoker-busy-threshold` would need env name like `CONFIG_whisk_loadbalancer_invokerBusyThreshold`. This currently works but poses following problems

1. Mapping config name to env name has some transformation involved and is a manual process
2. Flattening the config tree in env variables obscures the config and makes it tricky to get the context
3. Mapping list entries in config to env variable is tricky

It would be better to have a way where we can pass in the config from a file in typesafe config format to the container via some environment variable. This brings back all the [benefits of typesafe config](https://github.com/lightbend/config/blob/master/HOCON.md#goals--background) for custom config.

### Usage

This PR currently does not convert the existing ansible setup to switch to config format and just enables someone to use the new approach.

#### Step 1 - Config in File

Define the required config in a file. This can also be a jinja template

```
include classpath("application.conf")

whisk {
  couchdb {
    protocol = "{{ db.protocol }}"
    host     = "{{ db.host }}"
    port     = "{{ db.port }}"
    username = "{{ db.username }}"
    password = "{{ db.password }}"
    databases {
      WhiskAuth       = "{{ db.whisk.auth }}"
      WhiskEntity     = "{{ db.whisk.actions }}"
      WhiskActivation = "{{ db.whisk.activations }}"
    }
  }
}

```

#### Step 2 - Configure env variable

Configure env variable `OPENWHISK_CONFIG` with content of  above file

```yml
- name: Load config from template
  set_fact:
      openwhisk_config: "{{ lookup('template', 'config.j2') }}"

- name: populate environment variables for controller
  set_fact:
    env:
      "OPENWHISK_CONFIG": "{{ openwhisk_config }}"
```

With this at runtime config would also include config provided from the config file in addition to config set via env variables

### Implementation Detail 

This PR modifies the `transformEnvironment.sh` to copy the content of `OPENWHISK_CONFIG` to file `/openwhisk.conf` on file system. It also configures the system property `-Dconfig.file='/openwhisk.conf` which makes [typesafe config logic load](https://github.com/lightbend/config#standard-behavior) this file. 
 

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

