### PR TITLE
Make query limits configurable

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -234,6 +234,11 @@ whisk {
         std = 1
     }
 
+    query-limit {
+        max-list-limit     = 200  # max number of entities that can be requested from a collection on a list operation
+        default-list-limit = 30   # default limit on number of entities returned from a collection on a list operation
+    }
+
     mesos {
         master-url = "http://localhost:5050" //your mesos master
         master-public-url = "http://localhost:5050" // if mesos-link-log-message == true, this link will be included with the static log message (may or may not be different from master-url)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
@@ -238,5 +238,6 @@ object ConfigKeys {
   val containerProxyTimeouts = s"$containerProxy.timeouts"
 
   val s3 = "whisk.s3"
+  val query = "whisk.query-limit"
 
 }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/Collection.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/Collection.scala
@@ -21,15 +21,14 @@ import org.apache.openwhisk.core.entitlement.Privilege._
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-
 import akka.http.scaladsl.model.HttpMethod
 import akka.http.scaladsl.model.HttpMethods.DELETE
 import akka.http.scaladsl.model.HttpMethods.GET
 import akka.http.scaladsl.model.HttpMethods.POST
 import akka.http.scaladsl.model.HttpMethods.PUT
-
 import org.apache.openwhisk.common.Logging
 import org.apache.openwhisk.common.TransactionId
+import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.entity.Identity
 import org.apache.openwhisk.core.entity.WhiskAction
 import org.apache.openwhisk.core.entity.WhiskActivation
@@ -37,6 +36,7 @@ import org.apache.openwhisk.core.entity.WhiskPackage
 import org.apache.openwhisk.core.entity.WhiskRule
 import org.apache.openwhisk.core.entity.WhiskTrigger
 import org.apache.openwhisk.core.entity.types.EntityStore
+import pureconfig._
 
 /**
  * A collection encapsulates the name of a collection and implicit rights when subject
@@ -109,9 +109,12 @@ protected[core] case class Collection protected (val path: String,
 /** An enumeration of known collections. */
 protected[core] object Collection {
 
+  private case class QueryLimit(maxListLimit: Int, defaultListLimit: Int)
+  private val queryLimit = loadConfigOrThrow[QueryLimit](ConfigKeys.query)
+
   /** Number of records allowed per query. */
-  protected[core] val DEFAULT_LIST_LIMIT = 30
-  protected[core] val MAX_LIST_LIMIT = 200
+  protected[core] val DEFAULT_LIST_LIMIT = queryLimit.defaultListLimit
+  protected[core] val MAX_LIST_LIMIT = queryLimit.maxListLimit
   protected[core] val DEFAULT_SKIP_LIMIT = 0
 
   protected[core] val ACTIONS = WhiskAction.collectionName


### PR DESCRIPTION
Make limits related to list operation against entities configurable. 


## Description

Currently the queries related to collections (used while doing list operation) make use of hard coded limits. 

### Impact due to wsk activation poll

For example if `limit=0` in list operation then it uses 200 has the default value. This is used in `wsk activation poll` which by default generates a GET request like

```
/api/v1/namespaces/_/activations?docs=true&limit=0&since=1542422386538&skip=0
```

Currently the poll command once started "probably" sticks to start time and we have seen user leaving such poll running for days (often left in one of the numerous tabs!) which causes the system to pull similar 200 records over and over.

### CosmosDB and higher resource usage

Further in our case (using CosmosDB) which does client side merging of query results a sorted query gets executed like below

1. Initial ask to fetch 200 records
2. SDK makes call to each partition to fetch query record with limit
    - If limit > default maxItemPerPageCount use maxItemPerPageCount i.e. 100
    - If limit < then use the limit
3. Perform a merge sort on client side

In such a case at times we have seen for listing 200 records SDK fetch ~ 900 records causing higher resource usage on db side

To reduce impact for such cases I would like to have these limits configurable

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

