### PR TITLE
Fix intermittent test failure related to sequence execution error propagation

### DIFF
--- a/tests/src/test/scala/system/basic/WskSequenceTests.scala
+++ b/tests/src/test/scala/system/basic/WskSequenceTests.scala
@@ -33,7 +33,7 @@ import common.rest.WskRestOperations
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import system.rest.RestUtil
-import org.apache.openwhisk.http.Messages.sequenceIsTooLong
+import org.apache.openwhisk.http.Messages._
 
 /**
  * Tests sequence execution
@@ -365,9 +365,9 @@ class WskSequenceTests extends TestHelpers with WskTestHelpers with StreamLoggin
         // the status should be error
         //activation.response.status shouldBe("application error")
         val result = activation.response.result.get
-        // the result of the activation should be timeout
-        result shouldBe (JsObject(
-          "error" -> JsString("The action exceeded its time limits of 10000 milliseconds during initialization.")))
+        // the result of the activation should be timeout or an abnormal initialization
+        result should (be(JsObject("error" -> timedoutActivation(shortDuration, true).toJson)) or be(
+          JsObject("error" -> abnormalInitialization.toJson)))
       }
   }
 


### PR DESCRIPTION
A test entitled `propagate execution error (timeout) from atomic action to sequence` is failing intermittently with an abnormal initialization error instead of an action timeout error. Since the action that is meant to fail will never complete the init phase, the socket responsible for performing the init may timeout resulting in the abnormal initialization error instead of an action timeout error. Changes here allow for either error message to be returned in the activation record.

Invoker log showing the init socket connection timing out:
```
[2019-03-14T04:00:22.911Z] [INFO] [#tid_36f2cb1fe73426dfa3a4f5738e4e990a] [ContainerPool] containerStart containerState: recreatedPrewarm container: Some(ContainerId(0a2e30bb9aa6a91767c247c3ff59c2a0ad81c698815a2ebccd4e67573c7d8aaf)) activations: 1 of max 1 action: initforever namespace: lime@us.ibm.com activationId: 475025d3eda548d19025d3eda548d13f
[2019-03-14T04:00:22.913Z] [INFO] [#tid_36f2cb1fe73426dfa3a4f5738e4e990a] [DockerContainer] sending initialization to ContainerId(0a2e30bb9aa6a91767c247c3ff59c2a0ad81c698815a2ebccd4e67573c7d8aaf) ContainerAddress(172.17.0.33,8080)
[2019-03-14T04:00:44.910Z] [INFO] [#tid_36f2cb1fe73426dfa3a4f5738e4e990a] [DockerContainer] initialization result: ConnectionError(java.net.SocketTimeoutException: Read timed out)
[2019-03-14T04:00:44.915Z] [INFO] [#tid_36f2cb1fe73426dfa3a4f5738e4e990a] [KafkaProducerConnector] sent message: completed0[0][354]
[2019-03-14T04:00:44.915Z] [INFO] [#tid_36f2cb1fe73426dfa3a4f5738e4e990a] [InvokerReactive] posted completion of activation 475025d3eda548d19025d3eda548d13f
```

Closes https://github.com/apache/incubator-openwhisk/issues/4341
<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

