### PR TITLE
update mesos-actor; cleanup orphaned failed task launches

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     compile 'io.kamon:kamon-core_2.12:0.6.7'
     compile 'io.kamon:kamon-statsd_2.12:0.6.7'
     //for mesos
-    compile 'com.adobe.api.platform.runtime:mesos-actor:0.0.13'
+    compile 'com.adobe.api.platform.runtime:mesos-actor:0.0.14'
 
     //tracing support
     compile 'io.opentracing:opentracing-api:0.31.0'

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/mesos/MesosTask.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/mesos/MesosTask.scala
@@ -37,8 +37,6 @@ import com.adobe.api.platform.runtime.mesos.SubmitTask
 import com.adobe.api.platform.runtime.mesos.TaskDef
 import com.adobe.api.platform.runtime.mesos.User
 import java.time.Instant
-import org.apache.mesos.v1.Protos.TaskState
-import org.apache.mesos.v1.Protos.TaskStatus
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.util.Failure
@@ -142,9 +140,14 @@ object MesosTask {
           transid.finished(this, start, s"launched task ${taskId} at ${taskDetails.hostname}:${taskDetails
             .hostports(0)}", logLevel = InfoLevel)
         case Failure(ate: AskTimeoutException) =>
-          transid.failed(this, start, ate.getMessage, ErrorLevel)
+          transid.failed(this, start, s"task launch timed out ${ate.getMessage}", ErrorLevel)
           MetricEmitter.emitCounterMetric(LoggingMarkers.INVOKER_MESOS_CMD_TIMEOUT(LAUNCH_CMD))
-        case Failure(t) => transid.failed(this, start, t.getMessage, ErrorLevel)
+          //kill the task whose launch timed out
+          destroy(mesosClientActor, mesosConfig, taskId)
+        case Failure(t) =>
+          //kill the task whose launch timed out
+          destroy(mesosClientActor, mesosConfig, taskId)
+          transid.failed(this, start, s"task launch failed ${t.getMessage}", ErrorLevel)
       }
       .map(taskDetails => {
         val taskHost = taskDetails.hostname
@@ -155,7 +158,29 @@ object MesosTask {
       })
 
   }
+  private def destroy(mesosClientActor: ActorRef, mesosConfig: MesosConfig, taskId: String)(
+    implicit transid: TransactionId,
+    logging: Logging,
+    ec: ExecutionContext): Future[Unit] = {
+    val taskDeleteTimeout = Timeout(mesosConfig.timeouts.taskDelete)
 
+    val start = transid.started(
+      this,
+      LoggingMarkers.INVOKER_MESOS_CMD(MesosTask.KILL_CMD),
+      s"killing mesos taskid $taskId (timeout: ${taskDeleteTimeout})",
+      logLevel = InfoLevel)
+
+    mesosClientActor
+      .ask(DeleteTask(taskId))(taskDeleteTimeout)
+      .andThen {
+        case Success(_) => transid.finished(this, start, logLevel = InfoLevel)
+        case Failure(ate: AskTimeoutException) =>
+          transid.failed(this, start, s"task destroy timed out ${ate.getMessage}", ErrorLevel)
+          MetricEmitter.emitCounterMetric(LoggingMarkers.INVOKER_MESOS_CMD_TIMEOUT(MesosTask.KILL_CMD))
+        case Failure(t) => transid.failed(this, start, s"task destroy failed ${t.getMessage}", ErrorLevel)
+      }
+      .map(_ => {})(ec)
+  }
 }
 
 object JsonFormatters extends DefaultJsonProtocol {
@@ -171,7 +196,6 @@ class MesosTask(override protected val id: ContainerId,
                 mesosClientActor: ActorRef,
                 mesosConfig: MesosConfig)
     extends Container {
-  val taskDeleteTimeout = Timeout(mesosConfig.timeouts.taskLaunch)
 
   /** Stops the container from consuming CPU cycles. */
   override def suspend()(implicit transid: TransactionId): Future[Unit] = {
@@ -187,30 +211,7 @@ class MesosTask(override protected val id: ContainerId,
 
   /** Completely destroys this instance of the container. */
   override def destroy()(implicit transid: TransactionId): Future[Unit] = {
-    val start = transid.started(
-      this,
-      LoggingMarkers.INVOKER_MESOS_CMD(MesosTask.KILL_CMD),
-      s"killing mesos taskid $taskId (timeout: ${taskDeleteTimeout})",
-      logLevel = InfoLevel)
-
-    mesosClientActor
-      .ask(DeleteTask(taskId))(taskDeleteTimeout)
-      .mapTo[TaskStatus]
-      .andThen {
-        case Success(_) => transid.finished(this, start, logLevel = InfoLevel)
-        case Failure(ate: AskTimeoutException) =>
-          transid.failed(this, start, ate.getMessage, ErrorLevel)
-          MetricEmitter.emitCounterMetric(LoggingMarkers.INVOKER_MESOS_CMD_TIMEOUT(MesosTask.KILL_CMD))
-        case Failure(t) => transid.failed(this, start, t.getMessage, ErrorLevel)
-      }
-      .map(taskStatus => {
-        // verify that task ended in TASK_KILLED state (but don't fail if it didn't...)
-        if (taskStatus.getState != TaskState.TASK_KILLED) {
-          logging.error(this, s"task kill resulted in unexpected state ${taskStatus.getState}")
-        } else {
-          logging.info(this, s"task killed ended with state ${taskStatus.getState}")
-        }
-      })(ec)
+    MesosTask.destroy(mesosClientActor, mesosConfig, taskId)
   }
 
   /**

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/mesos/MesosTask.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/mesos/MesosTask.scala
@@ -179,7 +179,7 @@ object MesosTask {
           MetricEmitter.emitCounterMetric(LoggingMarkers.INVOKER_MESOS_CMD_TIMEOUT(MesosTask.KILL_CMD))
         case Failure(t) => transid.failed(this, start, s"task destroy failed ${t.getMessage}", ErrorLevel)
       }
-      .map(_ => {})(ec)
+      .map(_ => {})
   }
 }
 


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->


## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
When task launch times out, cleanup tasks that were sent to mesos (or not yet sent).
Also updating mesos-actor which includes a fix for accepting resources that are not assigned to the frameworks role.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

