### PR TITLE
fetch logs from LogStore for `wsk activation get`

### DIFF
--- a/core/controller/src/main/scala/whisk/core/controller/Activations.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Activations.scala
@@ -191,7 +191,10 @@ trait WhiskActivationsApi extends Directives with AuthenticatedRouteProvider wit
     pathEndOrSingleSlash {
       getEntity(
         activationStore.get(ActivationId(docid.asString), context),
-        postProcess = Some((activation: WhiskActivation) => complete(activation.toExtendedJson)))
+        postProcess = Some((activation: WhiskActivation) => {
+          //do not assume logs are embedded in activation entity, fetch from logsStore
+          complete(logStore.fetchLogs(activation, context).map(activation.withLogs(_).toExtendedJson))
+        }))
     } ~ (pathPrefix(resultPath) & pathEnd) { fetchResponse(context, docid) } ~
       (pathPrefix(logsPath) & pathEnd) { fetchLogs(context, docid) }
   }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
Currently activations API assumes that logs are embedded in activation entity. 
This change make use of LogStore during `wsk activations get`. 
Default logstore still delegates to entity embedded logs.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

