### PR TITLE
Optimize Kamon metric update flow

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
@@ -187,6 +187,9 @@ case class LogMarkerToken(component: String,
                           tags: Map[String, String] = Map.empty) {
   private var finishToken: LogMarkerToken = _
   private var errorToken: LogMarkerToken = _
+
+  // Using var is safe wrt thread-safety because Kamon makes sure the instances
+  // (given the same key) are always the same, so a missed update is not harmful
   private var _counter: KCounter = _
   private var _histogram: KHistogram = _
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
@@ -24,6 +24,7 @@ import java.time.format.DateTimeFormatter
 import akka.event.Logging._
 import akka.event.LoggingAdapter
 import kamon.Kamon
+import kamon.metric.{Counter => KCounter, Histogram => KHistogram}
 import kamon.statsd.{MetricKeyGenerator, SimpleMetricKeyGenerator}
 import org.apache.openwhisk.core.entity.ControllerInstanceId
 
@@ -184,13 +185,71 @@ case class LogMarkerToken(component: String,
                           state: String,
                           subAction: Option[String] = None,
                           tags: Map[String, String] = Map.empty) {
+  private var finishToken: LogMarkerToken = _
+  private var errorToken: LogMarkerToken = _
+  private var _counter: KCounter = _
+  private var _histogram: KHistogram = _
 
   override val toString = component + "_" + action + "_" + state
-  val toStringWithSubAction =
+  val toStringWithSubAction: String =
     subAction.map(sa => component + "_" + action + "." + sa + "_" + state).getOrElse(toString)
 
-  def asFinish = copy(state = LoggingMarkers.finish)
-  def asError = copy(state = LoggingMarkers.error)
+  def asFinish: LogMarkerToken = {
+    if (finishToken == null) {
+      finishToken = copy(state = LoggingMarkers.finish)
+    }
+    finishToken
+  }
+
+  def asError: LogMarkerToken = {
+    if (errorToken == null) {
+      errorToken = copy(state = LoggingMarkers.error)
+    }
+    errorToken
+  }
+
+  def counter: KCounter = {
+    if (_counter == null) {
+      _counter = createCounter()
+    }
+    _counter
+  }
+
+  def histogram: KHistogram = {
+    if (_histogram == null) {
+      _histogram = createHistogram()
+    }
+    _histogram
+  }
+
+  private def createCounter() = {
+    if (TransactionId.metricsKamonTags) {
+      Kamon
+        .counter(createName(toString, "counter"))
+        .refine(tags)
+    } else {
+      Kamon.counter(createName(toStringWithSubAction, "counter"))
+    }
+  }
+
+  private def createHistogram() = {
+    if (TransactionId.metricsKamonTags) {
+      Kamon
+        .histogram(createName(toString, "histogram"))
+        .refine(tags)
+    } else {
+      Kamon.histogram(createName(toStringWithSubAction, "histogram"))
+    }
+  }
+
+  /**
+   * Kamon 1.0 onwards does not include the metric type in the metric name which cause issue
+   * for us as we use same metric name for counter and histogram. So to be backward compatible we
+   * need to prefix the name with type
+   */
+  private def createName(name: String, metricType: String) = {
+    s"$metricType.$name"
+  }
 }
 
 object LogMarkerToken {
@@ -214,37 +273,14 @@ object LogMarkerToken {
 object MetricEmitter {
   def emitCounterMetric(token: LogMarkerToken, times: Long = 1): Unit = {
     if (TransactionId.metricsKamon) {
-      if (TransactionId.metricsKamonTags) {
-        Kamon
-          .counter(createName(token.toString, "counter"))
-          .refine(token.tags)
-          .increment(times)
-      } else {
-        Kamon.counter(createName(token.toStringWithSubAction, "counter")).increment(times)
-      }
+      token.counter.increment(times)
     }
   }
 
   def emitHistogramMetric(token: LogMarkerToken, value: Long): Unit = {
     if (TransactionId.metricsKamon) {
-      if (TransactionId.metricsKamonTags) {
-        Kamon
-          .histogram(createName(token.toString, "histogram"))
-          .refine(token.tags)
-          .record(value)
-      } else {
-        Kamon.histogram(createName(token.toStringWithSubAction, "histogram")).record(value)
-      }
+      token.histogram.record(value)
     }
-  }
-
-  /**
-   * Kamon 1.0 onwards does not include the metric type in the metric name which cause issue
-   * for us as we use same metric name for counter and histogram. So to be backward compatible we
-   * need to prefix the name with type
-   */
-  private def createName(name: String, metricType: String) = {
-    s"$metricType.$name"
   }
 }
 


### PR DESCRIPTION
Fixes #4203. 

## Description
This PR implements the following recommendation for Kamon usage

> When possible, define and refine your metrics up front, as a static member or instance members on the instrumented components of your services. This saves a bit of time in looking up instruments.

Now the Metric instances are stored as part of `LogMarkerToken` and reused for later updates

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

