### PR TITLE
Put error message as tag into failed trace.

### DIFF
--- a/common/scala/src/main/scala/whisk/common/TransactionId.scala
+++ b/common/scala/src/main/scala/whisk/common/TransactionId.scala
@@ -154,7 +154,7 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
     MetricEmitter.emitCounterMetric(endMarker)
 
     //tracing support
-    WhiskTracerProvider.tracer.error(this)
+    WhiskTracerProvider.tracer.error(this, message)
   }
 
   /**

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
@@ -17,11 +17,10 @@
 
 package whisk.core.controller.actions
 
-import java.lang.Throwable
 import java.time.{Clock, Instant}
 
 import akka.actor.ActorSystem
-import akka.event.Logging.{ErrorLevel, InfoLevel}
+import akka.event.Logging.InfoLevel
 import spray.json._
 import whisk.common.{Logging, LoggingMarkers, TransactionId}
 import whisk.common.tracing.WhiskTracerProvider
@@ -177,7 +176,7 @@ protected[actions] trait PrimitiveActions {
 
     postedFuture andThen {
       case Success(_) => transid.finished(this, startLoadbalancer)
-      case Failure(e) => transid.failed(this, startLoadbalancer, e.getMessage, logLevel = ErrorLevel)
+      case Failure(e) => transid.failed(this, startLoadbalancer, e.getMessage)
     } flatMap { activeAckResponse =>
       // is caller waiting for the result of the activation?
       waitForResponse
@@ -192,7 +191,7 @@ protected[actions] trait PrimitiveActions {
         }
     } andThen {
       case Success(_) => transid.finished(this, startActivation)
-      case Failure(e) => transid.failed(this, startActivation, e.getMessage, logLevel = ErrorLevel)
+      case Failure(e) => transid.failed(this, startActivation, e.getMessage)
     }
   }
 

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
@@ -17,10 +17,11 @@
 
 package whisk.core.controller.actions
 
+import java.lang.Throwable
 import java.time.{Clock, Instant}
 
 import akka.actor.ActorSystem
-import akka.event.Logging.InfoLevel
+import akka.event.Logging.{ErrorLevel, InfoLevel}
 import spray.json._
 import whisk.common.{Logging, LoggingMarkers, TransactionId}
 import whisk.common.tracing.WhiskTracerProvider
@@ -174,23 +175,24 @@ protected[actions] trait PrimitiveActions {
 
     val postedFuture = loadBalancer.publish(action, message)
 
-    postedFuture.flatMap { activeAckResponse =>
-      // successfully posted activation request to the message bus
-      transid.finished(this, startLoadbalancer)
-
+    postedFuture andThen {
+      case Success(_) => transid.finished(this, startLoadbalancer)
+      case Failure(e) => transid.failed(this, startLoadbalancer, e.getMessage, logLevel = ErrorLevel)
+    } flatMap { activeAckResponse =>
       // is caller waiting for the result of the activation?
       waitForResponse
         .map { timeout =>
           // yes, then wait for the activation response from the message bus
           // (known as the active response or active ack)
           waitForActivationResponse(user, message.activationId, timeout, activeAckResponse)
-            .andThen { case _ => transid.finished(this, startActivation) }
         }
         .getOrElse {
           // no, return the activation id
-          transid.finished(this, startActivation)
           Future.successful(Left(message.activationId))
         }
+    } andThen {
+      case Success(_) => transid.finished(this, startActivation)
+      case Failure(e) => transid.failed(this, startActivation, e.getMessage, logLevel = ErrorLevel)
     }
   }
 

--- a/tests/src/test/scala/common/TestHelpers.scala
+++ b/tests/src/test/scala/common/TestHelpers.scala
@@ -23,12 +23,12 @@ import org.scalatest.TestData
 
 trait TestHelpers extends FlatSpec with BeforeAndAfterEachTestData {
 
-  override def beforeEach(td: TestData) {
+  override def beforeEach(td: TestData): Unit = {
     println(s"\nStarting test ${td.name} at ${TestUtils.getDateTime()}")
     super.beforeEach(td)
   }
 
-  override def afterEach(td: TestData) {
+  override def afterEach(td: TestData): Unit = {
     println(s"\nFinished test ${td.name} at ${TestUtils.getDateTime()}")
     super.afterEach(td)
   }


### PR DESCRIPTION
Prior error message doesn't put error tag into failed trace.
This is nice to have and useful on trouble shooting within request context via modern UI in Jaegar or Zipkin.

With a minor change in primitive action flow which didn't enclose with failed trace.

I'm not sure folks are consistent with tracing system because of conflicting goals that we already have transid in log. IMHO, at least, it shouldn't make traces confused once if user decides to take it into system: whether there's an accurate error message existed or not, we should know which one get failed.

Semantics followed by: 
https://github.com/opentracing/specification/blob/master/semantic_conventions.md

Snapshots in Jaegar:

![firstpage](https://user-images.githubusercontent.com/13405580/44993705-1083d880-afce-11e8-87ac-8b6b45134e42.png)
![second](https://user-images.githubusercontent.com/13405580/44993706-111c6f00-afce-11e8-95eb-b94b9aa538e1.png)


Signed-off-by: Tzu-Chiao Yeh <su3g4284zo6y7@gmail.com>


<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [x] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.