### PR TITLE
Protect Package Bindings from containing circular references

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/ErrorResponse.scala
@@ -112,6 +112,7 @@ object Messages {
   val requestedBindingIsNotValid = "Cannot bind to a resource that is not a package."
   val notAllowedOnBinding = "Operation not permitted on package binding."
   def packageNameIsReserved(name: String) = s"Package name '$name' is reserved."
+  def packageBindingCircularReference(name: String) = s"Package binding '$name' contains a circular reference."
 
   /** Error messages for triggers */
   def triggerWithInactiveRule(rule: String, action: String) = {

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Packages.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Packages.scala
@@ -300,7 +300,7 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
         val docid = b.fullyQualifiedName.toDocId
         logging.debug(this, s"fetching package '$docid' for reference")
         if (docid == wp.docid) {
-          logging.error(this, "unexpected package binding refers to itself: $docid")
+          logging.error(this, s"unexpected package binding refers to itself: $docid")
           terminate(UnprocessableEntity, Messages.packageBindingCircularReference(b.fullyQualifiedName.toString))
         } else {
           getEntity(WhiskPackage.get(entityStore, docid), Some {

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Packages.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Packages.scala
@@ -243,7 +243,7 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
       wp.binding map {
         // pre-existing entity is a binding, check that new binding is valid
         b =>
-          checkBinding(b.fullyQualifiedName)
+          checkBinding(binding.fullyQualifiedName)
       } getOrElse {
         // pre-existing entity is a package, cannot make it a binding
         Future.failed(RejectRequest(Conflict, Messages.packageCannotBecomeBinding))

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Packages.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Packages.scala
@@ -242,7 +242,7 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
     val validateBinding = content.binding map { binding =>
       wp.binding map {
         // pre-existing entity is a binding, check that new binding is valid
-        b =>
+        _ =>
           checkBinding(binding.fullyQualifiedName)
       } getOrElse {
         // pre-existing entity is a package, cannot make it a binding
@@ -301,7 +301,7 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
         logging.debug(this, s"fetching package '$docid' for reference")
         if (docid == wp.docid) {
           logging.error(this, "unexpected package binding refers to itself: $docid")
-          terminate(InternalServerError)
+          terminate(UnprocessableEntity, Messages.packageBindingCircularReference(b.fullyQualifiedName.toString))
         } else {
           getEntity(WhiskPackage.get(entityStore, docid), Some {
             mergePackageWithBinding(Some { wp }) _

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/PackageCollection.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/PackageCollection.scala
@@ -99,7 +99,7 @@ class PackageCollection(entityStore: EntityStore)(implicit logging: Logging) ext
           val pkgDocid = binding.docid
           logging.debug(this, s"checking subject has privilege '$right' for bound package '$pkgDocid'")
           if (doc == pkgDocid) {
-            logging.error(this, "unexpected package binding refers to itself: $docid")
+            logging.error(this, s"unexpected package binding refers to itself: $doc")
             Future.failed(
               RejectRequest(
                 UnprocessableEntity,

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/PackageCollection.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/PackageCollection.scala
@@ -98,10 +98,15 @@ class PackageCollection(entityStore: EntityStore)(implicit logging: Logging) ext
           val pkgOwner = namespaces.contains(binding.namespace.asString)
           val pkgDocid = binding.docid
           logging.debug(this, s"checking subject has privilege '$right' for bound package '$pkgDocid'")
-          if (doc == pkgDocid)
-            Future.successful(true)
-          else
+          if (doc == pkgDocid) {
+            logging.error(this, "unexpected package binding refers to itself: $docid")
+            Future.failed(
+              RejectRequest(
+                UnprocessableEntity,
+                Messages.packageBindingCircularReference(binding.fullyQualifiedName.toString)))
+          } else {
             checkPackageReadPermission(namespaces, pkgOwner, pkgDocid)
+          }
         } else {
           logging.debug(this, s"entitlement check on package binding, '$right' allowed?: false")
           Future.successful(false)

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/PackageCollection.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/PackageCollection.scala
@@ -98,7 +98,10 @@ class PackageCollection(entityStore: EntityStore)(implicit logging: Logging) ext
           val pkgOwner = namespaces.contains(binding.namespace.asString)
           val pkgDocid = binding.docid
           logging.debug(this, s"checking subject has privilege '$right' for bound package '$pkgDocid'")
-          checkPackageReadPermission(namespaces, pkgOwner, pkgDocid)
+          if (doc == pkgDocid)
+            Future.successful(true)
+          else
+            checkPackageReadPermission(namespaces, pkgOwner, pkgDocid)
         } else {
           logging.debug(this, s"entitlement check on package binding, '$right' allowed?: false")
           Future.successful(false)

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackagesApiTests.scala
@@ -712,6 +712,21 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     }
   }
 
+  it should "reject update package reference when new binding refers to itself" in {
+    implicit val tid = transid()
+    // create package and valid reference binding to it
+    val provider = WhiskPackage(namespace, aname())
+    val reference = WhiskPackage(namespace, aname(), provider.bind)
+    put(entityStore, provider)
+    put(entityStore, reference)
+    // manipulate package reference such that it attempts to bind to itself
+    val content = WhiskPackagePut(Some(Binding(namespace.root, reference.name)))
+    Put(s"$collectionPath/${reference.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+      status should be(BadRequest)
+      responseAs[ErrorResponse].error should include(Messages.bindingCannotReferenceBinding)
+    }
+  }
+
   it should "reject update package reference when new binding refers to private package in another namespace" in {
     implicit val tid = transid()
     val privateCreds = WhiskAuthHelpers.newIdentity()

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackagesApiTests.scala
@@ -725,6 +725,13 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
       status should be(BadRequest)
       responseAs[ErrorResponse].error should include(Messages.bindingCannotReferenceBinding)
     }
+    // verify that the reference is still pointing to the original provider
+    Get(s"$collectionPath/${reference.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskPackage]
+      response should be(reference)
+      response.binding should be(provider.bind)
+    }
   }
 
   it should "reject update package reference when new binding refers to private package in another namespace" in {


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
We ran across an issue where a package binding can contain a reference to itself. When this happens, any attempt at reading the package results in an infinite loop, eventually leading to the controller falling over. This can occur by simply performing the following commands using the `wsk` tool.
```bash
$ wsk package create target
$ wsk package bind target binding
$ wsk package bind binding binding
```
There are two changes contained in this PR
1. Prevent allowing an incoming binding update to point to itself as a reference, which previously created an invalid data record.
2. Prevent following a package's binding reference when it points to itself which causes the infinite loop.

<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [X] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

