### PR TITLE
Track activation counts in ContainerPool (not ContainerProxy)

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
@@ -223,6 +223,7 @@ trait Container {
   private def closeConnections(toClose: Option[ContainerClient]): Future[Unit] = {
     toClose.map(_.close()).getOrElse(Future.successful(()))
   }
+  override def toString() = s"${id.toString}"
 }
 
 /** Indicates a general error with the container */

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
@@ -223,6 +223,9 @@ trait Container {
   private def closeConnections(toClose: Option[ContainerClient]): Future[Unit] = {
     toClose.map(_.close()).getOrElse(Future.successful(()))
   }
+
+  /** This is so that we can easily log the container id during ContainerPool.logContainerStart().
+   *  Null check is here since some tests use stub[Container] so id is null during those tests. */
   override def toString() = if (id == null) "no-container-id" else id.toString
 }
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
@@ -223,7 +223,7 @@ trait Container {
   private def closeConnections(toClose: Option[ContainerClient]): Future[Unit] = {
     toClose.map(_.close()).getOrElse(Future.successful(()))
   }
-  override def toString() = s"${id.toString}"
+  override def toString() = if (id == null) "no-container-id" else id.toString
 }
 
 /** Indicates a general error with the container */

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
@@ -219,6 +219,9 @@ class ContainerPool(childFactory: ActorRefFactory => ActorRef,
         case Some(oldData: WarmingData) =>
           //init is done, but run is not; retain active count
           (data.copy(activeActivationCount = oldData.activeActivationCount), oldData.activeActivationCount)
+        case Some(oldData: PreWarmedData) =>
+          //init is done, but run is not; retain active count (WarmingData is ONLY used for concurrent actions, otherwise PrewarmedData)
+          (data.copy(activeActivationCount = oldData.activeActivationCount), oldData.activeActivationCount)
         case Some(oldData: NoData) =>
           //when NoData (cold start); retain active count
           (data.copy(activeActivationCount = oldData.activeActivationCount), oldData.activeActivationCount)

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
@@ -153,14 +153,14 @@ class ContainerPool(childFactory: ActorRefFactory => ActorRef,
                 if (r.action.limits.concurrency.maxConcurrent > 1) {
                   WarmingData(p.container, r.msg.user.namespace.name, r.action, Instant.now, 1) -> Some(p.container)
                 } else {
-                  p -> Some(p.container)
+                  p.copy(activeActivationCount = 1) -> Some(p.container)
                 }
+              case w: WarmedData =>
+                w.copy(activeActivationCount = w.activeActivationCount + 1) -> Some(w.container)
               case pw: WarmingData =>
                 pw.copy(activeActivationCount = pw.activeActivationCount + 1) -> Some(pw.container)
               case wnd: WarmingColdData =>
                 wnd.copy(activeActivationCount = wnd.activeActivationCount + 1) -> None
-              case w: WarmedData =>
-                w.copy(activeActivationCount = w.activeActivationCount + 1) -> Some(w.container)
               case n: NoData => //convert NoData -> WarmingColdData for concurrent cases
                 if (r.action.limits.concurrency.maxConcurrent > 1) {
                   WarmingColdData(r.msg.user.namespace.name, r.action, Instant.now, 1) -> None

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
@@ -117,6 +117,9 @@ class ContainerPool(childFactory: ActorRefFactory => ActorRef,
                   case _: WarmedData      => "warm" //already warm
                   case _: WarmingData     => "warming" //prewarm initing with concurrent support
                   case _: WarmingColdData => "warmingCold" //cold initing with concurrent support
+                  case w =>
+                    logging.warn(this, s"unexpected warm data type ${w}")
+                    "warm" //already warm
                 }
                 (container, warmState)
               }

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
@@ -300,9 +300,8 @@ class ContainerPool(childFactory: ActorRefFactory => ActorRef,
   }
 
   /** Creates a new prewarmed container */
-  def prewarmContainer(exec: CodeExec[_], memoryLimit: ByteSize): Unit = {
+  def prewarmContainer(exec: CodeExec[_], memoryLimit: ByteSize): Unit =
     childFactory(context) ! Start(exec, memoryLimit)
-  }
 
   /**
    * Takes a prewarm container out of the prewarmed pool
@@ -452,8 +451,7 @@ object ContainerPool {
   def props(factory: ActorRefFactory => ActorRef,
             poolConfig: ContainerPoolConfig,
             feed: ActorRef,
-            prewarmConfig: List[PrewarmingConfig] = List.empty,
-            maxConcurrent: Int = 1) =
+            prewarmConfig: List[PrewarmingConfig] = List.empty) =
     Props(new ContainerPool(factory, feed, prewarmConfig, poolConfig))
 }
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
@@ -22,7 +22,6 @@ import akka.actor.Status.{Failure => FailureMessage}
 import akka.actor.{FSM, Props, Stash}
 import akka.event.Logging.InfoLevel
 import akka.pattern.pipe
-import org.apache.openwhisk.common.Logging
 import pureconfig.loadConfigOrThrow
 import scala.collection.immutable
 import spray.json.DefaultJsonProtocol._

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
@@ -63,6 +63,7 @@ case class PreWarmedData(container: Container,
                          override val memoryLimit: ByteSize,
                          override val activeActivationCount: Int = 0)
     extends ContainerData(Instant.EPOCH, memoryLimit, activeActivationCount) {
+  require(activeActivationCount >= 0, s"cannot set active count < 0 ${activeActivationCount}")
   def incrementActive = this.copy(activeActivationCount = activeActivationCount + 1)
   def decrementActive = this.copy(activeActivationCount = activeActivationCount - 1)
 }
@@ -72,6 +73,7 @@ case class WarmingData(container: Container,
                        override val lastUsed: Instant,
                        override val activeActivationCount: Int = 0)
     extends ContainerData(lastUsed, action.limits.memory.megabytes.MB, activeActivationCount) {
+  require(activeActivationCount >= 0, s"cannot set active count < 0 ${activeActivationCount}")
   def incrementActive = this.copy(activeActivationCount = activeActivationCount + 1)
   def decrementActive = this.copy(activeActivationCount = activeActivationCount - 1)
 }
@@ -81,6 +83,7 @@ case class WarmedData(container: Container,
                       override val lastUsed: Instant,
                       override val activeActivationCount: Int = 0)
     extends ContainerData(lastUsed, action.limits.memory.megabytes.MB, activeActivationCount) {
+  require(activeActivationCount >= 0, s"cannot set active count < 0 ${activeActivationCount}")
   def incrementActive = this.copy(activeActivationCount = activeActivationCount + 1)
   def decrementActive = this.copy(activeActivationCount = activeActivationCount - 1)
 }

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
@@ -18,13 +18,12 @@
 package org.apache.openwhisk.core.containerpool
 
 import java.time.Instant
-
 import akka.actor.Status.{Failure => FailureMessage}
 import akka.actor.{FSM, Props, Stash}
 import akka.event.Logging.InfoLevel
 import akka.pattern.pipe
+import org.apache.openwhisk.common.Logging
 import pureconfig.loadConfigOrThrow
-
 import scala.collection.immutable
 import spray.json.DefaultJsonProtocol._
 import spray.json._
@@ -38,7 +37,6 @@ import org.apache.openwhisk.core.entity._
 import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.core.invoker.InvokerReactive.ActiveAck
 import org.apache.openwhisk.http.Messages
-
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
@@ -55,9 +53,7 @@ case object Paused extends ContainerState
 case object Removing extends ContainerState
 
 // Data
-sealed abstract class ContainerData(val lastUsed: Instant, val memoryLimit: ByteSize, val activeActivationCount: Int) {
-  require(activeActivationCount >= 0, s"cannot set active count < 0 ${this}")
-}
+sealed abstract class ContainerData(val lastUsed: Instant, val memoryLimit: ByteSize, val activeActivationCount: Int)
 case class NoData(override val activeActivationCount: Int = 0)
     extends ContainerData(Instant.EPOCH, 0.B, activeActivationCount) {}
 case class MemoryData(override val memoryLimit: ByteSize, override val activeActivationCount: Int = 0)

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
@@ -708,7 +708,7 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
     val data = warmingColdData(active = maxConcurrent - 1, action = action)
     val data2 = warmedData(active = maxConcurrent - 1, action = action)
     val pool = Map('warming -> data, 'warm -> data2)
-    ContainerPool.schedule(data.action, data.invocationNamespace, pool) shouldBe Some('warming, data)
+    ContainerPool.schedule(data.action, data.invocationNamespace, pool) shouldBe Some('warm, data2)
 
   }
   it should "use a warmingCold when active activation count < maxconcurrent" in {
@@ -720,10 +720,11 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
     val pool = Map('warmingCold -> data)
     ContainerPool.schedule(data.action, data.invocationNamespace, pool) shouldBe Some('warmingCold, data)
 
-    val data2 = warmedData(active = maxConcurrent - 1, action = action)
-    val pool2 = pool ++ Map('warm -> data2)
+    //after scheduling, the pool will update with new data to set active = maxConcurrent
+    val data2 = warmingColdData(active = maxConcurrent, action = action)
+    val pool2 = Map('warmingCold -> data2)
 
-    ContainerPool.schedule(data2.action, data2.invocationNamespace, pool2) shouldBe Some('warm, data2)
+    ContainerPool.schedule(data2.action, data2.invocationNamespace, pool2) shouldBe None
 
   }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
@@ -86,6 +86,7 @@ class ContainerPoolTests
   val invocationNamespace = EntityName("invocationSpace")
   val differentInvocationNamespace = EntityName("invocationSpace2")
   val action = ExecutableWhiskAction(EntityPath("actionSpace"), EntityName("actionName"), exec)
+  val concurrencyEnabled = Option(WhiskProperties.getProperty("whisk.action.concurrency")).exists(_.toBoolean)
   val concurrentAction = ExecutableWhiskAction(
     EntityPath("actionSpace"),
     EntityName("actionName"),

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
@@ -86,6 +86,11 @@ class ContainerPoolTests
   val invocationNamespace = EntityName("invocationSpace")
   val differentInvocationNamespace = EntityName("invocationSpace2")
   val action = ExecutableWhiskAction(EntityPath("actionSpace"), EntityName("actionName"), exec)
+  val concurrentAction = ExecutableWhiskAction(
+    EntityPath("actionSpace"),
+    EntityName("actionName"),
+    exec,
+    limits = ActionLimits(concurrency = ConcurrencyLimit(3)))
   val differentAction = action.copy(name = EntityName("actionName2"))
   val largeAction =
     action.copy(
@@ -98,6 +103,8 @@ class ContainerPoolTests
   val runMessageDifferentVersion = createRunMessage(action.copy().revision(DocRevision("v2")), invocationNamespace)
   val runMessageDifferentNamespace = createRunMessage(action, differentInvocationNamespace)
   val runMessageDifferentEverything = createRunMessage(differentAction, differentInvocationNamespace)
+  val runMessageConcurrent = createRunMessage(concurrentAction, invocationNamespace)
+  val runMessageConcurrentDifferentNamespace = createRunMessage(concurrentAction, differentInvocationNamespace)
 
   /** Helper to create PreWarmedData */
   def preWarmedData(kind: String, memoryLimit: ByteSize = memoryLimit) =
@@ -471,6 +478,82 @@ class ContainerPoolTests
     containers(4).send(pool, NeedWork(warmedData()))
     feed.expectMsg(MessageFeed.Processed)
   }
+
+  it should "increase activation counts when scheduling to containers whose actions that support concurrency" in {
+    val (containers, factory) = testContainers(2)
+    val feed = TestProbe()
+
+    val pool = system.actorOf(ContainerPool.props(factory, poolConfig(MemoryLimit.stdMemory * 4), feed.ref))
+
+    // container0 is created and used
+    pool ! runMessageConcurrent
+    containers(0).expectMsg(runMessageConcurrent)
+
+    // container0 is reused
+    pool ! runMessageConcurrent
+    containers(0).expectMsg(runMessageConcurrent)
+
+    // container0 is reused
+    pool ! runMessageConcurrent
+    containers(0).expectMsg(runMessageConcurrent)
+
+    // container1 is created and used (these concurrent containers are configured with max 3 concurrent activations)
+    pool ! runMessageConcurrent
+    containers(1).expectMsg(runMessageConcurrent)
+  }
+
+  it should "schedule concurrent activations to different containers for different namespaces" in {
+    val (containers, factory) = testContainers(2)
+    val feed = TestProbe()
+
+    val pool = system.actorOf(ContainerPool.props(factory, poolConfig(MemoryLimit.stdMemory * 4), feed.ref))
+
+    // container0 is created and used
+    pool ! runMessageConcurrent
+    containers(0).expectMsg(runMessageConcurrent)
+
+    // container1 is created and used
+    pool ! runMessageConcurrentDifferentNamespace
+    containers(1).expectMsg(runMessageConcurrentDifferentNamespace)
+
+  }
+  it should "decrease activation counts when receiving NeedWork for actions that support concurrency" in {
+    val (containers, factory) = testContainers(2)
+    val feed = TestProbe()
+
+    val pool = system.actorOf(ContainerPool.props(factory, poolConfig(MemoryLimit.stdMemory * 4), feed.ref))
+
+    // container0 is created and used
+    pool ! runMessageConcurrent
+    containers(0).expectMsg(runMessageConcurrent)
+
+    // container0 is reused
+    pool ! runMessageConcurrent
+    containers(0).expectMsg(runMessageConcurrent)
+
+    // container0 is reused
+    pool ! runMessageConcurrent
+    containers(0).expectMsg(runMessageConcurrent)
+
+    // container1 is created and used (these concurrent containers are configured with max 3 concurrent activations)
+    pool ! runMessageConcurrent
+    containers(1).expectMsg(runMessageConcurrent)
+
+    // container1 is reused
+    pool ! runMessageConcurrent
+    containers(1).expectMsg(runMessageConcurrent)
+
+    // container1 is reused
+    pool ! runMessageConcurrent
+    containers(1).expectMsg(runMessageConcurrent)
+
+    containers(0).send(pool, NeedWork(warmedData(action = concurrentAction)))
+
+    // container0 is reused (since active count decreased)
+    pool ! runMessageConcurrent
+    containers(0).expectMsg(runMessageConcurrent)
+
+  }
 }
 
 /**
@@ -503,6 +586,13 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
                   lastUsed: Instant = Instant.now,
                   active: Int = 0) =
     WarmingData(stub[Container], EntityName(namespace), action, lastUsed, active)
+
+  /** Helper to create WarmingData with sensible defaults */
+  def warmingColdData(action: ExecutableWhiskAction = createAction(),
+                      namespace: String = standardNamespace.asString,
+                      lastUsed: Instant = Instant.now,
+                      active: Int = 0) =
+    WarmingColdData(EntityName(namespace), action, lastUsed, active)
 
   /** Helper to create PreWarmedData with sensible defaults */
   def preWarmedData(kind: String = "anyKind") = PreWarmedData(stub[Container], kind, 256.MB)
