### PR TITLE
upgrade pip before installing ansible

### DIFF
--- a/tools/ansibleRunner/Dockerfile
+++ b/tools/ansibleRunner/Dockerfile
@@ -29,6 +29,7 @@ tar --strip-components 1 -xvzf docker-${DOCKER_VERSION}.tgz -C /usr/bin docker/d
 rm -f docker-${DOCKER_VERSION}.tgz && \
 chmod +x /usr/bin/docker
 
+RUN pip install --upgrade pip
 RUN pip install --upgrade setuptools
 RUN pip install ansible==2.5.2
 RUN pip install jinja2==2.9.6


### PR DESCRIPTION
When building on a new machine (no cached docker images), building the ansibleRunner failed with the error:
```
> Task :tools:ansibleRunner:distDocker
Wed Sep 26 17:00:49 EDT 2018: Executing 'docker build -t ansible-runner /Users/dgrove/code/openwhisk/openwhisk/tools/ansibleRunner'

Collecting jinja2 (from ansible==2.5.2)
  Downloading https://files.pythonhosted.org/packages/7f/ff/ae64bacdfc95f27a016a7bed8e8686763ba4d277a78ca76f32659220a731/Jinja2-2.10-py2.py3-none-any.whl (126kB)
Collecting PyYAML (from ansible==2.5.2)
  Downloading https://files.pythonhosted.org/packages/9e/a3/1d13970c3f36777c583f136c136f804d70f500168edc1edea6daa7200769/PyYAML-3.13.tar.gz (270kB)
Collecting paramiko (from ansible==2.5.2)
  Downloading https://files.pythonhosted.org/packages/cf/ae/94e70d49044ccc234bfdba20114fa947d7ba6eb68a2e452d89b920e62227/paramiko-2.4.2-py2.py3-none-any.whl (193kB)
Collecting cryptography (from ansible==2.5.2)
  Downloading https://files.pythonhosted.org/packages/22/21/233e38f74188db94e8451ef6385754a98f3cad9b59bedf3a8e8b14988be4/cryptography-2.3.1.tar.gz (449kB)
Requirement already satisfied: setuptools in /usr/lib/python2.7/site-packages (from ansible==2.5.2) (40.4.3)
Collecting MarkupSafe>=0.23 (from jinja2->ansible==2.5.2)
  Downloading https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz
Collecting pyasn1>=0.1.7 (from paramiko->ansible==2.5.2)
  Downloading https://files.pythonhosted.org/packages/d1/a1/7790cc85db38daa874f6a2e6308131b9953feb1367f2ae2d1123bb93a9f5/pyasn1-0.4.4-py2.py3-none-any.whl (72kB)
Collecting bcrypt>=3.1.3 (from paramiko->ansible==2.5.2)
  Downloading https://files.pythonhosted.org/packages/f3/ec/bb6b384b5134fd881b91b6aa3a88ccddaad0103857760711a5ab8c799358/bcrypt-3.1.4.tar.gz (42kB)
Collecting pynacl>=1.0.1 (from paramiko->ansible==2.5.2)
  Downloading https://files.pythonhosted.org/packages/61/ab/2ac6dea8489fa713e2b4c6c5b549cc962dd4a842b5998d9e80cf8440b7cd/PyNaCl-1.3.0.tar.gz (3.4MB)
  Could not find a version that satisfies the requirement cffi>=1.4.1 (from versions: )
No matching distribution found for cffi>=1.4.1
You are using pip version 10.0.1, however version 18.0 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
The command '/bin/sh -c pip install ansible==2.5.2' returned a non-zero code: 1
```
As suggested, adding `pip install --upgrade pip` allowed the docker build to complete successfully.
