### PR TITLE
Increase max-content-length to 50 MB

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -8,6 +8,7 @@ akka.http {
     client {
         parsing.illegal-header-warnings = off
         parsing.max-chunk-size = 50m
+        parsing.max-content-length = 50m
     }
 
     host-connection-pool {

--- a/tests/src/test/scala/common/WhiskProperties.java
+++ b/tests/src/test/scala/common/WhiskProperties.java
@@ -349,6 +349,10 @@ public class WhiskProperties {
         return osname.equalsIgnoreCase("linux");
     }
 
+    public static int getMaxActionSizeMB(){
+        return Integer.parseInt(getProperty("whisk.action.size.max", "10"));
+    }
+
     /**
      * python interpreter.
      */
@@ -395,6 +399,14 @@ public class WhiskProperties {
 
     private static boolean isWhiskPropertiesRequired() {
         return getPropFromSystemOrEnv(WHISK_SERVER) == null;
+    }
+
+    private static String getProperty(String key, String defaultValue) {
+        String value = getPropFromSystemOrEnv(key);
+        if (value == null) {
+            value = whiskProperties.getProperty(key, defaultValue);
+        }
+        return value;
     }
 
     private static String getPropFromSystemOrEnv(String key) {

--- a/tests/src/test/scala/system/basic/WskActionTests.scala
+++ b/tests/src/test/scala/system/basic/WskActionTests.scala
@@ -17,10 +17,14 @@
 
 package system.basic
 
+import java.io.File
+import java.nio.charset.StandardCharsets
+
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import common._
 import common.rest.WskRestOperations
+import org.apache.commons.io.FileUtils
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
@@ -289,4 +293,26 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
       activation.logs.get.mkString(" ") should include(s"hello, $utf8")
     }
   }
+
+  it should "invoke action with large code" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "big-hello"
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      val filePath = TestUtils.getTestActionFilename("hello.js")
+      val code = FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8)
+      val largeCode = code + " " * (10 * FileUtils.ONE_MB).toInt
+      val tmpFile = File.createTempFile("whisk", ".js")
+      FileUtils.write(tmpFile, largeCode, StandardCharsets.UTF_8)
+      val result = action.create(name, Some(tmpFile.getAbsolutePath))
+      tmpFile.delete()
+      result
+    }
+
+    val hello = "hello"
+    val run = wsk.action.invoke(name, Map("payload" -> hello.toJson))
+    withActivation(wsk.activation, run) { activation =>
+      activation.response.status shouldBe "success"
+      activation.logs.get.mkString(" ") should include(s"hello, $hello")
+    }
+  }
+
 }

--- a/tests/src/test/scala/system/basic/WskActionTests.scala
+++ b/tests/src/test/scala/system/basic/WskActionTests.scala
@@ -299,7 +299,7 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
     assetHelper.withCleaner(wsk.action, name) { (action, _) =>
       val filePath = TestUtils.getTestActionFilename("hello.js")
       val code = FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8)
-      val largeCode = code + " " * (10 * FileUtils.ONE_MB).toInt
+      val largeCode = code + " " * (WhiskProperties.getMaxActionSizeMB * FileUtils.ONE_MB).toInt
       val tmpFile = File.createTempFile("whisk", ".js")
       FileUtils.write(tmpFile, largeCode, StandardCharsets.UTF_8)
       val result = action.create(name, Some(tmpFile.getAbsolutePath))


### PR DESCRIPTION
With current setup reading code attachment more than 8 MB results in error (#4028). Increase `max-content-length` to 50 MB allows reading code attachments upto maximum allowed 48 MB

## Description

Akka uses [max-content-length][1] to ensure limits on incoming request entities. By default it is 8 MB while OpenWhisk allows max code upto 48 MB. To enable such large action code as attachment increase the max-content-length to 50 MB

### Basic Test

This PR also adds a system basic test to ensure that such large actions can be created. Due to constrained resource on travis test only create action code upto 10 MB. However it can be increased via config by setting system property `whisk.action.size.max` (in MB)

This test would also help to validate if the proxy and other settings are properly configured. See #3712 for details on which all settings need to be configured

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#4028)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

[1]: https://github.com/akka/akka-http/blob/668d13d094edfb610251994d8154ac1e018a1d9c/akka-http-core/src/main/resources/reference.conf#L414