### PR TITLE
Revert "Mount an optional html directory for serving static content."

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -205,7 +205,6 @@ userLogs:
 
 nginx:
   confdir: "{{ config_root_dir }}/nginx"
-  htmldir: "{{ ui_path | default(false) }}"
   dir:
     become: "{{ nginx_dir_become | default(false) }}"
   version: "{{ nginx_version | default('1.13') }}"

--- a/ansible/roles/cli-install/tasks/deploy.yml
+++ b/ansible/roles/cli-install/tasks/deploy.yml
@@ -5,7 +5,7 @@
 
 - name: grab the local CLI from the binaries unarchived into nginx
   get_url:
-    url: "https://{{host}}/cli/{{os}}/{{arch}}/{{wsk}}"
+    url: "https://{{host}}/cli/go/download/{{os}}/{{arch}}/{{wsk}}"
     dest: "{{ openwhisk_home }}/bin"
     mode: "0755"
     validate_certs: no

--- a/ansible/roles/nginx/tasks/deploy.yml
+++ b/ansible/roles/nginx/tasks/deploy.yml
@@ -52,28 +52,6 @@
   retries: "{{ docker.pull.retries }}"
   delay: "{{ docker.pull.delay }}"
 
-- name: ensure html directory exists
-  stat:
-    path: "{{ nginx.htmldir }}"
-  register: nginx_html_dir_exists
-  when: nginx.htmldir
-
-- name: check if html directory exists
-  fail:
-    msg: html directory does not exist '{{ nginx.htmldir }}'
-  when: nginx.htmldir and not (nginx_html_dir_exists.stat.exists and nginx_html_dir_exists.stat.isdir)
-
-- name: configuration volumes to mount
-  set_fact:
-    volumes:
-      - "{{ whisk_logs_dir }}/nginx:/logs"
-      - "{{ nginx.confdir }}:/etc/nginx"
-
-- name: "optional html volume to mount"
-  set_fact:
-    volumes: "{{ volumes }} + [ '{{ nginx.htmldir }}:/usr/share/nginx/html' ]"
-  when: nginx.htmldir
-
 - name: (re)start nginx
   docker_container:
     name: nginx
@@ -82,7 +60,9 @@
     recreate: true
     restart_policy: "{{ docker.restart.policy }}"
     hostname: "nginx"
-    volumes: "{{ volumes }}"
+    volumes:
+      - "{{ whisk_logs_dir }}/nginx:/logs"
+      - "{{ nginx.confdir }}:/etc/nginx"
     expose:
       - 8443
     ports:

--- a/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/ansible/roles/nginx/templates/nginx.conf.j2
@@ -33,8 +33,6 @@ http {
     proxy_ssl_certificate_key /etc/nginx/{{ controller.ssl.key }};
 {% endif %}
 
-    gzip_static on;
-
     upstream controllers {
         # fail_timeout: period of time the server will be considered unavailable
         # Mark the controller as unavailable for at least 60 seconds, to not get any requests during restart.
@@ -117,20 +115,18 @@ http {
         location /blackbox.tar.gz {
             return 301 https://github.com/apache/incubator-openwhisk-runtime-docker/releases/download/sdk%400.1.0/blackbox-0.1.0.tar.gz;
         }
+        # leaving this for a while for clients out there to update to the new endpoint
+        location /blackbox-0.1.0.tar.gz {
+            return 301 /blackbox.tar.gz;
+        }
 
         location /OpenWhiskIOSStarterApp.zip {
             return 301 https://github.com/apache/incubator-openwhisk-client-swift/releases/download/0.3.0/starterapp-0.3.0.zip;
         }
 
-        location /cli {
+        location /cli/go/download {
             autoindex on;
-            alias /etc/nginx/cli/go/download;
+            root /etc/nginx;
         }
-
-{% if nginx.htmldir %}
-        location /ui {
-            alias /usr/share/nginx/html;
-        }
-{% endif %}
     }
 }

--- a/tests/src/test/scala/system/rest/GoCLINginxTests.scala
+++ b/tests/src/test/scala/system/rest/GoCLINginxTests.scala
@@ -32,7 +32,7 @@ import DefaultJsonProtocol._
  */
 @RunWith(classOf[JUnitRunner])
 class GoCLINginxTests extends FlatSpec with Matchers with RestUtil {
-  val DownloadLinkGoCli = "cli"
+  val DownloadLinkGoCli = "cli/go/download"
   val ServiceURL = getServiceURL()
 
   it should s"respond to all files in root directory" in {


### PR DESCRIPTION
Reverts apache/incubator-openwhisk#4252

We got reports from a downstream that this change broke based on some assumptions where they get the `wsk` binary location.
```
line 52: /home/<user>/workspace/Playground2/open/bin/wsk
```
Reverting to take another look and maybe put a verification step to make sure Travis catches this