### PR TITLE
Disable info level logging for Prometheus Metrics endpoint

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/http/BasicRasService.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/BasicRasService.scala
@@ -29,7 +29,7 @@ trait BasicRasService extends BasicHttpService {
   override def routes(implicit transid: TransactionId) = ping ~ MetricsRoute()
 
   override def loglevelForRoute(route: String): Logging.LogLevel = {
-    if (route == "/ping") {
+    if (route == "/ping" || route == "/metrics") {
       Logging.DebugLevel
     } else {
       super.loglevelForRoute(route)


### PR DESCRIPTION
Disables the info level logging for `/metrics` endpoint

## Description
Currently if we enable the Prometheus support (#4227) then following logs are logged upon each pull by Prometheus. This creates noise and hence should be disabled by logging such data at debug level like its being done for health check endpoint (`/ping`)

```
[2019-03-11T09:47:00.149Z] [INFO] [#tid_ZjiVLdaB6c3EZjFAMM13cgsyBpZiDj4Z] [BasicHttpService] [marker:http_get.404_count:35:35]
[2019-03-11T09:47:08.266Z] [INFO] [#tid_5Rs71DH03wKCwGPG6wGrgaStDNQGTpNB] GET /metrics 
[2019-03-11T09:47:08.272Z] [INFO] [#tid_5Rs71DH03wKCwGPG6wGrgaStDNQGTpNB] [BasicHttpService] [marker:http_get.200_count:2:2]
[2019-03-11T09:47:08.844Z] [INFO] [#tid_RsMjOrwwPCwgzandGi2PxIGg7alOtlMk] GET /metrics 
[2019-03-11T09:47:08.852Z] [INFO] [#tid_RsMjOrwwPCwgzandGi2PxIGg7alOtlMk] [BasicHttpService] [marker:http_get.200_count:9:9]
```
## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

