### PR TITLE
Add PHP 7.3 runtime

### DIFF
--- a/ansible/files/runtimes.json
+++ b/ansible/files/runtimes.json
@@ -194,11 +194,25 @@
             },
             {
                 "kind": "php:7.2",
-                "default": true,
+                "default": false,
                 "deprecated": false,
                 "image": {
                     "prefix": "openwhisk",
                     "name": "action-php-v7.2",
+                    "tag": "latest"
+                },
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
+            },
+            {
+                "kind": "php:7.3",
+                "default": true,
+                "deprecated": false,
+                "image": {
+                    "prefix": "openwhisk",
+                    "name": "action-php-v7.3",
                     "tag": "latest"
                 },
                 "attached": {

--- a/core/controller/src/main/resources/apiv1swagger.json
+++ b/core/controller/src/main/resources/apiv1swagger.json
@@ -1895,6 +1895,7 @@
                         "nodejs:default",
                         "php:7.1",
                         "php:7.2",
+                        "php:7.3",
                         "python:2",
                         "python:3",
                         "python:default",

--- a/docs/actions-new.md
+++ b/docs/actions-new.md
@@ -64,7 +64,7 @@ additional rqeuirements and best practices:
 Actions when created specify the desired runtime for the function via a property called "kind".
 When using the `wsk` CLI, this is specified as `--kind <runtime-kind>`. The value is a typically
 a string describing the language (e.g., `nodejs`) followed by a colon and the version for the runtime
-as in `nodejs:8` or `php:7.2`.
+as in `nodejs:8` or `php:7.3`.
 
 The manifest is a map of runtime family names to an array of specific kinds. The details of the
 schema are found in the [Exec Manifest](../common/scala/src/main/scala/org/apache/openwhisk/core/entity/ExecManifest.scala).

--- a/docs/actions-php.md
+++ b/docs/actions-php.md
@@ -23,10 +23,15 @@ The process of creating PHP actions is similar to that of [other actions](action
 The following sections guide you through creating and invoking a single PHP action,
 and demonstrate how to bundle multiple PHP files and third party dependencies.
 
-PHP actions are executed using PHP 7.2.6, with PHP 7.1.18 also available.
-To use the PHP 7.2 runtime, specify the `wsk` CLI parameter `--kind php:7.2` when creating or updating an action.
-This is the default when creating an action with file that has a `.php` extension.
-You can use `-- kind php:7.1 to use the PHP 7.1 runtime.
+PHP actions are executed using PHP 7.3. PHP 7.2 & PHP 7.1 are also available The specific
+version of PHP is listed in the CHANGELOG files in the [PHP runtime repository](https://github.com/apache/incubator-openwhisk-runtime-php).
+
+To use a PHP runtime, specify the `wsk` CLI parameter `--kind` when creating or
+updating an action. The available PHP kinds are:
+
+* PHP 7.3: `--kind php:7.3`
+* PHP 7.2: `--kind php:7.2`
+* PHP 7.1: `--kind php:7.1`
 
 An action is simply a top-level PHP function. For example, create a file called `hello.php`
 with the following source code:
@@ -53,7 +58,7 @@ wsk action create helloPHP hello.php
 ```
 
 The CLI automatically infers the type of the action from the source file extension.
-For `.php` source files, the action runs using a PHP 7.2 runtime.
+For `.php` source files, the action runs using a PHP 7.3 runtime.
 
 Action invocation is the same for PHP actions as it is for [any other action](actions.md#the-basics).
 
@@ -101,8 +106,12 @@ The PHP runtime will automatically include Composer's autoloader for you, so you
 use the dependencies in your action code. Note that if you don't include your own `vendor` folder,
 then the runtime will include one for you with the following Composer packages:
 
-- guzzlehttp/guzzle       v6.3.3
-- ramsey/uuid             v3.7.3
+- guzzlehttp/guzzle
+- ramsey/uuid
+
+The specific versions of these packages depends on the PHP runtime in use and is listed in the 
+CHANGELOG files in the [PHP runtime repository](https://github.com/apache/incubator-openwhisk-runtime-php).
+
 
 ## Built-in PHP extensions
 

--- a/docs/actions-php.md
+++ b/docs/actions-php.md
@@ -109,7 +109,7 @@ then the runtime will include one for you with the following Composer packages:
 - guzzlehttp/guzzle
 - ramsey/uuid
 
-The specific versions of these packages depends on the PHP runtime in use and is listed in the 
+The specific versions of these packages depends on the PHP runtime in use and is listed in the
 CHANGELOG files in the [PHP runtime repository](https://github.com/apache/incubator-openwhisk-runtime-php).
 
 

--- a/docs/actions-php.md
+++ b/docs/actions-php.md
@@ -23,7 +23,7 @@ The process of creating PHP actions is similar to that of [other actions](action
 The following sections guide you through creating and invoking a single PHP action,
 and demonstrate how to bundle multiple PHP files and third party dependencies.
 
-PHP actions are executed using PHP 7.3. PHP 7.2 & PHP 7.1 are also available The specific
+PHP actions are executed using PHP 7.3. PHP 7.2 & PHP 7.1 are also available. The specific
 version of PHP is listed in the CHANGELOG files in the [PHP runtime repository](https://github.com/apache/incubator-openwhisk-runtime-php).
 
 To use a PHP runtime, specify the `wsk` CLI parameter `--kind` when creating or

--- a/tests/dat/actions/unicode.tests/php-7.3.txt
+++ b/tests/dat/actions/unicode.tests/php-7.3.txt
@@ -1,0 +1,9 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor
+// license agreements; and to You under the Apache License, Version 2.0.
+
+function main(array $args) : array {
+    $str = $args['delimiter'] . " ☃ " . $args['delimiter'];
+    echo $str . "\n";
+    return  ["winter" => $str];
+}


### PR DESCRIPTION
Add support for the new PHP 7.3 runtime.


## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] Relatedissue to propose and discuss this change (#4174)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [x] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [x] I updated the documentation where necessary.
