### PR TITLE
Remove unused ansible parameters in group_vars/all file.

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -6,7 +6,6 @@ lean: false
 prompt_user: true
 openwhisk_home: "{{ lookup('env', 'OPENWHISK_HOME') | default(playbook_dir ~ '/..', true) }}"
 openwhisk_cli_home: "{{ lookup('env', 'OPENWHISK_CLI') | default(openwhisk_home ~ '/../incubator-openwhisk-cli', true) }}"
-openwhisk_build_dir: "{{ openwhisk_home }}/build"
 exclude_logs_from: []
 
 # This whisk_api_localhost_name_default is used to configure nginx to permit vanity URLs for web actions
@@ -75,7 +74,6 @@ controller:
   blackboxFraction: "{{ controller_blackbox_fraction | default(__controller_blackbox_fraction) }}"
   timeoutFactor: "{{ controller_timeout_factor | default(2) }}"
   instances: "{{ groups['controllers'] | length }}"
-  localBookkeeping: "{{ controller_local_bookkeeping | default('false') }}"
   akka:
     provider: cluster
     cluster:
@@ -176,7 +174,6 @@ invoker:
   heap: "{{ invoker_heap | default('2g') }}"
   arguments: "{{ invoker_arguments | default('') }}"
   userMemory: "{{ invoker_user_memory | default('2048m') }}"
-  instances: "{{ groups['invokers'] | length }}"
   # Specify if it is allowed to deploy more than 1 invoker on a single machine.
   allowMultipleInstances: "{{ invoker_allow_multiple_instances | default(false) }}"
   # Specify if it should use docker-runc or docker to pause/unpause containers
@@ -212,7 +209,6 @@ nginx:
   port:
     http: 80
     api: 443
-    adminportal: 8443
   ssl:
     path: "{{ openwhisk_home }}/ansible/roles/nginx/files"
     cert: "openwhisk-server-cert.pem"
@@ -259,7 +255,6 @@ db:
 apigateway:
   port:
     api: 9000
-    api_secure: 443
     mgmt: 9001
   # apigateway is an Apahce OpenWhisk project, so default to latest
   version: latest
@@ -292,14 +287,8 @@ docker:
     delay: 10
   timezone: "{{ docker_timezone | default('UTC') }}"
 
-sdk:
-  dir:
-    become: "{{ sdk_dir_become | default(false) }}"
-
 cli:
   path: "{{ openwhisk_home }}/bin/wsk"
-  dir:
-    become: "{{ cli_dir_become | default(false) }}"
 
 # The default name space is /whisk.system. The catalog namespace must begin with a slash "/".
 catalog_namespace: "/whisk.system"

--- a/ansible/roles/nginx/tasks/deploy.yml
+++ b/ansible/roles/nginx/tasks/deploy.yml
@@ -63,11 +63,8 @@
     volumes:
       - "{{ whisk_logs_dir }}/nginx:/logs"
       - "{{ nginx.confdir }}:/etc/nginx"
-    expose:
-      - 8443
     ports:
       - "{{ nginx.port.http }}:80"
       - "{{ nginx.port.api }}:443"
-      - "{{ nginx.port.adminportal }}:8443"
     env:
       TZ: "{{ docker.timezone }}"


### PR DESCRIPTION
## Description
This PR cleans up some config parameters in `group_vars/all`-file of ansible, taht are not used anymore.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.