### PR TITLE
Cache empty auth results to reduce db load

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Identity.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Identity.scala
@@ -50,7 +50,7 @@ protected[core] case class Identity(subject: Subject,
                                     rights: Set[Privilege],
                                     limits: UserLimits = UserLimits())
 
-object Identity extends MultipleReadersSingleWriterCache[Identity, DocInfo] with DefaultJsonProtocol {
+object Identity extends MultipleReadersSingleWriterCache[Option[Identity], DocInfo] with DefaultJsonProtocol {
 
   private val viewName = "subjects/identities"
 
@@ -75,16 +75,16 @@ object Identity extends MultipleReadersSingleWriterCache[Identity, DocInfo] with
         list(datastore, List(ns), limit = 1) map { list =>
           list.length match {
             case 1 =>
-              rowToIdentity(list.head, ns)
+              Some(rowToIdentity(list.head, ns))
             case 0 =>
               logger.info(this, s"$viewName[$namespace] does not exist")
-              throw new NoDocumentException("namespace does not exist")
+              None
             case _ =>
               logger.error(this, s"$viewName[$namespace] is not unique")
               throw new IllegalStateException("namespace is not unique")
           }
         }
-      })
+      }).map(_.getOrElse(throw new NoDocumentException("namespace does not exist")))
   }
 
   def get(datastore: AuthStore, authkey: BasicAuthenticationAuthKey)(
@@ -97,16 +97,16 @@ object Identity extends MultipleReadersSingleWriterCache[Identity, DocInfo] with
         list(datastore, List(authkey.uuid.asString, authkey.key.asString)) map { list =>
           list.length match {
             case 1 =>
-              rowToIdentity(list.head, authkey.uuid.asString)
+              Some(rowToIdentity(list.head, authkey.uuid.asString))
             case 0 =>
               logger.info(this, s"$viewName[${authkey.uuid}] does not exist")
-              throw new NoDocumentException("uuid does not exist")
+              None
             case _ =>
               logger.error(this, s"$viewName[${authkey.uuid}] is not unique")
               throw new IllegalStateException("uuid is not unique")
           }
         }
-      })
+      }).map(_.getOrElse(throw new NoDocumentException("namespace does not exist")))
   }
 
   def list(datastore: AuthStore, key: List[Any], limit: Int = 2)(

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/behavior/ArtifactStoreSubjectQueryBehaviors.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/behavior/ArtifactStoreSubjectQueryBehaviors.scala
@@ -82,6 +82,22 @@ trait ArtifactStoreSubjectQueryBehaviors extends ArtifactStoreBehaviorBase {
     Identity.get(authStore, ak1).failed.futureValue shouldBe a[NoDocumentException]
   }
 
+  it should "should throw NoDocumentException for non existing namespaces" in {
+    implicit val tid: TransactionId = transid()
+    val nonExistingNamesSpace = "nonExistingNamesSpace"
+    Identity.get(authStore, EntityName(nonExistingNamesSpace)).failed.futureValue shouldBe a[NoDocumentException]
+  }
+
+  it should "should throw NoDocumentException for non existing authKeys" in {
+    implicit val tid: TransactionId = transid()
+    val nonExistingUUID = "nonExistingUUID"
+    val nonExistingSecret = "nonExistingSecret"
+    Identity
+      .get(authStore, BasicAuthenticationAuthKey(UUID(nonExistingUUID), Secret()))
+      .failed
+      .futureValue shouldBe a[NoDocumentException]
+  }
+
   it should "find subject having multiple namespaces" in {
     implicit val tid: TransactionId = transid()
     val uuid1 = UUID()


### PR DESCRIPTION
Cache negative auth responses to avoid going to the DB with every identical call 

## Description
Since negative auth responses (Identity.get) are not cached, 
all requests with a non existing namespace or an invalid authkey will perform queries to the subject db.
A user can influence OW performance by issuing a high number of those calls.

ThIs PR changes that behavior in the way, that negative auth results are cached as None value.
Subsequent Identical calls will only use the cache (for the 5 minutes cache period).
The external interface and behavior of the Identity.get methods stays unchanged.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change 

## My changes affect the following components
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

