### PR TITLE
Always return activation without log on blocking invoke.

### DIFF
--- a/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
@@ -631,7 +631,7 @@ protected[actions] trait PrimitiveActions {
               LoggingMarkers.CONTROLLER_ACTIVATION_BLOCKING_DATABASE_RETRIEVAL,
               s"retrieved activation for blocking invocation via DB polling",
               logLevel = InfoLevel)
-            result.trySuccess(Right(activation))
+            result.trySuccess(Right(activation.withoutLogs))
           case Failure(_: NoDocumentException) => pollActivation(docid, context, result, wait, retries + 1, maxRetries)
           case Failure(t: Throwable)           => result.tryFailure(t)
         }

--- a/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/ActionsApiTests.scala
@@ -1271,7 +1271,8 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
       activationIdFactory.make(),
       start = Instant.now,
       end = Instant.now,
-      response = ActivationResponse.success(Some(JsObject("test" -> "yes".toJson))))
+      response = ActivationResponse.success(Some(JsObject("test" -> "yes".toJson))),
+      logs = ActivationLogs(Vector("first line", "second line")))
     put(entityStore, action)
     // storing the activation in the db will allow the db polling to retrieve it
     // the test harness makes sure the activation id observed by the test matches


### PR DESCRIPTION
If an user invokes an action blockingly today, the invoker executes the activation and sends back the result to the controller, which passes it back to the client. If it is not possible to pass the result back to the controller, it will try to get it from the database. And here's the problem. If the controller receives the result of the activation from the invoker, there are no logs included. If it polls it from the database, the logs are included. This should be unified to never return logs.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [x] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

