### PR TITLE
Use Gauge metric instead of Histogram where applicable

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaConsumerConnector.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaConsumerConnector.scala
@@ -190,7 +190,7 @@ class KafkaConsumerConnector(
             endOffset =>
               // endOffset could lag behind the offset reported by the consumer internally resulting in negative numbers
               val queueSize = (endOffset - offset).max(0)
-              MetricEmitter.emitHistogramMetric(queueMetric, queueSize)
+              MetricEmitter.emitGaugeMetric(queueMetric, queueSize)
           }
         }
       }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/CommonLoadBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/CommonLoadBalancer.scala
@@ -64,20 +64,20 @@ abstract class CommonLoadBalancer(config: WhiskConfig,
   protected val totalBlackBoxActivationMemory = new LongAdder()
   protected val totalManagedActivationMemory = new LongAdder()
 
-  protected def emitHistogramMetric() = {
-    MetricEmitter.emitHistogramMetric(LOADBALANCER_ACTIVATIONS_INFLIGHT(controllerInstance), totalActivations.longValue)
-    MetricEmitter.emitHistogramMetric(
+  protected def emitMetrics() = {
+    MetricEmitter.emitGaugeMetric(LOADBALANCER_ACTIVATIONS_INFLIGHT(controllerInstance), totalActivations.longValue)
+    MetricEmitter.emitGaugeMetric(
       LOADBALANCER_MEMORY_INFLIGHT(controllerInstance, ""),
       totalBlackBoxActivationMemory.longValue + totalManagedActivationMemory.longValue)
-    MetricEmitter.emitHistogramMetric(
+    MetricEmitter.emitGaugeMetric(
       LOADBALANCER_MEMORY_INFLIGHT(controllerInstance, "Blackbox"),
       totalBlackBoxActivationMemory.longValue)
-    MetricEmitter.emitHistogramMetric(
+    MetricEmitter.emitGaugeMetric(
       LOADBALANCER_MEMORY_INFLIGHT(controllerInstance, "Managed"),
       totalManagedActivationMemory.longValue)
   }
 
-  actorSystem.scheduler.schedule(10.seconds, 10.seconds)(emitHistogramMetric())
+  actorSystem.scheduler.schedule(10.seconds, 10.seconds)(emitMetrics())
 
   override def activeActivationsFor(namespace: UUID): Future[Int] =
     Future.successful(activationsPerNamespace.get(namespace).map(_.intValue()).getOrElse(0))

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/LeanBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/LeanBalancer.scala
@@ -82,8 +82,8 @@ class LeanBalancer(config: WhiskConfig,
     // Currently do nothing
   }
 
-  override protected def emitHistogramMetric() = {
-    super.emitHistogramMetric()
+  override protected def emitMetrics() = {
+    super.emitMetrics()
   }
 }
 

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
@@ -163,9 +163,9 @@ class ShardingContainerPoolBalancer(
     None
   }
 
-  override protected def emitHistogramMetric() = {
-    super.emitHistogramMetric()
-    MetricEmitter.emitHistogramMetric(
+  override protected def emitMetrics() = {
+    super.emitMetrics()
+    MetricEmitter.emitGaugeMetric(
       INVOKER_TOTALMEM_BLACKBOX,
       schedulingState.blackboxInvokers.foldLeft(0L) { (total, curr) =>
         if (curr.status.isUsable) {
@@ -174,7 +174,7 @@ class ShardingContainerPoolBalancer(
           total
         }
       })
-    MetricEmitter.emitHistogramMetric(
+    MetricEmitter.emitGaugeMetric(
       INVOKER_TOTALMEM_MANAGED,
       schedulingState.managedInvokers.foldLeft(0L) { (total, curr) =>
         if (curr.status.isUsable) {
@@ -183,30 +183,22 @@ class ShardingContainerPoolBalancer(
           total
         }
       })
-    MetricEmitter.emitHistogramMetric(
-      HEALTHY_INVOKER_MANAGED,
-      schedulingState.managedInvokers.count(_.status == Healthy))
-    MetricEmitter.emitHistogramMetric(
+    MetricEmitter.emitGaugeMetric(HEALTHY_INVOKER_MANAGED, schedulingState.managedInvokers.count(_.status == Healthy))
+    MetricEmitter.emitGaugeMetric(
       UNHEALTHY_INVOKER_MANAGED,
       schedulingState.managedInvokers.count(_.status == Unhealthy))
-    MetricEmitter.emitHistogramMetric(
+    MetricEmitter.emitGaugeMetric(
       UNRESPONSIVE_INVOKER_MANAGED,
       schedulingState.managedInvokers.count(_.status == Unresponsive))
-    MetricEmitter.emitHistogramMetric(
-      OFFLINE_INVOKER_MANAGED,
-      schedulingState.managedInvokers.count(_.status == Offline))
-    MetricEmitter.emitHistogramMetric(
-      HEALTHY_INVOKER_BLACKBOX,
-      schedulingState.blackboxInvokers.count(_.status == Healthy))
-    MetricEmitter.emitHistogramMetric(
+    MetricEmitter.emitGaugeMetric(OFFLINE_INVOKER_MANAGED, schedulingState.managedInvokers.count(_.status == Offline))
+    MetricEmitter.emitGaugeMetric(HEALTHY_INVOKER_BLACKBOX, schedulingState.blackboxInvokers.count(_.status == Healthy))
+    MetricEmitter.emitGaugeMetric(
       UNHEALTHY_INVOKER_BLACKBOX,
       schedulingState.blackboxInvokers.count(_.status == Unhealthy))
-    MetricEmitter.emitHistogramMetric(
+    MetricEmitter.emitGaugeMetric(
       UNRESPONSIVE_INVOKER_BLACKBOX,
       schedulingState.blackboxInvokers.count(_.status == Unresponsive))
-    MetricEmitter.emitHistogramMetric(
-      OFFLINE_INVOKER_BLACKBOX,
-      schedulingState.blackboxInvokers.count(_.status == Offline))
+    MetricEmitter.emitGaugeMetric(OFFLINE_INVOKER_BLACKBOX, schedulingState.blackboxInvokers.count(_.status == Offline))
   }
 
   /** State needed for scheduling. */


### PR DESCRIPTION
This PR introduces an abstraction for [Kamon Gauge](https://kamon.io/docs/latest/core/metrics/#gauges)

## Description
As mentioned in #4311 at some places we are using Histogram to track metric which should instead be tracked as Gauge. This PR converts such usage to Gauge based

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#4311)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

