### PR TITLE
Make exec aka code max size configurable

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -234,6 +234,9 @@ whisk {
         std = 1
     }
 
+    # maximum size of the action code
+    exec-size-limit = 48 m
+
     query-limit {
         max-list-limit     = 200  # max number of entities that can be requested from a collection on a list operation
         default-list-limit = 30   # default limit on number of entities returned from a collection on a list operation

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
@@ -239,5 +239,6 @@ object ConfigKeys {
 
   val s3 = "whisk.s3"
   val query = "whisk.query-limit"
+  val execSizeLimit = "whisk.exec-size-limit"
 
 }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Exec.scala
@@ -229,7 +229,12 @@ protected[core] case class SequenceExecMetaData(components: Vector[FullyQualifie
 
 protected[core] object Exec extends ArgNormalizer[Exec] with DefaultJsonProtocol {
 
+  val maxSize: ByteSize = 48.MB
   val sizeLimit = loadConfigOrThrow[ByteSize](ConfigKeys.execSizeLimit)
+
+  require(
+    sizeLimit <= maxSize,
+    s"Executable code size limit specified by ${ConfigKeys.execSizeLimit} should not be more than max size of $maxSize")
 
   // The possible values of the JSON 'kind' field for certain runtimes:
   // - Sequence because it is an intrinsic

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Exec.scala
@@ -19,15 +19,17 @@ package org.apache.openwhisk.core.entity
 
 import java.nio.charset.StandardCharsets
 
-import scala.language.postfixOps
-import scala.util.matching.Regex
+import org.apache.openwhisk.core.ConfigKeys
 
+import scala.util.matching.Regex
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import org.apache.openwhisk.core.entity.Attachments._
 import org.apache.openwhisk.core.entity.ExecManifest._
 import org.apache.openwhisk.core.entity.size.SizeInt
+import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.core.entity.size.SizeString
+import pureconfig.loadConfigOrThrow
 
 /**
  * Exec encodes the executable details of an action. For black
@@ -227,7 +229,7 @@ protected[core] case class SequenceExecMetaData(components: Vector[FullyQualifie
 
 protected[core] object Exec extends ArgNormalizer[Exec] with DefaultJsonProtocol {
 
-  val sizeLimit = 48 MB
+  val sizeLimit = loadConfigOrThrow[ByteSize](ConfigKeys.execSizeLimit)
 
   // The possible values of the JSON 'kind' field for certain runtimes:
   // - Sequence because it is an intrinsic
@@ -359,8 +361,6 @@ protected[core] object Exec extends ArgNormalizer[Exec] with DefaultJsonProtocol
 }
 
 protected[core] object ExecMetaDataBase extends ArgNormalizer[ExecMetaDataBase] with DefaultJsonProtocol {
-
-  val sizeLimit = 48 MB
 
   // The possible values of the JSON 'kind' field for certain runtimes:
   // - Sequence because it is an intrinsic

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Exec.scala
@@ -234,7 +234,7 @@ protected[core] object Exec extends ArgNormalizer[Exec] with DefaultJsonProtocol
 
   require(
     sizeLimit <= maxSize,
-    s"Executable code size limit specified by ${ConfigKeys.execSizeLimit} should not be more than max size of $maxSize")
+    s"Executable code size limit $sizeLimit specified by '${ConfigKeys.execSizeLimit}' should not be more than max size of $maxSize")
 
   // The possible values of the JSON 'kind' field for certain runtimes:
   // - Sequence because it is an intrinsic

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -81,7 +81,7 @@ The following table lists the default limits for actions.
 | logs | a container is not allowed to write more than N MB to stdout | per action | MB | 10 |
 | concurrent | no more than N activations may be submitted per namespace either executing or queued for execution | per namespace | number | 100 |
 | minuteRate | no more than N activations may be submitted per namespace per minute | per namespace | number | 120 |
-| codeSize | the maximum size of the actioncode | not configurable, limit per action | MB | 48 |
+| codeSize | the maximum size of the actioncode | configurable, limit per action | MB | 48 |
 | parameters | the maximum size of the parameters that can be attached | not configurable, limit per action/package/trigger | MB | 1 |
 | result | the maximum size of the action result | not configurable, limit per action | MB | 1 |
 
@@ -100,7 +100,7 @@ The following table lists the default limits for actions.
 * A user can change the limit when creating or updating the action.
 * Logs that exceed the set limit are truncated and a warning is added as the last output of the activation to indicate that the activation exceeded the set log limit.
 
-### Per action artifact (MB) (Fixed: 48MB)
+### Per action artifact (MB) (Default: 48MB)
 * The maximum code size for the action is 48MB.
 * It is recommended for a JavaScript action to use a tool to concatenate all source code including dependencies into a single bundled file.
 


### PR DESCRIPTION
Makes the exec hard coded 48 MB limit configurable. 

## Description
In our setups we may want to reduce the max size at controller level hence need to make it configurable. 

Note that for supporting higher value changes in other places would also be needed. See #3712 for more details

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [x] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [x] I updated the documentation where necessary.

