### PR TITLE
Fix test failures in case min and max concurrency settings are identical

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/limits/ActionLimitsTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/limits/ActionLimitsTests.scala
@@ -130,7 +130,11 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers with WskActorSys
       time <- Seq(None, Some(TimeLimit.MIN_DURATION), Some(TimeLimit.MAX_DURATION))
       mem <- Seq(None, Some(MemoryLimit.minMemory), Some(MemoryLimit.maxMemory))
       log <- Seq(None, Some(LogLimit.minLogSize), Some(LogLimit.maxLogSize))
-      concurrency <- Seq(None, Some(ConcurrencyLimit.minConcurrent), Some(ConcurrencyLimit.maxConcurrent))
+      concurrency <- if (ConcurrencyLimit.minConcurrent == ConcurrencyLimit.maxConcurrent) {
+        Seq(None, Some(ConcurrencyLimit.minConcurrent))
+      } else {
+        Seq(None, Some(ConcurrencyLimit.minConcurrent), Some(ConcurrencyLimit.maxConcurrent))
+      }
     } yield PermutationTestParameter(time, mem, log, concurrency)
   } ++
     // Add variations for negative tests
@@ -144,6 +148,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers with WskActorSys
       PermutationTestParameter(None, Some((MemoryLimit.maxMemory.toMB * 5).MB), None, None, BAD_REQUEST), // memory limit that is much higher than allowed
       PermutationTestParameter(None, None, Some((LogLimit.maxLogSize.toMB * 5).MB), None, BAD_REQUEST), // log size limit that is much higher than allowed
       PermutationTestParameter(None, None, None, Some(Int.MaxValue), BAD_REQUEST)) // concurrency limit that is much higher than allowed
+
   /**
    * Integration test to verify that valid timeout, memory, log size, and concurrency limits are accepted
    * when creating an action while any invalid limit is rejected.
@@ -153,7 +158,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers with WskActorSys
    * deployment to verify that limit settings of the tested deployment fit with the values
    * used in this test.
    */
-  perms.distinct.foreach { parm =>
+  perms.foreach { parm =>
     it should s"${parm.toExpectedResultString} creation of an action with these limits: ${parm}" in withAssetCleaner(
       wskprops) { (wp, assetHelper) =>
       val file = Some(TestUtils.getTestActionFilename("hello.js"))

--- a/tests/src/test/scala/org/apache/openwhisk/core/limits/ActionLimitsTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/limits/ActionLimitsTests.scala
@@ -144,7 +144,6 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers with WskActorSys
       PermutationTestParameter(None, Some((MemoryLimit.maxMemory.toMB * 5).MB), None, None, BAD_REQUEST), // memory limit that is much higher than allowed
       PermutationTestParameter(None, None, Some((LogLimit.maxLogSize.toMB * 5).MB), None, BAD_REQUEST), // log size limit that is much higher than allowed
       PermutationTestParameter(None, None, None, Some(Int.MaxValue), BAD_REQUEST)) // concurrency limit that is much higher than allowed
-
   /**
    * Integration test to verify that valid timeout, memory, log size, and concurrency limits are accepted
    * when creating an action while any invalid limit is rejected.
@@ -154,7 +153,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers with WskActorSys
    * deployment to verify that limit settings of the tested deployment fit with the values
    * used in this test.
    */
-  perms.foreach { parm =>
+  perms.distinct.foreach { parm =>
     it should s"${parm.toExpectedResultString} creation of an action with these limits: ${parm}" in withAssetCleaner(
       wskprops) { (wp, assetHelper) =>
       val file = Some(TestUtils.getTestActionFilename("hello.js"))


### PR DESCRIPTION
When min and max concurrency levels are identical redundant test configurations are generated
in `ActionLimitsTests.scala` and tests will fail.

Example with min and max set to one 
```
concurrency <- Seq(None, Some(ConcurrencyLimit.minConcurrent), Some(ConcurrencyLimit.maxConcurrent))
```
will become 
```
concurrency <- Seq(None, Some(1), Some(1))
```
(The 2nd and 3rd parameters are now identical and duplicate test configurations will be created)

This PR removes such duplicate test configurations.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

