### PR TITLE
Make WskRestRuleTests more stable.

### DIFF
--- a/tests/src/test/scala/system/basic/WskRestRuleTests.scala
+++ b/tests/src/test/scala/system/basic/WskRestRuleTests.scala
@@ -67,9 +67,9 @@ class WskRestRuleTests extends WskRuleTests with WskActorSystem {
 
     statusPermutations.foreach {
       case (trigger, status) =>
-        if (status == active) wsk.rule.enable(ruleName) else wsk.rule.disable(ruleName)
         // Needs to be retried since the enable/disable causes a cache invalidation which needs to propagate first
         retry({
+          if (status == active) wsk.rule.enable(ruleName) else wsk.rule.disable(ruleName)
           val createStdout = wsk.rule.create(ruleName, trigger, actionName, update = true).stdout
           val getStdout = wsk.rule.get(ruleName).stdout
           wsk.parseJsonString(createStdout).fields.get("status") shouldBe status


### PR DESCRIPTION
If there is an deployment with several controllers, the test `Whisk rules should preserve rule status when a rule is updated` fails intermittently. The reason is, that there are several modifications on the rule. These modifications are already retried. But enabling and disabling the rule also modifies the database document. But that change is currently not retried.
This PR puts the enabling/disabling of the rule into the retry block as well to make this test more stable against our eventual consistency.

Co-authored-by: Somaya Jamil <jamilsom@de.ibm.com>

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.