### PR TITLE
Emit CosmosDB request usage metric

### DIFF
--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -212,14 +212,16 @@ object MetricEmitter {
 
   val metrics = Kamon.metrics
 
-  def emitCounterMetric(token: LogMarkerToken): Unit = {
+  def emitCounterMetric(token: LogMarkerToken): Unit = emitCounterMetric(token, 1)
+
+  def emitCounterMetric(token: LogMarkerToken, times: Long): Unit = {
     if (TransactionId.metricsKamon) {
       if (TransactionId.metricsKamonTags) {
         metrics
           .counter(token.toString, token.tags)
-          .increment(1)
+          .increment(times)
       } else {
-        metrics.counter(token.toStringWithSubAction).increment(1)
+        metrics.counter(token.toStringWithSubAction).increment(times)
       }
     }
   }

--- a/common/scala/src/main/scala/whisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
@@ -28,7 +28,7 @@ import akka.util.{ByteString, ByteStringBuilder}
 import com.microsoft.azure.cosmosdb._
 import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient
 import spray.json.{DefaultJsonProtocol, JsObject, JsString, JsValue, RootJsonFormat, _}
-import whisk.common.{Logging, LoggingMarkers, TransactionId}
+import whisk.common.{LogMarkerToken, Logging, LoggingMarkers, MetricEmitter, TransactionId}
 import whisk.core.database.StoreUtils.{checkDocHasRevision, deserialize, reportFailure}
 import whisk.core.database._
 import whisk.core.database.cosmosdb.CosmosDBArtifactStoreProvider.DocumentClientRef
@@ -67,6 +67,13 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
   private val _id = "_id"
   private val _rev = "_rev"
 
+  private val putToken = createToken("put", read = false)
+  private val delToken = createToken("del", read = false)
+  private val getToken = createToken("get")
+  private val queryToken = createToken("query")
+  private val countToken = createToken("count")
+  private val putAttachmentToken = createToken("putAttachment", read = false)
+
   override protected[core] implicit val executionContext: ExecutionContext = system.dispatcher
 
   override protected[database] def put(d: DocumentAbstraction)(implicit transid: TransactionId): Future[DocInfo] = {
@@ -88,6 +95,7 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
       .transform(
         { r =>
           transid.finished(this, start, s"[PUT] '$collName' completed document: '$docinfoStr'")
+          collectMetrics(putToken, r.getRequestCharge)
           toDocInfo(r.getResource)
         }, {
           case e: DocumentClientException if isConflict(e) =>
@@ -106,8 +114,9 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
       .deleteDocument(selfLinkOf(doc.id), matchRevOption(doc))
       .head()
       .transform(
-        { _ =>
+        { r =>
           transid.finished(this, start, s"[DEL] '$collName' completed document: '$doc'")
+          collectMetrics(delToken, r.getRequestCharge)
           true
         }, {
           case e: DocumentClientException if isNotFound(e) =>
@@ -139,6 +148,7 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
         { rr =>
           val js = getResultToWhiskJsonDoc(rr.getResource)
           transid.finished(this, start, s"[GET] '$collName' completed: found document '$doc'")
+          collectMetrics(getToken, rr.getRequestCharge)
           deserialize[A, DocumentAbstraction](doc, js)
         }, {
           case e: DocumentClientException if isNotFound(e) =>
@@ -167,6 +177,7 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
       .map { rr =>
         val js = getResultToWhiskJsonDoc(rr.getResource)
         transid.finished(this, start, s"[GET_BY_ID] '$collName' completed: found document '$id'")
+        collectMetrics(getToken, rr.getRequestCharge)
         Some(js)
       }
       .recoverWith {
@@ -206,6 +217,10 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
       RxReactiveStreams.toPublisher(client.queryDocuments(collection.getSelfLink, querySpec, newFeedOptions()))
     val f = Source
       .fromPublisher(publisher)
+      .map { f =>
+        collectMetrics(queryToken, f.getRequestCharge)
+        f
+      }
       .mapConcat(asSeq)
       .drop(skip)
       .map(queryResultToWhiskJsonDoc)
@@ -241,6 +256,7 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
       .map { r =>
         val count = r.getResults.asScala.head.getLong(aggregate).longValue()
         transid.finished(this, start, s"[COUNT] '$collName' completed: count $count")
+        collectMetrics(countToken, r.getRequestCharge)
         if (count > skip) count - skip else 0L
       }
 
@@ -321,9 +337,10 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
       .upsertAttachment(selfLinkOf(doc.id), s, options, matchRevOption(doc))
       .head()
       .transform(
-        { _ =>
+        { r =>
           transid
             .finished(this, start, s"[ATT_PUT] '$collName' completed uploading attachment '$name' of document '$doc'")
+          collectMetrics(putAttachmentToken, r.getRequestCharge)
           doc //Adding attachment does not change the revision of document. So retain the doc info
         }, {
           case e: DocumentClientException if isConflict(e) =>
@@ -494,5 +511,16 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
   private def checkDoc[T <: Resource](doc: T): Unit = {
     require(doc.getId != null, s"$doc does not have id field set")
     require(doc.getETag != null, s"$doc does not have etag field set")
+  }
+
+  private def collectMetrics(token: LogMarkerToken, charge: Double): Unit = {
+    MetricEmitter.emitCounterMetric(token, Math.round(charge))
+  }
+
+  private def createToken(action: String, read: Boolean = true): LogMarkerToken = {
+    val mode = if (read) "read" else "write"
+    val tags = Map("action" -> action, "mode" -> mode, "collection" -> collName)
+    if (TransactionId.metricsKamonTags) LogMarkerToken("cosmosdb", "ru", "used", tags = tags)
+    else LogMarkerToken("cosmosdb", "ru", collName, Some(action))
   }
 }


### PR DESCRIPTION
CosmosDB make use of [Request Units (RU)](https://docs.microsoft.com/en-us/azure/cosmos-db/request-units) for throughput provisioning. This PR emits the changed RU as a metric which helps in monitoring the resource consumption based on collection and action performed.

## Description
Each request made to CosmosDB incurs some change in the form of RU spent for that request processing. This charge info is provided via response header `x-ms-request-charge`

```
x-ms-session-token: 4:3
x-ms-request-charge: 5.24
x-ms-serviceversion: version=2.0.0.0
```

This PR expose the charge as a metric named `cosmosdb_ru_used`. It also associates some tags like

- `mode` - `read` or `write`
- `collection` - Name of collection i.e. `activations`, `whisks` and `subjects`
- `action` - Type of operation performed. Example `get`, `put` etc

If tags are not enabled the metric name is generated like `cosmosdb.ru.<collecton name>.<action>`

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

