### PR TITLE
Fix typo (activations->activation)

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -176,7 +176,7 @@ wsk action invoke /whisk.system/samples/greeting
 ok: invoked /whisk.system/samples/greeting with id 5a64676ec8aa46b5a4676ec8aaf6b5d2
  ```
 
-To retrieve the activation record, you use the `wsk activations get <id>` command, as in:
+To retrieve the activation record, you use the `wsk activation get <id>` command, as in:
 ```
 wsk activation get 5a64676ec8aa46b5a4676ec8aaf6b5d2
 ok: got activation 5a64676ec8aa46b5a4676ec8aaf6b5d2


### PR DESCRIPTION
## Description
When trying to get the action activation, we tried to copy&paste a sample from here. There is a typo in one place, the correct parameter is called `activation` not `activations`.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [x] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [x] I updated the documentation where necessary.

