### PR TITLE
Enable couchdb persist_path in a distributed environment as well

### DIFF
--- a/ansible/roles/couchdb/tasks/deploy.yml
+++ b/ansible/roles/couchdb/tasks/deploy.yml
@@ -11,6 +11,10 @@
   set_fact:
     volumes: []
 
+- name: "Set the nodes"
+  set_fact:
+    couchdb_nodes: []
+
 - name: check if db credentials are valid for CouchDB
   fail: msg="The db provider in your {{ hosts_dir }}/group_vars/all is {{ db.provider }}, it has to be CouchDB, pls double check"
   when: db.provider != "CouchDB"
@@ -88,6 +92,17 @@
     force_basic_auth: yes
   when: (create_users_db.status == 404) and (inventory_hostname == coordinator) and (couchdb.version is version_compare('2.0','>='))
 
+- name: check whether couchdb is clustered
+  uri:
+    url: "{{ db.protocol }}://{{ ansible_host }}:{{ db.port }}/_cluster_setup"
+    method: GET
+    status_code: 200
+    user: "{{ db.credentials.admin.user }}"
+    password: "{{ db.credentials.admin.pass }}"
+    force_basic_auth: yes
+  register: cluster_state
+  run_once: true
+
 - name: check clustered nodes
   uri:
     url: "{{ db.protocol }}://{{ ansible_host }}:{{ db.port }}/_membership"
@@ -99,21 +114,22 @@
   register: nodes_state
   run_once: true
 
+- name: generates couchdb node name
+  set_fact:
+    couchdb_nodes: "{{ couchdb_nodes }} + [ 'couchdb@{{ item }}' ]"
+  with_items: "{{ groups['db'] }}"
+  run_once: true
+
 - name: check if there is a new node
   set_fact:
     require_clustering: true
   when: item not in nodes_state.json.cluster_nodes
-  with_item: groups['db']
+  with_items: "{{ couchdb_nodes }}"
   run_once: true
-
-- set_fact:
-    require_clustering: "{{ item }}"
-  loop: "{{ groups['db'] }}"
-  when: item not in nodes_state.json.cluster_nodes
 
 - name: set node name
   set_fact:
-    node_name: "couchdb@{{ ansible_host  }}"
+    node_name: "couchdb@{{ ansible_host }}"
 
 - name: enable the cluster setup mode
   uri:
@@ -152,4 +168,5 @@
     user: "{{ db.credentials.admin.user }}"
     password: "{{ db.credentials.admin.pass }}"
     force_basic_auth: yes
-  when: (inventory_hostname == coordinator) and (db.instances|int >= 2) and require_clustering is defined
+  when: (inventory_hostname == coordinator) and (db.instances|int >= 2) and (cluster_state.json.state != "cluster_finished")
+

--- a/ansible/roles/couchdb/tasks/deploy.yml
+++ b/ansible/roles/couchdb/tasks/deploy.yml
@@ -88,6 +88,33 @@
     force_basic_auth: yes
   when: (create_users_db.status == 404) and (inventory_hostname == coordinator) and (couchdb.version is version_compare('2.0','>='))
 
+- name: check clustered nodes
+  uri:
+    url: "{{ db.protocol }}://{{ ansible_host }}:{{ db.port }}/_membership"
+    method: GET
+    status_code: 200
+    user: "{{ db.credentials.admin.user }}"
+    password: "{{ db.credentials.admin.pass }}"
+    force_basic_auth: yes
+  register: nodes_state
+  run_once: true
+
+- name: check if there is a new node
+  set_fact:
+    require_clustering: true
+  when: item not in nodes_state.json.cluster_nodes
+  with_item: groups['db']
+  run_once: true
+
+- set_fact:
+    require_clustering: "{{ item }}"
+  loop: "{{ groups['db'] }}"
+  when: item not in nodes_state.json.cluster_nodes
+
+- name: set node name
+  set_fact:
+    node_name: "couchdb@{{ ansible_host  }}"
+
 - name: enable the cluster setup mode
   uri:
     url: "{{ db.protocol }}://{{ ansible_host }}:{{ db.port }}/_cluster_setup"
@@ -99,7 +126,7 @@
     user: "{{ db.credentials.admin.user }}"
     password: "{{ db.credentials.admin.pass }}"
     force_basic_auth: yes
-  when: (inventory_hostname == coordinator) and (db.instances|int >= 2)
+  when: (inventory_hostname == coordinator) and (db.instances|int >= 2) and require_clustering is defined
 
 - name: add remote nodes to the cluster
   uri:
@@ -112,7 +139,7 @@
     user: "{{ db.credentials.admin.user }}"
     password: "{{ db.credentials.admin.pass }}"
     force_basic_auth: yes
-  when: (inventory_hostname != coordinator) and (db.instances|int >= 2)
+  when: (inventory_hostname != coordinator) and (db.instances|int >= 2)  and require_clustering is defined and node_name not in nodes_state.json.cluster_nodes
 
 - name: finish the cluster setup mode
   uri:
@@ -125,4 +152,4 @@
     user: "{{ db.credentials.admin.user }}"
     password: "{{ db.credentials.admin.pass }}"
     force_basic_auth: yes
-  when: (inventory_hostname == coordinator) and (db.instances|int >= 2)
+  when: (inventory_hostname == coordinator) and (db.instances|int >= 2) and require_clustering is defined


### PR DESCRIPTION
## Description
This is to enable CouchDB `persist_path` in a distributed environment as well.
OW operators can freely redeploy CouchDB without any issue as it supports idempotency.
Also, in case new hosts are added in the inventory_host, they will also join the cluster on redeployment.


## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#????)
This is a subsequent PR from https://github.com/apache/incubator-openwhisk/pull/4250

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

