### PR TITLE
recreate http client on resume()

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/mesos/MesosTask.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/mesos/MesosTask.scala
@@ -205,8 +205,8 @@ class MesosTask(override protected val id: ContainerId,
 
   /** Dual of halt. */
   override def resume()(implicit transid: TransactionId): Future[Unit] = {
-    // resume not supported
-    Future.successful(Unit)
+    super.resume()
+    // resume not supported (just return result from super)
   }
 
   /** Completely destroys this instance of the container. */

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerContainer.scala
@@ -174,8 +174,9 @@ class DockerContainer(protected val id: ContainerId,
   override def suspend()(implicit transid: TransactionId): Future[Unit] = {
     super.suspend().flatMap(_ => if (useRunc) runc.pause(id) else docker.pause(id))
   }
-  def resume()(implicit transid: TransactionId): Future[Unit] =
-    if (useRunc) { runc.resume(id) } else { docker.unpause(id) }
+  override def resume()(implicit transid: TransactionId): Future[Unit] = {
+    if (useRunc) { runc.resume(id) } else { docker.unpause(id) }.map(_ => super.resume())
+  }
   override def destroy()(implicit transid: TransactionId): Future[Unit] = {
     super.destroy()
     docker.rm(id)

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerContainer.scala
@@ -175,7 +175,7 @@ class DockerContainer(protected val id: ContainerId,
     super.suspend().flatMap(_ => if (useRunc) runc.pause(id) else docker.pause(id))
   }
   override def resume()(implicit transid: TransactionId): Future[Unit] = {
-    if (useRunc) { runc.resume(id) } else { docker.unpause(id) }.map(_ => super.resume())
+    (if (useRunc) { runc.resume(id) } else { docker.unpause(id) }).flatMap(_ => super.resume())
   }
   override def destroy()(implicit transid: TransactionId): Future[Unit] = {
     super.destroy()

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesContainer.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesContainer.scala
@@ -104,7 +104,8 @@ class KubernetesContainer(protected[core] val id: ContainerId,
     super.suspend().flatMap(_ => kubernetes.suspend(this))
   }
 
-  def resume()(implicit transid: TransactionId): Future[Unit] = kubernetes.resume(this)
+  override def resume()(implicit transid: TransactionId): Future[Unit] =
+    kubernetes.resume(this).map(_ => super.resume())
 
   override def destroy()(implicit transid: TransactionId): Future[Unit] = {
     super.destroy()

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesContainer.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesContainer.scala
@@ -105,7 +105,7 @@ class KubernetesContainer(protected[core] val id: ContainerId,
   }
 
   override def resume()(implicit transid: TransactionId): Future[Unit] =
-    kubernetes.resume(this).map(_ => super.resume())
+    kubernetes.resume(this).flatMap(_ => super.resume())
 
   override def destroy()(implicit transid: TransactionId): Future[Unit] = {
     super.destroy()

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/logging/test/DockerToActivationLogStoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/logging/test/DockerToActivationLogStoreTests.scala
@@ -107,7 +107,7 @@ class DockerToActivationLogStoreTests extends FlatSpec with Matchers with WskAct
                                                                                    val logging: Logging)
       extends Container {
     override def suspend()(implicit transid: TransactionId): Future[Unit] = ???
-    def resume()(implicit transid: TransactionId): Future[Unit] = ???
+    override def resume()(implicit transid: TransactionId): Future[Unit] = ???
 
     def logs(limit: ByteSize, waitForSentinel: Boolean)(implicit transid: TransactionId) = lines
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -18,7 +18,6 @@
 package org.apache.openwhisk.core.containerpool.test
 
 import java.time.Instant
-
 import akka.actor.FSM.{CurrentState, SubscribeTransitionCallBack, Transition}
 import akka.actor.{ActorRef, ActorSystem, FSM}
 import akka.stream.scaladsl.Source
@@ -26,7 +25,6 @@ import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.ByteString
 import common.{LoggedFunction, StreamLogging, SynchronizedLoggedFunction, WhiskProperties}
 import java.util.concurrent.atomic.AtomicInteger
-
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
@@ -41,7 +39,6 @@ import org.apache.openwhisk.core.entity._
 import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.http.Messages
 import org.apache.openwhisk.core.database.UserContext
-
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future, Promise}
 
@@ -1079,11 +1076,17 @@ class ContainerProxyTests
     def runCount = atomicRunCount.get()
     override def suspend()(implicit transid: TransactionId): Future[Unit] = {
       suspendCount += 1
-      super.suspend()
+      val s = super.suspend()
+      //verify that httpconn is closed
+      httpConnection should be(None)
+      s
     }
-    def resume()(implicit transid: TransactionId): Future[Unit] = {
+    override def resume()(implicit transid: TransactionId): Future[Unit] = {
       resumeCount += 1
-      Future.successful(())
+      val r = super.resume()
+      //verify that httpconn is recreated
+      httpConnection should be('defined)
+      r
     }
     override def destroy()(implicit transid: TransactionId): Future[Unit] = {
       destroyCount += 1

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -39,6 +39,7 @@ import org.apache.openwhisk.core.entity._
 import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.http.Messages
 import org.apache.openwhisk.core.database.UserContext
+import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future, Promise}
 
@@ -1077,6 +1078,7 @@ class ContainerProxyTests
     override def suspend()(implicit transid: TransactionId): Future[Unit] = {
       suspendCount += 1
       val s = super.suspend()
+      Await.result(s, 5.seconds)
       //verify that httpconn is closed
       httpConnection should be(None)
       s
@@ -1084,6 +1086,7 @@ class ContainerProxyTests
     override def resume()(implicit transid: TransactionId): Future[Unit] = {
       resumeCount += 1
       val r = super.resume()
+      Await.result(r, 5.seconds)
       //verify that httpconn is recreated
       httpConnection should be('defined)
       r


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
In testing concurrent actions (multiple activations in same container) we noticed that when a container is used after `Container.suspend()`, the http connection may be re-created multiple times (and may have side affects of losing connections each time a new one is created.



## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
This PR addresses this by:
- using a separate function for creating the connection - this will be invoked first during /init
- same function will be invoked again during `Container.resume()` (which means that subclasses must invoke `super.resume()`)

This way the subsequent + multiple calls to /run will arrive after connection has already been recreated.
I extended the ContainerProxyTests to assert connection state (exists or not) after `suspend()` and after `resume()`.
## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

