### PR TITLE
Handle kafka exception thrown when creating the admin client

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaMessagingProvider.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaMessagingProvider.scala
@@ -60,30 +60,35 @@ object KafkaMessagingProvider extends MessagingProvider {
       } getOrElse Map.empty)
 
     val commonConfig = configMapToKafkaConfig(loadConfigOrThrow[Map[String, String]](ConfigKeys.kafkaCommon))
-    val client = AdminClient.create(commonConfig + (AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> config.kafkaHosts))
-    val partitions = 1
-    val nt = new NewTopic(topic, partitions, kafkaConfig.replicationFactor).configs(topicConfig.asJava)
+    Try(AdminClient.create(commonConfig + (AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> config.kafkaHosts)))
+      .map(client => {
+        val partitions = 1
+        val nt = new NewTopic(topic, partitions, kafkaConfig.replicationFactor).configs(topicConfig.asJava)
 
-    def createTopic(retries: Int = 5): Try[Unit] = {
-      Try(client.createTopics(List(nt).asJava).values().get(topic).get())
-        .map(_ => logging.info(this, s"created topic $topic"))
-        .recoverWith {
-          case CausedBy(_: TopicExistsException) =>
-            Success(logging.info(this, s"topic $topic already existed"))
-          case CausedBy(t: RetriableException) if retries > 0 =>
-            logging.warn(this, s"topic $topic could not be created because of $t, retries left: $retries")
-            Thread.sleep(1.second.toMillis)
-            createTopic(retries - 1)
-          case t =>
-            logging.error(this, s"ensureTopic for $topic failed due to $t")
-            Failure(t)
+        def createTopic(retries: Int = 5): Try[Unit] = {
+          Try(client.createTopics(List(nt).asJava).values().get(topic).get())
+            .map(_ => logging.info(this, s"created topic $topic"))
+            .recoverWith {
+              case CausedBy(_: TopicExistsException) =>
+                Success(logging.info(this, s"topic $topic already existed"))
+              case CausedBy(t: RetriableException) if retries > 0 =>
+                logging.warn(this, s"topic $topic could not be created because of $t, retries left: $retries")
+                Thread.sleep(1.second.toMillis)
+                createTopic(retries - 1)
+              case t =>
+                logging.error(this, s"ensureTopic for $topic failed due to $t")
+                Failure(t)
+            }
         }
-    }
 
-    val result = createTopic()
-
-    client.close()
-    result
+        val result = createTopic()
+        client.close()
+      })
+      .recoverWith {
+        case e =>
+          logging.error(this, s"ensureTopic for $topic failed due to $e")
+          Failure(e)
+      }
   }
 }
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaMessagingProvider.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaMessagingProvider.scala
@@ -60,8 +60,9 @@ object KafkaMessagingProvider extends MessagingProvider {
       } getOrElse Map.empty)
 
     val commonConfig = configMapToKafkaConfig(loadConfigOrThrow[Map[String, String]](ConfigKeys.kafkaCommon))
+
     Try(AdminClient.create(commonConfig + (AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> config.kafkaHosts)))
-      .map(client => {
+      .flatMap(client => {
         val partitions = 1
         val nt = new NewTopic(topic, partitions, kafkaConfig.replicationFactor).configs(topicConfig.asJava)
 
@@ -83,6 +84,7 @@ object KafkaMessagingProvider extends MessagingProvider {
 
         val result = createTopic()
         client.close()
+        result
       })
       .recoverWith {
         case e =>


### PR DESCRIPTION
## Description
The KafkaMessagingProvider does not handle KafkaExceptions that are thrown when creating the admin client. Not handling these exceptions kills the invokers main thread (see stack trace below).

```
Exception in thread "main" org.apache.kafka.common.KafkaException: Failed create new KafkaAdminClient
        at org.apache.kafka.clients.admin.KafkaAdminClient.createInternal(KafkaAdminClient.java:370)
        at org.apache.kafka.clients.admin.AdminClient.create(AdminClient.java:52)
        at org.apache.openwhisk.connector.kafka.KafkaMessagingProvider$.ensureTopic(KafkaMessagingProvider.scala:63)
        at org.apache.openwhisk.core.invoker.Invoker$.main(Invoker.scala:156)
        at org.apache.openwhisk.core.invoker.Invoker.main(Invoker.scala)
```

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

