### PR TITLE
Include nanohttpd to avoid class not found error on stop

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -71,9 +71,7 @@ dependencies {
     compile ('io.kamon:kamon-system-metrics_2.12:1.0.0') {
         exclude group: 'io.kamon', module: 'sigar-loader'
     }
-    compile ('io.kamon:kamon-prometheus_2.12:1.1.1'){
-        exclude group: 'org.nanohttpd'
-    }
+    compile ('io.kamon:kamon-prometheus_2.12:1.1.1')
     //for mesos
     compile 'com.adobe.api.platform.runtime:mesos-actor:0.0.17'
 


### PR DESCRIPTION
PR to enable Prometheus (#4227) support excluded the dependency on [Nano HTTP](https://github.com/NanoHttpd/nanohttpd) server. This causes `NoClassDefFoundError` upon shutdown. 

```
[2019-02-13T11:33:00.245Z] [INFO] [#tid_sid_unknown] [Invoker] Shutting down Kamon with coordinated shutdown
Exception in thread "kamon.prometheus.PrometheusReporter" java.lang.BootstrapMethodError: java.lang.NoClassDefFoundError: fi/iki/elonen/NanoHTTPD
	at kamon.prometheus.PrometheusReporter.stopEmbeddedServer(PrometheusReporter.scala:91)
	at kamon.prometheus.PrometheusReporter.stop(PrometheusReporter.scala:48)
	at kamon.ReporterRegistry$Default.$anonfun$stopMetricReporter$2(ReporterRegistry.scala:279)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
	at scala.util.Try$.apply(Try.scala:209)
	at kamon.ReporterRegistry$Default.$anonfun$stopMetricReporter$1(ReporterRegistry.scala:279)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
	at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:654)
	at scala.util.Success.$anonfun$map$1(Try.scala:251)
	at scala.util.Success.map(Try.scala:209)
	at scala.concurrent.Future.$anonfun$map$1(Future.scala:288)
	at scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:29)
	at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:29)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:60)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.NoClassDefFoundError: fi/iki/elonen/NanoHTTPD
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:763)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:467)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:73)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:368)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:362)
	at java.security.AccessController.doPrivileged(Native Method)
```
As we are using Akka HTTP the thought was to avoid packaging the Nano HTTP server. However now as it causes error to be logged upon shutdown its better to include it and still not use it

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

