### PR TITLE
Ensure CosmosDBArtifactStore return query results within limits

### DIFF
--- a/common/scala/src/main/scala/whisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
@@ -218,7 +218,7 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
 
     val publisher =
       RxReactiveStreams.toPublisher(client.queryDocuments(collection.getSelfLink, querySpec, newFeedOptions()))
-    val f = Source
+    val s = Source
       .fromPublisher(publisher)
       .wireTap(Sink.foreach(r => collectMetrics(queryToken, r.getRequestCharge)))
       .mapConcat(asSeq)
@@ -229,6 +229,12 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
           .transformViewResult(ddoc, viewName, startKey, endKey, realIncludeDocs, js, CosmosDBArtifactStore.this))
       .mapAsync(1)(identity)
       .mapConcat(identity)
+
+    //If limit is specified then only take that many elements. With join its possible that
+    //number of entries become > limit
+    val s2 = if (limit > 0) s.take(limit) else s
+
+    val f = s2
       .runWith(Sink.seq)
       .map(_.toList)
 


### PR DESCRIPTION
`CosmosDBArtifactStore` may return more results than those specified by `limit`

## Description
`CosmosDBArtifactStore` query can return more results than those specified via limit. This would happen for the case involving join operation which can result in more than 1 result for a given input.

This can happen when a subject is queried by name. For example consider a subject having 2 namespaces

```json
{
  "_id": "team1",
  "_rev": "1-c3fa3d69b8474f97dbbee70cde821802",
  "namespaces": [
    {
      "name": "team1",
      "key": "k1",
      "uuid": "uuid1"
    },
    {
      "name": "team1-dev",
      "key": "k2",
      "uuid": "uuid2"
    }
  ],
  "subject": "team1"
}
```

When we query this via 

```
SELECT r AS view 
FROM root r 
JOIN n in r.namespaces 
WHERE 
  (NOT(IS_DEFINED(r.blocked)) OR r.blocked = false) 
    AND (r.subject = 'team1' OR n.name = 'team1')
```
For such queries the limit is not passed on to the db as some of the checks related to subjects are not possible via query. Hence we fetch more results than limit. In this case it would result in 2 entries referring to same `team1`. 

For such cases we need to ensure that stream result in entries under specified `limit`

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

