### PR TITLE
Allow updating auth key for user with wskadmin-next

### DIFF
--- a/tools/admin/README-NEXT.md
+++ b/tools/admin/README-NEXT.md
@@ -80,6 +80,14 @@ $ wskadmin-next user create userA -ns space1
 $ wskadmin-next user create userB -ns space1
 <prints new key specific to userB and space1>
 
+# force update a user with new uuid:key
+$ wskadmin-next user create -f userA
+<prints new UUID and new key>
+
+# revoke auth key of a user and regenerate a new key
+$ wskadmin-next user create -r userA
+<prints old UUID and new key>
+
 # list all users sharing a space
 $ wskadmin-next user list space1 -a
 <key for userA>   userA

--- a/tools/admin/src/main/scala/whisk/core/database/UserCommand.scala
+++ b/tools/admin/src/main/scala/whisk/core/database/UserCommand.scala
@@ -85,8 +85,6 @@ class UserCommand extends Subcommand("user") with WhiskCommand {
 
     def desiredNamespace(authKey: BasicAuthenticationAuthKey) =
       Namespace(EntityName(namespace.getOrElse(subject()).trim), authKey.uuid)
-
-    def isForced= force.isSupplied && auth.isSupplied
   }
 
   val create = new CreateUserCmd
@@ -178,7 +176,7 @@ class UserCommand extends Subcommand("user") with WhiskCommand {
         var newNS = auth.namespaces.filter(_.namespace.name != nsToUpdate)
         if (auth.isBlocked) {
           Future.successful(Left(IllegalState(CommandMessages.subjectBlocked)))
-        } else if (!auth.namespaces.exists(_.namespace.name == nsToUpdate) || create.isForced) {
+        } else if (!auth.namespaces.exists(_.namespace.name == nsToUpdate) || create.force.isSupplied) {
           newNS = newNS.+(WhiskNamespace(create.desiredNamespace(authKey), authKey))
           val newAuth = WhiskAuth(auth.subject, newNS).revision[WhiskAuth](auth.rev)
           authStore.put(newAuth).map(_ => Right(authKey.compact))

--- a/tools/admin/src/main/scala/whisk/core/database/UserCommand.scala
+++ b/tools/admin/src/main/scala/whisk/core/database/UserCommand.scala
@@ -54,7 +54,7 @@ class UserCommand extends Subcommand("user") with WhiskCommand {
         short = 'r')
     val force =
       opt[Boolean](
-        descr = "force update an existing subject authorization key",
+        descr = "force update an existing subject authorization uuid:key",
         short = 'f')
     val subject = trailArg[String](descr = "the subject to create")
 
@@ -171,10 +171,10 @@ class UserCommand extends Subcommand("user") with WhiskCommand {
   def createUser(authStore: AuthStore)(implicit transid: TransactionId,
                                        ec: ExecutionContext): Future[Either[CommandError, String]] = {
     val authKey = create.auth.map(BasicAuthenticationAuthKey(_)).getOrElse(BasicAuthenticationAuthKey())
-    val nsToUpdate = create.desiredNamespace(authKey).name
     authStore
       .get[ExtendedAuth](DocInfo(create.subject()))
       .flatMap { auth =>
+        val nsToUpdate = create.desiredNamespace(authKey).name
         var newNS = auth.namespaces.filter(_.namespace.name != nsToUpdate)
         if (auth.isBlocked) {
           Future.successful(Left(IllegalState(CommandMessages.subjectBlocked)))


### PR DESCRIPTION
This PR enhances the [wskadmin-next](https://github.com/apache/incubator-openwhisk/blob/master/tools/admin/README-NEXT.md) tooling with `--force` and `--revoke` flags that allow updating user auth key.

## Description
Currently wskadmin (and next) allow adding a namespace with or without specific auth key.
In some cases, it is handy to allow updating existing namespace with specific auth key, or regenerating new key.
There are 2 flags being added in this PR:
- `--revoke`, abbreviated `-r`: regenerate a new key for the user / namespace, UUID remains the same
- `--force`, abbreviated `-f`:
    - with `--auth uuid:key`: the new auth value is updated for the user
    - without `--auth`: an auth of new UUID and key is randomly generated

## Related issue and scope
- #3965 

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [x] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [x] My changes require further changes to the documentation.
- [x] I updated the documentation where necessary.

