### PR TITLE
Revert back to the previous Scala image version, as the new base image causes reg…

### DIFF
--- a/common/scala/Dockerfile
+++ b/common/scala/Dockerfile
@@ -1,7 +1,7 @@
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements; and to You under the Apache License, Version 2.0.
 
-FROM adoptopenjdk/openjdk8:x86_64-alpine-jdk8u202-b08
+FROM adoptopenjdk/openjdk8:x86_64-alpine-jdk8u172-b11
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en


### PR DESCRIPTION
…ression in performance tests.


<!--- Provide a concise summary of your changes in the Title -->

## Description
Reverting back to `adoptopenjdk/openjdk8:x86_64-alpine-jdk8u172-b11` from `adoptopenjdk/openjdk8:x86_64-alpine-jdk8u202-b08` ([commit](https://github.com/apache/incubator-openwhisk/commit/df3acee881c24527b2f74d78fa852928e8631c1e#diff-27f60a73819012c7e10f8f9dea28df6b)) as we see regression in Latency.

With the version: `jdk8u172-b11`

![Screen Shot 2019-03-15 at 14 28 56](https://user-images.githubusercontent.com/12074169/54435022-d55a2300-472f-11e9-8489-b7cca06fbe7e.png)


With the version: `jdk8u202-b08`

![Screen Shot 2019-03-15 at 14 52 01](https://user-images.githubusercontent.com/12074169/54436012-0e939280-4732-11e9-979d-da554a806426.png)


After briefly debugging, we found that the time was lost between Controller->Invoker & Invoker->Controller (as reverting version already helps to improve the problem there seems to be an issue with the communication with kafka). We didnt find a quick solution so reverting back to the old version, and in the meanwhile will continue to look for the root cause.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

