### PR TITLE
Avoid Database Replicator Failures

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/ReplicatorTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/ReplicatorTests.scala
@@ -350,13 +350,18 @@ class ReplicatorTests
   it should "continuously update a database" in {
     // Create a database to backup
     val dbName = testDbPrefix + "database_for_continous_replication"
+    val backupDbName = s"continuous_$dbName"
+
+    // Pre-test cleanup of previously created entities
+    removeDatabase(backupDbName, true)
+    removeReplicationDoc(backupDbName)
+
     val client = createDatabase(dbName, Some(designDocPath))
 
     // Trigger replication and verify the created databases have the correct format
     val (createdBackupDbs, _, _) = runReplicator(dbUrl, dbUrl, testDbPrefix, 10.minutes, continuous = true)
     createdBackupDbs should have size 1
-    val backupDbName = createdBackupDbs.head
-    backupDbName shouldBe s"continuous_$dbName"
+    createdBackupDbs.head shouldBe backupDbName
 
     // Wait for the replicated database to appear
     val backupClient = waitForDatabase(backupDbName)

--- a/tools/db/replicateDbs.py
+++ b/tools/db/replicateDbs.py
@@ -79,11 +79,6 @@ def replicateDatabases(args):
         filterDesignDocument = sourceDb[db].get("_design/%s" % filterName)
         if not args.continuous and filterDesignDocument:
             replicateDesignDocument["filter"] = "%s/withoutDeletedAndDesignDocuments" % filterName
-
-        existingDoc = replicator.get(backupDb)
-        if existingDoc is not None:
-            replicateDesignDocument['_rev'] = existingDoc['_rev']
-
         replicator.save(replicateDesignDocument)
 
     def isBackupDb(dbName):

--- a/tools/db/replicateDbs.py
+++ b/tools/db/replicateDbs.py
@@ -79,6 +79,11 @@ def replicateDatabases(args):
         filterDesignDocument = sourceDb[db].get("_design/%s" % filterName)
         if not args.continuous and filterDesignDocument:
             replicateDesignDocument["filter"] = "%s/withoutDeletedAndDesignDocuments" % filterName
+
+        existingDoc = replicator.get(backupDb)
+        if existingDoc is not None:
+            replicateDesignDocument['_rev'] = existingDoc['_rev']
+
         replicator.save(replicateDesignDocument)
 
     def isBackupDb(dbName):


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
When using `replicateDbs.py`, document update conflict errors may occur when the `_replicator` database already contains a document of the same name that is being replicated. When replicating a document that already exists in `_replicator`, these changes add the `_rev` ID from the existing document to the document being replicated.

Stack trace from test failure:
```
org.apache.openwhisk.core.database.test.ReplicatorTests > Database replication script should continuously update a database STANDARD_OUT
    Removing database: replicatortest_whisk_local_database_for_continous_replication
    Creating database: replicatortest_whisk_local_database_for_continous_replication
    Running replicator: omitted, omitted, replicatortest_whisk_local_, 10 minutes, true, List(), List()
    expected exit code = 0
    exit code = 1
    stdout: ----- Create backups -----
    create backup: continuous_replicatortest_whisk_local_database_for_continous_replication

    stderr: Traceback (most recent call last):
      File "/home/cusina/workspace/mainOpenwhisk/tools/db/replicateDbs.py", line 144, in <module>
        arguments.func(arguments)
      File "/home/cusina/workspace/mainOpenwhisk/tools/db/replicateDbs.py", line 82, in replicateDatabases
        replicator.save(replicateDesignDocument)
      File "/usr/local/lib/python2.7/dist-packages/couchdb/client.py", line 510, in save
        _, _, data = func(body=doc, **options)
      File "/usr/local/lib/python2.7/dist-packages/couchdb/http.py", line 570, in put_json
        **params)
      File "/usr/local/lib/python2.7/dist-packages/couchdb/http.py", line 585, in _request_json
        headers=headers, **params)
      File "/usr/local/lib/python2.7/dist-packages/couchdb/http.py", line 581, in _request
        credentials=self.credentials)
      File "/usr/local/lib/python2.7/dist-packages/couchdb/http.py", line 417, in request
        raise ResourceConflict(error)
    couchdb.http.ResourceConflict: (u'conflict', u'Document update conflict.')


org.apache.openwhisk.core.database.test.ReplicatorTests > Database replication script should continuously update a database FAILED
    java.lang.AssertionError: Exit code:1
        at org.junit.Assert.fail(Assert.java:88)
        at org.junit.Assert.assertTrue(Assert.java:41)
        at common.TestUtils$RunResult.validateExitCode(TestUtils.java:242)
        at common.TestUtils.runCmd(TestUtils.java:332)
        at common.TestUtils.runCmd(TestUtils.java:281)
        at common.TestUtils.runCmd(TestUtils.java:266)
        at org.apache.openwhisk.core.database.test.ReplicatorTests.runReplicator(ReplicatorTests.scala:99)
        at org.apache.openwhisk.core.database.test.ReplicatorTests.$anonfun$new$22(ReplicatorTests.scala:356)
        at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
        at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
        at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
        at org.scalatest.Transformer.apply(Transformer.scala:22)
        at org.scalatest.Transformer.apply(Transformer.scala:20)
        at org.scalatest.FlatSpecLike$$anon$1.apply(FlatSpecLike.scala:1682)
        at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
        at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)
        at org.scalatest.FlatSpec.withFixture(FlatSpec.scala:1685)
        at org.scalatest.FlatSpecLike.invokeWithFixture$1(FlatSpecLike.scala:1680)
        at org.scalatest.FlatSpecLike.$anonfun$runTest$1(FlatSpecLike.scala:1692)
        at org.scalatest.SuperEngine.runTestImpl(Engine.scala:289)
        at org.scalatest.FlatSpecLike.runTest(FlatSpecLike.scala:1692)
        at org.scalatest.FlatSpecLike.runTest$(FlatSpecLike.scala:1674)
        at org.scalatest.FlatSpec.runTest(FlatSpec.scala:1685)
        at org.scalatest.FlatSpecLike.$anonfun$runTests$1(FlatSpecLike.scala:1750)
        at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:396)
        at scala.collection.immutable.List.foreach(List.scala:388)
        at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:384)
        at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:373)
        at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:410)
        at scala.collection.immutable.List.foreach(List.scala:388)
        at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:384)
        at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:379)
        at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:461)
        at org.scalatest.FlatSpecLike.runTests(FlatSpecLike.scala:1750)
        at org.scalatest.FlatSpecLike.runTests$(FlatSpecLike.scala:1749)
        at org.scalatest.FlatSpec.runTests(FlatSpec.scala:1685)
        at org.scalatest.Suite.run(Suite.scala:1147)
        at org.scalatest.Suite.run$(Suite.scala:1129)
        at org.scalatest.FlatSpec.org$scalatest$FlatSpecLike$$super$run(FlatSpec.scala:1685)
        at org.scalatest.FlatSpecLike.$anonfun$run$1(FlatSpecLike.scala:1795)
        at org.scalatest.SuperEngine.runImpl(Engine.scala:521)
        at org.scalatest.FlatSpecLike.run(FlatSpecLike.scala:1795)
        at org.scalatest.FlatSpecLike.run$(FlatSpecLike.scala:1793)
        at org.apache.openwhisk.core.database.test.ReplicatorTests.org$scalatest$BeforeAndAfterAll$$super$run(ReplicatorTests.scala:42)
        at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)
        at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
        at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
        at org.apache.openwhisk.core.database.test.ReplicatorTests.run(ReplicatorTests.scala:42)
```
## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

