### PR TITLE
MBean to dump config information at a path

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/common/ConfigMXBean.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/ConfigMXBean.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.common
+import java.lang.management.ManagementFactory
+
+import com.typesafe.config.{ConfigFactory, ConfigRenderOptions}
+import javax.management.ObjectName
+
+trait ConfigMXBean {
+  def getConfig(path: String, originComment: Boolean): String
+}
+
+object ConfigMXBean extends ConfigMXBean {
+  val name = new ObjectName("org.apache.openwhisk:name=config")
+  private val renderOptions =
+    ConfigRenderOptions.defaults().setComments(false).setOriginComments(true).setFormatted(true).setJson(false)
+
+  override def getConfig(path: String, originComment: Boolean): String =
+    ConfigFactory.load().getConfig(path).root().render(renderOptions.setOriginComments(originComment))
+
+  def register(): Unit = {
+    ManagementFactory.getPlatformMBeanServer.registerMBean(ConfigMXBean, name)
+  }
+
+  def unregister(): Unit = {
+    ManagementFactory.getPlatformMBeanServer.unregisterMBean(name)
+  }
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/ConfigMXBean.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/ConfigMXBean.scala
@@ -22,6 +22,15 @@ import com.typesafe.config.{ConfigFactory, ConfigRenderOptions}
 import javax.management.ObjectName
 
 trait ConfigMXBean {
+
+  /**
+   * Renders the config value to a string
+   *
+   * @param path root of subtree which needs to be rendered. Pass `.` for getting whole subtree rendered
+   * @param originComment {@link ConfigValue#origin} of that setting's value. For example these
+   *                            comments might tell you which file a setting comes from.
+   * @return rendered config
+   */
   def getConfig(path: String, originComment: Boolean): String
 }
 
@@ -30,8 +39,11 @@ object ConfigMXBean extends ConfigMXBean {
   private val renderOptions =
     ConfigRenderOptions.defaults().setComments(false).setOriginComments(true).setFormatted(true).setJson(false)
 
-  override def getConfig(path: String, originComment: Boolean): String =
-    ConfigFactory.load().getConfig(path).root().render(renderOptions.setOriginComments(originComment))
+  override def getConfig(path: String, originComment: Boolean): String = {
+    val config = ConfigFactory.load()
+    val co = if (path == ".") config.root() else config.getConfig(path).root()
+    co.render(renderOptions.setOriginComments(originComment))
+  }
 
   def register(): Unit = {
     ManagementFactory.getPlatformMBeanServer.registerMBean(ConfigMXBean, name)

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
@@ -29,7 +29,7 @@ import pureconfig.loadConfigOrThrow
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 import org.apache.openwhisk.common.Https.HttpsConfig
-import org.apache.openwhisk.common.{AkkaLogging, Logging, LoggingMarkers, TransactionId}
+import org.apache.openwhisk.common.{AkkaLogging, ConfigMXBean, Logging, LoggingMarkers, TransactionId}
 import org.apache.openwhisk.core.WhiskConfig
 import org.apache.openwhisk.core.connector.MessagingProvider
 import org.apache.openwhisk.core.containerpool.logging.LogStoreProvider
@@ -207,6 +207,7 @@ object Controller {
       "runtimes" -> runtimes.toJson)
 
   def main(args: Array[String]): Unit = {
+    ConfigMXBean.register()
     Kamon.loadReportersFromConfig()
     implicit val actorSystem = ActorSystem("controller-actor-system")
     implicit val logger = new AkkaLogging(akka.event.Logging.getLogger(actorSystem, this))

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
@@ -64,6 +64,7 @@ object Invoker {
   }
 
   def main(args: Array[String]): Unit = {
+    ConfigMXBean.register()
     Kamon.loadReportersFromConfig()
     implicit val ec = ExecutionContextFactory.makeCachedThreadPoolExecutionContext()
     implicit val actorSystem: ActorSystem =

--- a/tests/src/test/scala/org/apache/openwhisk/common/ConfigMXBeanTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/common/ConfigMXBeanTests.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.common
+import java.lang.management.ManagementFactory
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{FlatSpec, Matchers}
+
+@RunWith(classOf[JUnitRunner])
+class ConfigMXBeanTests extends FlatSpec with Matchers {
+  behavior of "ConfigMBean"
+
+  it should "return config at path" in {
+    ConfigMXBean.register()
+    val config = ManagementFactory.getPlatformMBeanServer.invoke(
+      ConfigMXBean.name,
+      "getConfig",
+      Array("whisk.spi", java.lang.Boolean.FALSE),
+      Array("java.lang.String", "boolean"))
+    config.asInstanceOf[String] should include("ArtifactStoreProvider")
+    ConfigMXBean.unregister()
+  }
+}


### PR DESCRIPTION
This PR adds an MBean which enables dumping the typesafe config including details from where config is getting picked up. This is useful to troubleshoot config issues and confirm if the intended config is being picked up properly.

## Description

This PR registers an MBean which enables fetching typesafe config at specific path like `whisk.kafka`. It acceps a second boolean param which enables dumping of location information from where config value was picked up

```scala
trait ConfigMXBean {
  def getConfig(path: String, originComment: Boolean): String
}
```
The MBean is registered with name `org.apache.openwhisk:name=config`

### Usage

```bash
$ docker exec -it xxx bash # Open bash shell to controller docker container
# cd $HOME
# wget https://search.maven.org/remotecontent?filepath=org/cyclopsgroup/jmxterm/1.0.0/jmxterm-1.0.0-uber.jar
# java -jar jmxterm-1.0.0-uber.jar
# open 1
# run -b org.apache.openwhisk:name=config getConfig whisk.spi true
#calling operation getConfig of mbean org.apache.openwhisk:name=config with params [whisk.spi, true]
#operation returns:
    # reference.conf @ jar:file:/controller/lib/openwhisk-common-1.0.0-SNAPSHOT.jar!/reference.conf: 8
ActivationStoreProvider="org.apache.openwhisk.core.database.ArtifactActivationStoreProvider"
...
LoadBalancerProvider="org.apache.openwhisk.core.loadBalancer.ShardingContainerPoolBalancer"
    # system properties
LogStoreProvider="org.apache.openwhisk.core.containerpool.logging.DockerToActivationLogStoreProvider"
    # reference.conf @ jar:file:/controller/lib/openwhisk-common-1.0.0-SNAPSHOT.jar!/reference.conf: 9
MessagingProvider="org.apache.openwhisk.connector.kafka.KafkaMessagingProvider"
```

So one can see that LogStoreProvider is set via system property

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.