### PR TITLE
Update to Kamon 1.1.3 from 0.6 series

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -64,8 +64,8 @@ dependencies {
     compile 'com.github.ben-manes.caffeine:caffeine:2.6.2'
     compile 'com.google.code.findbugs:jsr305:3.0.2'
     compile 'io.fabric8:kubernetes-client:4.0.3'
-    compile 'io.kamon:kamon-core_2.12:0.6.7'
-    compile 'io.kamon:kamon-statsd_2.12:0.6.7'
+    compile 'io.kamon:kamon-core_2.12:1.1.3'
+    compile 'io.kamon:kamon-statsd_2.12:1.0.0'
     //for mesos
     compile 'com.adobe.api.platform.runtime:mesos-actor:0.0.17'
 

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -19,7 +19,11 @@ akka.http {
 
 #kamon related configuration
 kamon {
-
+    environment {
+      # Identifier for this service. For keeping it backward compatible setting to natch previous
+      # statsd name
+      service = "openwhisk-statsd"
+    }
     metric {
         tick-interval = 1 second
     }
@@ -38,13 +42,6 @@ kamon {
             actor      =  [ "*" ]
             trace      =  [ "*" ]
             dispatcher =  [ "*" ]
-        }
-
-        simple-metric-key-generator {
-            # Application prefix for all metrics pushed to StatsD. The default namespacing scheme for metrics follows
-            # this pattern:
-            #    application.host.entity.entity-name.metric-name
-            application = "openwhisk-statsd"
         }
     }
 

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -45,9 +45,9 @@ kamon {
         }
     }
 
-    modules {
-        kamon-statsd.auto-start = yes
-    }
+    reporters = [
+        "kamon.statsd.StatsDReporter"
+    ]
 }
 
 whisk {

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -43,6 +43,8 @@ kamon {
             trace      =  [ "*" ]
             dispatcher =  [ "*" ]
         }
+
+        metric-key-generator = org.apache.openwhisk.common.WhiskStatsDMetricKeyGenerator
     }
 
     reporters = [

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
@@ -210,18 +210,15 @@ object LogMarkerToken {
 }
 
 object MetricEmitter {
-  import kamon.metric.InstrumentFactory.InstrumentTypes._
-  import kamon.metric.InstrumentFactory._
-
   def emitCounterMetric(token: LogMarkerToken, times: Long = 1): Unit = {
     if (TransactionId.metricsKamon) {
       if (TransactionId.metricsKamonTags) {
         Kamon
-          .counter(createName(token.toString, Counter))
+          .counter(createName(token.toString, "counter"))
           .refine(token.tags)
           .increment(times)
       } else {
-        Kamon.counter(createName(token.toStringWithSubAction, Counter)).increment(times)
+        Kamon.counter(createName(token.toStringWithSubAction, "counter")).increment(times)
       }
     }
   }
@@ -230,11 +227,11 @@ object MetricEmitter {
     if (TransactionId.metricsKamon) {
       if (TransactionId.metricsKamonTags) {
         Kamon
-          .histogram(createName(token.toString, Histogram))
+          .histogram(createName(token.toString, "histogram"))
           .refine(token.tags)
           .record(value)
       } else {
-        Kamon.histogram(createName(token.toStringWithSubAction, Histogram)).record(value)
+        Kamon.histogram(createName(token.toStringWithSubAction, "histogram")).record(value)
       }
     }
   }
@@ -244,8 +241,8 @@ object MetricEmitter {
    * for us as we use same metric name for counter and histogram. So to be backward compatible we
    * need to prefix the name with type
    */
-  private def createName(name: String, metricType: InstrumentType) = {
-    s"${metricType.name.toLowerCase}.$name"
+  private def createName(name: String, metricType: String) = {
+    s"$metricType.$name"
   }
 }
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
@@ -211,16 +211,15 @@ object LogMarkerToken {
 
 object MetricEmitter {
 
-  val metrics = Kamon.metrics
-
   def emitCounterMetric(token: LogMarkerToken, times: Long = 1): Unit = {
     if (TransactionId.metricsKamon) {
       if (TransactionId.metricsKamonTags) {
-        metrics
-          .counter(token.toString, token.tags)
+        Kamon
+          .counter(token.toString)
+          .refine(token.tags)
           .increment(times)
       } else {
-        metrics.counter(token.toStringWithSubAction).increment(times)
+        Kamon.counter(token.toStringWithSubAction).increment(times)
       }
     }
   }
@@ -228,11 +227,12 @@ object MetricEmitter {
   def emitHistogramMetric(token: LogMarkerToken, value: Long): Unit = {
     if (TransactionId.metricsKamon) {
       if (TransactionId.metricsKamonTags) {
-        metrics
-          .histogram(token.toString, token.tags)
+        Kamon
+          .histogram(token.toString)
+          .refine(token.tags)
           .record(value)
       } else {
-        metrics.histogram(token.toStringWithSubAction).record(value)
+        Kamon.histogram(token.toStringWithSubAction).record(value)
       }
     }
   }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
@@ -207,6 +207,7 @@ object Controller {
       "runtimes" -> runtimes.toJson)
 
   def main(args: Array[String]): Unit = {
+    Kamon.loadReportersFromConfig()
     implicit val actorSystem = ActorSystem("controller-actor-system")
     implicit val logger = new AkkaLogging(akka.event.Logging.getLogger(actorSystem, this))
 

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
@@ -44,7 +44,7 @@ import org.apache.openwhisk.spi.SpiLoader
 
 import scala.concurrent.ExecutionContext.Implicits
 import scala.concurrent.duration.DurationInt
-import scala.concurrent.{Await, Future}
+import scala.concurrent.Await
 import scala.util.{Failure, Success}
 
 /**
@@ -214,7 +214,6 @@ object Controller {
     CoordinatedShutdown(actorSystem).addTask(CoordinatedShutdown.PhaseActorSystemTerminate, "shutdownKamon") { () =>
       logger.info(this, s"Shutting down Kamon with coordinated shutdown")
       Kamon.stopAllReporters().map(_ => Done)(Implicits.global)
-      Future.successful(Done)
     }
 
     // extract configuration data from the environment

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
@@ -64,6 +64,7 @@ object Invoker {
   }
 
   def main(args: Array[String]): Unit = {
+    Kamon.loadReportersFromConfig()
     implicit val ec = ExecutionContextFactory.makeCachedThreadPoolExecutionContext()
     implicit val actorSystem: ActorSystem =
       ActorSystem(name = "invoker-actor-system", defaultExecutionContext = Some(ec))


### PR DESCRIPTION
Updates Kamon to 1.x release (1.1.3) from current 0.6 version

## Description

Going forward I would like to enable metrics reporting via Prometheus. [Kamon Prometheus][1] support was added with Kamon 1.0 series. Hence the need to update Kamon

[Kamon 1.0][2] was a major release involving some breaking changes which needs some [migration work][3]

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

[1]: https://kamon.io/documentation/1.x/reporters/prometheus/
[2]: https://kamon.io/teamblog/2018/01/18/kamon-1.0.0-is-out/
[3]: https://kamon.io/documentation/1.x/recipes/migrating-from-kamon-0.6/

