### PR TITLE
Use redis-cli (via docker) to test status of Redis in ansible PING-PONG

### DIFF
--- a/ansible/roles/redis/tasks/deploy.yml
+++ b/ansible/roles/redis/tasks/deploy.yml
@@ -26,10 +26,8 @@
       "docker-entrypoint.sh --requirepass {{ redis.password }}"
 
 - name: wait until redis is up and running
-# using RESP protocol to set redis password and validate it's up
-# inspired by: https://www.compose.com/articles/how-to-talk-raw-redis/
-  action: shell (printf "*2\r\n\$4\r\nAUTH\r\n\${{redis.password|length}}\r\n{{ redis.password }}\r\n*1\r\n\$4\r\nPING\r\n"; sleep 1) | nc {{ ansible_host }} {{ redis.port }}
+  shell: "docker run --link redis:redis --rm redis:{{ redis.version }} redis-cli -h redis -p 6379 -a {{ redis.password }} ping"
   register: result
-  until: (result.rc == 0) and (result.stdout == '+OK\r\n+PONG')
+  until: (result.rc == 0) and (result.stdout == 'PONG')
   retries: 12
   delay: 5


### PR DESCRIPTION
Rather than `echo`ing to `nc`, take advantage of `docker run` to use `redis-cli` to test that redis is running during the ansible deployment.

<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [X] Controller
- [X] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [X] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

