### PR TITLE
Ensure cache gets properly updated with concurrent access for action with attachments

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/DocumentFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/DocumentFactory.scala
@@ -231,7 +231,7 @@ trait DocumentFactory[W <: DocumentRevisionProvider] extends MultipleReadersSing
       implicit val ec = db.executionContext
       val key = doc.asDocInfo(rev)
       _ =>
-        cacheLookup(CacheKey(key), db.get[W](key, Some(attachmentHandler)) flatMap { postProcess }, fromCache)
+        cacheLookup(CacheKey(key), db.get[W](key, Some(attachmentHandler)).flatMap(postProcess), fromCache)
     } match {
       case Success(f) => f
       case Failure(t) => Future.failed(t)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/DocumentFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/DocumentFactory.scala
@@ -21,9 +21,6 @@ import java.io.InputStream
 import java.io.OutputStream
 
 import scala.concurrent.{Future, Promise}
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
 import akka.http.scaladsl.model.ContentType
 import akka.stream.IOResult
 import akka.stream.scaladsl.StreamConverters
@@ -102,24 +99,12 @@ trait DocumentFactory[W <: DocumentRevisionProvider] extends MultipleReadersSing
   def put[Wsuper >: W](db: ArtifactStore[Wsuper], doc: W, old: Option[W])(
     implicit transid: TransactionId,
     notifier: Option[CacheChangeNotification]): Future[DocInfo] = {
-    Try {
-      require(db != null, "db undefined")
-      require(doc != null, "doc undefined")
-    } map { _ =>
-      implicit val logger = db.logging
-      implicit val ec = db.executionContext
-
-      val key = CacheKey(doc)
-      val docInfo = doc.docinfo
-
-      cacheUpdate(doc, key, db.put(doc) map { newDocInfo =>
-        doc.revision[W](newDocInfo.rev)
-        doc.docinfo
-      })
-    } match {
-      case Success(f) => f
-      case Failure(t) => Future.failed(t)
-    }
+    implicit val logger = db.logging
+    implicit val ec = db.executionContext
+    cacheUpdate(doc, CacheKey(doc), db.put(doc) map { newDocInfo =>
+      doc.revision[W](newDocInfo.rev)
+      doc.docinfo
+    })
   }
 
   def putAndAttach[Wsuper >: W](db: ArtifactStore[Wsuper],
@@ -131,49 +116,31 @@ trait DocumentFactory[W <: DocumentRevisionProvider] extends MultipleReadersSing
                                 postProcess: Option[W => W] = None)(
     implicit transid: TransactionId,
     notifier: Option[CacheChangeNotification]): Future[DocInfo] = {
+    implicit val logger = db.logging
+    implicit val ec = db.executionContext
 
-    Try {
-      require(db != null, "db undefined")
-      require(doc != null, "doc undefined")
-    } map { _ =>
-      implicit val logger = db.logging
-      implicit val ec = db.executionContext
+    val key = CacheKey(doc)
+    val src = StreamConverters.fromInputStream(() => bytes)
 
-      val key = CacheKey(doc)
-      val src = StreamConverters.fromInputStream(() => bytes)
-
-      val p = Promise[W]
-      cacheUpdate(p.future, key, db.putAndAttach[W](doc, update, contentType, src, oldAttachment) map {
-        case (newDocInfo, attached) =>
-          val newDoc = update(doc, attached)
-          val cacheDoc = postProcess map { _(newDoc) } getOrElse newDoc
-          cacheDoc.revision[W](newDocInfo.rev)
-          p.success(cacheDoc)
-          newDocInfo
-      })
-
-    } match {
-      case Success(f) => f
-      case Failure(t) => Future.failed(t)
-    }
+    val p = Promise[W]
+    cacheUpdate(p.future, key, db.putAndAttach[W](doc, update, contentType, src, oldAttachment) map {
+      case (newDocInfo, attached) =>
+        val newDoc = update(doc, attached)
+        val cacheDoc = postProcess map { _(newDoc) } getOrElse newDoc
+        cacheDoc.revision[W](newDocInfo.rev)
+        p.success(cacheDoc)
+        newDocInfo
+    })
   }
 
   def del[Wsuper >: W](db: ArtifactStore[Wsuper], doc: DocInfo)(
     implicit transid: TransactionId,
     notifier: Option[CacheChangeNotification]): Future[Boolean] = {
-    Try {
-      require(db != null, "db undefined")
-      require(doc != null, "doc undefined")
-    } map { _ =>
-      implicit val logger = db.logging
-      implicit val ec = db.executionContext
+    implicit val logger = db.logging
+    implicit val ec = db.executionContext
 
-      val key = CacheKey(doc.id.asDocInfo)
-      cacheInvalidate(key, db.del(doc))
-    } match {
-      case Success(f) => f
-      case Failure(t) => Future.failed(t)
-    }
+    val key = CacheKey(doc.id.asDocInfo)
+    cacheInvalidate(key, db.del(doc))
   }
 
   /**
@@ -198,18 +165,10 @@ trait DocumentFactory[W <: DocumentRevisionProvider] extends MultipleReadersSing
     doc: DocId,
     rev: DocRevision = DocRevision.empty,
     fromCache: Boolean = cacheEnabled)(implicit transid: TransactionId, mw: Manifest[W]): Future[W] = {
-    Try {
-      require(db != null, "db undefined")
-    } map {
-      implicit val logger = db.logging
-      implicit val ec = db.executionContext
-      val key = doc.asDocInfo(rev)
-      _ =>
-        cacheLookup(CacheKey(key), db.get[W](key, None), fromCache)
-    } match {
-      case Success(f) => f
-      case Failure(t) => Future.failed(t)
-    }
+    implicit val logger = db.logging
+    implicit val ec = db.executionContext
+    val key = doc.asDocInfo(rev)
+    cacheLookup(CacheKey(key), db.get[W](key, None), fromCache)
   }
 
   /**
@@ -224,68 +183,39 @@ trait DocumentFactory[W <: DocumentRevisionProvider] extends MultipleReadersSing
     fromCache: Boolean,
     attachmentHandler: (W, Attached) => W,
     postProcess: W => Future[W])(implicit transid: TransactionId, mw: Manifest[W]): Future[W] = {
-    Try {
-      require(db != null, "db undefined")
-    } map {
-      implicit val logger = db.logging
-      implicit val ec = db.executionContext
-      val key = doc.asDocInfo(rev)
-      _ =>
-        cacheLookup(CacheKey(key), db.get[W](key, Some(attachmentHandler)).flatMap(postProcess), fromCache)
-    } match {
-      case Success(f) => f
-      case Failure(t) => Future.failed(t)
-    }
+    implicit val logger = db.logging
+    implicit val ec = db.executionContext
+    val key = doc.asDocInfo(rev)
+    cacheLookup(CacheKey(key), db.get[W](key, Some(attachmentHandler)).flatMap(postProcess), fromCache)
   }
 
-  def getAttachment[Wsuper >: W](
+  protected def getAttachment[Wsuper >: W](
     db: ArtifactStore[Wsuper],
     doc: W,
     attached: Attached,
     outputStream: OutputStream,
     postProcess: Option[W => W] = None)(implicit transid: TransactionId, mw: Manifest[W]): Future[W] = {
-
     implicit val ec = db.executionContext
     implicit val notifier: Option[CacheChangeNotification] = None
+    implicit val logger = db.logging
 
-    Try {
-      require(db != null, "db defined")
-      require(doc != null, "doc undefined")
-    } map { _ =>
-      implicit val logger = db.logging
-      implicit val ec = db.executionContext
+    val docInfo = doc.docinfo
+    val key = CacheKey(docInfo)
+    val sink = StreamConverters.fromOutputStream(() => outputStream)
 
-      val docInfo = doc.docinfo
-      val key = CacheKey(docInfo)
-      val sink = StreamConverters.fromOutputStream(() => outputStream)
+    db.readAttachment[IOResult](docInfo, attached, sink).map { _ =>
+      val cacheDoc = postProcess.map(_(doc)).getOrElse(doc)
 
-      db.readAttachment[IOResult](docInfo, attached, sink).map {
-        case _ =>
-          val cacheDoc = postProcess map { _(doc) } getOrElse doc
-
-          cacheUpdate(cacheDoc, key, Future.successful(docInfo)) map { newDocInfo =>
-            cacheDoc.revision[W](newDocInfo.rev)
-          }
-          cacheDoc
+      cacheUpdate(cacheDoc, key, Future.successful(docInfo)) map { newDocInfo =>
+        cacheDoc.revision[W](newDocInfo.rev)
       }
-
-    } match {
-      case Success(f) => f
-      case Failure(t) => Future.failed(t)
+      cacheDoc
     }
   }
 
   def deleteAttachments[Wsuper >: W](db: ArtifactStore[Wsuper], doc: DocInfo)(
     implicit transid: TransactionId): Future[Boolean] = {
-    Try {
-      require(db != null, "db defined")
-      require(doc != null, "doc undefined")
-    } map { _ =>
-      implicit val ec = db.executionContext
-      db.deleteAttachments(doc)
-    } match {
-      case Success(f) => f
-      case Failure(t) => Future.failed(t)
-    }
+    implicit val ec = db.executionContext
+    db.deleteAttachments(doc)
   }
 }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskAction.scala
@@ -376,9 +376,7 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
 
     implicit val ec = db.executionContext
 
-    val fa = super.getWithAttachment(db, doc, rev, fromCache, Some(attachmentHandler _))
-
-    fa.flatMap { action =>
+    val inlineActionCode: WhiskAction => Future[WhiskAction] = { action =>
       def getWithAttachment(attached: Attached, binary: Boolean, exec: AttachedCode) = {
         val boas = new ByteArrayOutputStream()
         val wrapped = if (binary) Base64.getEncoder().wrap(boas) else boas
@@ -400,6 +398,7 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
           Future.successful(action)
       }
     }
+    super.getWithAttachment(db, doc, rev, fromCache, attachmentHandler, inlineActionCode)
   }
 
   def attachmentHandler(action: WhiskAction, attached: Attached): WhiskAction = {

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
@@ -1076,7 +1076,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     //Loading action with attachment concurrently should load only attachment once
     val logs = stream.toString
     withClue(s"db logs $logs") {
-      StringUtils.countMatches(logs, "finding attachment") shouldBe 1
+      StringUtils.countMatches(logs, "finding document") shouldBe 1
       StringUtils.countMatches(logs, "finding attachment") shouldBe 1
     }
     stream.reset()

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
@@ -36,8 +36,8 @@ import org.apache.openwhisk.core.entitlement.Collection
 import org.apache.openwhisk.http.ErrorResponse
 import org.apache.openwhisk.http.Messages
 import org.apache.openwhisk.core.database.UserContext
-
 import akka.http.scaladsl.model.headers.RawHeader
+import org.apache.commons.lang3.StringUtils
 import org.apache.openwhisk.core.entity.Attachments.Inline
 
 /**
@@ -1025,6 +1025,61 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         stream.toString should include regex (expectedGetLog)
         stream.reset()
     }
+  }
+
+  it should "concurrently get an action with attachment that is not cached" in {
+    implicit val tid = transid()
+    val action = WhiskAction(namespace, aname(), jsDefault(nonInlinedCode(entityStore)), Parameters("x", "b"))
+    val kind = NODEJS6
+
+    val content = WhiskActionPut(
+      Some(action.exec),
+      Some(action.parameters),
+      Some(
+        ActionLimitsOption(
+          Some(action.limits.timeout),
+          Some(action.limits.memory),
+          Some(action.limits.logs),
+          Some(action.limits.concurrency))))
+    val name = action.name
+    val cacheKey = s"${CacheKey(action)}".replace("(", "\\(").replace(")", "\\)")
+    val expectedGetLog = Seq(
+      s"finding document: 'id: ${action.namespace}/${action.name}",
+      s"finding attachment '[\\w-/:]+' of document 'id: ${action.namespace}/${action.name}").mkString("(?s).*")
+
+    Put(s"$collectionPath/$name", content) ~> Route.seal(routes(creds)(transid())) ~> check {
+      status should be(OK)
+    }
+
+    removeFromCache(action, WhiskAction)
+
+    stream.reset()
+
+    val expectedAction = WhiskAction(
+      action.namespace,
+      action.name,
+      action.exec,
+      action.parameters,
+      action.limits,
+      action.version,
+      action.publish,
+      action.annotations ++ Parameters(WhiskAction.execFieldName, kind))
+
+    (0 until 5).par.map { i =>
+      Get(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
+        status should be(OK)
+        val response = responseAs[WhiskAction]
+        response should be(expectedAction)
+      }
+    }
+
+    //Loading action with attachment concurrently should load only attachment once
+    val logs = stream.toString
+    withClue(s"db logs $logs") {
+      StringUtils.countMatches(logs, "finding attachment") shouldBe 1
+      StringUtils.countMatches(logs, "finding attachment") shouldBe 1
+    }
+    stream.reset()
   }
 
   it should "update an existing action with attachment that is not cached" in {


### PR DESCRIPTION
@tysonnorris notices with concurrent action invocation scenario that same attachment is being fetched multiple times in case of cache miss. 

## Description

If multiple request try to load an action with attachment which is not present in cache then currently it leads to multiple request to load the same attachment from backing store. This PR adds a new test which demonstrate this behavior. This test would try to concurrently read action (5 threads). Without fix you would see logs like below which show that attachment is being read multiple times

```
db logs [2018-12-17T08:50:49.800Z] [DEBUG] [#tid_7] [LocalEntitlementProvider] checking user 'anon-nKWrAIa7elnkH4XMmEEsb75ZB9v' has privilege 'READ' for 'actions/anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2'
[2018-12-17T08:50:49.800Z] [DEBUG] [#tid_6] [LocalEntitlementProvider] checking user 'anon-nKWrAIa7elnkH4XMmEEsb75ZB9v' has privilege 'READ' for 'actions/anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2'
[2018-12-17T08:50:49.800Z] [DEBUG] [#tid_4] [LocalEntitlementProvider] checking user 'anon-nKWrAIa7elnkH4XMmEEsb75ZB9v' has privilege 'READ' for 'actions/anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2'
[2018-12-17T08:50:49.800Z] [DEBUG] [#tid_3] [LocalEntitlementProvider] checking user 'anon-nKWrAIa7elnkH4XMmEEsb75ZB9v' has privilege 'READ' for 'actions/anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2'
[2018-12-17T08:50:49.800Z] [DEBUG] [#tid_5] [LocalEntitlementProvider] checking user 'anon-nKWrAIa7elnkH4XMmEEsb75ZB9v' has privilege 'READ' for 'actions/anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2'
[2018-12-17T08:50:49.801Z] [DEBUG] [#tid_3] [LocalEntitlementProvider] authorized
[2018-12-17T08:50:49.801Z] [DEBUG] [#tid_7] [LocalEntitlementProvider] authorized
[2018-12-17T08:50:49.801Z] [DEBUG] [#tid_4] [LocalEntitlementProvider] authorized
[2018-12-17T08:50:49.801Z] [DEBUG] [#tid_5] [LocalEntitlementProvider] authorized
[2018-12-17T08:50:49.802Z] [DEBUG] [#tid_6] [LocalEntitlementProvider] authorized
[2018-12-17T08:50:49.803Z] [DEBUG] [#tid_5] [WhiskAction] read initiated
[2018-12-17T08:50:49.803Z] [INFO] [#tid_5] [WhiskAction] [GET] serving from datastore: CacheKey(anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2) [marker:database_cacheMiss_count:5]
[2018-12-17T08:50:49.803Z] [INFO] [#tid_5] [CouchDbRestStore] [GET] 'whisk_local_whisks' finding document: 'id: anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2' [marker:database_getDocument_start:5]
[2018-12-17T08:50:49.804Z] [DEBUG] [#tid_4] [WhiskAction] coalesced read
[2018-12-17T08:50:49.804Z] [DEBUG] [#tid_7] [WhiskAction] coalesced read
[2018-12-17T08:50:49.805Z] [DEBUG] [#tid_6] [WhiskAction] coalesced read
[2018-12-17T08:50:49.805Z] [INFO] [#tid_4] [WhiskAction] [GET] serving from cache: CacheKey(anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2) [marker:database_cacheHit_count:7]
[2018-12-17T08:50:49.805Z] [INFO] [#tid_7] [WhiskAction] [GET] serving from cache: CacheKey(anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2) [marker:database_cacheHit_count:7]
[2018-12-17T08:50:49.805Z] [INFO] [#tid_6] [WhiskAction] [GET] serving from cache: CacheKey(anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2) [marker:database_cacheHit_count:7]
[2018-12-17T08:50:49.806Z] [DEBUG] [#tid_3] [WhiskAction] coalesced read
[2018-12-17T08:50:49.806Z] [INFO] [#tid_3] [WhiskAction] [GET] serving from cache: CacheKey(anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2) [marker:database_cacheHit_count:8]
[2018-12-17T08:50:49.814Z] [INFO] [#tid_5] [CouchDbRestStore] [marker:database_getDocument_finish:16:11]
[2018-12-17T08:50:49.824Z] [DEBUG] [#tid_5] [WhiskAction] read backend part done, now marking cache entry as done
[2018-12-17T08:50:49.825Z] [DEBUG] [#tid_5] [Entry] read finished
[2018-12-17T08:50:49.828Z] [INFO] [#tid_6] [CouchDbRestStore] [ATT_GET] 'whisk_local_whisks' finding attachment '75ee1112-fcdb-4043-ae11-12fcdbb043e7' of document 'id: anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2, rev: 2-d43fa9eb21253e04d440162630082ce9' [marker:database_getDocumentAttachment_start:30]
[2018-12-17T08:50:49.830Z] [INFO] [#tid_4] [CouchDbRestStore] [ATT_GET] 'whisk_local_whisks' finding attachment '75ee1112-fcdb-4043-ae11-12fcdbb043e7' of document 'id: anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2, rev: 2-d43fa9eb21253e04d440162630082ce9' [marker:database_getDocumentAttachment_start:32]
[2018-12-17T08:50:49.831Z] [INFO] [#tid_5] [CouchDbRestStore] [ATT_GET] 'whisk_local_whisks' finding attachment '75ee1112-fcdb-4043-ae11-12fcdbb043e7' of document 'id: anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2, rev: 2-d43fa9eb21253e04d440162630082ce9' [marker:database_getDocumentAttachment_start:33]
[2018-12-17T08:50:49.831Z] [INFO] [#tid_7] [CouchDbRestStore] [ATT_GET] 'whisk_local_whisks' finding attachment '75ee1112-fcdb-4043-ae11-12fcdbb043e7' of document 'id: anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2, rev: 2-d43fa9eb21253e04d440162630082ce9' [marker:database_getDocumentAttachment_start:33]
[2018-12-17T08:50:49.832Z] [INFO] [#tid_3] [CouchDbRestStore] [ATT_GET] 'whisk_local_whisks' finding attachment '75ee1112-fcdb-4043-ae11-12fcdbb043e7' of document 'id: anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2, rev: 2-d43fa9eb21253e04d440162630082ce9' [marker:database_getDocumentAttachment_start:34]
[2018-12-17T08:50:49.872Z] [INFO] [#tid_6] [CouchDbRestStore] [marker:database_getDocumentAttachment_finish:74:44]
[2018-12-17T08:50:49.875Z] [INFO] [#tid_6] [WhiskAction] write initiated on new cache entry
[2018-12-17T08:50:49.875Z] [DEBUG] [#tid_6] [ActionsApiTests] [GET] entity success
[2018-12-17T08:50:49.875Z] [DEBUG] [#tid_6] [WhiskAction] write backend part done, now marking cache entry as done
[2018-12-17T08:50:49.875Z] [DEBUG] [#tid_6] [Entry] write finished
[2018-12-17T08:50:49.876Z] [INFO] [#tid_6] [WhiskAction] write all done, caching CacheKey(anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2) Cached
[2018-12-17T08:50:49.890Z] [INFO] [#tid_4] [CouchDbRestStore] [marker:database_getDocumentAttachment_finish:92:59]
[2018-12-17T08:50:49.891Z] [DEBUG] [#tid_4] [ActionsApiTests] [GET] entity success
[2018-12-17T08:50:49.891Z] [INFO] [#tid_4] [WhiskAction] write initiated on existing cache entry, invalidating CacheKey(anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2), tid 4, state WriteInProgress
[2018-12-17T08:50:49.892Z] [DEBUG] [#tid_4] [WhiskAction] write backend part done, now marking cache entry as done
[2018-12-17T08:50:49.892Z] [INFO] [#tid_5] [CouchDbRestStore] [marker:database_getDocumentAttachment_finish:94:61]
[2018-12-17T08:50:49.892Z] [DEBUG] [#tid_4] [Entry] write finished
[2018-12-17T08:50:49.892Z] [INFO] [#tid_4] [WhiskAction] write all done, caching CacheKey(anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2) Cached
[2018-12-17T08:50:49.892Z] [DEBUG] [#tid_5] [ActionsApiTests] [GET] entity success
[2018-12-17T08:50:49.892Z] [INFO] [#tid_5] [WhiskAction] write initiated on existing cache entry, invalidating CacheKey(anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2), tid 5, state WriteInProgress
[2018-12-17T08:50:49.893Z] [DEBUG] [#tid_5] [WhiskAction] write backend part done, now marking cache entry as done
[2018-12-17T08:50:49.893Z] [DEBUG] [#tid_5] [Entry] write finished
[2018-12-17T08:50:49.893Z] [INFO] [#tid_5] [WhiskAction] write all done, caching CacheKey(anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2) Cached
[2018-12-17T08:50:49.914Z] [INFO] [#tid_3] [CouchDbRestStore] [marker:database_getDocumentAttachment_finish:116:82]
[2018-12-17T08:50:49.914Z] [INFO] [#tid_3] [WhiskAction] write initiated on existing cache entry, invalidating CacheKey(anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2), tid 3, state WriteInProgress
[2018-12-17T08:50:49.915Z] [DEBUG] [#tid_3] [ActionsApiTests] [GET] entity success
[2018-12-17T08:50:49.915Z] [DEBUG] [#tid_3] [WhiskAction] write backend part done, now marking cache entry as done
[2018-12-17T08:50:49.915Z] [DEBUG] [#tid_3] [Entry] write finished
[2018-12-17T08:50:49.915Z] [INFO] [#tid_3] [WhiskAction] write all done, caching CacheKey(anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2) Cached
[2018-12-17T08:50:49.921Z] [INFO] [#tid_7] [CouchDbRestStore] [marker:database_getDocumentAttachment_finish:123:90]
[2018-12-17T08:50:49.921Z] [INFO] [#tid_7] [WhiskAction] write initiated on existing cache entry, invalidating CacheKey(anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2), tid 7, state WriteInProgress
[2018-12-17T08:50:49.921Z] [DEBUG] [#tid_7] [ActionsApiTests] [GET] entity success
[2018-12-17T08:50:49.922Z] [DEBUG] [#tid_7] [WhiskAction] write backend part done, now marking cache entry as done
[2018-12-17T08:50:49.922Z] [DEBUG] [#tid_7] [Entry] write finished
[2018-12-17T08:50:49.922Z] [INFO] [#tid_7] [WhiskAction] write all done, caching CacheKey(anon-nKWrAIa7elnkH4XMmEEsb75ZB9v/action_tests_name2) Cached
5 was not equal to 1
ScalaTestFailureLocation: org.apache.openwhisk.core.controller.test.ActionsApiTests at (ActionsApiTests.scala:1079)
```

As a fix now the cache update operation also includes the inline logic. So a cache update would be considered complete only when the action code is also inlined. This ensures even with concurrent reader threads only one thread performs the db access and others make use of the cache

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

