### PR TITLE
Feature flag support to turn on/off support for provide-api-key annotation

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -398,6 +398,13 @@ whisk {
             polling-from-db: true
         }
     }
+
+    feature-flags {
+        # Enables support for `provide-api-key` annotation.
+        # See https://github.com/apache/incubator-openwhisk/pull/4284
+        # for details
+        require-api-key-annotation = true
+    }
 }
 #placeholder for test overrides so that tests can override defaults in application.conf (todo: move all defaults to reference.conf)
 test {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/FeatureFlags.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/FeatureFlags.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core
+import pureconfig.loadConfigOrThrow
+
+object FeatureFlags {
+  private case class FeatureFlagConfig(requireApiKeyAnnotation: Boolean)
+  private val config = loadConfigOrThrow[FeatureFlagConfig](ConfigKeys.featureFlags)
+
+  val requireApiKeyAnnotation: Boolean = config.requireApiKeyAnnotation
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
@@ -249,4 +249,5 @@ object ConfigKeys {
   val activationStoreWithFileStorage = s"$activationStore.with-file-storage"
 
   val metrics = "whisk.metrics"
+  val featureFlags = "whisk.feature-flags"
 }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Actions.scala
@@ -33,7 +33,7 @@ import akka.http.scaladsl.unmarshalling._
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import org.apache.openwhisk.common.TransactionId
-import org.apache.openwhisk.core.WhiskConfig
+import org.apache.openwhisk.core.{FeatureFlags, WhiskConfig}
 import org.apache.openwhisk.core.controller.RestApiCommons.{ListLimit, ListSkip}
 import org.apache.openwhisk.core.controller.actions.PostActionActivation
 import org.apache.openwhisk.core.database.{ActivationStore, CacheChangeNotification, NoDocumentException}
@@ -67,7 +67,7 @@ object WhiskActionsApi {
    * 2. An [[execAnnotation]] consistent with the action kind; this annotation is always added and overrides a pre-existing value
    */
   protected[core] def amendAnnotations(annotations: Parameters, exec: Exec, create: Boolean = true): Parameters = {
-    val newAnnotations = if (create) {
+    val newAnnotations = if (create && FeatureFlags.requireApiKeyAnnotation) {
       // these annotations are only added on newly created actions
       // since they can break existing actions created before the
       // annotation was created


### PR DESCRIPTION
Enables support for feature flags which for now is used to enable or disable support for `provide-api-key` (#4284)

## Description

With #4284 support was added for `provide-api-key` annotation. In some cases we may want to enable this feature later. This PR introduces a feature flag support which allow disabling such feature based on config. To disable this feature use config like below

```
whisk {
    feature-flags {
        require-api-key-annotation = false
    }
}
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

