### PR TITLE
Fixes the issue of failing to read empty Splunk JSON objects

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/SplunkLogStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/SplunkLogStore.scala
@@ -146,9 +146,7 @@ class SplunkLogStore(
                         s"The log message might have been too large " +
                           s"for '${splunkConfig.index}' Splunk index and can't be retrieved, ${t.getMessage}")
                       s"The log message can't be retrieved, ${t.getMessage}"
-                  }
-              )
-          )
+                  }))
       })
   }
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/SplunkLogStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/SplunkLogStore.scala
@@ -137,10 +137,17 @@ class SplunkLogStore(
             ActivationLogs(
               r.results
                 .map(l =>
-                  //format same as org.apache.openwhisk.core.containerpool.logging.LogLine.toFormattedString
-                  f"${l.fields(splunkConfig.logTimestampField).convertTo[String]}%-30s ${l
-                    .fields(splunkConfig.logStreamField)
-                    .convertTo[String]}: ${l.fields(splunkConfig.logMessageField).convertTo[String].trim}"))
+                  try {
+                    //format same as org.apache.openwhisk.core.containerpool.logging.LogLine.toFormattedString
+                    f"${l.fields(splunkConfig.logTimestampField).convertTo[String]}%-30s ${l
+                      .fields(splunkConfig.logStreamField)
+                      .convertTo[String]}: ${l.fields(splunkConfig.logMessageField).convertTo[String].trim}"
+                  } catch {
+                    case e: Exception =>
+                      logging.debug(this,s"Log message might have been be too large for '${splunkConfig.index}' Splunk index and can't be retrieved, ${e.getMessage}")
+                      s"Log message could not be retrieved, ${e.getMessage}"
+                  }
+                ))
           })
       })
   }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/SplunkLogStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/SplunkLogStore.scala
@@ -133,11 +133,10 @@ class SplunkLogStore(
         logging.debug(this, s"splunk API response ${response}")
         Unmarshal(response.entity)
           .to[SplunkResponse]
-          .map(r => {
-            ActivationLogs(
-              r.results
-                .map(l =>
- r.results
+          .map(
+            r =>
+              ActivationLogs(
+                r.results
                   .map(js => Try(toLogLine(js)))
                   .map {
                     case Success(s) => s
@@ -147,20 +146,16 @@ class SplunkLogStore(
                         s"The log message might have been too large " +
                           s"for '${splunkConfig.index}' Splunk index and can't be retrieved, ${t.getMessage}")
                       s"The log message can't be retrieved, ${t.getMessage}"
-                  })
-                    //format same as org.apache.openwhisk.core.containerpool.logging.LogLine.toFormattedString
-                    f"${l.fields(splunkConfig.logTimestampField).convertTo[String]}%-30s ${l
-                      .fields(splunkConfig.logStreamField)
-                      .convertTo[String]}: ${l.fields(splunkConfig.logMessageField).convertTo[String].trim}"
-                  } catch {
-                    case e: Exception =>
-                      logging.debug(this,s"The log message might have been too large for '${splunkConfig.index}' Splunk index and can't be retrieved, ${e.getMessage}")
-                      s"The log message can't be retrieved, ${e.getMessage}"
                   }
-                ))
-          })
+              )
+          )
       })
   }
