### PR TITLE
Adjust error handling in the Cloudant Rest Store

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/ArtifactStoreExceptions.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/ArtifactStoreExceptions.scala
@@ -27,7 +27,13 @@ case class DocumentTypeMismatchException(message: String) extends ArtifactStoreE
 
 case class DocumentUnreadable(message: String) extends ArtifactStoreException(message)
 
+case class GetException(message: String) extends ArtifactStoreException(message)
+
 case class PutException(message: String) extends ArtifactStoreException(message)
+
+case class DeleteException(message: String) extends ArtifactStoreException(message)
+
+case class QueryException(message: String) extends ArtifactStoreException(message)
 
 sealed abstract class ArtifactStoreRuntimeException(message: String) extends RuntimeException(message)
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestStore.scala
@@ -129,7 +129,7 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
             start,
             s"[PUT] '$dbName' failed to put document: '${docinfoStr}'; http status: '${code}'",
             ErrorLevel)
-          throw new Exception("Unexpected http response code: " + code)
+          throw new PutException("Unexpected http response code: " + code)
       }
     }
 
@@ -164,7 +164,7 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
 
         case Left(code) =>
           transid.failed(this, start, s"'$dbName' failed to put documents, http status: '${code}'", ErrorLevel)
-          throw new Exception("Unexpected http response code: " + code)
+          throw new PutException("Unexpected http response code: " + code)
       }
     }
 
@@ -200,7 +200,7 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
             start,
             s"[DEL] '$dbName' failed to delete document: '${doc}'; http status: '${code}'",
             ErrorLevel)
-          throw new Exception("Unexpected http response code: " + code)
+          throw new DeleteException("Unexpected http response code: " + code)
       }
     }
 
@@ -241,7 +241,7 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
 
         case Left(code) =>
           transid.failed(this, start, s"[GET] '$dbName' failed to get document: '${doc}'; http status: '${code}'")
-          throw new Exception("Unexpected http response code: " + code)
+          throw new GetException("Unexpected http response code: " + code)
       }
     } recoverWith {
       case e: DeserializationException => throw DocumentUnreadable(Messages.corruptedEntity)
@@ -310,7 +310,7 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
 
         case Left(code) =>
           transid.failed(this, start, s"Unexpected http response code: $code", ErrorLevel)
-          throw new Exception("Unexpected http response code: " + code)
+          throw new QueryException("Unexpected http response code: " + code)
       }
 
     reportFailure(
@@ -344,7 +344,7 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
 
         case Left(code) =>
           transid.failed(this, start, s"Unexpected http response code: $code", ErrorLevel)
-          throw new Exception("Unexpected http response code: " + code)
+          throw new QueryException("Unexpected http response code: " + code)
       }
 
     reportFailure(
@@ -431,7 +431,7 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
             this,
             start,
             s"[ATT_PUT] '$dbName' failed to upload attachment '$name' of document '$doc'; http status '$code'")
-          throw new Exception("Unexpected http response code: " + code)
+          throw new PutException("Unexpected http response code: " + code)
       }
     }
 
@@ -495,7 +495,7 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
               this,
               start,
               s"[ATT_GET] '$dbName' failed to get attachment '$name' of document '$doc'; http status: '$code'")
-            throw new Exception("Unexpected http response code: " + code)
+            throw new GetException("Unexpected http response code: " + code)
         }
 
     reportFailure(

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestStore.scala
@@ -240,7 +240,7 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
           throw NoDocumentException("not found on 'get'")
 
         case Left(code) =>
-          transid.finished(this, start, s"[GET] '$dbName' failed to get document: '${doc}'; http status: '${code}'")
+          transid.failed(this, start, s"[GET] '$dbName' failed to get document: '${doc}'; http status: '${code}'")
           throw new Exception("Unexpected http response code: " + code)
       }
     } recoverWith {


### PR DESCRIPTION
## Description
This PR cleans the error handling in the CouchDBRestStore so that metrics and logs are not send twice. It also cleans a case were a success metric was send in an error situation.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

