### PR TITLE
Move runtimesRegistry to pureconfig.

### DIFF
--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -227,7 +227,7 @@
       "WHISK_API_HOST_PROTO": "{{ whisk_api_host_proto | default('https') }}"
       "WHISK_API_HOST_PORT": "{{ whisk_api_host_port | default('443') }}"
       "WHISK_API_HOST_NAME": "{{ whisk_api_host_name | default(groups['edge'] | first) }}"
-      "RUNTIMES_REGISTRY": "{{ runtimes_registry | default('') }}"
+      "CONFIG_whisk_containerFactory_runtimesRegistry_url": "{{ runtimes_registry | default('') }}"
       "RUNTIMES_MANIFEST": "{{ runtimesManifest | to_json }}"
       "CONFIG_whisk_runtimes_bypassPullForLocalImages": "{{ runtimes_bypass_pull_for_local_images | default() | string }}"
       "CONFIG_whisk_runtimes_localImagePrefix": "{{ runtimes_local_image_prefix | default() }}"

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
@@ -70,7 +70,6 @@ class WhiskConfig(requiredProperties: Map[String, String],
   val dbPrefix = this(WhiskConfig.dbPrefix)
   val mainDockerEndpoint = this(WhiskConfig.mainDockerEndpoint)
 
-  val runtimesRegistry = this(WhiskConfig.runtimesRegistry)
   val runtimesManifest = this(WhiskConfig.runtimesManifest)
   val actionInvokePerMinuteLimit = this(WhiskConfig.actionInvokePerMinuteLimit)
   val actionInvokeConcurrentLimit = this(WhiskConfig.actionInvokeConcurrentLimit)
@@ -175,7 +174,6 @@ object WhiskConfig {
   val kafkaHosts = Map(kafkaHostList -> null)
   val zookeeperHosts = Map(zookeeperHostList -> null)
 
-  val runtimesRegistry = "runtimes.registry"
   val runtimesManifest = "runtimes.manifest"
 
   val actionSequenceMaxLimit = "limits.actions.sequence.maxLength"
@@ -220,6 +218,7 @@ object ConfigKeys {
 
   val containerFactory = "whisk.container-factory"
   val containerArgs = s"$containerFactory.container-args"
+  val runtimesRegistry = s"$containerFactory.runtimes-registry"
   val containerPool = "whisk.container-pool"
   val blacklist = "whisk.blacklist"
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
@@ -47,6 +47,8 @@ case class ContainerPoolConfig(userMemory: ByteSize, concurrentPeekFactor: Doubl
   def cpuShare(reservedMemory: ByteSize) = (totalShare / (userMemory.toBytes / reservedMemory.toBytes)).toInt
 }
 
+case class RuntimesRegistryConfig(url: String, user: Option[String], password: Option[String])
+
 /**
  * An abstraction for Container creation
  */

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
@@ -47,7 +47,9 @@ case class ContainerPoolConfig(userMemory: ByteSize, concurrentPeekFactor: Doubl
   def cpuShare(reservedMemory: ByteSize) = (totalShare / (userMemory.toBytes / reservedMemory.toBytes)).toInt
 }
 
-case class RuntimesRegistryConfig(url: String, user: Option[String], password: Option[String])
+case class RuntimesRegistryCredentials(user: String, password: String)
+
+case class RuntimesRegistryConfig(url: String, credentials: Option[RuntimesRegistryCredentials])
 
 /**
  * An abstraction for Container creation

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/mesos/MesosContainerFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/mesos/MesosContainerFactory.scala
@@ -29,7 +29,9 @@ import com.adobe.api.platform.runtime.mesos.SubscribeComplete
 import com.adobe.api.platform.runtime.mesos.Teardown
 import com.adobe.api.platform.runtime.mesos.UNLIKE
 import java.time.Instant
+
 import pureconfig.loadConfigOrThrow
+
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -41,10 +43,7 @@ import org.apache.openwhisk.common.Logging
 import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.WhiskConfig
-import org.apache.openwhisk.core.containerpool.Container
-import org.apache.openwhisk.core.containerpool.ContainerArgsConfig
-import org.apache.openwhisk.core.containerpool.ContainerFactory
-import org.apache.openwhisk.core.containerpool.ContainerFactoryProvider
+import org.apache.openwhisk.core.containerpool._
 import org.apache.openwhisk.core.entity.ByteSize
 import org.apache.openwhisk.core.entity.ExecManifest
 import org.apache.openwhisk.core.entity.InvokerInstanceId
@@ -91,6 +90,8 @@ class MesosContainerFactory(config: WhiskConfig,
                             parameters: Map[String, Set[String]],
                             containerArgs: ContainerArgsConfig =
                               loadConfigOrThrow[ContainerArgsConfig](ConfigKeys.containerArgs),
+                            runtimesRegistryConfig: RuntimesRegistryConfig =
+                              loadConfigOrThrow[RuntimesRegistryConfig](ConfigKeys.runtimesRegistry),
                             mesosConfig: MesosConfig = loadConfigOrThrow[MesosConfig](ConfigKeys.mesos),
                             clientFactory: (ActorSystem, MesosConfig) => ActorRef = MesosContainerFactory.createClient,
                             taskIdGenerator: () => String = MesosContainerFactory.taskIdGenerator _)
@@ -128,7 +129,7 @@ class MesosContainerFactory(config: WhiskConfig,
     val image = if (userProvidedImage) {
       actionImage.publicImageName
     } else {
-      actionImage.localImageName(config.runtimesRegistry)
+      actionImage.localImageName(runtimesRegistryConfig.url)
     }
     val constraintStrings = if (userProvidedImage) {
       mesosConfig.blackboxConstraints

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/LeanBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/LeanBalancer.scala
@@ -98,7 +98,6 @@ object LeanBalancer extends LoadBalancerProvider {
   }
 
   def requiredProperties =
-    Map(runtimesRegistry -> "") ++
-      ExecManifest.requiredProperties ++
+    ExecManifest.requiredProperties ++
       wskApiHost
 }

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -67,13 +67,18 @@ whisk {
   }
 
   # args for 'docker run' to use
-  container-factory.container-args {
-    network: bridge
-    # See https://docs.docker.com/config/containers/container-networking/#dns-services for documentation of dns-*
-    dns-servers: []
-    dns-search: []
-    dns-options: []
-    extra-args: {}   # to pass additional args to 'docker run'; format is `{key1: [v1, v2], key2: [v1, v2]}`
+  container-factory {
+    container-args {
+      network: bridge
+      # See https://docs.docker.com/config/containers/container-networking/#dns-services for documentation of dns-*
+      dns-servers: []
+      dns-search: []
+      dns-options: []
+      extra-args: {}   # to pass additional args to 'docker run'; format is `{key1: [v1, v2], key2: [v1, v2]}`
+    }
+    runtimes-registry {
+      url: ""
+    }
   }
 
   container-proxy {

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerContainerFactory.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerContainerFactory.scala
@@ -25,10 +25,7 @@ import scala.concurrent.Future
 import org.apache.openwhisk.common.Logging
 import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.core.WhiskConfig
-import org.apache.openwhisk.core.containerpool.Container
-import org.apache.openwhisk.core.containerpool.ContainerFactory
-import org.apache.openwhisk.core.containerpool.ContainerFactoryProvider
-import org.apache.openwhisk.core.containerpool.ContainerArgsConfig
+import org.apache.openwhisk.core.containerpool._
 import org.apache.openwhisk.core.entity.ByteSize
 import org.apache.openwhisk.core.entity.ExecManifest
 import org.apache.openwhisk.core.entity.InvokerInstanceId
@@ -45,6 +42,8 @@ class DockerContainerFactory(instance: InvokerInstanceId,
                              parameters: Map[String, Set[String]],
                              containerArgsConfig: ContainerArgsConfig =
                                loadConfigOrThrow[ContainerArgsConfig](ConfigKeys.containerArgs),
+                             runtimesRegistryConfig: RuntimesRegistryConfig =
+                               loadConfigOrThrow[RuntimesRegistryConfig](ConfigKeys.runtimesRegistry),
                              dockerContainerFactoryConfig: DockerContainerFactoryConfig =
                                loadConfigOrThrow[DockerContainerFactoryConfig](ConfigKeys.dockerContainerFactory))(
   implicit actorSystem: ActorSystem,
@@ -63,7 +62,8 @@ class DockerContainerFactory(instance: InvokerInstanceId,
                                cpuShares: Int)(implicit config: WhiskConfig, logging: Logging): Future[Container] = {
     DockerContainer.create(
       tid,
-      image = if (userProvidedImage) Left(actionImage) else Right(actionImage.localImageName(config.runtimesRegistry)),
+      image =
+        if (userProvidedImage) Left(actionImage) else Right(actionImage.localImageName(runtimesRegistryConfig.url)),
       memory = memory,
       cpuShares = cpuShares,
       environment = Map("__OW_API_HOST" -> config.wskApiHost),

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesContainerFactory.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesContainerFactory.scala
@@ -24,20 +24,24 @@ import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
-
 import org.apache.openwhisk.common.Logging
 import org.apache.openwhisk.common.TransactionId
-import org.apache.openwhisk.core.containerpool.Container
-import org.apache.openwhisk.core.containerpool.ContainerFactory
-import org.apache.openwhisk.core.containerpool.ContainerFactoryProvider
+import org.apache.openwhisk.core.containerpool.{
+  Container,
+  ContainerFactory,
+  ContainerFactoryProvider,
+  RuntimesRegistryConfig
+}
 import org.apache.openwhisk.core.entity.ByteSize
 import org.apache.openwhisk.core.entity.ExecManifest.ImageName
 import org.apache.openwhisk.core.entity.InvokerInstanceId
 import org.apache.openwhisk.core.{ConfigKeys, WhiskConfig}
 
-class KubernetesContainerFactory(label: String, config: WhiskConfig)(implicit actorSystem: ActorSystem,
-                                                                     ec: ExecutionContext,
-                                                                     logging: Logging)
+class KubernetesContainerFactory(
+  label: String,
+  config: WhiskConfig,
+  runtimesRegistryConfig: RuntimesRegistryConfig = loadConfigOrThrow[RuntimesRegistryConfig](
+    ConfigKeys.runtimesRegistry))(implicit actorSystem: ActorSystem, ec: ExecutionContext, logging: Logging)
     extends ContainerFactory {
 
   implicit val kubernetes = initializeKubeClient()
@@ -69,7 +73,7 @@ class KubernetesContainerFactory(label: String, config: WhiskConfig)(implicit ac
     val image = if (userProvidedImage) {
       actionImage.publicImageName
     } else {
-      actionImage.localImageName(config.runtimesRegistry)
+      actionImage.localImageName(runtimesRegistryConfig.url)
     }
 
     KubernetesContainer.create(

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
@@ -50,7 +50,7 @@ object Invoker {
    * An object which records the environment variables required for this component to run.
    */
   def requiredProperties =
-    Map(servicePort -> 8080.toString, runtimesRegistry -> "") ++
+    Map(servicePort -> 8080.toString) ++
       ExecManifest.requiredProperties ++
       kafkaHosts ++
       zookeeperHosts ++

--- a/tests/src/test/resources/application.conf.j2
+++ b/tests/src/test/resources/application.conf.j2
@@ -80,6 +80,10 @@ whisk {
     user-events {
         enabled = {{ user_events }}
     }
+
+    container-factory.runtimes-registry {
+        url = "{{ runtimes_registry | default('') }}"
+    }
 }
 
 #test-only overrides so that tests can override defaults in application.conf (todo: move all defaults to reference.conf)

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/mesos/test/MesosContainerFactoryTest.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/mesos/test/MesosContainerFactoryTest.scala
@@ -112,8 +112,8 @@ class MesosContainerFactoryTest
       logging,
       Map("--arg1" -> Set("v1", "v2")),
       containerArgsConfig,
-      mesosConfig,
-      (system, mesosConfig) => testActor)
+      mesosConfig = mesosConfig,
+      clientFactory = (system, mesosConfig) => testActor)
 
     expectMsg(Subscribe)
   }
