### PR TITLE
Fix controller logs in docker-machine

### DIFF
--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -27,6 +27,14 @@
     mode: 0777
   become: "{{ logs.dir.become }}"
 
+# We need to create the file with proper permissions because the dir creation above
+# does not result in a dir with full permissions in docker machine especially with macos mounts
+- name: ensure controller log file is created with permissions
+  file:
+    path: "{{ whisk_logs_dir }}/{{ controller_name }}/{{ controller_name }}_logs.log"
+    state: touch
+    mode: 0777
+
 - name: ensure controller config directory is created with permissions
   file:
     path: "{{ controller.confdir }}/{{ controller_name }}"

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -34,6 +34,7 @@
     path: "{{ whisk_logs_dir }}/{{ controller_name }}/{{ controller_name }}_logs.log"
     state: touch
     mode: 0777
+  when: environment_type is defined and environment_type == "docker-machine"
 
 - name: ensure controller config directory is created with permissions
   file:


### PR DESCRIPTION
With the change https://github.com/apache/incubator-openwhisk/pull/3579, controller logs file was not being created due to lack of permissions when OW is deployed on docker-machine. This is because ansible is not able to create a folder with full permissions within a mounted folder in docker-machine. However creating a file with full permissions through ansible does work.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

