### PR TITLE
Making Redis password protected

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -263,6 +263,7 @@ apigateway:
 redis:
   version: 4.0
   port: 6379
+  password: openwhisk 
 
 linux:
   version: 4.4.0-31

--- a/ansible/roles/apigateway/tasks/deploy.yml
+++ b/ansible/roles/apigateway/tasks/deploy.yml
@@ -14,6 +14,7 @@
     env:
       "REDIS_HOST": "{{ groups['redis'] | first }}"
       "REDIS_PORT": "{{ redis.port }}"
+      "REDIS_PASS": "{{ redis.password }}"
       "PUBLIC_MANAGEDURL_HOST": "{{ ansible_host }}"
       "PUBLIC_MANAGEDURL_PORT": "{{ apigateway.port.mgmt }}"
       "TZ": "{{ docker.timezone }}"

--- a/ansible/roles/redis/tasks/deploy.yml
+++ b/ansible/roles/redis/tasks/deploy.yml
@@ -21,10 +21,15 @@
       - "{{ redis.port }}:6379"
     env:
       TZ: "{{ docker.timezone }}"
+    command:
+      /bin/sh -c
+      "docker-entrypoint.sh --requirepass {{ redis.password }}"
 
 - name: wait until redis is up and running
-  action: shell (echo PING; sleep 1) | nc {{ ansible_host }} {{ redis.port }}
+# using RESP protocol to set redis password and validate it's up
+# inspired by: https://www.compose.com/articles/how-to-talk-raw-redis/
+  action: shell (printf "*2\r\n\$4\r\nAUTH\r\n\${{redis.password|length}}\r\n{{ redis.password }}\r\n*1\r\n\$4\r\nPING\r\n"; sleep 1) | nc {{ ansible_host }} {{ redis.port }}
   register: result
-  until: (result.rc == 0) and (result.stdout == '+PONG')
+  until: (result.rc == 0) and (result.stdout == '+OK\r\n+PONG')
   retries: 12
   delay: 5


### PR DESCRIPTION
## Description
Currently default openwhisk (apigateway) setup doesn't secure Redis with password.
This PR adds password protection to Redis ansible 

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

