### PR TITLE
Ensure that limits are set properly

### DIFF
--- a/tests/src/test/scala/whisk/core/database/LimitsCommandTests.scala
+++ b/tests/src/test/scala/whisk/core/database/LimitsCommandTests.scala
@@ -55,7 +55,7 @@ class LimitsCommandTests extends FlatSpec with WhiskAdminCliTestBase {
       ns) shouldBe CommandMessages.limitsSuccessfullySet(ns)
 
     val limits = limitsStore.get[LimitEntity](DocInfo(LimitsCommand.limitIdOf(EntityName(ns)))).futureValue
-    limits.limits shouldBe UserLimits(Some(3), Some(7), Some(11), Some(Set("nodejs:6", "blackbox")))
+    limits.limits shouldBe UserLimits(Some(3), Some(11), Some(7), Some(Set("nodejs:6", "blackbox")))
 
     resultOk("limits", "set", "--invocationsPerMinute", "13", ns) shouldBe CommandMessages.limitsSuccessfullyUpdated(ns)
 

--- a/tests/src/test/scala/whisk/core/database/LimitsCommandTests.scala
+++ b/tests/src/test/scala/whisk/core/database/LimitsCommandTests.scala
@@ -55,7 +55,11 @@ class LimitsCommandTests extends FlatSpec with WhiskAdminCliTestBase {
       ns) shouldBe CommandMessages.limitsSuccessfullySet(ns)
 
     val limits = limitsStore.get[LimitEntity](DocInfo(LimitsCommand.limitIdOf(EntityName(ns)))).futureValue
-    limits.limits shouldBe UserLimits(Some(3), Some(11), Some(7), Some(Set("nodejs:6", "blackbox")))
+    limits.limits shouldBe UserLimits(
+      invocationsPerMinute = Some(3),
+      firesPerMinute = Some(7),
+      concurrentInvocations = Some(11),
+      allowedKinds = Some(Set("nodejs:6", "blackbox")))
 
     resultOk("limits", "set", "--invocationsPerMinute", "13", ns) shouldBe CommandMessages.limitsSuccessfullyUpdated(ns)
 

--- a/tools/admin/src/main/scala/whisk/core/database/LimitsCommand.scala
+++ b/tools/admin/src/main/scala/whisk/core/database/LimitsCommand.scala
@@ -77,8 +77,8 @@ class LimitsCommand extends Subcommand("limits") with WhiskCommand {
         EntityName(namespace()),
         UserLimits(
           invocationsPerMinute.toOption,
-          firesPerMinute.toOption,
           concurrentInvocations.toOption,
+          firesPerMinute.toOption,
           allowedKinds.toOption.map(_.toSet)))
   }
   addSubcommand(set)


### PR DESCRIPTION
`limits` command in `wskadmin-next` currently uses incorrect names i.e. order of name is incorrect. Thus `firesPerMinute` was being set as `concurrentInvocations`

Thanks to @asteed  for noticing this!

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [x] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

