### PR TITLE
Upgrade caffeine to get multi expiry support with the latest fixes

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     compile ('com.fasterxml.uuid:java-uuid-generator:3.1.3') {
         exclude group: 'log4j'
     }
-    compile 'com.github.ben-manes.caffeine:caffeine:2.4.0'
+    compile 'com.github.ben-manes.caffeine:caffeine:2.6.2'
     compile 'com.google.code.findbugs:jsr305:3.0.2'
     compile 'io.fabric8:kubernetes-client:4.0.3'
     compile 'io.kamon:kamon-core_2.11:0.6.7'


### PR DESCRIPTION
This change upgrades caffeine to the latest version 2.6.2

## Description
This change upgrades caffeine to the latest version.
Main reason for this change is to make the expiration per entry interfaces available
with the latest fixes. Though openwhisk does exploit this feature (yet),
authentication SPI implementations can use this feature to cache tokens based on their
expiry date.

The selected version is also the one required b the latest version of `scaffeine`
which might be a worthwhile way to scala-fy the usage of caffeine in openwhisk.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

