### PR TITLE
add wskdeploy to scriptRunner Dockerfile

### DIFF
--- a/tools/scriptRunner/Dockerfile
+++ b/tools/scriptRunner/Dockerfile
@@ -14,6 +14,12 @@ RUN wget -q https://github.com/apache/incubator-openwhisk-cli/releases/download/
     tar xzf OpenWhisk_CLI-$WHISK_CLI_VERSION-linux-amd64.tgz -C /usr/local/bin wsk && \
     rm OpenWhisk_CLI-$WHISK_CLI_VERSION-linux-amd64.tgz
 
+# Install `wskdeploy` cli in /usr/local/bin
+ENV WHISKDEPLOY_CLI_VERSION latest
+RUN wget -q https://github.com/apache/incubator-openwhisk-wskdeploy/releases/download/$WHISKDEPLOY_CLI_VERSION/openwhisk_wskdeploy-$WHISKDEPLOY_CLI_VERSION-linux-amd64.tgz && \
+    tar xzf openwhisk_wskdeploy-$WHISK_CLI_VERSION-linux-amd64.tgz -C /usr/local/bin wskdeploy && \
+    rm openwhisk_wskdeploy-$WHISK_CLI_VERSION-linux-amd64.tgz
+
 COPY init.sh /init.sh
 RUN chmod +x /init.sh
 


### PR DESCRIPTION
Prepare for wskdeploy being used to install catalog
by including wskdeploy cli in this image (which is used
to install the catalog in the kube-deploy project).
