### PR TITLE
Enable passing config string as part of ansible scripts

### DIFF
--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -118,6 +118,10 @@
       -Dcom.sun.management.jmxremote.rmi.port={{ jmx_remote_rmi_port }}
       -Dcom.sun.management.jmxremote.port={{ jmx_remote_port }}
 
+- name: Load config from template
+  set_fact:
+      openwhisk_config: "{{ lookup('template', 'config.j2') | b64encode }}"
+
 - name: populate environment variables for controller
   set_fact:
     env:
@@ -131,7 +135,7 @@
       "CONTROLLER_OPTS": "{{ controller_args | default(controller.arguments) }}"
       "CONTROLLER_INSTANCES": "{{ controller.instances }}"
       "JMX_REMOTE": "{{ jmx.enabled }}"
-
+      "OPENWHISK_ENCODED_CONFIG": "{{ openwhisk_config }}"
       "PORT": "8080"
       "TZ": "{{ docker.timezone }}"
 

--- a/ansible/roles/controller/templates/config.j2
+++ b/ansible/roles/controller/templates/config.j2
@@ -1,0 +1,8 @@
+include classpath("application.conf")
+
+# Specify any custom config here. For example
+# whisk {
+#   metrics {
+#     prometheus-enabled = true
+#   }
+# }

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -183,12 +183,18 @@
   set_fact:
     invoker_ports_to_expose: "{{ invoker_ports_to_expose }} + [ \"{{ jmx.basePortInvoker + (invoker_index | int) }}:{{ jmx.basePortInvoker + (invoker_index | int) }}\" ] + [ \"{{ jmx.rmiBasePortInvoker + (invoker_index | int) }}:{{ jmx.rmiBasePortInvoker + (invoker_index | int) }}\" ]"
 
+
+- name: Load config from template
+  set_fact:
+    openwhisk_config: "{{ lookup('template', 'config.j2') | b64encode }}"
+
 - name: populate environment variables for invoker
   set_fact:
     env:
       "JAVA_OPTS": "-Xmx{{ invoker.heap }} -XX:+CrashOnOutOfMemoryError -XX:+UseGCOverheadLimit -XX:ErrorFile=/logs/java_error.log"
       "INVOKER_OPTS": "{{ invoker_args | default(invoker.arguments) }}"
       "JMX_REMOTE": "{{ jmx.enabled }}"
+      "OPENWHISK_ENCODED_CONFIG": "{{ openwhisk_config }}"
       "PORT": "8080"
       "TZ": "{{ docker.timezone }}"
       "KAFKA_HOSTS": "{{ kafka_connect_string }}"

--- a/ansible/roles/invoker/templates/config.j2
+++ b/ansible/roles/invoker/templates/config.j2
@@ -1,0 +1,8 @@
+include classpath("application.conf")
+
+# Specify any custom config here. For example
+# whisk {
+#   metrics {
+#     prometheus-enabled = true
+#   }
+# }


### PR DESCRIPTION
This PR builds up on #4039 to allow passing config string as part of ansible deployment step

## Description

PR #4039 enabled support for passing config string encoded as base64 via `OPENWHISK_ENCODED_CONFIG` env variable. This PR extends that and adds base empty templates which can be modified to pass in such config in ansible deployments. Currently the config templates are empty and we can decide later to port existing or newer config via this mechanism

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

