### PR TITLE
Redirect http to https and other nginx config cleanup.

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -29,7 +29,7 @@ whisk_api_localhost_name_default: "localhost"
 environmentInformation:
   type: "{{ environment_type | default('local') }}"
 
-hosts_dir: "{{ inventory_dir | default(env_hosts_dir) }}"
+hosts_dir: "{{ inventory_dir | default(env_hosts_dir) }}"
 
 whisk:
   version:
@@ -209,15 +209,14 @@ nginx:
   version: "{{ nginx_version | default('1.13') }}"
   port:
     http: 80
-    api: 443
+    https: 443
   ssl:
-    path: "{{ openwhisk_home }}/ansible/roles/nginx/files"
-    cert: "openwhisk-server-cert.pem"
-    key: "openwhisk-server-key.pem"
-    password_enabled: false
-    password_file: "ssl.pass"
-    client_ca_cert: "{{ openwhisk_client_ca_cert | default('openwhisk-client-ca-cert.pem') }}"
+    path: "{{ nginx_ssl_path | default(playbook_dir +'/roles/nginx/files') }}"
+    cert: "{{ nginx_ssl_server_cert | default('openwhisk-server-cert.pem') }}"
+    key: "{{ nginx_ssl_server_key | default('openwhisk-server-key.pem') }}"
+    client_ca_cert: "{{ nginx_ssl_client_ca_cert | default('openwhisk-client-ca-cert.pem') }}"
     verify_client: "{{ nginx_ssl_verify_client | default('off') }}"
+    password_file: "{{ nginx_ssl_password_file | default(false) }}"
   wpn:
     router: "{{ nginx_wpn_router | default('1') }}"
   special_users: "{{ nginx_special_users | default('[]') }}"
@@ -298,8 +297,8 @@ catalog_namespace: "/whisk.system"
 # The catalog_auth_key is used to determine the secret key to authenticate the openwhisk service.
 # The value for this variable can be set to either the secret key itself or the file, which
 # saves the secret key.
-# By default, we take the key from {{ openwhisk_home }}/ansible/files/auth.whisk.system.
-catalog_auth_key: "{{ openwhisk_home }}/ansible/files/auth.whisk.system"
+# By default, we take the key from ansible/files/auth.whisk.system.
+catalog_auth_key: "{{ playbook_dir }}/files/auth.whisk.system"
 
 # The catalog_repos is used to specify all the catalog names and repository URLs,
 # so that openwhisk knows where to download the catalog and install them. The key

--- a/ansible/roles/nginx/tasks/deploy.yml
+++ b/ansible/roles/nginx/tasks/deploy.yml
@@ -16,7 +16,7 @@
 
 - name: copy cert files from local to remote in nginx config directory
   copy:
-    src: "files/{{ item }}"
+    src: "{{ nginx.ssl.path }}/{{ item }}"
     dest: "{{ nginx.confdir }}"
   with_items:
         - "{{ nginx.ssl.cert }}"
@@ -25,9 +25,9 @@
 
 - name: copy password files for cert from local to remote in nginx config directory
   copy:
-    src: "files/{{ nginx.ssl.password_file }}"
+    src: "{{ nginx.ssl.path }}/{{ nginx.ssl.password_file }}"
     dest: "{{ nginx.confdir }}"
-  when: nginx.ssl.password_enabled == true
+  when: nginx.ssl.password_file
 
 - name: copy controller cert for authentication
   copy:
@@ -83,10 +83,8 @@
     restart_policy: "{{ docker.restart.policy }}"
     hostname: "nginx"
     volumes: "{{ volumes }}"
-    expose:
-      - 8443
     ports:
       - "{{ nginx.port.http }}:80"
-      - "{{ nginx.port.api }}:443"
+      - "{{ nginx.port.https }}:443"
     env:
       TZ: "{{ docker.timezone }}"

