### PR TITLE
Use runtime tags specified in runtime manifest for YARNContainerFactoryTests

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ExecHelpers.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ExecHelpers.scala
@@ -42,15 +42,15 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
 
   private def attFmt[T: JsonFormat] = Attachments.serdes[T]
 
-  protected def imagename(name: String) = {
-    ExecManifest.runtimesManifest.runtimes.flatMap(_.versions).find(_.kind == name).get.image
-  }
+  protected def imageName(name: String) = ExecManifest.runtimesManifest.runtimes.flatMap(_.versions).find(_.kind == name).get.image
+
+  protected def imageTag(name: String) = ExecManifest.runtimesManifest.runtimes.flatMap(_.versions).find(_.kind == name).get.image.tag
 
   protected def js10Old(code: String, main: Option[String] = None) = {
     CodeExecAsString(
       RuntimeManifest(
         NODEJS10,
-        imagename(NODEJS10),
+        imageName(NODEJS10),
         default = Some(true),
         deprecated = Some(false),
         stemCells = Some(List(StemCell(2, 256.MB)))),
@@ -73,7 +73,7 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
     CodeExecMetaDataAsString(
       RuntimeManifest(
         NODEJS10,
-        imagename(NODEJS10),
+        imageName(NODEJS10),
         default = Some(true),
         deprecated = Some(false),
         stemCells = Some(List(StemCell(2, 256.MB)))),

--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ExecHelpers.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ExecHelpers.scala
@@ -42,9 +42,11 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
 
   private def attFmt[T: JsonFormat] = Attachments.serdes[T]
 
-  protected def imageName(name: String) = ExecManifest.runtimesManifest.runtimes.flatMap(_.versions).find(_.kind == name).get.image
+  protected def imageName(name: String) =
+    ExecManifest.runtimesManifest.runtimes.flatMap(_.versions).find(_.kind == name).get.image
 
-  protected def imageTag(name: String) = ExecManifest.runtimesManifest.runtimes.flatMap(_.versions).find(_.kind == name).get.image.tag
+  protected def imageTag(name: String) =
+    ExecManifest.runtimesManifest.runtimes.flatMap(_.versions).find(_.kind == name).get.image.tag
 
   protected def js10Old(code: String, main: Option[String] = None) = {
     CodeExecAsString(


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
Modifies `YARNContainerFactoryTests` to use the runtime tags provided in a deployment's runtime manifest instead of using the `latest` tag. Using the `latest` tag for runtimes is problematic as a deployment may use tags other than `latest`.

Failure example:
```
java.util.NoSuchElementException: key not found: ImageName(nodejs6action,Some(openwhisk),Some(latest))
	at scala.collection.MapLike.default(MapLike.scala:231)
	at scala.collection.MapLike.default$(MapLike.scala:230)
	at scala.collection.AbstractMap.default(Map.scala:59)
	at scala.collection.MapLike.apply(MapLike.scala:140)
	at scala.collection.MapLike.apply$(MapLike.scala:139)
	at scala.collection.AbstractMap.apply(Map.scala:59)
	at org.apache.openwhisk.core.yarn.YARNContainerFactory.createContainer(YARNContainerFactory.scala:131)
	at org.apache.openwhisk.core.containerpool.yarn.test.YARNContainerFactoryTests.$anonfun$new$8(YARNContainerFactoryTests.scala:138)
````

Related to: https://github.com/apache/incubator-openwhisk/commit/6e883f9392aeb8e1ceced92bf08eab517109281f
## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