@@ -140,9 +140,9 @@ class MesosContainerFactoryTest
         logging,
         Map("--arg1" -> Set("v1", "v2"), "--arg2" -> Set("v3", "v4"), "other" -> Set("v5", "v6")),
         containerArgsConfig,
-        mesosConfig,
-        (_, _) => testActor,
-        testTaskId _)
+        mesosConfig = mesosConfig,
+        clientFactory = (_, _) => testActor,
+        taskIdGenerator = testTaskId _)
 
     expectMsg(Subscribe)
     factory.createContainer(
@@ -184,9 +184,9 @@ class MesosContainerFactoryTest
         logging,
         Map("--arg1" -> Set("v1", "v2"), "--arg2" -> Set("v3", "v4"), "other" -> Set("v5", "v6")),
         containerArgsConfig,
-        mesosConfig,
-        (system, mesosConfig) => probe.testActor,
-        testTaskId _)
+        mesosConfig = mesosConfig,
+        clientFactory = (system, mesosConfig) => probe.testActor,
+        taskIdGenerator = testTaskId _)
 
     probe.expectMsg(Subscribe)
     //emulate successful subscribe
@@ -258,9 +258,9 @@ class MesosContainerFactoryTest
           Seq.empty,
           Seq.empty,
           Map("extra1" -> Set("e1", "e2"), "extra2" -> Set("e3", "e4"))),
-        mesosConfig,
-        (system, mesosConfig) => probe.testActor,
-        testTaskId _)
+        mesosConfig = mesosConfig,
+        clientFactory = (system, mesosConfig) => probe.testActor,
+        taskIdGenerator = testTaskId _)
 
     probe.expectMsg(Subscribe)
     //emulate successful subscribe


### PR DESCRIPTION
This PR moves the config of the runtimes-registry to pureconfig. In addition it adds the ability to provide credentials for this registry. They are not used yet in the default implementations of the container factory. But they can be used in the SPIs.



## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.