### PR TITLE
during api create, correctly handle non-default (i.e. "_") namespaces

### DIFF
--- a/core/routemgmt/common/apigw-utils.js
+++ b/core/routemgmt/common/apigw-utils.js
@@ -853,7 +853,8 @@ function updateNamespace(apidoc, namespace) {
     if (apidoc.action) {
       // The action namespace does not have to match the CLI user's namespace
       // If it is different, leave it alone; otherwise use the replacement namespace
-      if (apidoc.namespace === apidoc.action.namespace) {
+      // And only replace when the namespace is the default '_' which needs replacement
+      if (apidoc.namespace === apidoc.action.namespace && apidoc.namespace === '_') {
         apidoc.action.namespace = namespace;
         apidoc.action.backendUrl = replaceNamespaceInUrl(apidoc.action.backendUrl, namespace);      }
     }

--- a/core/routemgmt/common/apigw-utils.js
+++ b/core/routemgmt/common/apigw-utils.js
@@ -854,7 +854,7 @@ function updateNamespace(apidoc, namespace) {
       // The action namespace does not have to match the CLI user's namespace
       // If it is different, leave it alone; otherwise use the replacement namespace
       // And only replace when the namespace is the default '_' which needs replacement
-      if (apidoc.namespace === apidoc.action.namespace && apidoc.namespace === '_') {
+      if (apidoc.action.namespace === '_') {
         apidoc.action.namespace = namespace;
         apidoc.action.backendUrl = replaceNamespaceInUrl(apidoc.action.backendUrl, namespace);      }
     }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
When creating an API with a specified namespace, the "wsk api create" command will override the namespace with the "__ow_user" value which is not the intended namespace.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [x] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

