### PR TITLE
script runner now has nodejs

### DIFF
--- a/tools/scriptRunner/Dockerfile
+++ b/tools/scriptRunner/Dockerfile
@@ -1,7 +1,7 @@
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements; and to You under the Apache License, Version 2.0.
 
-from alpine
+FROM node:alpine
 
 RUN apk --no-cache add \
   bash \
@@ -17,6 +17,6 @@ RUN wget -q https://github.com/apache/incubator-openwhisk-cli/releases/download/
     rm OpenWhisk_CLI-$WHISK_CLI_VERSION-linux-amd64.tgz
 
 COPY init.sh /init.sh
-RUN chmod +X /init.sh
+RUN chmod +x /init.sh
 
 CMD ["/init.sh"]


### PR DESCRIPTION

## Description
script runner container used in kubernetes deployment requires nodejs
some of the catalog scripts need to npm install and then zip actions

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [x] Deployment Kubernetes


## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).

