### PR TITLE
Fix pattern for system basic tests

### DIFF
--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -96,7 +96,7 @@ ext.testSets = [
     ],
     "REQUIRE_SYSTEM_BASIC" : [
         "includes" : [
-            "org/apache/openwhisk/testEntities/system/basic/**"
+            "system/basic/**"
         ]
     ]
 ]


### PR DESCRIPTION
As part of package rename done in #4073 the pattern for system basic tests was incorrectly set to `             "org/apache/openwhisk/testEntities/system/basic/**` instead of `system/basic/**`. As the package name for system basic test was not changed this PR reverts the change in pattern there

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

