### PR TITLE
update from redis 3.2 to 4.0

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -259,7 +259,7 @@ apigateway:
   version: 0.9.10
 
 redis:
-  version: 3.2
+  version: 4.0
   port: 6379
 
 linux:


### PR DESCRIPTION
Redis 4.0 was GA in mid-2017 and is the current maintained production stream for Redis.  
