### PR TITLE
Run a clean step before build.

### DIFF
--- a/tools/jenkins/apache/dockerhub.groovy
+++ b/tools/jenkins/apache/dockerhub.groovy
@@ -32,6 +32,7 @@ node('xenial&&!H21&&!H22&&!H11&&!ubuntu-eu3') {
       def PUSH_CMD = "./gradlew :core:controller:distDocker :core:invoker:distDocker :tools:ow-utils:distDocker -PdockerRegistry=docker.io -PdockerImagePrefix=openwhisk"
       def gitCommit = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
       def shortCommit = gitCommit.take(7)
+      sh "./gradlew clean"
       sh "${PUSH_CMD} -PdockerImageTag=latest"
       sh "${PUSH_CMD} -PdockerImageTag=${shortCommit}"
     }


### PR DESCRIPTION
This attempts to fix Jenkins failure:
```
> Task :common:scala:compileScala
/home/jenkins/jenkins-slave/workspace/OpenWhisk-DockerHub/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ExecManifest.scala:79: Cannot find JsonReader or JsonFormat type class for Map[String,Set[org.apache.openwhisk.core.entity.ExecManifest.RuntimeManifest]]
      .map(_.convertTo[Map[String, Set[RuntimeManifest]]].map {
                      ^
/home/jenkins/jenkins-slave/workspace/OpenWhisk-DockerHub/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ExecManifest.scala:81: type mismatch;
 found   : Any
 required: String
 Note: implicit value runtimeManifestSerdes is not applicable here because it comes after the application point and it lacks an explicit result type
          RuntimeFamily(name, versions.map { mf =>
                        ^
/home/jenkins/jenkins-slave/workspace/OpenWhisk-DockerHub/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ExecManifest.scala:81: value map is not a member of Any
 Note: implicit value runtimeManifestSerdes is not applicable here because it comes after the application point and it lacks an explicit result type
          RuntimeFamily(name, versions.map { mf =>
                                       ^
/home/jenkins/jenkins-slave/workspace/OpenWhisk-DockerHub/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ExecManifest.scala:89: Cannot find JsonReader or JsonFormat type class for Set[org.apache.openwhisk.core.entity.ExecManifest.ImageName]
      .map(_.convertTo[Set[ImageName]].map { image =>
                      ^
four errors found

> Task :common:scala:compileScala FAILED
```