### PR TITLE
Exclude unused transitive dependencies

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -72,7 +72,9 @@ dependencies {
     //tracing support
     compile 'io.opentracing:opentracing-api:0.31.0'
     compile 'io.opentracing:opentracing-util:0.31.0'
-    compile 'io.opentracing.brave:brave-opentracing:0.31.0'
+    compile ('io.opentracing.brave:brave-opentracing:0.31.0'){
+        exclude group: 'io.zipkin.brave', module:'brave-tests'
+    }
     compile 'io.zipkin.reporter2:zipkin-sender-okhttp3:2.6.1'
     compile 'io.zipkin.reporter2:zipkin-reporter:2.6.1'
 

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -32,7 +32,10 @@ repositories {
 dependencies {
     compile "org.scala-lang:scala-library:${gradle.scala.version}"
 
-    compile 'com.github.pureconfig:pureconfig_2.12:0.9.0'
+    compile ('com.github.pureconfig:pureconfig_2.12:0.9.0') {
+        exclude group: 'org.scala-lang', module: 'scala-compiler'
+        exclude group: 'org.scala-lang', module: 'scala-reflect'
+    }
     compile 'io.spray:spray-json_2.12:1.3.5'
     compile 'com.lihaoyi:fastparse_2.12:1.0.0'
 


### PR DESCRIPTION
Excludes some of the transitive dependencies which are not used at runtime saving 14MB in disk space. 

## Description

Some of the dependencies can be excluded from build as they would not be used. The dependencies were analyzed via following command

```
./gradlew :core:controller:dependencies --configuration runtime
```

### Scala Compiler

pureconfig transitively pulls in scala compiler  pureconfig/pureconfig#433

```
+--- com.github.pureconfig:pureconfig_2.12:0.9.0
|    +--- org.scala-lang:scala-library:2.12.4 -> 2.12.7
|    +--- com.github.pureconfig:pureconfig-macros_2.12:0.9.0
|    |    +--- org.scala-lang:scala-compiler:2.12.4
|    |    |    +--- org.scala-lang:scala-library:2.12.4 -> 2.12.7
|    |    |    +--- org.scala-lang:scala-reflect:2.12.4
|    |    |    |    \--- org.scala-lang:scala-library:2.12.4 -> 2.12.7
|    |    |    \--- org.scala-lang.modules:scala-xml_2.12:1.0.6
|    |    |         \--- org.scala-lang:scala-library:2.12.0 -> 2.12.7
|    |    +--- org.scala-lang:scala-library:2.12.4 -> 2.12.7
|    |    +--- org.scala-lang:scala-reflect:2.12.4 (*)
|    |    \--- org.typelevel:macro-compat_2.12:1.1.1
|    |         \--- org.scala-lang:scala-library:2.12.0 -> 2.12.7
|    +--- com.chuusai:shapeless_2.12:2.3.2
|    |    +--- org.scala-lang:scala-library:2.12.0 -> 2.12.7
|    |    \--- org.typelevel:macro-compat_2.12:1.1.1 (*)
|    \--- com.typesafe:config:1.3.1 -> 1.3.2
```

### Opentracing pulls in test dependencies

opentracing bravo pulls in test dependencies

```
+--- io.opentracing.brave:brave-opentracing:0.31.0
|    +--- io.opentracing:opentracing-api:0.31.0
|    +--- io.zipkin.brave:brave:5.0.0
|    |    +--- io.zipkin.zipkin2:zipkin:2.8.4
|    |    \--- io.zipkin.reporter2:zipkin-reporter:2.6.1
|    |         \--- io.zipkin.zipkin2:zipkin:2.8.4
|    \--- io.zipkin.brave:brave-tests:5.0.0
|         +--- io.zipkin.brave:brave:5.0.0 (*)
|         +--- junit:junit:4.12
|         |    \--- org.hamcrest:hamcrest-core:1.3
|         \--- org.assertj:assertj-core:3.9.0
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

