### PR TITLE
Added a comment for vagrant image issue on MacOS Mojave with VirtualB…

### DIFF
--- a/tools/vagrant/README.md
+++ b/tools/vagrant/README.md
@@ -22,8 +22,11 @@
 The following instructions were tested on Mac OS X El Capitan, Ubuntu 16.04 LTS.
 
 ## Requirements
--   Install [VirtualBox](https://www.virtualbox.org/wiki/Downloads) (tested with version 5.2.8)
--   Install [Vagrant](https://www.vagrantup.com/downloads.html) (tested with version 2.0.3)
+-   Install [VirtualBox](https://www.virtualbox.org/wiki/Downloads) (tested with version 6.0.2)
+-   Install [Vagrant](https://www.vagrantup.com/downloads.html) (tested with version 2.2.3)
+
+*There is an issue with the `ubuntu/xenial64` image 
+(v20190118.0.0 at the time of writing this) on MacOS Mojave 10.14.2 and VirtualBox 6. This can be fixed by replacing this image with `bento/ubuntu-16.04`. See below the "Override Vagrant Box" section to find out how to use another image.*
 
 ## Setup
 

--- a/tools/vagrant/README.md
+++ b/tools/vagrant/README.md
@@ -25,8 +25,7 @@ The following instructions were tested on Mac OS X El Capitan, Ubuntu 16.04 LTS.
 -   Install [VirtualBox](https://www.virtualbox.org/wiki/Downloads) (tested with version 6.0.2)
 -   Install [Vagrant](https://www.vagrantup.com/downloads.html) (tested with version 2.2.3)
 
-*There is an issue with the `ubuntu/xenial64` image 
-(v20190118.0.0 at the time of writing this) on MacOS Mojave 10.14.2 and VirtualBox 6. This can be fixed by replacing this image with `bento/ubuntu-16.04`. See below the "Override Vagrant Box" section to find out how to use another image.*
+*There is an issue with the `ubuntu/xenial64` image (v20190118.0.0 at the time of writing this) on MacOS Mojave 10.14.2 and VirtualBox 6. This can be fixed by replacing this image with `bento/ubuntu-16.04`. See below the "Override Vagrant Box" section to find out how to use another image.*
 
 ## Setup
 


### PR DESCRIPTION
…ox 6

## Description
This documents an issue with the vagrant image on MacOS Mojave with VirtuaBox 6.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [x] Documentation


