### PR TITLE
Send activations of sequences to events topic.

### DIFF
--- a/common/scala/src/main/scala/whisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/whisk/core/connector/Message.scala
@@ -221,5 +221,11 @@ object EventMessage extends DefaultJsonProtocol {
   implicit val format =
     jsonFormat(EventMessage.apply _, "source", "body", "subject", "namespace", "userId", "eventType", "timestamp")
 
+  def from(a: WhiskActivation, source: String, userId: UUID): Try[EventMessage] = {
+    Activation.from(a).map { body =>
+      EventMessage(source, body, a.subject, a.namespace.toString, userId, body.typeName)
+    }
+  }
+
   def parse(msg: String) = format.read(msg.parseJson)
 }

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
@@ -22,23 +22,23 @@ import java.time.{Clock, Instant}
 import akka.actor.ActorSystem
 import akka.event.Logging.InfoLevel
 import spray.json._
-import whisk.common.{Logging, LoggingMarkers, TransactionId}
 import whisk.common.tracing.WhiskTracerProvider
-import whisk.core.connector.ActivationMessage
+import whisk.common.{Logging, LoggingMarkers, TransactionId, UserEvents}
+import whisk.core.connector.{Activation, ActivationMessage, EventMessage, MessagingProvider}
 import whisk.core.controller.WhiskServices
-import whisk.core.database.{ActivationStore, NoDocumentException}
+import whisk.core.database.{ActivationStore, NoDocumentException, UserContext}
 import whisk.core.entitlement.{Resource, _}
 import whisk.core.entity.ActivationResponse.ERROR_FIELD
 import whisk.core.entity._
 import whisk.core.entity.size.SizeInt
 import whisk.core.entity.types.EntityStore
 import whisk.http.Messages._
+import whisk.spi.SpiLoader
 import whisk.utils.ExecutionContextFactory.FutureExtensions
-import whisk.core.database.UserContext
 
 import scala.collection.mutable.Buffer
-import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.language.postfixOps
 import scala.util.{Failure, Success}
 