@@ -608,6 +698,56 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
     val pool2 = pool ++ Map('warm -> data2)
 
     ContainerPool.schedule(data2.action, data2.invocationNamespace, pool2) shouldBe Some('warm, data2)
+
+  }
+  it should "prefer warm to warming when active activation count < maxconcurrent" in {
+    val concurrencyEnabled = Option(WhiskProperties.getProperty("whisk.action.concurrency")).exists(_.toBoolean)
+    val maxConcurrent = if (concurrencyEnabled) 25 else 1
+
+    val action = createAction(limits = ActionLimits(concurrency = ConcurrencyLimit(maxConcurrent)))
+    val data = warmingColdData(active = maxConcurrent - 1, action = action)
+    val data2 = warmedData(active = maxConcurrent - 1, action = action)
+    val pool = Map('warming -> data, 'warm -> data2)
+    ContainerPool.schedule(data.action, data.invocationNamespace, pool) shouldBe Some('warming, data)
+
+  }
+  it should "use a warmingCold when active activation count < maxconcurrent" in {
+    val concurrencyEnabled = Option(WhiskProperties.getProperty("whisk.action.concurrency")).exists(_.toBoolean)
+    val maxConcurrent = if (concurrencyEnabled) 25 else 1
+
+    val action = createAction(limits = ActionLimits(concurrency = ConcurrencyLimit(maxConcurrent)))
+    val data = warmingColdData(active = maxConcurrent - 1, action = action)
+    val pool = Map('warmingCold -> data)
+    ContainerPool.schedule(data.action, data.invocationNamespace, pool) shouldBe Some('warmingCold, data)
+
+    val data2 = warmedData(active = maxConcurrent - 1, action = action)
+    val pool2 = pool ++ Map('warm -> data2)
+
+    ContainerPool.schedule(data2.action, data2.invocationNamespace, pool2) shouldBe Some('warm, data2)
+
+  }
+
+  it should "prefer warm to warmingCold when active activation count < maxconcurrent" in {
+    val concurrencyEnabled = Option(WhiskProperties.getProperty("whisk.action.concurrency")).exists(_.toBoolean)
+    val maxConcurrent = if (concurrencyEnabled) 25 else 1
+
+    val action = createAction(limits = ActionLimits(concurrency = ConcurrencyLimit(maxConcurrent)))
+    val data = warmingColdData(active = maxConcurrent - 1, action = action)
+    val data2 = warmedData(active = maxConcurrent - 1, action = action)
+    val pool = Map('warmingCold -> data, 'warm -> data2)
+    ContainerPool.schedule(data.action, data.invocationNamespace, pool) shouldBe Some('warm, data2)
+
+  }
+
+  it should "prefer warming to warmingCold when active activation count < maxconcurrent" in {
+    val concurrencyEnabled = Option(WhiskProperties.getProperty("whisk.action.concurrency")).exists(_.toBoolean)
+    val maxConcurrent = if (concurrencyEnabled) 25 else 1
+
+    val action = createAction(limits = ActionLimits(concurrency = ConcurrencyLimit(maxConcurrent)))
+    val data = warmingColdData(active = maxConcurrent - 1, action = action)
+    val data2 = warmingData(active = maxConcurrent - 1, action = action)
+    val pool = Map('warmingCold -> data, 'warming -> data2)
+    ContainerPool.schedule(data.action, data.invocationNamespace, pool) shouldBe Some('warming, data2)
 
   }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
@@ -479,7 +479,7 @@ class ContainerPoolTests
     feed.expectMsg(MessageFeed.Processed)
   }
 
-  it should "increase activation counts when scheduling to containers whose actions that support concurrency" in {
+  it should "increase activation counts when scheduling to containers whose actions support concurrency" in {
     val (containers, factory) = testContainers(2)
     val feed = TestProbe()
 
@@ -515,8 +515,8 @@ class ContainerPoolTests
     // container1 is created and used
     pool ! runMessageConcurrentDifferentNamespace
     containers(1).expectMsg(runMessageConcurrentDifferentNamespace)
-
   }
+
   it should "decrease activation counts when receiving NeedWork for actions that support concurrency" in {
     val (containers, factory) = testContainers(2)
     val feed = TestProbe()
@@ -552,7 +552,6 @@ class ContainerPoolTests
     // container0 is reused (since active count decreased)
     pool ! runMessageConcurrent
     containers(0).expectMsg(runMessageConcurrent)
-
   }
 }
 
@@ -698,8 +697,8 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
     val pool2 = pool ++ Map('warm -> data2)
 
     ContainerPool.schedule(data2.action, data2.invocationNamespace, pool2) shouldBe Some('warm, data2)
-
   }
+
   it should "prefer warm to warming when active activation count < maxconcurrent" in {
     val concurrencyEnabled = Option(WhiskProperties.getProperty("whisk.action.concurrency")).exists(_.toBoolean)
     val maxConcurrent = if (concurrencyEnabled) 25 else 1
@@ -709,8 +708,8 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
     val data2 = warmedData(active = maxConcurrent - 1, action = action)
     val pool = Map('warming -> data, 'warm -> data2)
     ContainerPool.schedule(data.action, data.invocationNamespace, pool) shouldBe Some('warm, data2)
-
   }
+
   it should "use a warmingCold when active activation count < maxconcurrent" in {
     val concurrencyEnabled = Option(WhiskProperties.getProperty("whisk.action.concurrency")).exists(_.toBoolean)
     val maxConcurrent = if (concurrencyEnabled) 25 else 1
@@ -725,7 +724,6 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
     val pool2 = Map('warmingCold -> data2)
 
     ContainerPool.schedule(data2.action, data2.invocationNamespace, pool2) shouldBe None
-
   }
 
   it should "prefer warm to warmingCold when active activation count < maxconcurrent" in {
@@ -737,7 +735,6 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
     val data2 = warmedData(active = maxConcurrent - 1, action = action)
     val pool = Map('warmingCold -> data, 'warm -> data2)
     ContainerPool.schedule(data.action, data.invocationNamespace, pool) shouldBe Some('warm, data2)
-
   }
 
   it should "prefer warming to warmingCold when active activation count < maxconcurrent" in {
@@ -749,7 +746,6 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
     val data2 = warmingData(active = maxConcurrent - 1, action = action)
     val pool = Map('warmingCold -> data, 'warming -> data2)
     ContainerPool.schedule(data.action, data.invocationNamespace, pool) shouldBe Some('warming, data2)
-
   }
 
   behavior of "ContainerPool remove()"

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
@@ -479,79 +479,81 @@ class ContainerPoolTests
     feed.expectMsg(MessageFeed.Processed)
   }
 
-  it should "increase activation counts when scheduling to containers whose actions support concurrency" in {
-    val (containers, factory) = testContainers(2)
-    val feed = TestProbe()
+  if (concurrencyEnabled) {
+    it should "increase activation counts when scheduling to containers whose actions support concurrency" in {
+      val (containers, factory) = testContainers(2)
+      val feed = TestProbe()
 
-    val pool = system.actorOf(ContainerPool.props(factory, poolConfig(MemoryLimit.stdMemory * 4), feed.ref))
+      val pool = system.actorOf(ContainerPool.props(factory, poolConfig(MemoryLimit.stdMemory * 4), feed.ref))
 
-    // container0 is created and used
-    pool ! runMessageConcurrent
-    containers(0).expectMsg(runMessageConcurrent)
+      // container0 is created and used
+      pool ! runMessageConcurrent
+      containers(0).expectMsg(runMessageConcurrent)
 
-    // container0 is reused
-    pool ! runMessageConcurrent
-    containers(0).expectMsg(runMessageConcurrent)
+      // container0 is reused
+      pool ! runMessageConcurrent
+      containers(0).expectMsg(runMessageConcurrent)
 
-    // container0 is reused
-    pool ! runMessageConcurrent
-    containers(0).expectMsg(runMessageConcurrent)
+      // container0 is reused
+      pool ! runMessageConcurrent
+      containers(0).expectMsg(runMessageConcurrent)
 
-    // container1 is created and used (these concurrent containers are configured with max 3 concurrent activations)
-    pool ! runMessageConcurrent
-    containers(1).expectMsg(runMessageConcurrent)
-  }
+      // container1 is created and used (these concurrent containers are configured with max 3 concurrent activations)
+      pool ! runMessageConcurrent
+      containers(1).expectMsg(runMessageConcurrent)
+    }
 
-  it should "schedule concurrent activations to different containers for different namespaces" in {
-    val (containers, factory) = testContainers(2)
-    val feed = TestProbe()
+    it should "schedule concurrent activations to different containers for different namespaces" in {
+      val (containers, factory) = testContainers(2)
+      val feed = TestProbe()
 
-    val pool = system.actorOf(ContainerPool.props(factory, poolConfig(MemoryLimit.stdMemory * 4), feed.ref))
+      val pool = system.actorOf(ContainerPool.props(factory, poolConfig(MemoryLimit.stdMemory * 4), feed.ref))
 
-    // container0 is created and used
-    pool ! runMessageConcurrent
-    containers(0).expectMsg(runMessageConcurrent)
+      // container0 is created and used
+      pool ! runMessageConcurrent
+      containers(0).expectMsg(runMessageConcurrent)
 
-    // container1 is created and used
-    pool ! runMessageConcurrentDifferentNamespace
-    containers(1).expectMsg(runMessageConcurrentDifferentNamespace)
-  }
+      // container1 is created and used
+      pool ! runMessageConcurrentDifferentNamespace
+      containers(1).expectMsg(runMessageConcurrentDifferentNamespace)
+    }
 
-  it should "decrease activation counts when receiving NeedWork for actions that support concurrency" in {
-    val (containers, factory) = testContainers(2)
-    val feed = TestProbe()
+    it should "decrease activation counts when receiving NeedWork for actions that support concurrency" in {
+      val (containers, factory) = testContainers(2)
+      val feed = TestProbe()
 
-    val pool = system.actorOf(ContainerPool.props(factory, poolConfig(MemoryLimit.stdMemory * 4), feed.ref))
+      val pool = system.actorOf(ContainerPool.props(factory, poolConfig(MemoryLimit.stdMemory * 4), feed.ref))
 
-    // container0 is created and used
-    pool ! runMessageConcurrent
-    containers(0).expectMsg(runMessageConcurrent)
+      // container0 is created and used
+      pool ! runMessageConcurrent
+      containers(0).expectMsg(runMessageConcurrent)
 
-    // container0 is reused
-    pool ! runMessageConcurrent
-    containers(0).expectMsg(runMessageConcurrent)
+      // container0 is reused
+      pool ! runMessageConcurrent
+      containers(0).expectMsg(runMessageConcurrent)
 
-    // container0 is reused
-    pool ! runMessageConcurrent
-    containers(0).expectMsg(runMessageConcurrent)
+      // container0 is reused
+      pool ! runMessageConcurrent
+      containers(0).expectMsg(runMessageConcurrent)
 
-    // container1 is created and used (these concurrent containers are configured with max 3 concurrent activations)
-    pool ! runMessageConcurrent
-    containers(1).expectMsg(runMessageConcurrent)
+      // container1 is created and used (these concurrent containers are configured with max 3 concurrent activations)
+      pool ! runMessageConcurrent
+      containers(1).expectMsg(runMessageConcurrent)
 
-    // container1 is reused
-    pool ! runMessageConcurrent
-    containers(1).expectMsg(runMessageConcurrent)
+      // container1 is reused
+      pool ! runMessageConcurrent
+      containers(1).expectMsg(runMessageConcurrent)
 
-    // container1 is reused
-    pool ! runMessageConcurrent
-    containers(1).expectMsg(runMessageConcurrent)
+      // container1 is reused
+      pool ! runMessageConcurrent
+      containers(1).expectMsg(runMessageConcurrent)
 
-    containers(0).send(pool, NeedWork(warmedData(action = concurrentAction)))
+      containers(0).send(pool, NeedWork(warmedData(action = concurrentAction)))
 
-    // container0 is reused (since active count decreased)
-    pool ! runMessageConcurrent
-    containers(0).expectMsg(runMessageConcurrent)
+      // container0 is reused (since active count decreased)
+      pool ! runMessageConcurrent
+      containers(0).expectMsg(runMessageConcurrent)
+    }
   }
 }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -127,13 +127,10 @@ class ContainerProxyTests
   }
 
   /** Run the common action on the state-machine, assumes good cases */
-  def run(machine: ActorRef, currentState: ContainerState, expectInit: Boolean = true) = {
+  def run(machine: ActorRef, currentState: ContainerState) = {
     machine ! Run(action, message)
     expectMsg(Transition(machine, currentState, Running))
-    if (expectInit) {
-      expectWarmed(invocationNamespace.name, action, 1)
-    }
-    expectAnyWarmed(invocationNamespace.name, action)
+    expectWarmed(invocationNamespace.name, action)
     expectMsg(Transition(machine, Running, Ready))
   }
 
@@ -143,16 +140,10 @@ class ContainerProxyTests
   }
 
   /** Expect a NeedWork message with warmed data */
-  def expectWarmed(namespace: String, action: ExecutableWhiskAction, count: Int) = {
+  def expectWarmed(namespace: String, action: ExecutableWhiskAction) = {
     val test = EntityName(namespace)
     expectMsgPF() {
       case a @ NeedWork(WarmedData(_, `test`, `action`, _, _)) => //matched, otherwise will fail
-    }
-  }
-  def expectAnyWarmed(namespace: String, action: ExecutableWhiskAction) = {
-    val test = EntityName(namespace)
-    expectMsgPF() {
-      case NeedWork(WarmedData(_, `test`, `action`, _, _)) => true
     }
   }
 
@@ -257,7 +248,7 @@ class ContainerProxyTests
     registerCallback(machine)
 
     preWarm(machine)
-    run(machine, Started, true)
+    run(machine, Started)
 
     // Timeout causes the container to pause
     timeout(machine)
@@ -303,7 +294,7 @@ class ContainerProxyTests
 
     run(machine, Started)
     // Note that there are no intermediate state changes
-    run(machine, Ready, false)
+    run(machine, Ready)
 
     awaitAssert {
       factory.calls should have size 1
@@ -359,7 +350,7 @@ class ContainerProxyTests
     run(machine, Started)
     timeout(machine)
     expectPause(machine)
-    run(machine, Paused, false)
+    run(machine, Paused)
 
     awaitAssert {
       factory.calls should have size 1
@@ -400,7 +391,7 @@ class ContainerProxyTests
             poolConfig,
             pauseGrace = pauseGrace))
     registerCallback(machine)
-    run(machine, Uninitialized, true)
+    run(machine, Uninitialized)
 
     awaitAssert {
       factory.calls should have size 1
@@ -443,8 +434,7 @@ class ContainerProxyTests
 
     machine ! Run(noLogsAction, message)
     expectMsg(Transition(machine, Uninitialized, Running))
-    expectWarmed(invocationNamespace.name, noLogsAction, 1)
-    expectWarmed(invocationNamespace.name, noLogsAction, 0)
+    expectWarmed(invocationNamespace.name, noLogsAction)
     expectMsg(Transition(machine, Running, Ready))
 
     awaitAssert {
@@ -505,17 +495,16 @@ class ContainerProxyTests
 
     //complete the init
     initPromise.success(initInterval)
-    expectWarmed(invocationNamespace.name, concurrentAction, 1) //when init completes
 
     //complete the first run
     runPromises(0).success(runInterval, ActivationResponse.success())
-    expectWarmed(invocationNamespace.name, concurrentAction, 0) //when first completes (count is 0 since stashed not counted)
+    expectWarmed(invocationNamespace.name, concurrentAction) //when first completes (count is 0 since stashed not counted)
     expectMsg(Transition(machine, Running, Ready)) //wait for first to complete to skip the delay step that can only reliably be tested in single threaded
     expectMsg(Transition(machine, Ready, Running)) //when second starts (after delay...)
 
     //complete the second run
     runPromises(1).success(runInterval, ActivationResponse.success())
-    expectWarmed(invocationNamespace.name, concurrentAction, 0) //when second completes
+    expectWarmed(invocationNamespace.name, concurrentAction) //when second completes
 
     //go back to ready after first and second runs are complete
     expectMsg(Transition(machine, Running, Ready))
@@ -536,13 +525,12 @@ class ContainerProxyTests
 
     //complete the fifth run (request new work, 1 active remain)
     runPromises(4).success(runInterval, ActivationResponse.success())
-    expectWarmed(invocationNamespace.name, concurrentAction, 1) //when fifth completes
+    expectWarmed(invocationNamespace.name, concurrentAction) //when fifth completes
 
     //complete the sixth run (request new work 0 active remain)
     runPromises(5).success(runInterval, ActivationResponse.success())
 
-    //expectWarmed(invocationNamespace.name, concurrentAction, 1) //when sixth completes
-    expectWarmed(invocationNamespace.name, concurrentAction, 0) //when sixth completes
+    expectWarmed(invocationNamespace.name, concurrentAction) //when sixth completes
 
     // back to ready
     expectMsg(Transition(machine, Running, Ready))
@@ -611,7 +599,7 @@ class ContainerProxyTests
 
     // Note that there are no intermediate state changes
     //second one will succeed
-    run(machine, Ready, false)
+    run(machine, Ready)
 
     //With exception of the error on first run, the assertions should be the same as in
     //         `run an action and continue with a next run without pausing the container`
@@ -763,7 +751,6 @@ class ContainerProxyTests
     registerCallback(machine)
     machine ! Run(action, message)
     expectMsg(Transition(machine, Uninitialized, Running))
-    expectWarmed(invocationNamespace.name, action, 1)
     expectMsg(ContainerRemoved) // The message is sent as soon as the container decides to destroy itself
     expectMsg(Transition(machine, Running, Removing))
 
@@ -802,7 +789,6 @@ class ContainerProxyTests
     registerCallback(machine)
     machine ! Run(action, message)
     expectMsg(Transition(machine, Uninitialized, Running))
-    expectWarmed(invocationNamespace.name, action, 1)
     expectMsg(ContainerRemoved) // The message is sent as soon as the container decides to destroy itself
     expectMsg(Transition(machine, Running, Removing))
 
@@ -840,7 +826,6 @@ class ContainerProxyTests
     registerCallback(machine)
     machine ! Run(action, message)
     expectMsg(Transition(machine, Uninitialized, Running))
-    expectWarmed(invocationNamespace.name, action, 1)
     expectMsg(ContainerRemoved) // The message is sent as soon as the container decides to destroy itself
     expectMsg(Transition(machine, Running, Removing))
 
@@ -978,8 +963,7 @@ class ContainerProxyTests
 
     // Finish /init, note that /run and log-collecting happens nonetheless
     initPromise.success(Interval.zero)
-    expectWarmed(invocationNamespace.name, action, 1)
-    expectWarmed(invocationNamespace.name, action, 0)
+    expectWarmed(invocationNamespace.name, action)
     expectMsg(Transition(machine, Running, Ready))
 
     // Remove the container after the transaction finished

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -133,7 +133,7 @@ class ContainerProxyTests
     if (expectInit) {
       expectWarmed(invocationNamespace.name, action, 1)
     }
-    expectWarmed(invocationNamespace.name, action, 0)
+    expectAnyWarmed(invocationNamespace.name, action)
     expectMsg(Transition(machine, Running, Ready))
   }
 
@@ -146,13 +146,13 @@ class ContainerProxyTests
   def expectWarmed(namespace: String, action: ExecutableWhiskAction, count: Int) = {
     val test = EntityName(namespace)
     expectMsgPF() {
-      case a @ NeedWork(WarmedData(_, `test`, `action`, _, _)) if a.data.activeActivationCount == count => //matched, otherwise will fail
+      case a @ NeedWork(WarmedData(_, `test`, `action`, _, _)) => //matched, otherwise will fail
     }
   }
   def expectAnyWarmed(namespace: String, action: ExecutableWhiskAction) = {
     val test = EntityName(namespace)
     expectMsgPF() {
-      case a @ NeedWork(WarmedData(_, `test`, `action`, _, _)) =>
+      case NeedWork(WarmedData(_, `test`, `action`, _, _)) => true
     }
   }
 
@@ -1062,7 +1062,7 @@ class ContainerProxyTests
   class TestContainer(initPromise: Option[Promise[Interval]] = None,
                       runPromises: Seq[Promise[(Interval, ActivationResponse)]] = Seq.empty)
       extends Container {
-    protected val id = ContainerId("testcontainer")
+    protected[core] val id = ContainerId("testcontainer")
     protected val addr = ContainerAddress("0.0.0.0")
     protected implicit val logging: Logging = log
     protected implicit val ec: ExecutionContext = system.dispatcher

--- a/tests/src/test/scala/org/apache/openwhisk/core/limits/ConcurrencyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/limits/ConcurrencyTests.scala
@@ -137,7 +137,7 @@ class ConcurrencyTests extends TestHelpers with WskTestHelpers with WskActorSyst
       }
 
       //none of the actions will complete till the requestCount is reached
-      Await.result(Future.sequence(runs), 30.seconds).foreach { run =>
+      Await.result(Future.sequence(runs), 50.seconds).foreach { run =>
         withActivation(wsk.activation, run) { response =>
           val logs = response.logs.get
           withClue(logs) { logs.size shouldBe 0 }


### PR DESCRIPTION
Move concurrent activation count tracking from ContainerProxy -> ContainerPool, so that prewam/cold -> warm can be tracked as `WarmingData` and receive activations to avoid spawning extra containers.

This adds a new ContainerData `WarmingData`, used for routing concurrent incoming activations to a ContainerProxy that is initing (from prewarm or cold), up to max concurrency.

<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

