### PR TITLE
Add nodejs:10 to default set of runtimes for ansible/vagrant

### DIFF
--- a/ansible/files/runtimes.json
+++ b/ansible/files/runtimes.json
@@ -47,6 +47,20 @@
                     "attachmentName": "codefile",
                     "attachmentType": "text/plain"
                 }
+            },
+            {
+                "kind": "nodejs:10",
+                "default": false,
+                "image": {
+                    "prefix": "openwhisk",
+                    "name": "action-nodejs-v10",
+                    "tag": "latest"
+                },
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
             }
         ],
         "python": [

--- a/core/controller/src/main/resources/apiv1swagger.json
+++ b/core/controller/src/main/resources/apiv1swagger.json
@@ -1891,6 +1891,7 @@
                         "java:default",
                         "nodejs:6",
                         "nodejs:8",
+                        "nodejs:10",
                         "nodejs:default",
                         "php:7.1",
                         "php:7.2",

--- a/docs/actions-nodejs.md
+++ b/docs/actions-nodejs.md
@@ -220,7 +220,7 @@ To create an OpenWhisk action from this package:
   wsk action create packageAction --kind nodejs:6 action.zip
   ```
 
-  When creating an action from a `.zip` archive with the CLI tool, you must explicitly provide a value for the `--kind` flag by using `nodejs:6`, `nodejs:8` or `nodejs:10`s.
+  When creating an action from a `.zip` archive with the CLI tool, you must explicitly provide a value for the `--kind` flag by using `nodejs:6`, `nodejs:8` or `nodejs:10`.
 
 4. You can invoke the action like any other:
 

--- a/docs/actions-nodejs.md
+++ b/docs/actions-nodejs.md
@@ -43,7 +43,7 @@ and demonstrate how to bundle multiple JavaScript files and third party dependen
 
   The CLI automatically infers the type of the action by using the source file extension.
   For `.js` source files, the action runs by using a Node.js runtime. You may specify
-  the Node.js runtime to use by explicitly specifying the parameter `--kind nodejs:6` or `--kind nodejs:8`.
+  the Node.js runtime to use by explicitly specifying the parameter `--kind nodejs:10`, `--kind nodejs:8`, or `--kind nodejs:10`
 
 
 ## Creating asynchronous actions
@@ -220,7 +220,7 @@ To create an OpenWhisk action from this package:
   wsk action create packageAction --kind nodejs:6 action.zip
   ```
 
-  When creating an action from a `.zip` archive with the CLI tool, you must explicitly provide a value for the `--kind` flag by using `nodejs:6` or `nodejs:8`.
+  When creating an action from a `.zip` archive with the CLI tool, you must explicitly provide a value for the `--kind` flag by using `nodejs:6`, `nodejs:8` or `nodejs:10`s.
 
 4. You can invoke the action like any other:
 
@@ -330,9 +330,9 @@ JavaScript actions can be executed in Node.js version 6 or Node.js version 8.
 Currently actions are executed by default in a Node.js version 6 environment.
 
 ### Node.js version 6 environment
-The Node.js 6.14.2 environment will be used for an action if the `--kind` flag is explicitly specified with a value of 'nodejs:6' when creating/updating the action.
+The Node.js 6.14.4 environment will be used for an action if the `--kind` flag is explicitly specified with a value of 'nodejs:6' when creating/updating the action.
 
-The following packages are available to be used in the Node.js 6.14.2 environment:
+The following packages are available to be used in the Node.js 6 environment:
 
 - [apn v2.1.2](https://www.npmjs.com/package/apn) - A Node.js module for interfacing with the Apple Push Notification service.
 - [async v2.1.4](https://www.npmjs.com/package/async) - Provides functions for working with asynchronous functions.
@@ -358,7 +358,7 @@ The following packages are available to be used in the Node.js 6.14.2 environmen
 - [node-uuid v1.4.7](https://www.npmjs.com/package/node-uuid) - Deprecated UUID packaged.
 - [nodemailer v2.6.4](https://www.npmjs.com/package/nodemailer) - Send e-mails from Node.js – easy as cake!
 - [oauth2-server v2.4.1](https://www.npmjs.com/package/oauth2-server) - Complete, compliant, and well tested module for implementing an OAuth2 Server/Provider with express in Node.js.
-- [openwhisk v3.16.0](https://www.npmjs.com/package/openwhisk) - JavaScript client library for the OpenWhisk platform. Provides a wrapper around the OpenWhisk APIs.
+- [openwhisk v3.18.0](https://www.npmjs.com/package/openwhisk) - JavaScript client library for the OpenWhisk platform. Provides a wrapper around the OpenWhisk APIs.
 - [pkgcloud v1.4.0](https://www.npmjs.com/package/pkgcloud) - pkgcloud is a standard library for Node.js that abstracts away differences among multiple cloud providers.
 - [process v0.11.9](https://www.npmjs.com/package/process) - Require('process'); just like any other module.
 - [pug v2.0.0-beta6](https://www.npmjs.com/package/pug) - Implements the Pug templating language.
@@ -387,11 +387,18 @@ The following packages are available to be used in the Node.js 6.14.2 environmen
 - [yauzl v2.7.0](https://www.npmjs.com/package/yauzl) - Yet another unzip library for node. For zipping.
 
 ### Node.js version 8 environment
-The Node.js version 8.11.2 environment is used if the `--kind` flag is explicitly specified with a value of 'nodejs:8' when creating or updating an Action.
+The Node.js version 8.12.0 environment is used if the `--kind` flag is explicitly specified with a value of 'nodejs:8' when creating or updating an Action.
 
-The following packages are pre-installed in the Node.js version 8.11.2 environment:
+The following packages are pre-installed in the Node.js version 8 environment:
 
-- [openwhisk v3.16.0](https://www.npmjs.com/package/openwhisk) - JavaScript client library for the OpenWhisk platform. Provides a wrapper around the OpenWhisk APIs.
+- [openwhisk v3.18.0](https://www.npmjs.com/package/openwhisk) - JavaScript client library for the OpenWhisk platform. Provides a wrapper around the OpenWhisk APIs.
+
+### Node.js version 10 environment
+The Node.js version 10.13.0 environment is used if the `--kind` flag is explicitly specified with a value of 'nodejs:10' when creating or updating an Action.
+
+The following packages are pre-installed in the Node.js version 10 environment:
+
+- [openwhisk v3.18.0](https://www.npmjs.com/package/openwhisk) - JavaScript client library for the OpenWhisk platform. Provides a wrapper around the OpenWhisk APIs.
 
 ### Packaging npm packages with your actions
 For any `npm` packages that are not pre-installed in the Node.js environment, you can bundle them as dependencies when you create or update your action.

--- a/docs/actions-nodejs.md
+++ b/docs/actions-nodejs.md
@@ -43,7 +43,7 @@ and demonstrate how to bundle multiple JavaScript files and third party dependen
 
   The CLI automatically infers the type of the action by using the source file extension.
   For `.js` source files, the action runs by using a Node.js runtime. You may specify
-  the Node.js runtime to use by explicitly specifying the parameter `--kind nodejs:10`, `--kind nodejs:8`, or `--kind nodejs:10`
+  the Node.js runtime to use by explicitly specifying the parameter `--kind nodejs:10`, `--kind nodejs:8`, or `--kind nodejs:6`
 
 
 ## Creating asynchronous actions
@@ -220,7 +220,7 @@ To create an OpenWhisk action from this package:
   wsk action create packageAction --kind nodejs:6 action.zip
   ```
 
-  When creating an action from a `.zip` archive with the CLI tool, you must explicitly provide a value for the `--kind` flag by using `nodejs:6`, `nodejs:8` or `nodejs:10`.
+  When creating an action from a `.zip` archive with the CLI tool, you must explicitly provide a value for the `--kind` flag by using `nodejs:10`, `nodejs:8` or `nodejs:6`.
 
 4. You can invoke the action like any other:
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -56,7 +56,7 @@ paths more suitable. Or, you can [create a new runtime](actions-new.md).
 
 * [Go](actions-go.md)
 * [Java](actions-java.md)
-* [JavaScript](actions-node.md)
+* [JavaScript](actions-nodejs.md)
 * [PHP](actions-php.md)
 * [Python](actions-python.md)
 * [Ruby](actions-ruby.md)

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -29,7 +29,7 @@ Concurrent activation processing within the same action container can be enabled
 
 * enable the akka http client at invoker config
   * e.g. CONFIG_whisk_containerPool_akkaClient=true
-* use a kind that supports concurrency (currently only nodejs:6 and nodejs:8)
+* use a kind that supports concurrency (currently only `nodejs:6`, `nodejs:8` and `nodejs:10`)
 * enable concurrency at runtime container env (nodejs container only allows concurrency when started with an env var __OW_ALLOW_CONCURRENT=true)
   * e.g. CONFIG_whisk_containerFactory_containerArgs_extraArgs_env_0="__OW_ALLOW_CONCURRENT=true"
 * disable log collection at invoker

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -29,7 +29,7 @@ Concurrent activation processing within the same action container can be enabled
 
 * enable the akka http client at invoker config
   * e.g. CONFIG_whisk_containerPool_akkaClient=true
-* use a kind that supports concurrency (currently only `nodejs:6`, `nodejs:8` and `nodejs:10`)
+* use a kind that supports concurrency (currently only `nodejs:10`, `nodejs:8` and `nodejs:6`)
 * enable concurrency at runtime container env (nodejs container only allows concurrency when started with an env var __OW_ALLOW_CONCURRENT=true)
   * e.g. CONFIG_whisk_containerFactory_containerArgs_extraArgs_env_0="__OW_ALLOW_CONCURRENT=true"
 * disable log collection at invoker

--- a/tests/dat/actions/unicode.tests/nodejs-10.txt
+++ b/tests/dat/actions/unicode.tests/nodejs-10.txt
@@ -1,0 +1,8 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor
+// license agreements; and to You under the Apache License, Version 2.0.
+
+function main(args) {
+    var str = args.delimiter + " ☃ " + args.delimiter;
+    console.log(str);
+    return { "winter": str };
+}


### PR DESCRIPTION
## Description
Add nodejs:10 to default set of runtimes

## Related issue and scope
- [x] I opened an issue to propose and discuss this change (#4123)

## My changes affect the following components
- [x] API
- [x] Tests
- [x] Deployment
- [x] Documentation

## Types of changes
- [x] Enhancement or new feature (adds new functionality).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I updated tests to cover my changes.
- [x] I updated the documentation where necessary.

