### PR TITLE
Record clusterId performing change in CosmosDB

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -197,6 +197,10 @@ whisk {
         # ENABLING THIS VALUE MEANS YOUR DATA WILL NOT BE PERMANENTLY STORED
         # Can only be used for `WhiskActivation` for now
         # time-to-live      = 60 s
+
+        # Specifies the current clusterId whose value is recorded with document upon any update
+        # to indicate which cluster made the change. By default no such value is recorded
+        # cluster-id        =
         connection-policy {
             max-pool-size = 1000
             # When the value of this property is true, the SDK will direct write operations to

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfig.scala
@@ -37,7 +37,8 @@ case class CosmosDBConfig(endpoint: String,
                           throughput: Int,
                           consistencyLevel: ConsistencyLevel,
                           connectionPolicy: ConnectionPolicy,
-                          timeToLive: Option[Duration]) {
+                          timeToLive: Option[Duration],
+                          clusterId: Option[String]) {
 
   def createClient(): AsyncDocumentClient = {
     new AsyncDocumentClient.Builder()

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBUtil.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBUtil.scala
@@ -23,6 +23,10 @@ import org.apache.openwhisk.core.database.cosmosdb.CosmosDBConstants._
 import scala.collection.immutable.Iterable
 
 private[cosmosdb] object CosmosDBConstants {
+
+  /**
+   * Stores the computed properties required for view related queries
+   */
   val computed: String = "_c"
 
   val alias: String = "view"
@@ -35,6 +39,10 @@ private[cosmosdb] object CosmosDBConstants {
 
   val selfLink: String = SELF_LINK
 
+  /**
+   * Records the clusterId which performed changed in any document. This can vary over
+   * lifetime of a document as different clusters may change the same document at different times
+   */
   val clusterId: String = "_clusterId"
 }
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBUtil.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBUtil.scala
@@ -34,6 +34,8 @@ private[cosmosdb] object CosmosDBConstants {
   val aggregate: String = AGGREGATE
 
   val selfLink: String = SELF_LINK
+
+  val clusterId: String = "_clusterId"
 }
 
 private[cosmosdb] trait CosmosDBUtil {

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfigTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfigTests.scala
@@ -66,7 +66,9 @@ class CosmosDBConfigTests extends FlatSpec with Matchers {
       | }
          """.stripMargin).withFallback(globalConfig)
     val cosmos = CosmosDBConfig(config, "WhiskAuth")
-    cosmos should matchPattern { case CosmosDBConfig("http://localhost", "foo", "openwhisk", _, _, _, _) => }
+    cosmos.endpoint shouldBe "http://localhost"
+    cosmos.key shouldBe "foo"
+    cosmos.db shouldBe "openwhisk"
   }
 
   it should "work with extended config" in {
@@ -81,7 +83,9 @@ class CosmosDBConfigTests extends FlatSpec with Matchers {
       | }
          """.stripMargin).withFallback(globalConfig)
     val cosmos = CosmosDBConfig(config, "WhiskAuth")
-    cosmos should matchPattern { case CosmosDBConfig("http://localhost", "foo", "openwhisk", _, _, _, _) => }
+    cosmos.endpoint shouldBe "http://localhost"
+    cosmos.key shouldBe "foo"
+    cosmos.db shouldBe "openwhisk"
 
     cosmos.connectionPolicy.maxPoolSize shouldBe 42
     val policy = cosmos.connectionPolicy.asJava
@@ -115,7 +119,9 @@ class CosmosDBConfigTests extends FlatSpec with Matchers {
       | }
          """.stripMargin).withFallback(globalConfig)
     val cosmos = CosmosDBConfig(config, "WhiskAuth")
-    cosmos should matchPattern { case CosmosDBConfig("http://localhost", "foo", "openwhisk", _, _, _, _) => }
+    cosmos.endpoint shouldBe "http://localhost"
+    cosmos.key shouldBe "foo"
+    cosmos.db shouldBe "openwhisk"
 
     val policy = cosmos.connectionPolicy.asJava
     policy.isUsingMultipleWriteLocations shouldBe true

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBStoreBehaviorBase.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBStoreBehaviorBase.scala
@@ -37,7 +37,7 @@ trait CosmosDBStoreBehaviorBase extends FlatSpec with ArtifactStoreBehaviorBase 
 
   override lazy val storeAvailableCheck: Try[Any] = storeConfigTry
 
-  private lazy val config: CosmosDBConfig = storeConfig.copy(db = createTestDB().getId)
+  protected lazy val config: CosmosDBConfig = storeConfig.copy(db = createTestDB().getId)
 
   override lazy val authStore = {
     implicit val docReader: DocumentReader = WhiskDocumentReader


### PR DESCRIPTION
Enables storing the clusterId information as part of document json in db.

## Description

For Multi Region deployments (#4277) we need to differentiate which cluster made change to a document while emitting the cache invalidation event. This PR enables storing a `_clusterId` attribute which can be configured to uniquely identify current cluster. 

Later this attribute can be used by the cache invalidation service to filter out changes which are done by same cluster and only convert those changes from other cluster to local cache invalidation kafka topic
## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#4277 )

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

