### PR TITLE
package nodejs dependencies into routemgmt actions

### DIFF
--- a/ansible/roles/routemgmt/files/installRouteMgmt.sh
+++ b/ansible/roles/routemgmt/files/installRouteMgmt.sh
@@ -56,9 +56,20 @@ $WSK_CLI -i --apihost "$APIHOST" package update --auth "$AUTH"  --shared no "$NA
 -p gwUrlV2 "$GW_HOST_V2"
 
 echo Creating NPM module .zip files
-zip -j "$OPENWHISK_HOME/core/routemgmt/getApi/getApi.zip" "$OPENWHISK_HOME/core/routemgmt/getApi/getApi.js" "$OPENWHISK_HOME/core/routemgmt/getApi/package.json" "$OPENWHISK_HOME/core/routemgmt/common/utils.js" "$OPENWHISK_HOME/core/routemgmt/common/apigw-utils.js"
-zip -j "$OPENWHISK_HOME/core/routemgmt/createApi/createApi.zip" "$OPENWHISK_HOME/core/routemgmt/createApi/createApi.js" "$OPENWHISK_HOME/core/routemgmt/createApi/package.json" "$OPENWHISK_HOME/core/routemgmt/common/utils.js" "$OPENWHISK_HOME/core/routemgmt/common/apigw-utils.js"
-zip -j "$OPENWHISK_HOME/core/routemgmt/deleteApi/deleteApi.zip" "$OPENWHISK_HOME/core/routemgmt/deleteApi/deleteApi.js" "$OPENWHISK_HOME/core/routemgmt/deleteApi/package.json" "$OPENWHISK_HOME/core/routemgmt/common/utils.js" "$OPENWHISK_HOME/core/routemgmt/common/apigw-utils.js"
+cd "$OPENWHISK_HOME/core/routemgmt/getApi"
+cp "$OPENWHISK_HOME/core/routemgmt/common"/*.js .
+npm install
+zip -r getApi.zip *
+
+cd "$OPENWHISK_HOME/core/routemgmt/createApi"
+cp "$OPENWHISK_HOME/core/routemgmt/common"/*.js .
+npm install
+zip -r createApi.zip *
+
+cd "$OPENWHISK_HOME/core/routemgmt/deleteApi"
+cp "$OPENWHISK_HOME/core/routemgmt/common"/*.js .
+npm install
+zip -r deleteApi.zip *
 
 echo Installing apimgmt actions
 $WSK_CLI -i --apihost "$APIHOST" action update --auth "$AUTH" "$NAMESPACE/apimgmt/getApi" "$OPENWHISK_HOME/core/routemgmt/getApi/getApi.zip" \

--- a/core/routemgmt/createApi/package.json
+++ b/core/routemgmt/createApi/package.json
@@ -1,3 +1,7 @@
 {
-  "main": "createApi.js"
+  "main": "createApi.js",
+  "dependencies" : {
+    "lodash": "4.17.11",
+    "request": "2.88.0"
+  }
 }

--- a/core/routemgmt/deleteApi/package.json
+++ b/core/routemgmt/deleteApi/package.json
@@ -1,3 +1,7 @@
 {
-  "main": "deleteApi.js"
+  "main": "deleteApi.js",
+  "dependencies" : {
+    "lodash": "4.17.11",
+    "request": "2.88.0"
+  }
 }

--- a/core/routemgmt/getApi/package.json
+++ b/core/routemgmt/getApi/package.json
@@ -1,3 +1,7 @@
 {
-  "main": "getApi.js"
+  "main": "getApi.js",
+  "dependencies" : {
+    "lodash": "4.17.11",
+    "request": "2.88.0"
+  }
 }


### PR DESCRIPTION
Modify the apimgmt package's actions to support nodejs:10

## Description
Modify the apimgmt package's actions to support nodejs:10, which will soon be the default nodejs runtime for nodejs actions. The nodejs:10 runtime no longer provides the NPM packages the nodejs:6 runtime did, so each apimgmt action must be packaged (zipped) with its dependent NPM packages.

Existing test cases will be sufficient to validate the new packaging is correct.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#4265)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation
- [x] API GW Integration

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

