### PR TITLE
Use `latest` as default tag for apigateway

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -256,7 +256,8 @@ apigateway:
     api: 9000
     api_secure: 443
     mgmt: 9001
-  version: 0.9.10
+  # apigateway is an Apahce OpenWhisk project, so default to latest
+  version: latest
 
 redis:
   version: 3.2


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

The default tag for all openwhisk project docker images on the master branch should be `latest` so that we are always testing against our own latest code.  Operators can override to pin versions as desired in their own deployments.