+
+  private def toLogLine(l: JsObject) = //format same as org.apache.openwhisk.core.containerpool.logging.LogLine.toFormattedString
+    f"${l.fields(splunkConfig.logTimestampField).convertTo[String]}%-30s ${l
+      .fields(splunkConfig.logStreamField)
+      .convertTo[String]}: ${l.fields(splunkConfig.logMessageField).convertTo[String].trim}"
 
   //based on http://doc.akka.io/docs/akka-http/10.0.6/scala/http/client-side/host-level.html
   val queue =

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/SplunkLogStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/SplunkLogStore.scala
@@ -144,8 +144,8 @@ class SplunkLogStore(
                       .convertTo[String]}: ${l.fields(splunkConfig.logMessageField).convertTo[String].trim}"
                   } catch {
                     case e: Exception =>
-                      logging.debug(this,s"Log message might have been be too large for '${splunkConfig.index}' Splunk index and can't be retrieved, ${e.getMessage}")
-                      s"Log message could not be retrieved, ${e.getMessage}"
+                      logging.debug(this,s"The log message might have been too large for '${splunkConfig.index}' Splunk index and can't be retrieved, ${e.getMessage}")
+                      s"The log message can't be retrieved, ${e.getMessage}"
                   }
                 ))
           })

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/SplunkLogStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/SplunkLogStore.scala
@@ -137,7 +137,17 @@ class SplunkLogStore(
             ActivationLogs(
               r.results
                 .map(l =>
-                  try {
+ r.results
+                  .map(js => Try(toLogLine(js)))
+                  .map {
+                    case Success(s) => s
+                    case Failure(t) =>
+                      logging.debug(
+                        this,
+                        s"The log message might have been too large " +
+                          s"for '${splunkConfig.index}' Splunk index and can't be retrieved, ${t.getMessage}")
+                      s"The log message can't be retrieved, ${t.getMessage}"
+                  })
                     //format same as org.apache.openwhisk.core.containerpool.logging.LogLine.toFormattedString
                     f"${l.fields(splunkConfig.logTimestampField).convertTo[String]}%-30s ${l
                       .fields(splunkConfig.logStreamField)

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/logging/SplunkLogStoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/logging/SplunkLogStoreTests.scala
@@ -157,8 +157,8 @@ class SplunkLogStoreTests
       Vector(
         "2007-12-03T10:15:30Z           stdout: some log message",
         "2007-12-03T10:15:31Z           stderr: some other log message",
-        "Log message could not be retrieved, key not found: log_timestamp",
-        "Log message could not be retrieved, key not found: log_message"))
+        "The log message can't be retrieved, key not found: log_timestamp",
+        "The log message can't be retrieved, key not found: log_message"))
   }
 
   it should "fail to connect to bogus host" in {

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/logging/SplunkLogStoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/logging/SplunkLogStoreTests.scala
@@ -128,7 +128,7 @@ class SplunkLogStoreTests
                     StatusCodes.OK,
                     entity = HttpEntity(
                       ContentTypes.`application/json`,
-                      """{"preview":false,"init_offset":0,"messages":[],"fields":[{"name":"log_message"}],"results":[{"log_timestamp": "2007-12-03T10:15:30Z", "log_stream":"stdout", "log_message":"some log message"},{"log_timestamp": "2007-12-03T10:15:31Z", "log_stream":"stderr", "log_message":"some other log message"}], "highlighted":{}}"""))),
+                      """{"preview":false,"init_offset":0,"messages":[],"fields":[{"name":"log_message"}],"results":[{"log_timestamp": "2007-12-03T10:15:30Z", "log_stream":"stdout", "log_message":"some log message"},{"log_timestamp": "2007-12-03T10:15:31Z", "log_stream":"stderr", "log_message":"some other log message"},{},{"log_timestamp": "2007-12-03T10:15:32Z", "log_stream":"stderr"}], "highlighted":{}}"""))),
                 userContext)
             }
             .recover {
@@ -156,7 +156,9 @@ class SplunkLogStoreTests
     result shouldBe ActivationLogs(
       Vector(
         "2007-12-03T10:15:30Z           stdout: some log message",
-        "2007-12-03T10:15:31Z           stderr: some other log message"))
+        "2007-12-03T10:15:31Z           stderr: some other log message",
+        "Log message could not be retrieved, key not found: log_timestamp",
+        "Log message could not be retrieved, key not found: log_message"))
   }
 
   it should "fail to connect to bogus host" in {


### PR DESCRIPTION
## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

<!--- Provide a concise summary of your changes in the Title -->
There is currently an issue with `SplunkLogStore` that assumes that all JSON objects received from Splunk API should always contain these fields: `log_timestamp`, `log_stream` and `log_message`.



The problem occurs when trying to get the logs using: 
```
wsk activation logs $activation_id
```
as Splunk sometimes sends empty JSON objects. 

This PR handles the `NoSuchElementException`, displays an error message and allows the retrieval of all the other log messages for that particular activation. 

More details about the the issue here: #4347


## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#4347)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

