### PR TITLE
Set API key annotation for a WskConsole test

### DIFF
--- a/tests/src/test/scala/system/basic/WskConsoleTests.scala
+++ b/tests/src/test/scala/system/basic/WskConsoleTests.scala
@@ -35,6 +35,8 @@ import common.WskTestHelpers
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 
+import org.apache.openwhisk.core.entity.WhiskAction
+
 /**
  * Tests of the text console
  */
@@ -88,7 +90,10 @@ abstract class WskConsoleTests extends TestHelpers with WskTestHelpers {
   it should "show repeated activations" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
     val name = withTimestamp("countdown")
     assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(name, Some(TestUtils.getTestActionFilename("countdown.js")))
+      action.create(
+        name,
+        Some(TestUtils.getTestActionFilename("countdown.js")),
+        annotations = Map(WhiskAction.provideApiKeyAnnotationName -> JsBoolean(true)))
     }
 
     val count = 3


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
A CLI test suite that inherits from `WskConsoleTests` is failing due to recent API key security changes. Updating the `show repeated activations` console test to include an API key in the corresponding test action as that action uses the OpenWhisk Node.js client.

Test failure:
```
system.basic.WskCliConsoleTests > Wsk Activation Console should show repeated activations STANDARD_OUT
    check failed for activation 89bebcccd79b4c61bebcccd79bbc61a4: {"activationId":"89bebcccd79b4c61bebcccd79bbc61a4","annotations":[{"key":"path","value":"guest/countdown-1552068139417"},{"key":"waitTime","value":27},{"key":"kind","value":"nodejs:6"},{"key":"timeout","value":false},{"key":"limits","value":{"concurrency":1,"logs":10,"memory":256,"timeout":60000}},{"key":"initTime","value":271}],"duration":302,"end":1552068139896,"logs":["2019-03-08T18:02:19.900914879Z stderr: Error: Invalid constructor options. Missing api_key parameter or token plugin.","2019-03-08T18:02:19.900928425Z stderr: at Client.parseOptions (/node_modules/openwhisk/lib/client.js:97:13)","2019-03-08T18:02:19.900931236Z stderr: at new Client (/node_modules/openwhisk/lib/client.js:73:25)","2019-03-08T18:02:19.900933757Z stderr: at OpenWhisk (/node_modules/openwhisk/lib/main.js:15:18)","2019-03-08T18:02:19.900936305Z stderr: at NodeActionRunner.main [as userScriptMain] (eval at <anonymous> (/nodejsAction/runner.js:79:109), <anonymous>:11:15)","2019-03-08T18:02:19.90093952Z  stderr: at /nodejsAction/runner.js:98:45","2019-03-08T18:02:19.900941956Z stderr: at NodeActionRunner.run (/nodejsAction/runner.js:92:16)","2019-03-08T18:02:19.900944196Z stderr: at doRun (/nodejsAction/src/service.js:166:31)","2019-03-08T18:02:19.900946463Z stderr: at runCode (/nodejsAction/src/service.js:118:20)","2019-03-08T18:02:19.900948724Z stderr: at /nodejsAction/app.js:69:13","2019-03-08T18:02:19.900950998Z stderr: at Layer.handle [as handle_request] (/node_modules/express/lib/router/layer.js:95:5)"],"name":"countdown-1552068139417","namespace":"guest","publish":false,"response":{"result":{"error":"An error has occurred: Error: Invalid constructor options. Missing api_key parameter or token plugin."},"status":"action developer error","statusCode":0,"success":false},"start":1552068139594,"subject":"guest","version":"0.0.1"}
    Exception occurred during test execution: org.scalatest.exceptions.TestFailedException: expected activations of action 'countdown-1552068139417' since 2019-03-08T18:02:19.094Z, initial activation 89bebcccd79b4c61bebcccd79bbc61a4: 1 was not equal to 4
```
## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

