### PR TITLE
Enable configuring CosmosDB client per collection

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -186,7 +186,9 @@ whisk {
         # for activations then
     #   collections {
     #       WhiskActivation {            # Add entity specific overrides here
-    #           using-multiple-write-locations = true
+    #           connection-policy {
+    #              using-multiple-write-locations = true
+    #            }
     #       }
     #   }
     }

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -159,6 +159,8 @@ whisk {
     #   key               =               # Access key
     #   db                =               # Database name
         throughput        = 1000          # Throughput configured for each collection within this db
+        # Select from one of the supported
+        # https://azure.github.io/azure-cosmosdb-java/1.0.0/com/microsoft/azure/cosmosdb/ConsistencyLevel.html
         consistency-level = "Session"
         connection-policy {
             max-pool-size = 1000

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -154,12 +154,42 @@ whisk {
 
     # CosmosDB related configuration
     # For example:
-    # cosmosdb {
-    #     endpoint   =               # Endpoint URL like https://<account>.documents.azure.com:443/
-    #     key        =               # Access key
-    #     db         =               # Database name
-    #     throughput = 1000          # Throughput configure for each collection within this db
-    #}
+    cosmosdb {
+    #   endpoint          =               # Endpoint URL like https://<account>.documents.azure.com:443/
+    #   key               =               # Access key
+    #   db                =               # Database name
+        throughput        = 1000          # Throughput configured for each collection within this db
+        consistency-level = "Session"
+        connection-policy {
+            max-pool-size = 1000
+            # When the value of this property is true, the SDK will direct write operations to
+            # available writable locations of geo-replicated database account
+            using-multiple-write-locations = false
+
+            # Sets the preferred locations for geo-replicated database accounts e.g. "East US"
+            # See names at https://azure.microsoft.com/en-in/global-infrastructure/locations/
+            preferred-locations = []
+            retry-options {
+                # Sets the maximum number of retries in the case where the request fails
+                # because the service has applied rate limiting on the client.
+                max-retry-attempts-on-throttled-requests = 9
+
+                # Sets the maximum retry time
+                # If the cumulative wait time exceeds this SDK will stop retrying and return the
+                # error to the application.
+                max-retry-wait-time                      = 30 s
+            }
+        }
+
+        # Specify entity specific overrides below. By default all config values would be picked from top level. To override
+        # any config option for specific entity specify them below. For example if multiple writes need to be enabled
+        # for activations then
+    #   collections {
+    #       WhiskActivation {            # Add entity specific overrides here
+    #           using-multiple-write-locations = true
+    #       }
+    #   }
+    }
 
     # transaction ID related configuration
     transactions {

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -158,7 +158,10 @@ whisk {
     #   endpoint          =               # Endpoint URL like https://<account>.documents.azure.com:443/
     #   key               =               # Access key
     #   db                =               # Database name
-        throughput        = 1000          # Throughput configured for each collection within this db
+        # Throughput configured for each collection within this db
+        # This is configured only if collection is created fresh. If collection
+        # already exists then existing throughput would be used
+        throughput        = 1000
         # Select from one of the supported
         # https://azure.github.io/azure-cosmosdb-java/1.0.0/com/microsoft/azure/cosmosdb/ConsistencyLevel.html
         consistency-level = "Session"

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
@@ -21,7 +21,6 @@ import java.io.ByteArrayInputStream
 
 import _root_.rx.RxReactiveStreams
 import akka.actor.ActorSystem
-import akka.event.slf4j.SLF4JLogging
 import akka.http.scaladsl.model.{ContentType, StatusCodes, Uri}
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Sink, Source, StreamConverters}
@@ -57,8 +56,7 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
     with DefaultJsonProtocol
     with DocumentProvider
     with CosmosDBSupport
-    with AttachmentSupport[DocumentAbstraction]
-    with SLF4JLogging {
+    with AttachmentSupport[DocumentAbstraction] {
 
   private val cosmosScheme = "cosmos"
   val attachmentScheme: String = attachmentStore.map(_.scheme).getOrElse(cosmosScheme)
@@ -76,7 +74,8 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
   private val countToken = createToken("count")
   private val putAttachmentToken = createToken("putAttachment", read = false)
 
-  log.info(
+  logging.info(
+    this,
     s"Initializing CosmosDBArtifactStore for collection [$collName]. Service endpoint [${client.getServiceEndpoint}], " +
       s"Read endpoint [${client.getReadEndpoint}], Write endpoint [${client.getWriteEndpoint}], Connection Policy [${client.getConnectionPolicy}]")
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
@@ -21,6 +21,7 @@ import java.io.ByteArrayInputStream
 
 import _root_.rx.RxReactiveStreams
 import akka.actor.ActorSystem
+import akka.event.slf4j.SLF4JLogging
 import akka.http.scaladsl.model.{ContentType, StatusCodes, Uri}
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Sink, Source, StreamConverters}
@@ -56,7 +57,8 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
     with DefaultJsonProtocol
     with DocumentProvider
     with CosmosDBSupport
-    with AttachmentSupport[DocumentAbstraction] {
+    with AttachmentSupport[DocumentAbstraction]
+    with SLF4JLogging {
 
   private val cosmosScheme = "cosmos"
   val attachmentScheme: String = attachmentStore.map(_.scheme).getOrElse(cosmosScheme)
@@ -73,6 +75,10 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
   private val queryToken = createToken("query")
   private val countToken = createToken("count")
   private val putAttachmentToken = createToken("putAttachment", read = false)
+
+  log.info(
+    s"Initializing CosmosDBArtifactStore for collection [$collName]. Service endpoint [${client.getServiceEndpoint}], " +
+      s"Read endpoint [${client.getReadEndpoint}], Write endpoint [${client.getWriteEndpoint}], Connection Policy [${client.getConnectionPolicy}]")
 
   //Clone the returned instance as these are mutable
   def documentCollection(): DocumentCollection = new DocumentCollection(collection.toJson)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStoreProvider.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStoreProvider.scala
@@ -33,8 +33,6 @@ import org.apache.openwhisk.core.entity.{DocumentReader, WhiskActivation, WhiskA
 
 import scala.reflect.ClassTag
 
-case class CosmosDBConfig(endpoint: String, key: String, db: String, throughput: Int = 1000)
-
 case class ClientHolder(client: AsyncDocumentClient) extends Closeable {
   override def close(): Unit = client.close()
 }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStoreProvider.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStoreProvider.scala
@@ -22,14 +22,12 @@ import java.io.Closeable
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient
-import spray.json.RootJsonFormat
 import org.apache.openwhisk.common.Logging
-import org.apache.openwhisk.core.database._
-import pureconfig._
-import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.core.ConfigKeys
-import org.apache.openwhisk.core.database.cosmosdb.CosmosDBUtil.createClient
+import org.apache.openwhisk.core.database._
 import org.apache.openwhisk.core.entity.{DocumentReader, WhiskActivation, WhiskAuth, WhiskEntity}
+import pureconfig._
+import spray.json.RootJsonFormat
 
 import scala.reflect.ClassTag
 
@@ -107,6 +105,6 @@ object CosmosDBArtifactStoreProvider extends ArtifactStoreProvider {
   }
 
   private def createReference(config: CosmosDBConfig) =
-    new ReferenceCounted[ClientHolder](ClientHolder(createClient(config)))
+    new ReferenceCounted[ClientHolder](ClientHolder(config.createClient()))
 
 }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfig.scala
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.database.cosmosdb
+import java.util.concurrent.TimeUnit
+
+import com.microsoft.azure.cosmosdb.ConnectionPolicy.GetDefault
+import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient
+import com.microsoft.azure.cosmosdb.{
+  ConsistencyLevel,
+  ConnectionPolicy => JConnectionPolicy,
+  RetryOptions => JRetryOptions
+}
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigUtil.joinPath
+import org.apache.openwhisk.core.ConfigKeys
+import pureconfig._
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+
+case class CosmosDBConfig(endpoint: String,
+                          key: String,
+                          db: String,
+                          throughput: Int = 1000,
+                          consistencyLevel: ConsistencyLevel = ConsistencyLevel.Session,
+                          connectionPolicy: ConnectionPolicy = ConnectionPolicy()) {
+
+  def createClient(): AsyncDocumentClient = {
+    new AsyncDocumentClient.Builder()
+      .withServiceEndpoint(endpoint)
+      .withMasterKeyOrResourceToken(key)
+      .withConsistencyLevel(consistencyLevel)
+      .withConnectionPolicy(connectionPolicy.asJava)
+      .build()
+  }
+}
+
+case class ConnectionPolicy(maxPoolSize: Int = GetDefault().getMaxPoolSize,
+                            preferredLocations: Seq[String] = Seq.empty,
+                            usingMultipleWriteLocations: Boolean = GetDefault().isUsingMultipleWriteLocations,
+                            retryOptions: Option[RetryOptions] = None) {
+  def asJava: JConnectionPolicy = {
+    val p = new JConnectionPolicy
+    p.setMaxPoolSize(maxPoolSize)
+    p.setUsingMultipleWriteLocations(usingMultipleWriteLocations)
+    p.setPreferredLocations(preferredLocations.asJava)
+    retryOptions.foreach(r => p.setRetryOptions(r.asJava))
+    p
+  }
+}
+
+case class RetryOptions(
+  maxRetryAttemptsOnThrottledRequests: Int = GetDefault().getRetryOptions.getMaxRetryAttemptsOnThrottledRequests,
+  maxRetryWaitTime: Duration = Duration(GetDefault().getRetryOptions.getMaxRetryWaitTimeInSeconds, TimeUnit.SECONDS)) {
+  def asJava: JRetryOptions = {
+    val o = new JRetryOptions
+    o.setMaxRetryAttemptsOnThrottledRequests(maxRetryAttemptsOnThrottledRequests)
+    o.setMaxRetryWaitTimeInSeconds(maxRetryWaitTime.toSeconds.toInt)
+    o
+  }
+}
+
+object CosmosDBConfig {
+  val collections = "collections"
+
+  def apply(globalConfig: Config, entityTypeName: String): CosmosDBConfig = {
+    val config = globalConfig.getConfig(ConfigKeys.cosmosdb)
+    val specificConfigPath = joinPath(collections, entityTypeName)
+
+    //Merge config specific to entity with common config
+    val entityConfig = if (config.hasPath(specificConfigPath)) {
+      config.getConfig(specificConfigPath).withFallback(config)
+    } else {
+      config
+    }
+    loadConfigOrThrow[CosmosDBConfig](entityConfig)
+  }
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfig.scala
@@ -16,9 +16,6 @@
  */
 
 package org.apache.openwhisk.core.database.cosmosdb
-import java.util.concurrent.TimeUnit
-
-import com.microsoft.azure.cosmosdb.ConnectionPolicy.GetDefault
 import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient
 import com.microsoft.azure.cosmosdb.{
   ConsistencyLevel,
@@ -36,9 +33,9 @@ import scala.concurrent.duration._
 case class CosmosDBConfig(endpoint: String,
                           key: String,
                           db: String,
-                          throughput: Int = 1000,
-                          consistencyLevel: ConsistencyLevel = ConsistencyLevel.Session,
-                          connectionPolicy: ConnectionPolicy = ConnectionPolicy()) {
+                          throughput: Int,
+                          consistencyLevel: ConsistencyLevel,
+                          connectionPolicy: ConnectionPolicy) {
 
   def createClient(): AsyncDocumentClient = {
     new AsyncDocumentClient.Builder()
@@ -50,23 +47,21 @@ case class CosmosDBConfig(endpoint: String,
   }
 }
 
-case class ConnectionPolicy(maxPoolSize: Int = GetDefault().getMaxPoolSize,
-                            preferredLocations: Seq[String] = Seq.empty,
-                            usingMultipleWriteLocations: Boolean = GetDefault().isUsingMultipleWriteLocations,
-                            retryOptions: Option[RetryOptions] = None) {
+case class ConnectionPolicy(maxPoolSize: Int,
+                            preferredLocations: Seq[String],
+                            usingMultipleWriteLocations: Boolean,
+                            retryOptions: RetryOptions) {
   def asJava: JConnectionPolicy = {
     val p = new JConnectionPolicy
     p.setMaxPoolSize(maxPoolSize)
     p.setUsingMultipleWriteLocations(usingMultipleWriteLocations)
     p.setPreferredLocations(preferredLocations.asJava)
-    retryOptions.foreach(r => p.setRetryOptions(r.asJava))
+    p.setRetryOptions(retryOptions.asJava)
     p
   }
 }
 
-case class RetryOptions(
-  maxRetryAttemptsOnThrottledRequests: Int = GetDefault().getRetryOptions.getMaxRetryAttemptsOnThrottledRequests,
-  maxRetryWaitTime: Duration = Duration(GetDefault().getRetryOptions.getMaxRetryWaitTimeInSeconds, TimeUnit.SECONDS)) {
+case class RetryOptions(maxRetryAttemptsOnThrottledRequests: Int, maxRetryWaitTime: Duration) {
   def asJava: JRetryOptions = {
     val o = new JRetryOptions
     o.setMaxRetryAttemptsOnThrottledRequests(maxRetryAttemptsOnThrottledRequests)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBUtil.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBUtil.scala
@@ -17,7 +17,6 @@
 
 package org.apache.openwhisk.core.database.cosmosdb
 
-import com.microsoft.azure.cosmosdb._
 import com.microsoft.azure.cosmosdb.internal.Constants.Properties.{AGGREGATE, E_TAG, ID, SELF_LINK}
 import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient
 import org.apache.openwhisk.core.database.cosmosdb.CosmosDBConstants._
@@ -81,13 +80,7 @@ private[cosmosdb] trait CosmosDBUtil {
     case x            => x.toString
   }
 
-  def createClient(config: CosmosDBConfig): AsyncDocumentClient =
-    new AsyncDocumentClient.Builder()
-      .withServiceEndpoint(config.endpoint)
-      .withMasterKeyOrResourceToken(config.key)
-      .withConnectionPolicy(ConnectionPolicy.GetDefault)
-      .withConsistencyLevel(ConsistencyLevel.Session)
-      .build
+  def createClient(config: CosmosDBConfig): AsyncDocumentClient = config.createClient()
 
   /**
    * CosmosDB id considers '/', '\' , '?' and '#' as invalid. EntityNames can include '/' so

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBUtil.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBUtil.scala
@@ -18,7 +18,6 @@
 package org.apache.openwhisk.core.database.cosmosdb
 
 import com.microsoft.azure.cosmosdb.internal.Constants.Properties.{AGGREGATE, E_TAG, ID, SELF_LINK}
-import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient
 import org.apache.openwhisk.core.database.cosmosdb.CosmosDBConstants._
 
 import scala.collection.immutable.Iterable
@@ -79,8 +78,6 @@ private[cosmosdb] trait CosmosDBUtil {
     case m: Map[_, _] => asJsonLikeString(m)
     case x            => x.toString
   }
-
-  def createClient(config: CosmosDBConfig): AsyncDocumentClient = config.createClient()
 
   /**
    * CosmosDB id considers '/', '\' , '?' and '#' as invalid. EntityNames can include '/' so

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfigTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfigTests.scala
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.database.cosmosdb
+import com.typesafe.config.ConfigFactory
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{FlatSpec, Matchers}
+import com.microsoft.azure.cosmosdb.{ConnectionPolicy => JConnectionPolicy}
+
+import scala.collection.JavaConverters._
+
+@RunWith(classOf[JUnitRunner])
+class CosmosDBConfigTests extends FlatSpec with Matchers {
+  behavior of "CosmosDB Config"
+
+  it should "work with generic config" in {
+    val config = ConfigFactory.parseString(s"""
+      | whisk.cosmosdb {
+      |  endpoint = "http://localhost"
+      |  key = foo
+      |  db  = openwhisk
+      | }
+         """.stripMargin)
+    val cosmos = CosmosDBConfig(config, "WhiskAuth")
+    cosmos shouldBe CosmosDBConfig("http://localhost", "foo", "openwhisk")
+  }
+
+  it should "work with extended config" in {
+    val config = ConfigFactory.parseString(s"""
+      | whisk.cosmosdb {
+      |  endpoint = "http://localhost"
+      |  key = foo
+      |  db  = openwhisk
+      |  connection-policy {
+      |     max-pool-size = 42
+      |  }
+      | }
+         """.stripMargin)
+    val cosmos = CosmosDBConfig(config, "WhiskAuth")
+    cosmos should matchPattern { case CosmosDBConfig("http://localhost", "foo", "openwhisk", _, _, _) => }
+
+    cosmos.connectionPolicy.maxPoolSize shouldBe 42
+    val policy = cosmos.connectionPolicy.asJava
+    val defaultPolicy = JConnectionPolicy.GetDefault()
+    policy.getConnectionMode shouldBe defaultPolicy.getConnectionMode
+    policy.getRetryOptions.getMaxRetryAttemptsOnThrottledRequests shouldBe defaultPolicy.getRetryOptions.getMaxRetryAttemptsOnThrottledRequests
+    policy.getRetryOptions.getMaxRetryWaitTimeInSeconds shouldBe defaultPolicy.getRetryOptions.getMaxRetryWaitTimeInSeconds
+  }
+
+  it should "work with specific extended config" in {
+    val config = ConfigFactory.parseString(s"""
+      | whisk.cosmosdb {
+      |  endpoint = "http://localhost"
+      |  key = foo
+      |  db  = openwhisk
+      |  connection-policy {
+      |     max-pool-size = 42
+      |     retry-options {
+      |        max-retry-wait-time = 2 m
+      |     }
+      |  }
+      |  collections {
+      |     WhiskAuth = {
+      |        connection-policy {
+      |           using-multiple-write-locations = true
+      |           preferred-locations = [a, b]
+      |        }
+      |     }
+      |  }
+      | }
+         """.stripMargin)
+    val cosmos = CosmosDBConfig(config, "WhiskAuth")
+    cosmos should matchPattern { case CosmosDBConfig("http://localhost", "foo", "openwhisk", _, _, _) => }
+
+    val policy = cosmos.connectionPolicy.asJava
+    policy.isUsingMultipleWriteLocations shouldBe true
+    policy.getMaxPoolSize shouldBe 42
+    policy.getPreferredLocations.asScala.toSeq should contain only ("a", "b")
+    policy.getRetryOptions.getMaxRetryWaitTimeInSeconds shouldBe 120
+  }
+}

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBTestSupport.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBTestSupport.scala
@@ -30,7 +30,7 @@ trait CosmosDBTestSupport extends FlatSpec with BeforeAndAfterAll with RxObserva
   private val dbsToDelete = ListBuffer[Database]()
 
   lazy val storeConfigTry = Try { loadConfigOrThrow[CosmosDBConfig](ConfigKeys.cosmosdb) }
-  lazy val client = CosmosDBUtil.createClient(storeConfig)
+  lazy val client = storeConfig.createClient()
   val useExistingDB = java.lang.Boolean.getBoolean("whisk.cosmosdb.useExistingDB")
 
   def storeConfig = storeConfigTry.get


### PR DESCRIPTION
Currently same CosmosDB client is used for all collections. This PR enables configuring separate client having different config on per collection basis.

## Description

Depending on requirements it may be required to configure `AsyncDocumentClient` on per collection basis. For e.g. to use different config for each collection use following config

```
cosmosdb {
  endpoint          =  "https://<account>.documents.azure.com:443/"
  key               =  "secret"             # Access key
  db                =  "openwhisk"            # Database name
  throughput        = 1000          # Throughput configured for each collection within this db
  consistency-level = "Session"
  connection-policy {
    max-pool-size = 1000
    # When the value of this property is true, the SDK will direct write operations to
    # available writable locations of geo-replicated database account
    using-multiple-write-locations = false

    # Sets the preferred locations for geo-replicated database accounts e.g. "East US"
    # See names at https://azure.microsoft.com/en-in/global-infrastructure/locations/
    preferred-locations = []
    retry-options {
      # Sets the maximum number of retries in the case where the request fails
      # because the service has applied rate limiting on the client.
      max-retry-attempts-on-throttled-requests = 9

      # Sets the maximum retry time
      # If the cumulative wait time exceeds this SDK will stop retrying and return the
      # error to the application.
      max-retry-wait-time                      = 30 s
    }
  }

  # Specify entity specific overrides below. By default all config values would be picked from top level. To override
  # any config option for specific entity specify them below. For example if multiple region writes need to be enabled
  # for activations then
   collections {
        WhiskActivation {            # Add entity specific overrides here
            connection-policy {
                   using-multiple-write-locations = true
            }
        }
    }
}
```

Above example configures all supported properties. OpenWHisk configures the same defaults so if you need to only change some of the config then you can do it like below

```
cosmosdb {
  endpoint          =  "https://<account>.documents.azure.com:443/"
  key               =  "secret"             # Access key
  db                =  "openwhisk"            # Database name
  # Specify entity specific overrides below. By default all config values would be picked from top level. To override
  # any config option for specific entity specify them below. For example if multiple writes need to be enabled
  # for activations then
   collections {
        WhiskActivation {            # Add entity specific overrides here
            connection-policy {
              using-multiple-write-locations = true
            }
        }
    }
}
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

