### PR TITLE
upgrade from docker 1.12 to 18.06

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,10 +54,6 @@ cache:
     - $HOME/.gradle/wrapper/
 
 before_install:
-  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-  - sudo apt-get update
-  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
   - pip install --upgrade pip setuptools six
   - pip3 install --upgrade pip setuptools six
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,7 @@ group: deprecated-2017Q3
 
 language: scala
 scala:
-   - 2.11.8
-
-services:
-  - docker
+  - 2.11.8
 
 env:
   global:
@@ -57,6 +54,10 @@ cache:
     - $HOME/.gradle/wrapper/
 
 before_install:
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
   - pip install --upgrade pip setuptools six
   - pip3 install --upgrade pip setuptools six
 

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -275,7 +275,7 @@ docker:
   image:
     prefix: "{{ docker_image_prefix | default('whisk') }}"
     tag: "{{ docker_image_tag | default('latest') }}"
-  version: 1.12.0-0~trusty
+  version: 18.06.1-ce
   storagedriver: overlay
   port: 4243
   restart:

--- a/core/invoker/Dockerfile
+++ b/core/invoker/Dockerfile
@@ -13,7 +13,6 @@ RUN apk add --update openssl
 # Uncomment to fetch latest version of docker instead: RUN wget -qO- https://get.docker.com | sh
 # Install docker client
 RUN curl -sSL -o docker-${DOCKER_VERSION}.tgz https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz && \
-RUN curl -sSL -o docker-${DOCKER_VERSION}.tgz https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz && \
 echo "${DOCKER_DOWNLOAD_SHA256}  docker-${DOCKER_VERSION}.tgz" | sha256sum -c - && \
 tar --strip-components 1 -xvzf docker-${DOCKER_VERSION}.tgz -C /usr/bin docker/docker && \
 tar --strip-components 1 -xvzf docker-${DOCKER_VERSION}.tgz -C /usr/bin docker/docker-runc && \

--- a/core/invoker/Dockerfile
+++ b/core/invoker/Dockerfile
@@ -5,13 +5,14 @@ FROM scala
 
 ENV UID=1001 \
     NOT_ROOT_USER=owuser
-ENV DOCKER_VERSION=1.12.0 \
-    DOCKER_DOWNLOAD_SHA256=3dd07f65ea4a7b4c8829f311ab0213bca9ac551b5b24706f3e79a97e22097f8b
+ENV DOCKER_VERSION=18.06.1-ce \
+    DOCKER_DOWNLOAD_SHA256=83be159cf0657df9e1a1a4a127d181725a982714a983b2bdcc0621244df93687
 
 RUN apk add --update openssl
 
 # Uncomment to fetch latest version of docker instead: RUN wget -qO- https://get.docker.com | sh
 # Install docker client
