### PR TITLE
Collect and log CosmosDB query metrics when extra logging is enabled

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
@@ -40,6 +40,7 @@ import org.apache.openwhisk.http.Messages
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Success
 
 class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected val collName: String,
                                                                        protected val config: CosmosDBConfig,
@@ -223,11 +224,22 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
 
     val querySpec = viewMapper.prepareQuery(ddoc, viewName, startKey, endKey, realLimit, realIncludeDocs, descending)
 
+    val options = newFeedOptions()
+    val queryMetrics = if (transid.meta.extraLogging) {
+      options.setPopulateQueryMetrics(true)
+      Some(scala.collection.mutable.Buffer[QueryMetrics]())
+    } else None
+
+    def collectQueryMetrics(r: FeedResponse[Document]): Unit = {
+      collectMetrics(queryToken, r.getRequestCharge)
+      queryMetrics.foreach(_.appendAll(r.getQueryMetrics.values().asScala))
+    }
+
     val publisher =
-      RxReactiveStreams.toPublisher(client.queryDocuments(collection.getSelfLink, querySpec, newFeedOptions()))
+      RxReactiveStreams.toPublisher(client.queryDocuments(collection.getSelfLink, querySpec, options))
     val f = Source
       .fromPublisher(publisher)
-      .wireTap(Sink.foreach(r => collectMetrics(queryToken, r.getRequestCharge)))
+      .wireTap(Sink.foreach(collectQueryMetrics))
       .mapConcat(asSeq)
       .drop(skip)
       .map(queryResultToWhiskJsonDoc)
@@ -240,10 +252,17 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
       .map(_.toList)
       .map(l => if (limit > 0) l.take(limit) else l)
 
-    f.foreach { out =>
-      transid.finished(this, start, s"[QUERY] '$collName' completed: matched ${out.size}")
+    val g = f.andThen {
+      case Success(out) =>
+        queryMetrics.foreach { m =>
+          val combinedMetrics = QueryMetrics.ZERO.add(m: _*)
+          logging.debug(
+            this,
+            s"[QueryMetricsEnabled] Collection [$collName] - Query [${querySpec.getQueryText}].\nQueryMetrics\n[$combinedMetrics]")
+        }
+        transid.finished(this, start, s"[QUERY] '$collName' completed: matched ${out.size}")
     }
-    reportFailure(f, start, failure => s"[QUERY] '$collName' internal error, failure: '${failure.getMessage}'")
+    reportFailure(g, start, failure => s"[QUERY] '$collName' internal error, failure: '${failure.getMessage}'")
   }
 
   override protected[core] def count(table: String,


### PR DESCRIPTION
Collect and logs CosmosDB query metrics when extra logging is enabled

Fixes #4268

## Description

if a request is performed with `X-OW-EXTRA-LOGGING` header set to `on` like below

```
curl -k --user "23bc46b1-71f6-4ed5-8c54-816aa4f8c502:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP" \
     -H "X-OW-EXTRA-LOGGING: on" \
     "https://172.17.0.1:10001/api/v1/namespaces/_/activations?limit=30&skip=0"
```

Then in the logs following entries would logged which provide detailed insight into how query is executed by CosmosDB

```
[2019-02-13T14:11:48.689Z] [INFO] [#tid_FUn23vWbEbEQBFi5rIcioaZJkB4a2Wfw] [CosmosDBArtifactStore] [QueryMetricsEnabled] Collection [subjects] - Query [SELECT r AS view FROM root r JOIN n in r.namespaces WHERE (NOT(IS_DEFINED(r.blocked)) OR r.blocked = false) AND ((r.uuid = @uuid AND r.key = @key) OR (n.uuid = @uuid AND n.key = @key))].
QueryMetrics
[Retrieved Document Count                 :               1              
Retrieved Document Size                  :             428 bytes        
Output Document Count                    :               1              
Output Document Size                     :             682 bytes        
Index Utilization                        :          100.00 %            
Total Query Execution Time               :            0.00 milliseconds 
Query Preparation Times 
    Query Compilation Time               :        1.250000 milliseconds 
    Logical Plan Build Time              :        0.440000 milliseconds 
    Physical Plan Build Time             :        0.510000 milliseconds 
    Query Optimization Time              :        0.070000 milliseconds 
  Index Lookup Time                      :        0.640000 milliseconds 
  Document Load Time                     :        0.020000 milliseconds 
Runtime Execution Times 
    Query Engine Times                   :        0.090000 milliseconds 
    System Function Execution Time       :        0.000000 milliseconds 
    User-defined Function Execution Time :        0.000000 milliseconds 
  Document Write Time                    :        0.000000 milliseconds 
Client Side Metrics 
  Retry Count                            :              10              
  Request Charge                         :           15.25 RUs          
 
Partition Execution Timeline 
?------------?------------------------------------?----------------?----------------?-------------?-------------------?-----------? 
?Partition Id?                         Activity Id?Start Time (UTC)?  End Time (UTC)?Duration (ms)?Number of Documents?Retry Count? 
?------------?------------------------------------?----------------?----------------?-------------?-------------------?-----------? 
?           0?6d930ac9-39e8-49f9-a0c6-348ddc0a753b?   08:41:47:6920?   08:41:47:9370?        245.0?                  0?          4? 
?           0?4a823e13-f723-48e8-a6e9-aaa8c975b3b3?   08:41:47:4540?   08:41:47:6910?        237.0?                  0?          3? 
?           0?bc36fe9d-b75c-4a4f-a6d8-27c7aca7c209?   08:41:47:2170?   08:41:47:4540?        237.0?                  1?          2? 
?           0?22fd7bb1-1c99-4df1-b934-f8f6ae584f01?   08:41:46:9830?   08:41:47:2160?        233.0?                  0?          1? 
?           0?d0ddda24-5954-408e-9e16-038d36805301?   08:41:46:7380?   08:41:46:9720?        234.0?                  0?          0? 
?------------?------------------------------------?----------------?----------------?-------------?-------------------?-----------? 
 
Scheduling Metrics 
?------------?------------------?-------------?--------------?--------------------?---------------------? 
?Partition Id?Response Time (ms)?Run Time (ms)?Wait Time (ms)?Turnaround Time (ms)?Number of Preemptions? 
?------------?------------------?-------------?--------------?--------------------?---------------------? 
?           0?                 1?          233?             2?                 235?                    1? 
?           0?                 1?          232?           248?                 479?                    2? 
?           0?                 1?          236?           481?                 717?                    3? 
?           0?                 1?          236?           718?                 954?                    4? 
?           0?                 1?          244?           956?                1200?                    5? 
?------------?------------------?-------------?--------------?--------------------?---------------------? 
]
[2019-02-13T14:11:48.690Z] [INFO] [#tid_FUn23vWbEbEQBFi5rIcioaZJkB4a2Wfw] [CosmosDBArtifactStore]  [marker:database_queryView_finish:2342:2241]

```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#4268)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

