### PR TITLE
Configure a default throughput value for CosmosDB

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -150,9 +150,10 @@ whisk {
     # CosmosDB related configuration
     # For example:
     # cosmosdb {
-    #     endpoint =               # Endpoint URL like https://<account>.documents.azure.com:443/
-    #     key      =               # Access key
-    #     db       =               # Database name
+    #     endpoint   =               # Endpoint URL like https://<account>.documents.azure.com:443/
+    #     key        =               # Access key
+    #     db         =               # Database name
+    #     throughput = 1000          # Throughput configure for each collection within this db
     #}
 
     # transaction ID related configuration

--- a/common/scala/src/main/scala/whisk/core/database/cosmosdb/CosmosDBArtifactStoreProvider.scala
+++ b/common/scala/src/main/scala/whisk/core/database/cosmosdb/CosmosDBArtifactStoreProvider.scala
@@ -33,7 +33,7 @@ import whisk.core.entity.{DocumentReader, WhiskActivation, WhiskAuth, WhiskEntit
 
 import scala.reflect.ClassTag
 
-case class CosmosDBConfig(endpoint: String, key: String, db: String)
+case class CosmosDBConfig(endpoint: String, key: String, db: String, throughput: Int = 1000)
 
 case class ClientHolder(client: AsyncDocumentClient) extends Closeable {
   override def close(): Unit = client.close()

--- a/common/scala/src/main/scala/whisk/core/database/cosmosdb/CosmosDBSupport.scala
+++ b/common/scala/src/main/scala/whisk/core/database/cosmosdb/CosmosDBSupport.scala
@@ -57,7 +57,7 @@ private[cosmosdb] trait CosmosDBSupport extends RxObservableImplicits with Cosmo
         }
       }
       .getOrElse {
-        client.createCollection(database.getSelfLink, newDatabaseCollection, null).blockingResult()
+        client.createCollection(database.getSelfLink, newDatabaseCollection, dbOptions).blockingResult()
       }
   }
 
@@ -70,6 +70,12 @@ private[cosmosdb] trait CosmosDBSupport extends RxObservableImplicits with Cosmo
     defn.setIndexingPolicy(viewMapper.indexingPolicy.asJava())
     defn.setPartitionKey(viewMapper.partitionKeyDefn)
     defn
+  }
+
+  private def dbOptions = {
+    val opts = new RequestOptions
+    opts.setOfferThroughput(config.throughput)
+    opts
   }
 
   private def newDatabase = {


### PR DESCRIPTION
By default the collection created in CosmosDB have a throughput set to 5100. With this PR it would be made configurable and would default to 1000



## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

