### PR TITLE
Enable configuring Connection Mode for CosmosDB

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -203,6 +203,10 @@ whisk {
             # available writable locations of geo-replicated database account
             using-multiple-write-locations = false
 
+            # Select from one of the supported connection mode
+            # https://github.com/Azure/azure-cosmosdb-java/blob/master/commons/src/main/java/com/microsoft/azure/cosmosdb/ConnectionMode.java
+            connection-mode = "Gateway"
+
             # Sets the preferred locations for geo-replicated database accounts e.g. "East US"
             # See names at https://azure.microsoft.com/en-in/global-infrastructure/locations/
             preferred-locations = []

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfig.scala
@@ -18,6 +18,7 @@
 package org.apache.openwhisk.core.database.cosmosdb
 import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient
 import com.microsoft.azure.cosmosdb.{
+  ConnectionMode,
   ConsistencyLevel,
   ConnectionPolicy => JConnectionPolicy,
   RetryOptions => JRetryOptions
@@ -51,13 +52,15 @@ case class CosmosDBConfig(endpoint: String,
 case class ConnectionPolicy(maxPoolSize: Int,
                             preferredLocations: Seq[String],
                             usingMultipleWriteLocations: Boolean,
-                            retryOptions: RetryOptions) {
+                            retryOptions: RetryOptions,
+                            connectionMode: ConnectionMode) {
   def asJava: JConnectionPolicy = {
     val p = new JConnectionPolicy
     p.setMaxPoolSize(maxPoolSize)
     p.setUsingMultipleWriteLocations(usingMultipleWriteLocations)
     p.setPreferredLocations(preferredLocations.asJava)
     p.setRetryOptions(retryOptions.asJava)
+    p.setConnectionMode(connectionMode)
     p
   }
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfigTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfigTests.scala
@@ -20,7 +20,7 @@ import com.typesafe.config.ConfigFactory
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{FlatSpec, Matchers}
-import com.microsoft.azure.cosmosdb.{ConnectionPolicy => JConnectionPolicy}
+import com.microsoft.azure.cosmosdb.{ConnectionMode, ConnectionPolicy => JConnectionPolicy}
 
 import scala.collection.JavaConverters._
 
@@ -108,6 +108,7 @@ class CosmosDBConfigTests extends FlatSpec with Matchers {
       |        connection-policy {
       |           using-multiple-write-locations = true
       |           preferred-locations = [a, b]
+      |           connection-mode = Direct
       |        }
       |     }
       |  }
@@ -119,6 +120,7 @@ class CosmosDBConfigTests extends FlatSpec with Matchers {
     val policy = cosmos.connectionPolicy.asJava
     policy.isUsingMultipleWriteLocations shouldBe true
     policy.getMaxPoolSize shouldBe 42
+    policy.getConnectionMode shouldBe ConnectionMode.Direct
     policy.getPreferredLocations.asScala.toSeq should contain only ("a", "b")
     policy.getRetryOptions.getMaxRetryWaitTimeInSeconds shouldBe 120
   }


### PR DESCRIPTION
Enables configuring the connection mode via configuration. It currently defaults to `Gateway`. See [ConnectionMode](https://github.com/Azure/azure-cosmosdb-java/blob/master/commons/src/main/java/com/microsoft/azure/cosmosdb/ConnectionMode.java) for details

Fixes #4269


<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

