### PR TITLE
Support passing base64 encoded config via env

### DIFF
--- a/common/scala/transformEnvironment.sh
+++ b/common/scala/transformEnvironment.sh
@@ -34,10 +34,16 @@ configVariables=$(compgen -v | grep $prefix)
 
 props=()
 
-if [ -n "$OPENWHISK_CONFIG" ]
+if [ -n "$OPENWHISK_CONFIG" ]; then
+    config="$OPENWHISK_CONFIG"
+elif [ -n "$OPENWHISK_ENCODED_CONFIG" ]; then
+    config=$(echo "$OPENWHISK_ENCODED_CONFIG" | base64 -d)
+fi
+
+if [ -n "$config" ]
 then
     location="/config.conf"
-    printf "%s" "$OPENWHISK_CONFIG" > "$location"
+    printf "%s" "$config" > "$location"
     props+=("-Dconfig.file='$location'")
 fi
 


### PR DESCRIPTION
This PR extends #3984 by adding support for passing base64 encoded config via environment variable

## Description
With #3984 support was added for passing in typesafe config as env variable. Some env like Marathon based support specifying env value only as json value which makes it tricky to pass typesafe config which includes new lines.

To support such env this PR adds support for passing base64 encoded config via `OPENWHISK_ENCODED_CONFIG`

### Usage

```yml
- name: Load config from template
  set_fact:
      openwhisk_config: "{{ lookup('template', 'config.j2') }}"

- name: populate environment variables for controller
  set_fact:
    env:
      "OPENWHISK_ENCODED_CONFIG": "{{ openwhisk_config | b64encode }}"
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

