### PR TITLE
Complete blocking activations immediately

### DIFF
--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/actions/PrimitiveActions.scala
@@ -599,7 +599,8 @@ protected[actions] trait PrimitiveActions {
       case Right(activation) => result.trySuccess(Right(activation))
       case _ if (controllerActivationConfig.pollingFromDb) =>
         pollActivation(docid, context, result, i => 1.seconds + (2.seconds * i), maxRetries = 4)
-      case _ =>
+      case Left(activationId) =>
+        result.trySuccess(Left(activationId)) // complete the future immediately if it's configured to not poll db for blocking activations
     }
 
     if (controllerActivationConfig.pollingFromDb) {

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/actions/PrimitiveActions.scala
@@ -654,7 +654,7 @@ protected[actions] trait PrimitiveActions {
   /** Max atomic action count allowed for sequences */
   private lazy val actionSequenceLimit = whiskConfig.actionSequenceLimit.toInt
 
-  private val controllerActivationConfig =
+  protected val controllerActivationConfig =
     loadConfigOrThrow[ControllerActivationConfig](ConfigKeys.controllerActivation)
 
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
@@ -68,7 +68,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
   def aname() = MakeName.next("action_tests")
   val actionLimit = Exec.sizeLimit
   val parametersLimit = Parameters.sizeLimit
-  val controllerActivationConfig = loadConfigOrThrow[ControllerActivationConfig](ConfigKeys.controllerActivation)
+  override protected val controllerActivationConfig = loadConfigOrThrow[ControllerActivationConfig](ConfigKeys.controllerActivation)
 
   //// GET /actions
   it should "return empty list when no actions exist" in {

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
@@ -36,12 +36,9 @@ import org.apache.openwhisk.core.entitlement.Collection
 import org.apache.openwhisk.http.ErrorResponse
 import org.apache.openwhisk.http.Messages
 import org.apache.openwhisk.core.database.UserContext
-import org.apache.openwhisk.core.ConfigKeys
-import org.apache.openwhisk.core.controller.actions.ControllerActivationConfig
 import akka.http.scaladsl.model.headers.RawHeader
 import org.apache.commons.lang3.StringUtils
 import org.apache.openwhisk.core.entity.Attachments.Inline
-import pureconfig.loadConfigOrThrow
 
 /**
  * Tests Actions API.
@@ -68,8 +65,6 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
   def aname() = MakeName.next("action_tests")
   val actionLimit = Exec.sizeLimit
   val parametersLimit = Parameters.sizeLimit
-  override protected val controllerActivationConfig =
-    loadConfigOrThrow[ControllerActivationConfig](ConfigKeys.controllerActivation)
 
   //// GET /actions
   it should "return empty list when no actions exist" in {

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
@@ -68,7 +68,8 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
   def aname() = MakeName.next("action_tests")
   val actionLimit = Exec.sizeLimit
   val parametersLimit = Parameters.sizeLimit
-  override protected val controllerActivationConfig = loadConfigOrThrow[ControllerActivationConfig](ConfigKeys.controllerActivation)
+  override protected val controllerActivationConfig =
+    loadConfigOrThrow[ControllerActivationConfig](ConfigKeys.controllerActivation)
 
   //// GET /actions
   it should "return empty list when no actions exist" in {

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PollingFromDbTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PollingFromDbTests.scala
@@ -32,7 +32,6 @@ import spray.json._
 import spray.json.DefaultJsonProtocol._
 import org.apache.openwhisk.core.controller.WhiskActionsApi
 import org.apache.openwhisk.core.entity._
-import org.apache.openwhisk.core.database.UserContext
 import org.apache.openwhisk.core.controller.actions.ControllerActivationConfig
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PollingFromDbTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PollingFromDbTests.scala
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.controller.test
+
+import java.time.Instant
+
+import scala.concurrent.duration.DurationInt
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport.sprayJsonUnmarshaller
+import akka.http.scaladsl.server.Route
+import org.apache.openwhisk.common.TransactionId
+import org.apache.openwhisk.core.WhiskConfig
+import org.apache.openwhisk.core.connector.ActivationMessage
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+import org.apache.openwhisk.core.controller.WhiskActionsApi
+import org.apache.openwhisk.core.entity._
+import org.apache.openwhisk.core.database.UserContext
+import org.apache.openwhisk.core.controller.actions.ControllerActivationConfig
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+ * Tests PollingFromDb configuration.
+ *
+ * Unit tests of the controller service as a standalone component.
+ * These tests exercise a fresh instance of the service object in memory -- these
+ * tests do NOT communication with a whisk deployment.
+ *
+ *
+ * @Idioglossia
+ * "using Specification DSL to write unit tests, as in should, must, not, be"
+ * "using Specs2RouteTest DSL to chain HTTP requests for unit testing, as in ~>"
+ */
+@RunWith(classOf[JUnitRunner])
+class PollingFromDbTests extends ControllerTestCommon with WhiskActionsApi {
+
+  val creds = WhiskAuthHelpers.newIdentity()
+  val context = UserContext(creds)
+  val namespace = EntityPath(creds.subject.asString)
+  val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
+  def aname() = MakeName.next("action_tests")
+  override protected val controllerActivationConfig = ControllerActivationConfig(false)
+
+  override val loadBalancer = new AlwaysReturnLeftLoadBalancerService(whiskConfig)
+
+  it should "complete blocking activation request immediately when a Left is returned and pollingFromDb is set to false" in {
+    implicit val tid = transid()
+    val timeLimit = TimeLimit(1.minute)
+    val action = WhiskAction(namespace, aname(), jsDefault("??"), limits = ActionLimits(timeLimit))
+    val activation = WhiskActivation(
+      action.namespace,
+      action.name,
+      creds.subject,
+      activationIdFactory.make(),
+      start = Instant.now,
+      end = Instant.now,
+      response = ActivationResponse.success(Some(JsObject("test" -> "yes".toJson))),
+      logs = ActivationLogs(Vector("first line", "second line")))
+    put(entityStore, action)
+    Post(s"$collectionPath/${action.name}?blocking=true") ~> Route.seal(routes(creds)) ~> check {
+      status should be(Accepted)
+      val duration = Instant.now.toEpochMilli - activation.start.toEpochMilli
+      duration should be < timeLimit.millis.toLong
+      val response = responseAs[JsObject]
+      response should be(JsObject("activationId" -> JsString(activation.activationId.asString)))
+    }
+  }
+}
+
+
+class AlwaysReturnLeftLoadBalancerService(config: WhiskConfig)(implicit ec: ExecutionContext)
+    extends DegenerateLoadBalancerService(config) {
+
+  override def activeActivationsFor(namespace: UUID): Future[Int] = Future.successful(0)
+  override def totalActiveActivations: Future[Int] = Future.successful(0)
+
+  override def publish(action: ExecutableWhiskActionMetaData, msg: ActivationMessage)(
+    implicit transid: TransactionId): Future[Future[Either[ActivationId, WhiskActivation]]] = {
+    Future {
+      Future {
+        Left(msg.activationId)
+      }
+    }
+  }
+
+  override def invokerHealth() = Future.successful(IndexedSeq.empty)
+}

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PollingFromDbTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PollingFromDbTests.scala
@@ -85,7 +85,6 @@ class PollingFromDbTests extends ControllerTestCommon with WhiskActionsApi {
   }
 }
 
-
 class AlwaysReturnLeftLoadBalancerService(config: WhiskConfig)(implicit ec: ExecutionContext)
     extends DegenerateLoadBalancerService(config) {
 


### PR DESCRIPTION
Complete blocking activations immediately when a Left(activationId) is returned and controllerActivationConfig.pollingFromDb is false, otherwise this invocation will wait until timeout

## Description

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#4231)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