--- a/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/ansible/roles/nginx/templates/nginx.conf.j2
@@ -52,11 +52,11 @@ http {
     }
 
     upstream controllers {
-        # fail_timeout: period of time the server will be considered unavailable
-        # Mark the controller as unavailable for at least 60 seconds, to not get any requests during restart.
+        # Mark the controller as unavailable after fail_timeout seconds, to not get any requests during restart.
         # Otherwise, nginx would dispatch requests when the container is up, but the backend in the container not.
         # From the docs:
-        # "normally, requests with a non-idempotent method (POST, LOCK, PATCH) are not passed to the next server if a request has been sent to an upstream server"
+        #  "normally, requests with a non-idempotent method (POST, LOCK, PATCH) are not passed to
+        #   the next server if a request has been sent to an upstream server"
 {% for c in groups['controllers'] %}
         server {{ hostvars[c].ansible_host }}:{{ controller.basePort + groups['controllers'].index(c) }} fail_timeout=60s;
 {% endfor %}
@@ -89,12 +89,19 @@ http {
 {# Turn off sending information about the server to the client #}
     server_tokens off;
 
+    # Redirect all http to https.
+    server {
+        listen 80 default_server;
+        server_name _;
+        return 301 https://$host$request_uri;
+    }
+
     server {
         listen 443 default ssl;
 
-        # match namespace, note while OpenWhisk allows a richer character set for a
-        # namespace, not all those characters are permitted in the (sub)domain name;
-        # if namespace does not match, no vanity URL rewriting takes place.
+        # Match namespace, note while OpenWhisk allows a richer character set for a
+        # namespace, not all those characters are permitted in the (sub)domain name.
+        # If namespace does not match, no vanity URL rewriting takes place.
         server_name ~^(?<namespace>[0-9a-zA-Z-]+)\.{{ whisk_api_localhost_name | default(whisk_api_host_name) | default(whisk_api_localhost_name_default) }}$;
 
         # Recommended TLS settings from: https://wiki.mozilla.org/Security/Server_Side_TLS
@@ -102,7 +109,7 @@ http {
         ssl_session_timeout  10m;
         ssl_certificate      /etc/nginx/{{ nginx.ssl.cert }};
         ssl_certificate_key  /etc/nginx/{{ nginx.ssl.key }};
-        {% if nginx.ssl.password_enabled %}
+        {% if nginx.ssl.password_file %}
         ssl_password_file   "/etc/nginx/{{ nginx.ssl.password_file }}";
         {% endif %}
         ssl_client_certificate /etc/nginx/{{ nginx.ssl.client_ca_cert }};

--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -40,11 +40,11 @@
 
   # Generate nginx certificates
   - name: gen untrusted server certificate for host
-    local_action: shell "{{ playbook_dir }}/files/genssl.sh" "*.{{ whisk_api_localhost_name | default(whisk_api_host_name) | default(whisk_api_localhost_name_default) }}" "server" "{{ playbook_dir }}/roles/nginx/files"
+    local_action: shell "{{ playbook_dir }}/files/genssl.sh" "*.{{ whisk_api_localhost_name | default(whisk_api_host_name) | default(whisk_api_localhost_name_default) }}" "server" "{{ nginx.ssl.path }}"
     when: nginx.ssl.cert == "openwhisk-server-cert.pem"
 
   - name: gen untrusted client certificate for host
-    local_action: shell "{{ playbook_dir }}/files/genssl.sh" "*.{{ whisk_api_localhost_name | default(whisk_api_host_name) | default(whisk_api_localhost_name_default) }}" "client" "{{ playbook_dir }}/roles/nginx/files"
+    local_action: shell "{{ playbook_dir }}/files/genssl.sh" "*.{{ whisk_api_localhost_name | default(whisk_api_host_name) | default(whisk_api_localhost_name_default) }}" "client" "{{ nginx.ssl.path }}"
     when: nginx.ssl.client_ca_cert == "openwhisk-client-ca-cert.pem"
 
   # Generate Kafka certificates


### PR DESCRIPTION
This PR allows SSL certificates for the openwhisk nginx to be copied from an arbitrary path, and provides overrides for the certificate names. I believe these were intended by past changes there were some gaps. For example, the `ssl.path` value was not properly used in the nginx script and the files had to be copied into the ansible directory. Also the certificate names could not be easily overriden (one would have to specify a full json value).

As part of, I removed an unused exposed port, and redirected http to https as well.

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

