### PR TITLE
Update CosmosDB to 2.4.2

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -86,7 +86,7 @@ dependencies {
 
     compile 'io.reactivex:rxscala_2.12:0.26.5'
     compile 'io.reactivex:rxjava-reactive-streams:1.2.1'
-    compile ('com.microsoft.azure:azure-cosmosdb:2.4.0'){
+    compile ('com.microsoft.azure:azure-cosmosdb:2.4.2'){
         exclude group: 'commons-logging'
     }
 

--- a/tests/src/test/resources/application.conf.j2
+++ b/tests/src/test/resources/application.conf.j2
@@ -53,9 +53,10 @@ whisk {
     }
 
     cosmosdb {
-        endpoint = ${?COSMOSDB_ENDPOINT}
-        key      = ${?COSMOSDB_KEY}
-        db       = ${?COSMOSDB_NAME}
+        endpoint   = ${?COSMOSDB_ENDPOINT}
+        key        = ${?COSMOSDB_KEY}
+        db         = ${?COSMOSDB_NAME}
+        throughput = 400
     }
 
     controller {

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/behavior/ArtifactStoreAttachmentBehaviors.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/behavior/ArtifactStoreAttachmentBehaviors.scala
@@ -170,12 +170,15 @@ trait ArtifactStoreAttachmentBehaviors extends ArtifactStoreBehaviorBase with Ex
 
   it should "throw NoDocumentException for non existing attachment" in {
     implicit val tid: TransactionId = transid()
+    val attachmentName = "foo"
+    val attachmentId =
+      getAttachmentStore(entityStore).map(s => s"${s.scheme}:$attachmentName").getOrElse(attachmentName)
 
     val sink = StreamConverters.fromOutputStream(() => new ByteArrayOutputStream())
     entityStore
       .readAttachment[IOResult](
         DocInfo ! ("non-existing-doc", "42"),
-        Attached("foo", ContentTypes.`application/octet-stream`),
+        Attached(attachmentId, ContentTypes.`application/octet-stream`),
         sink)
       .failed
       .futureValue shouldBe a[NoDocumentException]


### PR DESCRIPTION
Updates CosmosDB to 2.4.2 (from 2.4.0) as it has some [fixes related to cross partition queries](https://github.com/Azure/azure-cosmosdb-java/tree/master/changelog#242)

## Description

Couple of changes in this PR

1. Update to CosmosDB SDK 2.4.2
2. Removes support for storing attachment in ComsosDB and requires an external AttachmentStore to be configured. (Fixes #4286)
3. Reduces the configured throughput for test runs to 400 from current 1000. Would save some money!

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

