### PR TITLE
Use custom runtime manifest for YARN tests

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/yarn/test/YARNContainerFactoryTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/yarn/test/YARNContainerFactoryTests.scala
@@ -37,10 +37,41 @@ import scala.concurrent.duration._
 
 @RunWith(classOf[JUnitRunner])
 class YARNContainerFactoryTests extends Suite with BeforeAndAfter with FlatSpecLike with ExecHelpers {
+
+  implicit val whiskConfig: WhiskConfig = new WhiskConfig(Map(wskApiHostname -> "apihost") ++ wskApiHost)
+
+  val customManifest = Some(s"""
+                               |{ "runtimes": {
+                               |    "runtime1": [
+                               |      {
+                               |        "kind": "somekind:1",
+                               |        "deprecated": false,
+                               |        "default": true,
+                               |        "image": {
+                               |          "prefix": "openwhisk",
+                               |          "name": "somekind",
+                               |          "tag": "latest"
+                               |        }
+                               |      }
+                               |    ],
+                               |    "runtime2": [
+                               |      {
+                               |        "kind": "anotherkind:1",
+                               |        "deprecated": false,
+                               |        "default": true,
+                               |        "image": {
+                               |          "prefix": "openwhisk",
+                               |          "name": "anotherkind",
+                               |          "tag": "latest"
+                               |        }
+                               |      }
+                               |    ]
+                               |  }
+                               |}
+                               |""".stripMargin)
   val images = Array(
-    ImageName("nodejs6action", Option("openwhisk"), imageTag("nodejs:6")),
-    ImageName("python3action", Option("openwhisk"), imageTag("python:3")))
-  val runtimes = ExecManifest.runtimesManifest.toJson.compactPrint
+    ImageName("somekind", Option("openwhisk"), Some("latest")),
+    ImageName("anotherkind", Option("openwhisk"), Some("latest")))
   val containerArgsConfig =
     new ContainerArgsConfig(
       "net1",
@@ -65,10 +96,7 @@ class YARNContainerFactoryTests extends Suite with BeforeAndAfter with FlatSpecL
   val serviceName1 = yarnConfig.serviceName + "-1"
   val properties: Map[String, Set[String]] = Map[String, Set[String]]()
 
-  implicit val whiskConfig: WhiskConfig = new WhiskConfig(
-    Map(wskApiHostname -> "apihost", runtimesManifest -> runtimes) ++ wskApiHost)
-
-  ExecManifest.initialize(whiskConfig)
+  ExecManifest.initialize(whiskConfig, customManifest)
 
   behavior of "YARNContainerFactory"
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ExecHelpers.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ExecHelpers.scala
@@ -45,9 +45,6 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
   protected def imageName(name: String) =
     ExecManifest.runtimesManifest.runtimes.flatMap(_.versions).find(_.kind == name).get.image
 
-  protected def imageTag(name: String) =
-    ExecManifest.runtimesManifest.runtimes.flatMap(_.versions).find(_.kind == name).get.image.tag
-
   protected def js10Old(code: String, main: Option[String] = None) = {
     CodeExecAsString(
       RuntimeManifest(


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
Restores the intent of using a custom manifest with YARN container tests. This decouples the YARN tests from runtimes supported by a deployment. Seeing https://github.com/apache/incubator-openwhisk/pull/4305#pullrequestreview-207940815 for additional information.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

