### PR TITLE
Include exception class in failure message from ArtifactStore

### DIFF
--- a/common/scala/src/main/scala/whisk/core/database/StoreUtils.scala
+++ b/common/scala/src/main/scala/whisk/core/database/StoreUtils.scala
@@ -41,7 +41,7 @@ private[database] object StoreUtils {
     f.onFailure({
       case _: ArtifactStoreException => // These failures are intentional and shouldn't trigger the catcher.
       case x =>
-        transid.failed(this, start, s"${failureMessage(x)}[${x.getClass.getSimpleName}]", ErrorLevel)
+        transid.failed(this, start, s"${failureMessage(x)} [${x.getClass.getSimpleName}]", ErrorLevel)
     })
     f
   }

--- a/common/scala/src/main/scala/whisk/core/database/StoreUtils.scala
+++ b/common/scala/src/main/scala/whisk/core/database/StoreUtils.scala
@@ -41,7 +41,7 @@ private[database] object StoreUtils {
     f.onFailure({
       case _: ArtifactStoreException => // These failures are intentional and shouldn't trigger the catcher.
       case x =>
-        transid.failed(this, start, s"${failureMessage(x)}[${x.getClass}]", ErrorLevel)
+        transid.failed(this, start, s"${failureMessage(x)}[${x.getClass.getSimpleName}]", ErrorLevel)
     })
     f
   }

--- a/common/scala/src/main/scala/whisk/core/database/StoreUtils.scala
+++ b/common/scala/src/main/scala/whisk/core/database/StoreUtils.scala
@@ -40,7 +40,8 @@ private[database] object StoreUtils {
     ec: ExecutionContext): Future[T] = {
     f.onFailure({
       case _: ArtifactStoreException => // These failures are intentional and shouldn't trigger the catcher.
-      case x                         => transid.failed(this, start, failureMessage(x), ErrorLevel)
+      case x =>
+        transid.failed(this, start, s"${failureMessage(x)}[${x.getClass}]", ErrorLevel)
     })
     f
   }


### PR DESCRIPTION
Sometime the exception message is null which leads to log message like `'activations' internal error, failure: 'null'`

```
[2018-10-11T06:46:11.034Z] [ERROR] [#tid_bASVetECuqu481V6WTm0f35UhQzqV2Zd] [StoreUtils] [QUERY] 'activations' internal error, failure: 'null' [marker:database_queryView_error:120:120]
```

To get more context of the actual exception it would be useful to also include the exception class. Post this the log would be like

```
[2018-10-12T09:00:39.758Z] [ERROR] [#tid_sid_testing] [StoreUtils] Test null [RuntimeException] [marker:database_getDocumentAttachment_error:739:29]
```



## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