+RUN curl -sSL -o docker-${DOCKER_VERSION}.tgz https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz && \
 RUN curl -sSL -o docker-${DOCKER_VERSION}.tgz https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz && \
 echo "${DOCKER_DOWNLOAD_SHA256}  docker-${DOCKER_VERSION}.tgz" | sha256sum -c - && \
 tar --strip-components 1 -xvzf docker-${DOCKER_VERSION}.tgz -C /usr/bin docker/docker && \

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClient.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClient.scala
@@ -124,7 +124,7 @@ class DockerClient(dockerHost: Option[String] = None,
         }
         .map(ContainerId.apply)
         .recoverWith {
-          // https://docs.docker.com/v1.12/engine/reference/run/#/exit-status
+          // https://docs.docker.com/engine/reference/run/#general-form
           // Exit status 125 means an error reported by the Docker daemon.
           // Examples:
           // - Unrecognized option specified

--- a/tools/ansibleRunner/Dockerfile
+++ b/tools/ansibleRunner/Dockerfile
@@ -3,7 +3,7 @@
 
 from debian:jessie-slim
 
-ENV DOCKER_VERSION 1.12.0
+ENV DOCKER_VERSION 18.06.1-ce
 
 RUN apt-get update && apt-get install -y \
   curl \

--- a/tools/ansibleRunner/Dockerfile
+++ b/tools/ansibleRunner/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
   zip
 
 # Install docker client
-RUN wget --no-verbose https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz && \
+RUN wget --no-verbose https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz && \
 tar --strip-components 1 -xvzf docker-${DOCKER_VERSION}.tgz -C /usr/bin docker/docker && \
 rm -f docker-${DOCKER_VERSION}.tgz && \
 chmod +x /usr/bin/docker

--- a/tools/macos/README.md
+++ b/tools/macos/README.md
@@ -26,7 +26,7 @@ If you prefer to use Docker-machine, you can follow instructions in [docker-mach
 
 The following are required to build and deploy OpenWhisk from a Mac host:
 
-- [Docker 1.12.0](https://docs.docker.com/docker-for-mac/)
+- [Docker 18.06](https://docs.docker.com/docker-for-mac/)
 - [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html) or [Open JDK 8](https://adoptopenjdk.net/releases.html#x64_mac)
 - [Scala 2.11](http://scala-lang.org/download/)
 - [Ansible 2.5.2](http://docs.ansible.com/ansible/intro_installation.html)

--- a/tools/macos/docker-machine/README.md
+++ b/tools/macos/docker-machine/README.md
@@ -27,7 +27,7 @@ You will make provision of a virtual machine with Docker-machine and communicate
 The following are required to build and deploy OpenWhisk from a Mac host:
 
 - [Oracle VM VirtualBox](https://www.virtualbox.org/wiki/Downloads)
-- [Docker 1.12.0](https://docs.docker.com/engine/installation/mac/) (including `docker-machine`)
+- [Docker 18.06](https://docs.docker.com/engine/installation/mac/) (including `docker-machine`)
 - [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 - [Scala 2.11](http://scala-lang.org/download/)
 - [Ansible 2.5.2](http://docs.ansible.com/ansible/intro_installation.html)
@@ -45,8 +45,8 @@ echo '
 brew tap caskroom/cask
 # install virtualbox
 brew cask install virtualbox
-# install docker 1.12.0
-brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/33301827c3d770bfd49f0e50d84e0b125b06b0b7/Formula/docker.rb
+# install docker 18.06.1-ce
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/7dc0879288ad46c3364f06f3a7e625e8b12940af/Formula/docker.rb
 # install docker-machine
 brew install docker-machine
 # install java 8
@@ -66,7 +66,7 @@ It is recommended that you create a virtual machine `whisk` with at least 4GB of
 ```
 docker-machine create -d virtualbox \
    --virtualbox-memory 4096 \
-   --virtualbox-boot2docker-url=https://github.com/boot2docker/boot2docker/releases/download/v1.12.0/boot2docker.iso \
+   --virtualbox-boot2docker-url=https://github.com/boot2docker/boot2docker/releases/download/v18.06.1-ce/boot2docker.iso \
     whisk # the name of your docker machine
 ```
 Note that by default the third octet chosen by docker-machine will be 99. If you've multiple docker machines

--- a/tools/travis/setup.sh
+++ b/tools/travis/setup.sh
@@ -31,12 +31,14 @@ function retry() {
 }
 
 #sudo gpasswd -a travis docker
-#sudo -E bash -c 'echo '\''DOCKER_OPTS="-H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock --storage-driver=overlay --userns-remap=default"'\'' > /etc/default/docker'
+sudo -E bash -c 'echo '\''DOCKER_OPTS="-H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock --storage-driver=overlay --userns-remap=default"'\'' > /etc/default/docker'
 
 # Docker
-#sudo apt-get -y update -qq
-#sudo apt-get -o Dpkg::Options::="--force-confold" --force-yes -y install docker-engine=1.12.0-0~trusty
-#sudo service docker restart
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+sudo apt-get update
+sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+sudo service docker restart
 echo "Docker Version:"
 docker version
 echo "Docker Info:"

--- a/tools/travis/setup.sh
+++ b/tools/travis/setup.sh
@@ -30,13 +30,13 @@ function retry() {
   fi
 }
 
-sudo gpasswd -a travis docker
-sudo -E bash -c 'echo '\''DOCKER_OPTS="-H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock --storage-driver=overlay --userns-remap=default"'\'' > /etc/default/docker'
+#sudo gpasswd -a travis docker
+#sudo -E bash -c 'echo '\''DOCKER_OPTS="-H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock --storage-driver=overlay --userns-remap=default"'\'' > /etc/default/docker'
 
 # Docker
-sudo apt-get -y update -qq
-sudo apt-get -o Dpkg::Options::="--force-confold" --force-yes -y install docker-engine=1.12.0-0~trusty
-sudo service docker restart
+#sudo apt-get -y update -qq
+#sudo apt-get -o Dpkg::Options::="--force-confold" --force-yes -y install docker-engine=1.12.0-0~trusty
+#sudo service docker restart
 echo "Docker Version:"
 docker version
 echo "Docker Info:"

--- a/tools/ubuntu-setup/docker.sh
+++ b/tools/ubuntu-setup/docker.sh
@@ -32,8 +32,11 @@ sudo apt-cache policy docker-engine
 sudo apt-get --no-install-recommends -y install linux-image-extra-virtual
 
 # DOCKER
-sudo apt-get install -y --force-yes docker-engine=1.12.0-0~trusty
-sudo apt-mark hold docker-engine
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+sudo apt-get update
+sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+
 
 # enable (security - use 127.0.0.1)
 sudo -E bash -c 'echo '\''DOCKER_OPTS="-H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock --storage-driver=aufs"'\'' >> /etc/default/docker'


### PR DESCRIPTION
docker cli tgz no longer available
https://get.docker.com/builds/Linux/x86_64/docker-12.0.tgz
