### PR TITLE
Enable Kamon System Metrics module

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -64,8 +64,13 @@ dependencies {
     compile 'com.github.ben-manes.caffeine:caffeine:2.6.2'
     compile 'com.google.code.findbugs:jsr305:3.0.2'
     compile 'io.fabric8:kubernetes-client:4.0.3'
-    compile 'io.kamon:kamon-core_2.12:1.1.3'
+    compile ('io.kamon:kamon-core_2.12:1.1.3') {
+        exclude group: 'com.lihaoyi'
+    }
     compile 'io.kamon:kamon-statsd_2.12:1.0.0'
+    compile ('io.kamon:kamon-system-metrics_2.12:1.0.0') {
+        exclude group: 'io.kamon', module: 'sigar-loader'
+    }
     //for mesos
     compile 'com.adobe.api.platform.runtime:mesos-actor:0.0.17'
 

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -46,6 +46,10 @@ kamon {
 
         metric-key-generator = org.apache.openwhisk.common.WhiskStatsDMetricKeyGenerator
     }
+    system-metrics {
+        # disable the host metrics as we are only interested in JVM metrics
+        host.enabled = false
+    }
 
     reporters = [
         "kamon.statsd.StatsDReporter"

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
@@ -25,6 +25,7 @@ import akka.event.Logging._
 import akka.event.LoggingAdapter
 import kamon.Kamon
 import kamon.statsd.{MetricKeyGenerator, SimpleMetricKeyGenerator}
+import kamon.system.SystemMetrics
 import org.apache.openwhisk.core.entity.ControllerInstanceId
 
 trait Logging {
@@ -212,6 +213,10 @@ object LogMarkerToken {
 }
 
 object MetricEmitter {
+  if (TransactionId.metricsKamon) {
+    SystemMetrics.startCollecting()
+  }
+
   def emitCounterMetric(token: LogMarkerToken, times: Long = 1): Unit = {
     if (TransactionId.metricsKamon) {
       if (TransactionId.metricsKamonTags) {


### PR DESCRIPTION
Enables capturing jvm metrics and exposing them via [Kamon System Metrics][1] module. This would help to understand the GC usage

## Description

This PR only enables the JVM level metrics and not the host level metrics. Such metrics would help to understand the GC nature of Controller and Invoker processes

```
gauges:
   { 'statsd.timestamp_lag': 0,
     'openwhisk-statsd.controller0.jvm_memory_buffer-pool_usage.component.system-metrics.measure.capacity.pool.mapped': 0,
     'openwhisk-statsd.controller0.jvm_memory_buffer-pool_usage.component.system-metrics.measure.used.pool.mapped': 0,
     'openwhisk-statsd.controller0.jvm_memory_buffer-pool_usage.component.system-metrics.measure.capacity.pool.direct': 472638,
     'openwhisk-statsd.controller0.jvm_memory_buffer-pool_usage.component.system-metrics.measure.used.pool.direct': 472638,
     'openwhisk-statsd.controller0.jvm_class-loading.component.system-metrics.mode.currently-loaded': 10317,
     'openwhisk-statsd.controller0.jvm_class-loading.component.system-metrics.mode.unloaded': 5,
     'openwhisk-statsd.controller0.jvm_class-loading.component.system-metrics.mode.loaded': 10322,
     'openwhisk-statsd.controller0.jvm_memory_buffer-pool_count.component.system-metrics.pool.direct': 46,
     'openwhisk-statsd.controller0.jvm_memory_buffer-pool_count.component.system-metrics.pool.mapped': 0,
     'openwhisk-statsd.controller0.jvm_threads.component.system-metrics.measure.peak': 61,
     'openwhisk-statsd.controller0.jvm_threads.component.system-metrics.measure.daemon': 20,
     'openwhisk-statsd.controller0.jvm_threads.component.system-metrics.measure.total': 59 }
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

[1]: https://github.com/kamon-io/kamon-system-metrics/