### PR TITLE
Enable passing absolute url to gatling test and few other fixes

### DIFF
--- a/tests/performance/gatling_tests/src/gatling/resources/conf/logback.xml
+++ b/tests/performance/gatling_tests/src/gatling/resources/conf/logback.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <immediateFlush>false</immediateFlush>
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-            <immediateFlush>false</immediateFlush>
         </encoder>
     </appender>
     <!-- This will log the details of the failed requests -->

--- a/tests/performance/gatling_tests/src/gatling/scala/extension/whisk/OpenWhiskProtocolBuilder.scala
+++ b/tests/performance/gatling_tests/src/gatling/scala/extension/whisk/OpenWhiskProtocolBuilder.scala
@@ -17,6 +17,8 @@
 
 package extension.whisk
 
+import java.net.URL
+
 import com.softwaremill.quicklens._
 import io.gatling.core.Predef._
 import io.gatling.core.config.GatlingConfiguration
@@ -33,6 +35,17 @@ import scala.language.implicitConversions
  * @param port port to use. e.g. 443
  */
 case class OpenWhiskProtocol(apiHost: String, protocol: String = "https", port: Int = 443)
+
+object OpenWhiskProtocol {
+
+  def apply(url: String): OpenWhiskProtocol = {
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+      val u = new URL(url)
+      val port = if (u.getPort > 0) u.getPort else u.getDefaultPort
+      OpenWhiskProtocol(u.getHost, u.toURI.getScheme, port)
+    } else new OpenWhiskProtocol(url)
+  }
+}
 
 case object OpenWhiskProtocolBuilderBase {
   def apiHost(url: String): OpenWhiskProtocolBuilder = OpenWhiskProtocolBuilder(OpenWhiskProtocol(url))

--- a/tests/performance/gatling_tests/src/gatling/scala/extension/whisk/OpenWhiskProtocolBuilder.scala
+++ b/tests/performance/gatling_tests/src/gatling/scala/extension/whisk/OpenWhiskProtocolBuilder.scala
@@ -62,6 +62,7 @@ case class OpenWhiskProtocolBuilder(private val protocol: OpenWhiskProtocol) {
       .baseURL(s"${protocol.protocol}://${protocol.apiHost}:${protocol.port}")
       .contentTypeHeader("application/json")
       .userAgentHeader("gatlingLoadTest")
+      .warmUp("http://google.com")
       .build
   }
 }


### PR DESCRIPTION
This PR does couple of fixes in gatling test runs

## Description

### A - Support absolute url

Currently gatling test presume that `OPENWHISK_HOST` is just the host. With this change it would be possible to pass complete url without needing to extract the host separately. This simplifies invoking it in existing CI setup

```
OPENWHISK_HOST="https://172.17.0.1:443" CONNECTIONS="100" REQUESTS_PER_SEC="1" ./gradlew gatlingRun-ApiV1Simulation
```

### B- Logback warning

Currently following [warning is seen in logs](https://travis-ci.org/apache/incubator-openwhisk/jobs/430454430#L2887)

```
> Task :tests:performance:gatling_tests:gatlingRun-ApiV1Simulation
10:12:19,372 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.xml]
10:12:19,372 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback.groovy]
10:12:19,372 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Found resource [logback.xml] at [file:/home/travis/build/apache/incubator-openwhisk/tests/performance/gatling_tests/build/resources/gatling/logback.xml]
10:12:19,586 |-INFO in ch.qos.logback.classic.joran.action.ConfigurationAction - debug attribute not set
10:12:19,586 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - About to instantiate appender of type [ch.qos.logback.core.ConsoleAppender]
10:12:19,618 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - Naming appender as [CONSOLE]
10:12:19,630 |-INFO in ch.qos.logback.core.joran.action.NestedComplexPropertyIA - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
10:12:19,637 |-WARN in ch.qos.logback.classic.encoder.PatternLayoutEncoder@17c68925 - As of version 1.2.0 "immediateFlush" property should be set within the enclosing Appender.
10:12:19,637 |-WARN in ch.qos.logback.classic.encoder.PatternLayoutEncoder@17c68925 - Please move "immediateFlush" property into the enclosing appender.
10:12:19,715 |-WARN in ch.qos.logback.classic.encoder.PatternLayoutEncoder@17c68925 - Setting the "immediateFlush" property of the enclosing appender to false
10:12:19,716 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [io.gatling.http.ahc] to DEBUG
10:12:19,717 |-INFO in ch.qos.logback.classic.joran.action.RootLoggerAction - Setting level of ROOT logger to WARN
10:12:19,717 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [CONSOLE] to Logger[ROOT]
10:12:19,717 |-INFO in ch.qos.logback.classic.joran.action.ConfigurationAction - End of configuration.
10:12:19,718 |-INFO in ch.qos.logback.classic.joran.JoranConfigurator@7e0ea639 - Registering current configuration as safe fallback point
```

### C - Gatling Ping Failure

Gatling does warmup ping which is [mostly failing as host is unreachable](https://travis-ci.org/apache/incubator-openwhisk/jobs/430454430#L2905). Change it to connect to google.com which should mostly work!

```
10:12:23.730 [main] DEBUG io.gatling.http.ahc.HttpEngine - Couldn't execute warm up request https://gatling.io
java.util.concurrent.ExecutionException: java.util.concurrent.TimeoutException: Request timeout to gatling.io/52.47.152.183:443 after 1000 ms
	at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:357)
	at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1895)
	at org.asynchttpclient.netty.NettyResponseFuture.get(NettyResponseFuture.java:172)
	at io.gatling.http.ahc.HttpEngine.warmpUp(HttpEngine.scala:99)
	at io.gatling.http.protocol.HttpProtocol$$anon$1.$anonfun$newComponents$1(HttpProtocol.scala:62)
	at io.gatling.core.protocol.ProtocolComponentsRegistry.comps$1(Protocol.scala:67)
	at io.gatling.core.protocol.ProtocolComponentsRegistry.$anonfun$components$4(Protocol.scala:69)
	at scala.collection.mutable.HashMap.getOrElseUpdate(HashMap.scala:82)
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

