### PR TITLE
Make ContainerProxyTests more stable.

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -311,11 +311,13 @@ class ContainerProxyTests
 
       // As the active acks are sent asynchronously, it is possible, that the activation with the init time is not the
       // first one in the buffer.
-      val initializedActivations =
-        acker.calls.filter(_._2.annotations.get(WhiskActivation.initTimeAnnotation).isDefined)
-      initializedActivations should have size 1
+      val (initRunActivation, runOnlyActivation) = {
+        // false is sorted before true
+        val sorted = acker.calls.sortBy(_._2.annotations.get(WhiskActivation.initTimeAnnotation).isEmpty)
+        (sorted.head._2, sorted(1)._2)
+      }
 
-      val initRunActivation = initializedActivations.head._2
+      initRunActivation.annotations.get(WhiskActivation.initTimeAnnotation) should not be empty
       initRunActivation.duration shouldBe Some((initInterval.duration + runInterval.duration).toMillis)
       initRunActivation.annotations
         .get(WhiskActivation.initTimeAnnotation)
@@ -327,8 +329,6 @@ class ContainerProxyTests
         .convertTo[Int] shouldBe
         Interval(message.transid.meta.start, initInterval.start).duration.toMillis
 
-      val runOnlyActivation =
-        acker.calls.filter(_._2.annotations.get(WhiskActivation.initTimeAnnotation).isEmpty).head._2
       runOnlyActivation.duration shouldBe Some(runInterval.duration.toMillis)
       runOnlyActivation.annotations.get(WhiskActivation.initTimeAnnotation) shouldBe empty
       runOnlyActivation.annotations.get(WhiskActivation.waitTimeAnnotation).get.convertTo[Int] shouldBe {
@@ -635,11 +635,13 @@ class ContainerProxyTests
 
       // As the active acks are sent asynchronously, it is possible, that the activation with the init time is not the
       // first one in the buffer.
-      val initializedActivations =
-        acker.calls.filter(_._2.annotations.get(WhiskActivation.initTimeAnnotation).isDefined)
-      initializedActivations should have size 1
+      val (initErrorActivation, runOnlyActivation) = {
+        // false is sorted before true
+        val sorted = acker.calls.sortBy(_._2.annotations.get(WhiskActivation.initTimeAnnotation).isEmpty)
+        (sorted.head._2, sorted(1)._2)
+      }
 
-      val initErrorActivation = initializedActivations.head._2
+      initErrorActivation.annotations.get(WhiskActivation.initTimeAnnotation) should not be empty
       initErrorActivation.duration shouldBe Some((initInterval.duration + errorInterval.duration).toMillis)
       initErrorActivation.annotations
         .get(WhiskActivation.initTimeAnnotation)
@@ -651,8 +653,6 @@ class ContainerProxyTests
         .convertTo[Int] shouldBe
         Interval(message.transid.meta.start, initInterval.start).duration.toMillis
 
-      val runOnlyActivation =
-        acker.calls.filter(_._2.annotations.get(WhiskActivation.initTimeAnnotation).isEmpty).head._2
       runOnlyActivation.duration shouldBe Some(runInterval.duration.toMillis)
       runOnlyActivation.annotations.get(WhiskActivation.initTimeAnnotation) shouldBe empty
       runOnlyActivation.annotations.get(WhiskActivation.waitTimeAnnotation).get.convertTo[Int] shouldBe {


### PR DESCRIPTION
As the active ack is sent asynchronously in the invoker, it could happen, that the order of them is wrong in the ContainerProxyTest. This has been proven with the following debug information: https://github.com/apache/incubator-openwhisk/pull/4278

This PR makes these tests more stable by not relying on the order of active acks.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.