### PR TITLE
Add support for TTL at collection level with CosmosDB

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -171,6 +171,8 @@ whisk {
         consistency-level = "Session"
 
         # TTL duration. By default no TTL is set unless explicitly configured
+        # ENABLING THIS VALUE MEANS YOUR DATA WILL NOT BE PERMANENTLY STORED
+        # Can only be used for `WhiskActivation` for now
     #   time-to-live      = 60 s
         connection-policy {
             max-pool-size = 1000

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -159,9 +159,9 @@ whisk {
     # CosmosDB related configuration
     # For example:
     cosmosdb {
-    #   endpoint          =               # Endpoint URL like https://<account>.documents.azure.com:443/
-    #   key               =               # Access key
-    #   db                =               # Database name
+        # endpoint          =               # Endpoint URL like https://<account>.documents.azure.com:443/
+        # key               =               # Access key
+        # db                =               # Database name
         # Throughput configured for each collection within this db
         # This is configured only if collection is created fresh. If collection
         # already exists then existing throughput would be used
@@ -173,7 +173,7 @@ whisk {
         # TTL duration. By default no TTL is set unless explicitly configured
         # ENABLING THIS VALUE MEANS YOUR DATA WILL NOT BE PERMANENTLY STORED
         # Can only be used for `WhiskActivation` for now
-    #   time-to-live      = 60 s
+        # time-to-live      = 60 s
         connection-policy {
             max-pool-size = 1000
             # When the value of this property is true, the SDK will direct write operations to
@@ -201,13 +201,13 @@ whisk {
         #   - WhiskEntity
         #   - WhiskActivation
         # For example if multiple writes need to be enabled for activations then
-    #   collections {
-    #       WhiskActivation {            # Add entity specific overrides here
-    #           connection-policy {
-    #              using-multiple-write-locations = true
-    #            }
-    #       }
-    #   }
+        # collections {
+        #   WhiskActivation {            # Add entity specific overrides here
+        #     connection-policy {
+        #        using-multiple-write-locations = true
+        #     }
+        #   }
+        # }
     }
 
     # transaction ID related configuration

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -169,6 +169,9 @@ whisk {
         # Select from one of the supported
         # https://azure.github.io/azure-cosmosdb-java/1.0.0/com/microsoft/azure/cosmosdb/ConsistencyLevel.html
         consistency-level = "Session"
+
+        # TTL duration. By default no TTL is set unless explicitly configured
+    #   time-to-live      = 60 s
         connection-policy {
             max-pool-size = 1000
             # When the value of this property is true, the SDK will direct write operations to
@@ -191,8 +194,11 @@ whisk {
         }
 
         # Specify entity specific overrides below. By default all config values would be picked from top level. To override
-        # any config option for specific entity specify them below. For example if multiple writes need to be enabled
-        # for activations then
+        # any config option for specific entity specify them below. Following names can be used
+        #   - WhiskAuth
+        #   - WhiskEntity
+        #   - WhiskActivation
+        # For example if multiple writes need to be enabled for activations then
     #   collections {
     #       WhiskActivation {            # Add entity specific overrides here
     #           connection-policy {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
@@ -62,7 +62,7 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
   val attachmentScheme: String = attachmentStore.map(_.scheme).getOrElse(cosmosScheme)
 
   protected val client: AsyncDocumentClient = clientRef.get.client
-  private val (database, collection) = initialize()
+  private[cosmosdb] val (database, collection) = initialize()
 
   private val _id = "_id"
   private val _rev = "_rev"

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
@@ -77,7 +77,8 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
   logging.info(
     this,
     s"Initializing CosmosDBArtifactStore for collection [$collName]. Service endpoint [${client.getServiceEndpoint}], " +
-      s"Read endpoint [${client.getReadEndpoint}], Write endpoint [${client.getWriteEndpoint}], Connection Policy [${client.getConnectionPolicy}]")
+      s"Read endpoint [${client.getReadEndpoint}], Write endpoint [${client.getWriteEndpoint}], Connection Policy [${client.getConnectionPolicy}], " +
+      s"Time to live [${collection.getDefaultTimeToLive} secs")
 
   //Clone the returned instance as these are mutable
   def documentCollection(): DocumentCollection = new DocumentCollection(collection.toJson)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfig.scala
@@ -36,7 +36,7 @@ case class CosmosDBConfig(endpoint: String,
                           throughput: Int,
                           consistencyLevel: ConsistencyLevel,
                           connectionPolicy: ConnectionPolicy,
-                          timeToLive: Option[Duration] = None) {
+                          timeToLive: Option[Duration]) {
 
   def createClient(): AsyncDocumentClient = {
     new AsyncDocumentClient.Builder()

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfig.scala
@@ -35,7 +35,8 @@ case class CosmosDBConfig(endpoint: String,
                           db: String,
                           throughput: Int,
                           consistencyLevel: ConsistencyLevel,
-                          connectionPolicy: ConnectionPolicy) {
+                          connectionPolicy: ConnectionPolicy,
+                          timeToLive: Option[Duration] = None) {
 
   def createClient(): AsyncDocumentClient = {
     new AsyncDocumentClient.Builder()

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBSupport.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBSupport.scala
@@ -69,6 +69,7 @@ private[cosmosdb] trait CosmosDBSupport extends RxObservableImplicits with Cosmo
     defn.setId(collName)
     defn.setIndexingPolicy(viewMapper.indexingPolicy.asJava())
     defn.setPartitionKey(viewMapper.partitionKeyDefn)
+    config.timeToLive.foreach(d => defn.setDefaultTimeToLive(d.toSeconds.toInt))
     defn
   }
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBSupport.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBSupport.scala
@@ -69,7 +69,8 @@ private[cosmosdb] trait CosmosDBSupport extends RxObservableImplicits with Cosmo
     defn.setId(collName)
     defn.setIndexingPolicy(viewMapper.indexingPolicy.asJava())
     defn.setPartitionKey(viewMapper.partitionKeyDefn)
-    config.timeToLive.foreach(d => defn.setDefaultTimeToLive(d.toSeconds.toInt))
+    val ttl = config.timeToLive.map(_.toSeconds.toInt).getOrElse(-1)
+    defn.setDefaultTimeToLive(ttl)
     defn
   }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfigTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfigTests.scala
@@ -66,7 +66,7 @@ class CosmosDBConfigTests extends FlatSpec with Matchers {
       | }
          """.stripMargin).withFallback(globalConfig)
     val cosmos = CosmosDBConfig(config, "WhiskAuth")
-    cosmos should matchPattern { case CosmosDBConfig("http://localhost", "foo", "openwhisk", _, _, _) => }
+    cosmos should matchPattern { case CosmosDBConfig("http://localhost", "foo", "openwhisk", _, _, _, _) => }
   }
 
   it should "work with extended config" in {
@@ -81,7 +81,7 @@ class CosmosDBConfigTests extends FlatSpec with Matchers {
       | }
          """.stripMargin).withFallback(globalConfig)
     val cosmos = CosmosDBConfig(config, "WhiskAuth")
-    cosmos should matchPattern { case CosmosDBConfig("http://localhost", "foo", "openwhisk", _, _, _) => }
+    cosmos should matchPattern { case CosmosDBConfig("http://localhost", "foo", "openwhisk", _, _, _, _) => }
 
     cosmos.connectionPolicy.maxPoolSize shouldBe 42
     val policy = cosmos.connectionPolicy.asJava
@@ -114,7 +114,7 @@ class CosmosDBConfigTests extends FlatSpec with Matchers {
       | }
          """.stripMargin).withFallback(globalConfig)
     val cosmos = CosmosDBConfig(config, "WhiskAuth")
-    cosmos should matchPattern { case CosmosDBConfig("http://localhost", "foo", "openwhisk", _, _, _) => }
+    cosmos should matchPattern { case CosmosDBConfig("http://localhost", "foo", "openwhisk", _, _, _, _) => }
 
     val policy = cosmos.connectionPolicy.asJava
     policy.isUsingMultipleWriteLocations shouldBe true

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBSupportTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBSupportTests.scala
@@ -41,6 +41,7 @@ class CosmosDBSupportTests extends FlatSpec with CosmosDBTestSupport with MockFa
 
     val indexedPaths1 = Set("/foo/?", "/bar/?")
     val (_, coll) = new CosmosTest(config, client, newMapper(indexedPaths1)).initialize()
+    coll.getDefaultTimeToLive shouldBe -1
     indexedPaths(coll) should contain theSameElementsAs indexedPaths1
 
     //Test if index definition is updated in code it gets updated in db also


### PR DESCRIPTION
Enables specifying [Time to live][1] at collection (or container level). 

## Description

For collection like `Activations` its desirable to expire the activations after some time. For CouchDB this is done by running a [cleaner script][2]. For CosmosDB we can make use of the [TTL][1] support which allows auto removal of entries after the TTL time has passed after their last modified time.

So to specify TTL for activations

```
whisk {
    cosmosdb {
        collections {
            WhiskActivation {
                time-to-live = 30 days
            }
        }
    }
}
```

This PR also now sets the default TTL to -1 which allow us to later specify TTL at individual item level if required.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

[1]: https://docs.microsoft.com/en-us/azure/cosmos-db/time-to-live
[2]: https://github.com/apache/incubator-openwhisk/blob/master/tools/db/cleanUpActivations.py