### PR TITLE
Fix mock-verification in Container-tests.

### DIFF
--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
@@ -352,8 +352,8 @@ class DockerContainerTests
     val suspend = container.suspend()
     val resume = container.resume()
 
-    Await.result(suspend, 500.milliseconds)
-    Await.result(resume, 500.milliseconds)
+    await(suspend)
+    await(resume)
 
     docker.unpauses should have size 0
     docker.pauses should have size 0
@@ -372,8 +372,8 @@ class DockerContainerTests
     val suspend = container.suspend()
     val resume = container.resume()
 
-    Await.result(suspend, 500.milliseconds)
-    Await.result(resume, 500.milliseconds)
+    await(suspend)
+    await(resume)
 
     docker.unpauses should have size 1
     docker.pauses should have size 1

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
@@ -343,31 +343,43 @@ class DockerContainerTests
    * DOCKER COMMANDS
    */
   it should "pause and resume container via runc" in {
-    implicit val docker = stub[DockerApiWithFileAccess]
-    implicit val runc = stub[RuncApi]
+    implicit val docker = new TestDockerClient
+    implicit val runc = new TestRuncClient
 
     val id = ContainerId("id")
     val container = new DockerContainer(id, ContainerAddress("ip"), true)
 
-    container.suspend()
-    container.resume()
+    val suspend = container.suspend()
+    val resume = container.resume()
 
-    (runc.pause(_: ContainerId)(_: TransactionId)).verify(id, transid)
-    (runc.resume(_: ContainerId)(_: TransactionId)).verify(id, transid)
+    Await.result(suspend, 500.milliseconds)
+    Await.result(resume, 500.milliseconds)
+
+    docker.unpauses should have size 0
+    docker.pauses should have size 0
+
+    runc.pauses should have size 1
+    runc.resumes should have size 1
   }
 
   it should "pause and unpause container via docker" in {
-    implicit val docker = stub[DockerApiWithFileAccess]
-    implicit val runc = stub[RuncApi]
+    implicit val docker = new TestDockerClient
+    implicit val runc = new TestRuncClient
 
     val id = ContainerId("id")
     val container = new DockerContainer(id, ContainerAddress("ip"), false)
 
-    container.suspend()
-    container.resume()
+    val suspend = container.suspend()
+    val resume = container.resume()
 
-    (docker.pause(_: ContainerId)(_: TransactionId)).verify(id, transid)
-    (docker.unpause(_: ContainerId)(_: TransactionId)).verify(id, transid)
+    Await.result(suspend, 500.milliseconds)
+    Await.result(resume, 500.milliseconds)
+
+    docker.unpauses should have size 1
+    docker.pauses should have size 1
+
+    runc.pauses should have size 0
+    runc.resumes should have size 0
   }
 
   it should "destroy a container via Docker" in {
@@ -768,6 +780,21 @@ class DockerContainerTests
     val processedLogsFalse = awaitLogs(container.logs(limit = 1.MB, waitForSentinel = false))
     processedLogsFalse should have size 1
     processedLogsFalse(0) shouldBe expectedLogEntry.toFormattedString
+  }
+
+  class TestRuncClient extends RuncApi {
+    var resumes = mutable.Buffer.empty[ContainerId]
+    var pauses = mutable.Buffer.empty[ContainerId]
+
+    override def resume(id: ContainerId)(implicit transid: TransactionId): Future[Unit] = {
+      resumes += id
+      Future.successful(())
+    }
+
+    override def pause(id: ContainerId)(implicit transid: TransactionId): Future[Unit] = {
+      pauses += id
+      Future.successful(())
+    }
   }
 
   class TestDockerClient extends DockerApiWithFileAccess {


### PR DESCRIPTION
## Description

These two tests are failing intermittently in our pipeline and travis. But unfortunately I'm not able to reproduce the problem locally.
But my theory, why these tests fail is the following:
The two commands `suspend` and `resume` are returning Futures. My theory is, that these asynchronous calls are not finished, when we check if the methods inside these methods have been called.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

