### PR TITLE
Correct rejection behavior in the multi authentication case

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/http/BasicHttpService.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/BasicHttpService.scala
@@ -63,6 +63,7 @@ trait BasicHttpService extends Directives {
   val prioritizeRejections = recoverRejections { rejections =>
     val priorityRejection = rejections.find {
       case rejection: UnacceptedResponseContentTypeRejection => true
+      case rejection: ValidationRejection                    => true
       case _                                                 => false
     }
 


### PR DESCRIPTION
## Description
The authentication SPI can be used to provides multiple parallel ways to authenticate against Open Whisk by combining different authentication directives (e.g Basic and Bearer authentication).
The unmatched authentication directives (only one directives will match for agiven request) 
are adding additional authentication rejections to the overall list of rejection collected for a given request.
Depending on the evaluation sequence of the additional validation rejections will overshadow meaningful validation rejections following the matched case.
This patch gives those validation rejections priority over the authentication rejections. 
In this way a meaningful error messages are returned to the user. 
An equivalent mechanism is already implemented for content type related rejections.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [x] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

