### PR TITLE
Add additional debug information for intermittently failing ContainerProxyTests

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -303,6 +303,10 @@ class ContainerProxyTests
       collector.calls should have size 2
       container.suspendCount shouldBe 0
       acker.calls should have size 2
+
+      // Add debugging information for the case of failure.
+      println(acker.calls.map(_._2.toJson.compactPrint))
+
       store.calls should have size 2
 
       val initRunActivation = acker.calls(0)._2
@@ -360,6 +364,10 @@ class ContainerProxyTests
       container.suspendCount shouldBe 1
       container.resumeCount shouldBe 1
       acker.calls should have size 2
+
+      // Add debugging information for the case of failure.
+      println(acker.calls.map(_._2.toJson.compactPrint))
+
       store.calls should have size 2
       acker
         .calls(0)
@@ -548,6 +556,10 @@ class ContainerProxyTests
       container.suspendCount shouldBe 1
       container.resumeCount shouldBe 0
       acker.calls should have size 6
+
+      // Add debugging information for the case of failure.
+      println(acker.calls.map(_._2.toJson.compactPrint))
+
       store.calls should have size 6
       acker
         .calls(0)
@@ -611,6 +623,10 @@ class ContainerProxyTests
       container.suspendCount shouldBe 0
       container.destroyCount shouldBe 0
       acker.calls should have size 2
+
+      // Add debugging information for the case of failure.
+      println(acker.calls.map(_._2.toJson.compactPrint))
+
       store.calls should have size 2
 
       val initErrorActivation = acker.calls(0)._2


### PR DESCRIPTION
Add additional debug information for intermittently failing ContainerProxyTests

The `ContainerProxyTests` are failing intermittently in the pipeline. All of these intermittent test failures have either a wrong initialisation-time or it is missing completely.
Our theory currently is, that the Buffer in `acker` is called in the wrong order, as these calls are made asynchronously. If that theory is correct, this can be proven with this additional output.
Unfortunatly I was not able to reproduce the error locally.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.