### PR TITLE
Route Gatling failure logs to file

### DIFF
--- a/ansible/logs.yml
+++ b/ansible/logs.yml
@@ -37,7 +37,7 @@
     - name: create "perf reports" folder
       file: path="{{ openwhisk_home }}/logs/perf-reports" state=directory
     - name: collect perf logs
-      local_action: shell cp  "{{ openwhisk_home }}/tests/performance/gatling_tests/build/*.log" "{{ openwhisk_home }}/logs/perf-logs/"
+      local_action: shell cp  "{{ openwhisk_home }}/tests/performance/gatling_tests/build/gatling.log" "{{ openwhisk_home }}/logs/perf-logs/"
       ignore_errors: true
 
 - hosts: all:!ansible

--- a/ansible/logs.yml
+++ b/ansible/logs.yml
@@ -34,6 +34,11 @@
         - test-results
       ignore_errors: true
       when: "'tests' not in exclude_logs_from"
+    - name: create "perf reports" folder
+      file: path="{{ openwhisk_home }}/logs/perf-reports" state=directory
+    - name: collect perf logs
+      local_action: shell cp  "{{ openwhisk_home }}/tests/performance/gatling_tests/build/*.log" "{{ openwhisk_home }}/logs/perf-logs/"
+      ignore_errors: true
 
 - hosts: all:!ansible
   serial: 1

--- a/ansible/logs.yml
+++ b/ansible/logs.yml
@@ -37,7 +37,7 @@
     - name: create "perf reports" folder
       file: path="{{ openwhisk_home }}/logs/perf-reports" state=directory
     - name: collect perf logs
-      local_action: shell cp  "{{ openwhisk_home }}/tests/performance/gatling_tests/build/gatling.log" "{{ openwhisk_home }}/logs/perf-logs/"
+      local_action: shell cp  "{{ openwhisk_home }}/tests/performance/gatling_tests/build/gatling.log" "{{ openwhisk_home }}/logs/perf-reports/"
       ignore_errors: true
 
 - hosts: all:!ansible

--- a/tests/performance/gatling_tests/src/gatling/resources/conf/logback.xml
+++ b/tests/performance/gatling_tests/src/gatling/resources/conf/logback.xml
@@ -6,9 +6,21 @@
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <immediateFlush>false</immediateFlush>
+        <file>build/gatling.log</file>
+        <append>false</append>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
     <!-- This will log the details of the failed requests -->
-    <logger name="io.gatling.http.ahc" level="DEBUG" />
+    <logger name="io.gatling.http.ahc" level="DEBUG" additivity="false" >
+        <appender-ref ref="FILE" />
+    </logger>
+
     <root level="WARN">
         <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE" />
     </root>
 </configuration>


### PR DESCRIPTION
High volume of Gatling failure logs from `io.gatling.http.ahc` category causes the Travis to terminate the build. Avoid that by routing those logs to a file

## Description
In many travis runs its being seen if the performance test fail for some reason then they may flood the logs so much that Travis [terminates the build](https://travis-ci.org/apache/incubator-openwhisk/jobs/461548522)

To enable investigating such issues we need server logs and hence need travis to complete. To enable that logs are now routed to a file and that file is made part of log collection

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