@@ -65,6 +65,10 @@ protected[actions] trait PrimitiveActions {
 
   /** Database service to get activations. */
   protected val activationStore: ActivationStore
+
+  /** Message producer. This is needed to write user-metrics. */
+  private val messagingProvider = SpiLoader.get[MessagingProvider]
+  private val producer = messagingProvider.getProducer(services.whiskConfig)
 
   /** A method that knows how to invoke a sequence of actions. */
   protected[actions] def invokeSequence(
@@ -553,6 +557,22 @@ protected[actions] trait PrimitiveActions {
         causedBy ++
         sequenceLimits,
       duration = Some(session.duration))
+
+    if (UserEvents.enabled) {
+      val event = Activation.from(activation).map { body =>
+        EventMessage(
+          activeAckTopicIndex.asString,
+          body,
+          activation.subject,
+          activation.namespace.toString,
+          user.namespace.uuid,
+          body.typeName)
+      }
+      event match {
+        case Success(msg) => UserEvents.send(producer, msg)
+        case Failure(t)   => logging.warn(this, s"activation event was not sent: $t")
+      }
+    }
 
     activationStore.store(activation, context)(transid, notifier = None)
 

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
@@ -24,7 +24,7 @@ import akka.event.Logging.InfoLevel
 import spray.json._
 import whisk.common.tracing.WhiskTracerProvider
 import whisk.common.{Logging, LoggingMarkers, TransactionId, UserEvents}
-import whisk.core.connector.{Activation, ActivationMessage, EventMessage, MessagingProvider}
+import whisk.core.connector.{ActivationMessage, EventMessage, MessagingProvider}
 import whisk.core.controller.WhiskServices
 import whisk.core.database.{ActivationStore, NoDocumentException, UserContext}
 import whisk.core.entitlement.{Resource, _}
@@ -559,16 +559,7 @@ protected[actions] trait PrimitiveActions {
       duration = Some(session.duration))
 
     if (UserEvents.enabled) {
-      val event = Activation.from(activation).map { body =>
-        EventMessage(
-          s"controller${activeAckTopicIndex.asString}",
-          body,
-          activation.subject,
-          activation.namespace.toString,
-          user.namespace.uuid,
-          body.typeName)
-      }
-      event match {
+      EventMessage.from(activation, s"controller${activeAckTopicIndex.asString}", user.namespace.uuid) match {
         case Success(msg) => UserEvents.send(producer, msg)
         case Failure(t)   => logging.warn(this, s"activation event was not sent: $t")
       }

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
@@ -561,7 +561,7 @@ protected[actions] trait PrimitiveActions {
     if (UserEvents.enabled) {
       val event = Activation.from(activation).map { body =>
         EventMessage(
-          activeAckTopicIndex.asString,
+          s"controller${activeAckTopicIndex.asString}",
           body,
           activation.subject,
           activation.namespace.toString,

--- a/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
@@ -17,30 +17,27 @@
 
 package whisk.core.controller.actions
 
-import java.time.Clock
-import java.time.Instant
+import java.time.{Clock, Instant}
 import java.util.concurrent.atomic.AtomicReference
 
-import scala.collection._
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.concurrent.duration._
-import scala.language.postfixOps
-import scala.util.Failure
-import scala.util.Success
 import akka.actor.ActorSystem
 import spray.json._
-import whisk.common.Logging
-import whisk.common.TransactionId
+import whisk.common.{Logging, TransactionId, UserEvents}
+import whisk.core.connector.{Activation, EventMessage, MessagingProvider}
 import whisk.core.controller.WhiskServices
-import whisk.core.database.ActivationStore
-import whisk.core.database.NoDocumentException
+import whisk.core.database.{ActivationStore, NoDocumentException, UserContext}
 import whisk.core.entity._
 import whisk.core.entity.size.SizeInt
 import whisk.core.entity.types._
 import whisk.http.Messages._
+import whisk.spi.SpiLoader
 import whisk.utils.ExecutionContextFactory.FutureExtensions
-import whisk.core.database.UserContext
+
+import scala.collection._
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
+import scala.language.postfixOps
+import scala.util.{Failure, Success}
 
 protected[actions] trait SequenceActions {
   /** The core collections require backend services to be injected in this trait. */
@@ -59,6 +56,13 @@ protected[actions] trait SequenceActions {
 
   /** Database service to get activations. */
   protected val activationStore: ActivationStore
+
+  /** Instace of the controller. This is needed to write user-metrics. */
+  protected val activeAckTopicIndex: ControllerInstanceId
+
+  /** Message producer. This is needed to write user-metrics. */
+  private val messagingProvider = SpiLoader.get[MessagingProvider]
+  private val producer = messagingProvider.getProducer(services.whiskConfig)
 
   /** A method that knows how to invoke a single primitive action. */
   protected[actions] def invokeAction(
@@ -165,6 +169,22 @@ protected[actions] trait SequenceActions {
       }
       .andThen {
         case Success((Right(seqActivation), _)) =>
+          if (UserEvents.enabled) {
+            val event = Activation.from(seqActivation).map { body =>
+              EventMessage(
+                activeAckTopicIndex.asString,
+                body,
+                seqActivation.subject,
+                seqActivation.namespace.toString,
+                user.namespace.uuid,
+                body.typeName)
+            }
+
+            event match {
+              case Success(msg) => UserEvents.send(producer, msg)
+              case Failure(t)   => logging.warn(this, s"activation event was not sent: $t")
+            }
+          }
           activationStore.store(seqActivation, context)(transid, notifier = None)
 
         // This should never happen; in this case, there is no activation record created or stored:

--- a/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
@@ -172,7 +172,7 @@ protected[actions] trait SequenceActions {
           if (UserEvents.enabled) {
             val event = Activation.from(seqActivation).map { body =>
               EventMessage(
-                activeAckTopicIndex.asString,
+                s"controller${activeAckTopicIndex.asString}",
                 body,
                 seqActivation.subject,
                 seqActivation.namespace.toString,

--- a/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/InvokerReactive.scala
@@ -131,17 +131,7 @@ class InvokerReactive(
     }
 
     if (UserEvents.enabled) {
-      val event = Activation.from(activationResult).map { body =>
-        EventMessage(
-          s"invoker${instance.instance}",
-          body,
-          activationResult.subject,
-          activationResult.namespace.toString,
-          userId,
-          body.typeName)
-      }
-
-      event match {
+      EventMessage.from(activationResult, s"invoker${instance.instance}", userId) match {
         case Success(msg) => UserEvents.send(producer, msg)
         case Failure(t)   => logging.error(this, s"activation event was not sent: $t")
       }

--- a/tests/src/test/scala/whisk/common/UserEventTests.scala
+++ b/tests/src/test/scala/whisk/common/UserEventTests.scala
@@ -77,7 +77,7 @@ class UserEventTests extends FlatSpec with Matchers with WskTestHelpers with Str
         event.body match {
           case a: Activation =>
             Seq(a.statusCode) should contain oneOf (0, 1, 2, 3)
-            event.source should fullyMatch regex "invoker\\d+".r
+            event.source should fullyMatch regex "(invoker|controller)\\d+".r
           case m: Metric =>
             Seq(m.metricName) should contain oneOf ("ConcurrentInvocations", "ConcurrentRateLimit", "TimedRateLimit")
             event.source should fullyMatch regex "controller\\d+".r


### PR DESCRIPTION
Currently, only the invoker sends activation-events to the user-metric-topic. With this PR, the controller will write activations of sequences as well.

This PR is based on #4006.

## My changes affect the following components
- [x] Controller
- [x] Message Bus (e.g., Kafka)
- [x] Intrinsic actions (e.g., sequences, conductors)

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).