### PR TITLE
fix bug in default CMD introduced in PR-4052

### DIFF
--- a/tools/ansibleRunner/Dockerfile
+++ b/tools/ansibleRunner/Dockerfile
@@ -25,4 +25,4 @@ RUN pip install --upgrade setuptools
 RUN pip install ansible==2.5.2
 RUN pip install jinja2==2.9.6
 
-CMD ["/usr/bin/ansible-playbook", "/task/playbook.yml"]
+CMD ["/usr/local/bin/ansible-playbook", "/task/playbook.yml"]


### PR DESCRIPTION
The switch from alpine to jessie-slim changed where ansible-playbook
is installed; I forgot to update the default CMD in the Dockerfile
accordingly in my previous commit.
