### PR TITLE
Change config location to work with non root user

### DIFF
--- a/common/scala/transformEnvironment.sh
+++ b/common/scala/transformEnvironment.sh
@@ -42,10 +42,7 @@ fi
 
 if [ -n "$config" ]
 then
-    location="/config.conf"
-    if [ -n "$NOT_ROOT_USER" ]; then
-        location="/home/$NOT_ROOT_USER/config.conf"
-    fi
+    location="$HOME/config.conf"
     printf "%s" "$config" > "$location"
     props+=("-Dconfig.file='$location'")
 fi

--- a/common/scala/transformEnvironment.sh
+++ b/common/scala/transformEnvironment.sh
@@ -43,6 +43,9 @@ fi
 if [ -n "$config" ]
 then
     location="/config.conf"
+    if [ -n "$NOT_ROOT_USER" ]; then
+        location="/home/$NOT_ROOT_USER/config.conf"
+    fi
     printf "%s" "$config" > "$location"
     props+=("-Dconfig.file='$location'")
 fi


### PR DESCRIPTION
Change config location to work with non root user support which was added in #3579
## Description
With the invoker and controller now having a new user (though invoker is still running as root), we need to put the config file within the new user's home directory to maintain the access when not using the root user.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

