### PR TITLE
improve splunk query; use consistent format for log output

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -209,6 +209,24 @@ whisk {
         teardown-on-exit = true //set to true to disable the mesos framework on system exit; set for false for HA deployments
     }
 
+    logstore {
+        #SplunkLogStore configuration
+        #splunk {
+        #    host = "splunkhost"                   #splunk api hostname
+        #    port = 8089                           #splunk api port
+        #    username = "splunkapiusername"        #splunk api username
+        #    password = "splunkapipassword"        #splunk api password
+        #    index = "splunkindex"                 #splunk index name
+        #    log-timestamp-field = "log_timestamp" #splunk field where timestamp is stored (to reflect log event generated time, not splunk's _time)
+        #    log-stream-field = "log_stream"       #splunk field where stream is stored (stdout/stderr)
+        #    log-message-field = "log_message"     #splunk field where log message is stored
+        #    activation-id-field = "activation_id" #splunk field where activation id is stored
+        #    query-constraints = ""                #additional constraints for splunk queries
+        #    query-timestamp-offset-seconds = ""   #splunk query will be broadened by this 2*<offset value>; e.g. "earliest_time=activation.start - offset" and "latest_time=activation.end + offset"
+        #    disableSNI = false                    #if true, disables hostname validation and cert validation (in case splunk api endpoint is using a self signed cert)
+        #}
+    }
+
     # tracing configuration
     tracing {
         cache-expiry = 30 seconds #how long to keep spans in cache. Set to appropriate value to trace long running requests

--- a/common/scala/src/main/scala/whisk/core/containerpool/logging/SplunkLogStore.scala
+++ b/common/scala/src/main/scala/whisk/core/containerpool/logging/SplunkLogStore.scala
@@ -60,12 +60,22 @@ case class SplunkLogStoreConfig(host: String,
                                 username: String,
                                 password: String,
                                 index: String,
+                                logTimestampField: String,
+                                logStreamField: String,
                                 logMessageField: String,
                                 activationIdField: String,
+                                queryTimestampOffsetSeconds: Int,
                                 disableSNI: Boolean)
 case class SplunkResponse(results: Vector[JsObject])
 object SplunkResponseJsonProtocol extends DefaultJsonProtocol {
   implicit val orderFormat = jsonFormat1(SplunkResponse)
+}
+
+/**
+ * Represents a single log line as read from a docker log
+ */
+protected[core] case class SplunkLogLine(time: String, stream: String, log: String) {
+  def toFormattedString = f"$time%-30s $stream: ${log.trim}"
 }
 
 /**
@@ -106,16 +116,18 @@ class SplunkLogStore(
     //    {"preview":false,"init_offset":0,"messages":[],"fields":[{"name":"log_message"}],"results":[{"log_message":"some log message"}], "highlighted":{}}
     //note: splunk returns results in reverse-chronological order, therefore we include "| reverse" to cause results to arrive in chronological order
     val search =
-      s"""search index="${splunkConfig.index}"| spath ${splunkConfig.activationIdField}| search ${splunkConfig.activationIdField}=${activation.activationId.toString}| table ${splunkConfig.logMessageField}| reverse"""
+      s"""search index="${splunkConfig.index}"| spath ${splunkConfig.activationIdField}| search ${splunkConfig.activationIdField}=${activation.activationId.toString}| table ${splunkConfig.logTimestampField}, ${splunkConfig.logStreamField}, ${splunkConfig.logMessageField}| reverse"""
 
     val entity = FormData(
       Map(
         "exec_mode" -> "oneshot",
         "search" -> search,
         "output_mode" -> "json",
-        "earliest_time" -> activation.start.toString, //assume that activation start/end are UTC zone, and splunk events are the same
+        "earliest_time" -> activation.start
+          .minusSeconds(splunkConfig.queryTimestampOffsetSeconds)
+          .toString, //assume that activation start/end are UTC zone, and splunk events are the same
         "latest_time" -> activation.end
-          .plusSeconds(5) //add 5s to avoid a timerange of 0 on short-lived activations
+          .plusSeconds(splunkConfig.queryTimestampOffsetSeconds) //add 5s to avoid a timerange of 0 on short-lived activations
           .toString)).toEntity
 
     logging.debug(this, "sending request")
@@ -130,7 +142,11 @@ class SplunkLogStore(
           .map(r => {
             ActivationLogs(
               r.results
-                .map(_.fields(splunkConfig.logMessageField).convertTo[String]))
+                .map(l =>
+                  //format same as whisk.core.containerpool.logging.LogLine.toFormattedString
+                  f"${l.fields(splunkConfig.logTimestampField).convertTo[String]}%-30s ${l
+                    .fields(splunkConfig.logStreamField)
+                    .convertTo[String]}: ${l.fields(splunkConfig.logMessageField).convertTo[String].trim}"))
           })
       })
   }

--- a/common/scala/src/main/scala/whisk/core/containerpool/logging/SplunkLogStore.scala
+++ b/common/scala/src/main/scala/whisk/core/containerpool/logging/SplunkLogStore.scala
@@ -64,18 +64,12 @@ case class SplunkLogStoreConfig(host: String,
                                 logStreamField: String,
                                 logMessageField: String,
                                 activationIdField: String,
+                                queryConstraints: String,
                                 queryTimestampOffsetSeconds: Int,
                                 disableSNI: Boolean)
 case class SplunkResponse(results: Vector[JsObject])
 object SplunkResponseJsonProtocol extends DefaultJsonProtocol {
   implicit val orderFormat = jsonFormat1(SplunkResponse)
-}
-
-/**
- * Represents a single log line as read from a docker log
- */
-protected[core] case class SplunkLogLine(time: String, stream: String, log: String) {
-  def toFormattedString = f"$time%-30s $stream: ${log.trim}"
 }
 
 /**
@@ -116,7 +110,7 @@ class SplunkLogStore(
     //    {"preview":false,"init_offset":0,"messages":[],"fields":[{"name":"log_message"}],"results":[{"log_message":"some log message"}], "highlighted":{}}
     //note: splunk returns results in reverse-chronological order, therefore we include "| reverse" to cause results to arrive in chronological order
     val search =
-      s"""search index="${splunkConfig.index}"| spath ${splunkConfig.activationIdField}| search ${splunkConfig.activationIdField}=${activation.activationId.toString}| table ${splunkConfig.logTimestampField}, ${splunkConfig.logStreamField}, ${splunkConfig.logMessageField}| reverse"""
+      s"""search index="${splunkConfig.index}"| spath ${splunkConfig.activationIdField}| search ${splunkConfig.queryConstraints} ${splunkConfig.activationIdField}=${activation.activationId.toString}| table ${splunkConfig.logTimestampField}, ${splunkConfig.logStreamField}, ${splunkConfig.logMessageField}| reverse"""
 
     val entity = FormData(
       Map(

--- a/tests/src/test/scala/whisk/core/containerpool/logging/SplunkLogStoreTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/logging/SplunkLogStoreTests.scala
@@ -64,6 +64,7 @@ class SplunkLogStoreTests
     "log_stream",
     "log_message",
     "activation_id",
+    "somefield::somevalue",
     22,
     disableSNI = false)
 
@@ -119,7 +120,7 @@ class SplunkLogStoreTests
               outputMode shouldBe Some("json")
               execMode shouldBe Some("oneshot")
               search shouldBe Some(
-                s"""search index="${testConfig.index}"| spath ${testConfig.activationIdField}| search ${testConfig.activationIdField}=${activation.activationId.toString}| table ${testConfig.logTimestampField}, ${testConfig.logStreamField}, ${testConfig.logMessageField}| reverse""")
+                s"""search index="${testConfig.index}"| spath ${testConfig.activationIdField}| search ${testConfig.queryConstraints} ${testConfig.activationIdField}=${activation.activationId.toString}| table ${testConfig.logTimestampField}, ${testConfig.logStreamField}, ${testConfig.logMessageField}| reverse""")
 
               (
                 Success(

--- a/tests/src/test/scala/whisk/core/containerpool/logging/SplunkLogStoreTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/logging/SplunkLogStoreTests.scala
@@ -60,15 +60,19 @@ class SplunkLogStoreTests
     "splunk-user",
     "splunk-pass",
     "splunk-index",
+    "log_timestamp",
+    "log_stream",
     "log_message",
     "activation_id",
+    22,
     disableSNI = false)
 
   behavior of "Splunk LogStore"
 
   val startTime = "2007-12-03T10:15:30Z"
+  val startTimePlusOffset = "2007-12-03T10:15:08Z" //queried end time range is endTime-22
   val endTime = "2007-12-03T10:15:45Z"
-  val endTimePlus5 = "2007-12-03T10:15:50Z" //queried end time range is endTime+5
+  val endTimePlusOffset = "2007-12-03T10:16:07Z" //queried end time range is endTime+22
   val uuid = UUID()
   val user =
     Identity(Subject(), Namespace(EntityName("testSpace"), uuid), BasicAuthenticationAuthKey(uuid, Secret()), Set.empty)
@@ -110,12 +114,12 @@ class SplunkLogStoreTests
 
               request.uri.path.toString() shouldBe "/services/search/jobs"
               request.headers shouldBe List(Authorization.basic(testConfig.username, testConfig.password))
-              earliestTime shouldBe Some(startTime)
-              latestTime shouldBe Some(endTimePlus5)
+              earliestTime shouldBe Some(startTimePlusOffset)
+              latestTime shouldBe Some(endTimePlusOffset)
               outputMode shouldBe Some("json")
               execMode shouldBe Some("oneshot")
               search shouldBe Some(
-                s"""search index="${testConfig.index}"| spath ${testConfig.activationIdField}| search ${testConfig.activationIdField}=${activation.activationId.toString}| table ${testConfig.logMessageField}| reverse""")
+                s"""search index="${testConfig.index}"| spath ${testConfig.activationIdField}| search ${testConfig.activationIdField}=${activation.activationId.toString}| table ${testConfig.logTimestampField}, ${testConfig.logStreamField}, ${testConfig.logMessageField}| reverse""")
 
               (
                 Success(
@@ -123,7 +127,7 @@ class SplunkLogStoreTests
                     StatusCodes.OK,
                     entity = HttpEntity(
                       ContentTypes.`application/json`,
-                      """{"preview":false,"init_offset":0,"messages":[],"fields":[{"name":"log_message"}],"results":[{"log_message":"some log message"},{"log_message":"some other log message"}], "highlighted":{}}"""))),
+                      """{"preview":false,"init_offset":0,"messages":[],"fields":[{"name":"log_message"}],"results":[{"log_timestamp": "2007-12-03T10:15:30Z", "log_stream":"stdout", "log_message":"some log message"},{"log_timestamp": "2007-12-03T10:15:31Z", "log_stream":"stderr", "log_message":"some other log message"}], "highlighted":{}}"""))),
                 userContext)
             }
             .recover {
@@ -148,7 +152,10 @@ class SplunkLogStoreTests
     //use the a flow that asserts the request structure and provides a response in the expected format
     val splunkStore = new SplunkLogStore(system, Some(testFlow), testConfig)
     val result = await(splunkStore.fetchLogs(activation, context))
-    result shouldBe ActivationLogs(Vector("some log message", "some other log message"))
+    result shouldBe ActivationLogs(
+      Vector(
+        "2007-12-03T10:15:30Z           stdout: some log message",
+        "2007-12-03T10:15:31Z           stderr: some other log message"))
   }
 
   it should "fail to connect to bogus host" in {


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
Existing SplunkLogStore suffers from:
- inaccurate queries, where cases when activation timestamp varies from log collection delay > 5 seconds
- inconsistent log output (compared to DockerToActivationLogStore)

This PR addresses these by:
- adding a config to indicate the splunk query offset, where query will be `<activation start> - offset` and `<activation end> + offset`
- refactoring splunk api results to be formatted same as DockerToActivationLogStore

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

