### PR TITLE
Optionally return a small portion of user logs for blocking invocations

### DIFF
--- a/common/scala/src/main/scala/whisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/whisk/core/connector/Message.scala
@@ -48,6 +48,7 @@ case class ActivationMessage(override val transid: TransactionId,
                              activationId: ActivationId,
                              rootControllerIndex: ControllerInstanceId,
                              blocking: Boolean,
+                             blockingLogs: Boolean,
                              content: Option[JsObject],
                              cause: Option[ActivationId] = None,
                              traceContext: Option[Map[String, String]] = None)
@@ -68,7 +69,7 @@ object ActivationMessage extends DefaultJsonProtocol {
   def parse(msg: String) = Try(serdes.read(msg.parseJson))
 
   private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
-  implicit val serdes = jsonFormat10(ActivationMessage.apply)
+  implicit val serdes = jsonFormat11(ActivationMessage.apply)
 }
 
 /**

--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -235,7 +235,14 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
                     .getOrElse(true)
 
                   if (allowInvoke) {
-                    doInvoke(user, actionWithMergedParams, payload, blocking, waitOverride, blocking && logs, result)
+                    doInvoke(
+                      user,
+                      actionWithMergedParams,
+                      payload,
+                      blocking,
+                      waitOverride,
+                      blocking && logs && !result,
+                      result)
                   } else {
                     terminate(BadRequest, Messages.parametersNotAllowed)
                   }

--- a/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/WebActions.scala
@@ -629,7 +629,13 @@ trait WhiskWebActionsApi extends Directives with ValidateRequestSize with PostAc
       if (isRawHttpAction || context
             .overrides(webApiDirectives.reservedProperties ++ action.immutableParameters)) {
         val content = context.toActionArgument(onBehalfOf, isRawHttpAction)
-        invokeAction(actionOwnerIdentity, action, Some(JsObject(content)), maxWaitForWebActionResult, cause = None)
+        invokeAction(
+          actionOwnerIdentity,
+          action,
+          Some(JsObject(content)),
+          maxWaitForWebActionResult,
+          false,
+          cause = None)
       } else {
         Future.failed(RejectRequest(BadRequest, Messages.parametersNotAllowed))
       }

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PostActionActivation.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PostActionActivation.scala
@@ -49,6 +49,7 @@ protected[core] trait PostActionActivation extends PrimitiveActions with Sequenc
     action: WhiskActionMetaData,
     payload: Option[JsObject],
     waitForResponse: Option[FiniteDuration],
+    responseWithLogs: Boolean,
     cause: Option[ActivationId])(implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
     action.toExecutableWhiskAction match {
       // this is a topmost sequence
@@ -57,7 +58,7 @@ protected[core] trait PostActionActivation extends PrimitiveActions with Sequenc
         invokeSequence(user, action, components, payload, waitForResponse, cause, topmost = true, 0).map(r => r._1)
       // a non-deprecated ExecutableWhiskAction
       case Some(executable) if !executable.exec.deprecated =>
-        invokeSingleAction(user, executable, payload, waitForResponse, cause)
+        invokeSingleAction(user, executable, payload, waitForResponse, responseWithLogs, cause)
       // a deprecated exec
       case _ =>
         Future.failed(RejectRequest(BadRequest, Messages.runtimeDeprecated(action.exec)))

--- a/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
@@ -66,6 +66,7 @@ protected[actions] trait SequenceActions {
     action: WhiskActionMetaData,
     payload: Option[JsObject],
     waitForResponse: Option[FiniteDuration],
+    responseWithLogs: Boolean,
     cause: Option[ActivationId])(implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]]
 
   /**
@@ -337,7 +338,7 @@ protected[actions] trait SequenceActions {
           // this is an invoke for an atomic action
           logging.debug(this, s"sequence invoking an enclosed atomic action $action")
           val timeout = action.limits.timeout.duration + 1.minute
-          invokeAction(user, action, inputPayload, waitForResponse = Some(timeout), cause) map {
+          invokeAction(user, action, inputPayload, waitForResponse = Some(timeout), false, cause) map {
             case res => (res, accounting.atomicActionCnt + 1)
           }
       }

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
@@ -408,6 +408,7 @@ class InvokerActor(invokerInstance: InvokerInstanceId, controllerInstance: Contr
         activationId = new ActivationIdGenerator {}.make(),
         rootControllerIndex = controllerInstance,
         blocking = false,
+        blockingLogs = false,
         content = None)
 
       context.parent ! ActivationRequest(activationMessage, invokerInstance)

--- a/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
@@ -417,10 +417,13 @@ class ContainerProxy(
     // Storing the record. Entirely asynchronous and not waited upon.
     activationWithLogs.map(_.fold(_.activation, identity)).foreach(storeActivation(tid, _, context))
 
+    logging.debug(this, "WERWERWERWERWERWERWER")
+    logging.debug(this, s"TESTETESTSETESTSET ${job.msg.blockingLogs}")
+    println(s"TESTETESTSETESTSET ${job.msg.blockingLogs}")
     // Disambiguate activation errors and transform the Either into a failed/successful Future respectively.
     activationWithLogs.flatMap {
       case Right(act) if !act.response.isSuccess =>
-        if (job.msg.blocking) {
+        if (job.msg.blocking && job.msg.blockingLogs) {
           sendActiveAck(
             tid,
             act.withLogs(getTruncatedLogs(act.logs)),
@@ -438,7 +441,7 @@ class ContainerProxy(
           sendActiveAck(tid, _, job.msg.blocking, job.msg.rootControllerIndex, job.msg.user.namespace.uuid))
         Future.failed(error)
       case Right(act) =>
-        if (job.msg.blocking) {
+        if (job.msg.blocking && job.msg.blockingLogs) {
           sendActiveAck(
             tid,
             act.withLogs(getTruncatedLogs(act.logs)),

--- a/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
@@ -431,12 +431,9 @@ class ContainerProxy(
 
     // Disambiguate activation errors and transform the Either into a failed/successful Future respectively.
     activationWithLogs.flatMap {
-      case Right(act) if !act.response.isSuccess =>
-        Future.failed(ActivationUnsuccessfulError(act))
-      case Left(error) =>
-        Future.failed(error)
-      case Right(act) =>
-        Future.successful(act)
+      case Right(act) if !act.response.isSuccess => Future.failed(ActivationUnsuccessfulError(act))
+      case Left(error)                           => Future.failed(error)
+      case Right(act)                            => Future.successful(act)
     }
   }
 }

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
@@ -122,6 +122,14 @@ class InvokerReactive(
     implicit val transid: TransactionId = tid
 
     def send(res: Either[ActivationId, WhiskActivation], recovery: Boolean = false) = {
+      //val msg = CompletionMessage(transid, res, instance)
+
+      //val a = res.right.get
+      //val b = a.withLogs(ActivationLogs(Vector("asdf", "wqer")))
+      //println("rdtfgyhuijokphiugyfabejknrjghiugfjknldr")
+      //println(a.toJson)
+      //println(b.toJson)
+
       val msg = CompletionMessage(transid, res, instance)
       producer.send(topic = "completed" + controllerInstance.asString, msg).andThen {
         case Success(_) =>

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
@@ -122,14 +122,6 @@ class InvokerReactive(
     implicit val transid: TransactionId = tid
 
     def send(res: Either[ActivationId, WhiskActivation], recovery: Boolean = false) = {
-      //val msg = CompletionMessage(transid, res, instance)
-
-      //val a = res.right.get
-      //val b = a.withLogs(ActivationLogs(Vector("asdf", "wqer")))
-      //println("rdtfgyhuijokphiugyfabejknrjghiugfjknldr")
-      //println(a.toJson)
-      //println(b.toJson)
-
       val msg = CompletionMessage(transid, res, instance)
       producer.send(topic = "completed" + controllerInstance.asString, msg).andThen {
         case Success(_) =>

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
@@ -144,7 +144,7 @@ class InvokerReactive(
                 totalLogSize = totalLogSize + log.size
                 log
               } else {
-                val l = "..." + log.substring(log.size - (maxLogSize - totalLogSize))
+                val l = s"...${log.substring(log.size - (maxLogSize - totalLogSize))}"
                 totalLogSize = maxLogSize
                 l
               }

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerPoolTests.scala
@@ -80,6 +80,7 @@ class ContainerPoolTests
       ActivationId.generate(),
       ControllerInstanceId("0"),
       blocking = false,
+      blockingLogs = false,
       content = None)
     Run(action, message)
   }

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
@@ -90,6 +90,7 @@ class ContainerProxyTests
     ActivationId.generate(),
     ControllerInstanceId("0"),
     blocking = false,
+    blockingLogs = false,
     content = None)
 
   /*
@@ -141,7 +142,7 @@ class ContainerProxyTests
 
   /** Creates an inspectable version of the ack method, which records all calls in a buffer */
   def createAcker(a: ExecutableWhiskAction = action) = LoggedFunction {
-    (_: TransactionId, activation: WhiskActivation, _: Boolean, _: ControllerInstanceId, _: UUID) =>
+    (_: TransactionId, activation: WhiskActivation, _: Boolean, _: Boolean, _: ControllerInstanceId, _: UUID) =>
       activation.annotations.get("limits") shouldBe Some(a.limits.toJson)
       activation.annotations.get("path") shouldBe Some(a.fullyQualifiedName(false).toString.toJson)
       activation.annotations.get("kind") shouldBe Some(a.exec.kind.toJson)

--- a/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/WebActionsApiTests.scala
@@ -261,6 +261,7 @@ trait WebActionsApiBaseTests extends ControllerTestCommon with BeforeAndAfterEac
     action: WhiskActionMetaData,
     payload: Option[JsObject],
     waitForResponse: Option[FiniteDuration],
+    responseWithLogs: Boolean,
     cause: Option[ActivationId])(implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
     invocationCount = invocationCount + 1
 

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/InvokerSupervisionTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/InvokerSupervisionTests.scala
@@ -194,6 +194,7 @@ class InvokerSupervisionTests
       activationId = new ActivationIdGenerator {}.make(),
       rootControllerIndex = ControllerInstanceId("0"),
       blocking = false,
+      blockingLogs = false,
       content = None)
     val msg = ActivationRequest(activationMessage, invokerInstance)
 


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
Currently after invoking a blocking request, a user must call `activation get` with the corresponding activation ID to see associated logs. Changes here improve the development experience by optionally allowing a user to retrieve the last 4KB of user logs for blocking invocations. 

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

