### PR TITLE
Update KindRestrictor to merge namespace and default whitelists

### DIFF
--- a/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/KindRestrictor.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/KindRestrictor.scala
@@ -46,7 +46,7 @@ case class KindRestrictor(whitelist: Option[Set[String]] = None)(implicit loggin
     })(TransactionId.controller)
 
   def check(user: Identity, kind: String): Boolean = {
-    val kindList = user.limits.allowedKinds.getOrElse(Set()).union(whitelist.getOrElse(Set()))
+    val kindList = user.limits.allowedKinds.getOrElse(Set.empty).union(whitelist.getOrElse(Set.empty))
     kindList.isEmpty || kindList.contains(kind)
   }
 

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/KindRestrictor.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/KindRestrictor.scala
@@ -46,10 +46,8 @@ case class KindRestrictor(whitelist: Option[Set[String]] = None)(implicit loggin
     })(TransactionId.controller)
 
   def check(user: Identity, kind: String): Boolean = {
-    user.limits.allowedKinds
-      .orElse(whitelist)
-      .map(allowed => allowed.contains(kind))
-      .getOrElse(true)
+    val kindList = user.limits.allowedKinds.getOrElse(Set()).union(whitelist.getOrElse(Set()))
+    kindList.isEmpty || kindList.contains(kind)
   }
 
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/KindRestrictorTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/KindRestrictorTests.scala
@@ -49,16 +49,16 @@ class KindRestrictorTests extends FlatSpec with Matchers with StreamLogging {
     allKinds.foreach(k => kr.check(subject, k) shouldBe true)
   }
 
-  it should "not grant subject access to any kinds if limit is the empty set" in {
+  it should "grant subject access to any kinds if limit is the empty set" in {
     val subject = WhiskAuthHelpers.newIdentity().copy(limits = UserLimits(allowedKinds = Some(Set.empty)))
     val kr = KindRestrictor()
-    allKinds.foreach(k => kr.check(subject, k) shouldBe false)
+    allKinds.foreach(k => kr.check(subject, k) shouldBe true)
   }
 
-  it should "not grant subject access to any kinds if white list is the empty set" in {
+  it should "grant subject access to any kinds if white list is the empty set" in {
     val subject = WhiskAuthHelpers.newIdentity()
     val kr = KindRestrictor(Set[String]())
-    allKinds.foreach(k => kr.check(subject, k) shouldBe false)
+    allKinds.foreach(k => kr.check(subject, k) shouldBe true)
   }
 
   it should "grant subject access only to subject-limited kinds" in {
@@ -75,11 +75,11 @@ class KindRestrictorTests extends FlatSpec with Matchers with StreamLogging {
     disallowedKinds.foreach(k => kr.check(subject, k) shouldBe false)
   }
 
-  it should "grant subject access only to explicitly limited kind" in {
+  it should "grant subject access both explicitly limited kinds and default whitelisted kinds" in {
     val explicitKind = allowedKinds.head
     val subject = WhiskAuthHelpers.newIdentity().copy(limits = UserLimits(allowedKinds = Some(Set(explicitKind))))
     val kr = KindRestrictor(allowedKinds.tail)
-    allKinds.foreach(k => kr.check(subject, k) shouldBe (k == explicitKind))
+    allKinds.foreach(k => kr.check(subject, k) shouldBe allowedKinds.contains(k))
   }
 
 }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
## Description
When performing `KindRestrictor.check()`, merge the contents of both the namespace's `allowedKinds` limit with the system's default `whitelist` of allowed kinds.

Originally, the namespace's value for the `allowedKinds` limit was used _instead of_ the value of the default `whitelist` set for the system. However, while crafting a deployment plan enabling whitelist support, we ran into concerns around maintaining these per-namespace whitelists as the system and user/namespace population grows.

The most notable scenario of concern is when a kind is added or removed from the OW system's runtime manifest. After these are added to the manifest, any existing default `whitelist` will need to be updated to include/exclude the new kind. This is an expected maintenance operation. However, in addition to this, _all **existing** limits_ for namespaces' `allowedKinds` additionally have to be modified.

As new kinds enter the system, enabling access to new kinds (which are _already accessible_ for those _without_ an explicit namespace `allowedKinds` limit) will require a batch operation (or similar migration) to update all existing `allowedKinds` namespace limits. This becomes a particularly unnecessary operation that can grow over time.

The solution outlined in this PR is to reduce the need to perform updates per-namespace when the default whitelist can be merged together with the namespace limit.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [X] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [X] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

