### PR TITLE
apigateway should always append request.path if response type is http

### DIFF
--- a/core/routemgmt/common/apigw-utils.js
+++ b/core/routemgmt/common/apigw-utils.js
@@ -566,7 +566,7 @@ function setActionOperationInvocationDetails(swagger, endpoint, operationId, res
   var caseIdx = getCaseOperationIdx(caseArr, operationId);
   var operations = [operationId];
   _.set(swagger, 'x-ibm-configuration.assembly.execute[0].operation-switch.case['+caseIdx+'].operations', operations);
-  _.set(swagger, 'x-ibm-configuration.assembly.execute[0].operation-switch.case['+caseIdx+'].execute[0].invoke.target-url',  makeWebActionBackendUrl(endpoint.action, responsetype) + (responsetype === 'http' ? "$(request.path)" : ""));
+  _.set(swagger, 'x-ibm-configuration.assembly.execute[0].operation-switch.case['+caseIdx+'].execute[0].invoke.target-url',  makeWebActionBackendUrl(endpoint.action, responsetype, true) );
   _.set(swagger, 'x-ibm-configuration.assembly.execute[0].operation-switch.case['+caseIdx+'].execute[0].invoke.verb', 'keep');
   if (endpoint.action.secureKey) {
     _.set(swagger, 'x-ibm-configuration.assembly.execute[0].operation-switch.case['+caseIdx+'].execute[1].set-variable.actions[0].set', 'message.headers.X-Require-Whisk-Auth' );
@@ -599,12 +599,13 @@ function getCaseOperationIdx(caseArr, operationId) {
 //   parameters           - the parameters defined in the path, if any.
 // Returns:
 //   string               - web-action URL
-function makeWebActionBackendUrl(endpointAction, endpointResponseType) {
+function makeWebActionBackendUrl(endpointAction, endpointResponseType, isTargetUrl = false) {
   host = getHostFromActionUrl(endpointAction.backendUrl);
   ns = endpointAction.namespace;
   pkg = getPackageNameFromFqActionName(endpointAction.name) || 'default';
   name = getActionNameFromFqActionName(endpointAction.name);
-  return 'https://' + host + '/api/v1/web/' + ns + '/' + pkg + '/' + name + '.' + endpointResponseType;
+  reqPath = isTargetUrl && endpointResponseType === 'http' ? "$(request.path)" : "";
+  return 'https://' + host + '/api/v1/web/' + ns + '/' + pkg + '/' + name + '.' + endpointResponseType + reqPath;
 }
 
 /*

--- a/core/routemgmt/common/apigw-utils.js
+++ b/core/routemgmt/common/apigw-utils.js
@@ -566,7 +566,7 @@ function setActionOperationInvocationDetails(swagger, endpoint, operationId, res
   var caseIdx = getCaseOperationIdx(caseArr, operationId);
   var operations = [operationId];
   _.set(swagger, 'x-ibm-configuration.assembly.execute[0].operation-switch.case['+caseIdx+'].operations', operations);
-  _.set(swagger, 'x-ibm-configuration.assembly.execute[0].operation-switch.case['+caseIdx+'].execute[0].invoke.target-url',  makeWebActionBackendUrl(endpoint.action, responsetype, getPathParameters(endpoint.gatewayPath)));
+  _.set(swagger, 'x-ibm-configuration.assembly.execute[0].operation-switch.case['+caseIdx+'].execute[0].invoke.target-url',  makeWebActionBackendUrl(endpoint.action, responsetype) + (responsetype === 'http' ? "$(request.path)" : ""));
   _.set(swagger, 'x-ibm-configuration.assembly.execute[0].operation-switch.case['+caseIdx+'].execute[0].invoke.verb', 'keep');
   if (endpoint.action.secureKey) {
     _.set(swagger, 'x-ibm-configuration.assembly.execute[0].operation-switch.case['+caseIdx+'].execute[1].set-variable.actions[0].set', 'message.headers.X-Require-Whisk-Auth' );
@@ -599,13 +599,12 @@ function getCaseOperationIdx(caseArr, operationId) {
 //   parameters           - the parameters defined in the path, if any.
 // Returns:
 //   string               - web-action URL
-function makeWebActionBackendUrl(endpointAction, endpointResponseType, parameters) {
+function makeWebActionBackendUrl(endpointAction, endpointResponseType) {
   host = getHostFromActionUrl(endpointAction.backendUrl);
   ns = endpointAction.namespace;
   pkg = getPackageNameFromFqActionName(endpointAction.name) || 'default';
   name = getActionNameFromFqActionName(endpointAction.name);
-  reqPath = parameters != null && parameters.length > 0 ? "$(request.path)" : "";
-  return 'https://' + host + '/api/v1/web/' + ns + '/' + pkg + '/' + name + '.' + endpointResponseType + reqPath;
+  return 'https://' + host + '/api/v1/web/' + ns + '/' + pkg + '/' + name + '.' + endpointResponseType;
 }
 
 /*

--- a/tests/src/test/scala/whisk/core/cli/test/ApiGwRestTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/ApiGwRestTests.scala
@@ -202,7 +202,7 @@ class ApiGwRestTests extends ApiGwRestBasicTests with RestUtil with WskActorSyst
     val openwhisk = RestResult.getFieldJsObject(urlop, "x-openwhisk")
     val actionN = RestResult.getField(openwhisk, "action")
     actionN shouldBe actionName
-    rr.stdout should include regex (s""""target-url":\\s*".*${actionName}.${responseType}"""")
+    rr.stdout should include regex (s""""target-url":\\s*".*${actionName}.${responseType}.*"""")
   }
 
   override def verifyInvalidSwagger(rr: RunResult): Unit = {


### PR DESCRIPTION
Closes #4055 

## Description
Bug creating api for apigateway doesn't append request.path

## Related issue and scope
Issue #4055 

## My changes affect the following components
- [x] RouteMgmt Web Actions

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).

