### PR TITLE
Add the private docker registry for three VMs under Apache

### DIFF
--- a/ansible/environments/jenkins/group_vars/all
+++ b/ansible/environments/jenkins/group_vars/all
@@ -6,7 +6,7 @@ config_root_dir: "{{ openwhisk_tmp_dir }}/wskconf"
 whisk_logs_dir: "{{ openwhisk_tmp_dir }}/wsklogs"
 coverage_enabled: "{{ lookup('env', 'GRADLE_COVERAGE') | default('false', true) | bool}}"
 coverage_logs_dir: "{{ openwhisk_tmp_dir }}/wskcov"
-docker_registry: ""
+docker_registry: "openwhisk-vm1-he-de.apache.org:444/"
 docker_dns: ""
 runtimes_bypass_pull_for_local_images: true
 invoker_use_runc: "{{ ansible_distribution != 'MacOSX' }}"

--- a/tools/jenkins/Jenkinsfile
+++ b/tools/jenkins/Jenkinsfile
@@ -18,37 +18,40 @@
 
 timeout(time: 4, unit: 'HOURS') {
 
-    node("openwhisk2") {
-        deleteDir()
-        stage ('Checkout and build on OpenWhisk2') {
-            checkout([$class: 'GitSCM', branches: [[name: '${Branch}']], doGenerateSubmoduleConfigurations: false,
-                      extensions: [], submoduleCfg: [],
-                      userRemoteConfigs: [[credentialsId: '', url: 'https://github.com/${Fork}/${RepoName}']]])
-            sh './gradlew :core:invoker:distDocker'
-        }
-    }
-
-    node("openwhisk3") {
-        deleteDir()
-        stage ('Checkout and build on OpenWhisk3') {
-            checkout([$class: 'GitSCM', branches: [[name: '${Branch}']], doGenerateSubmoduleConfigurations: false,
-                     extensions: [], submoduleCfg: [],
-                     userRemoteConfigs: [[credentialsId: '', url: 'https://github.com/${Fork}/${RepoName}']]])
-            sh './gradlew :core:invoker:distDocker'
-       }
-    }
+    def domainName = "openwhisk-vm1-he-de.apache.org"
+    def port = "444"
+    def tag = "latest"
+    def prefix = "whisk"
+    def cert = "domain.crt"
+    def key = "domain.key"
 
     node("openwhisk1") {
         deleteDir()
-        stage ('Checkout and build on OpenWhisk1') {
+        stage ('Checkout') {
             checkout([$class: 'GitSCM', branches: [[name: '${Branch}']], doGenerateSubmoduleConfigurations: false,
                       extensions: [], submoduleCfg: [],
                       userRemoteConfigs: [[credentialsId: '', url: 'https://github.com/${Fork}/${RepoName}']]])
-            sh './gradlew distDocker'
+        }
+
+        stage ('Build') {
+            // Set up a private docker registry service, accessed by all the OpenWhisk VMs.
+            try {
+                sh "docker container stop registry && docker container rm -v registry"
+            } catch (exp) {
+                println("Unable to stop and remove the container registry.")
+            }
+
+            sh "docker run -d --restart=always --name registry -v \"$HOME\"/certs:/certs \
+                -e REGISTRY_HTTP_ADDR=0.0.0.0:${port} -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/${cert} \
+                -e REGISTRY_HTTP_TLS_KEY=/certs/${key} -p ${port}:${port} registry:2"
+            // Build the controller and invoker images.
+            sh "./gradlew distDocker -PdockerRegistry=${domainName}:${port}"
         }
 
         stage('Deploy') {
             dir("ansible") {
+                // Copy the jenkins ansible configuration under the directory ansible. This can make sure the SSH is used to
+                // access the VMs of invokers by the VM of the controller.
                 sh '[ -f "environments/jenkins/ansible_jenkins.cfg" ] && cp environments/jenkins/ansible_jenkins.cfg ansible.cfg'
                 sh 'ansible-playbook -i environments/jenkins setup.yml'
                 sh 'ansible-playbook -i environments/jenkins openwhisk.yml -e mode=clean'


### PR DESCRIPTION
A private docker registry has been set up for the VMs dedicated to
OpenWhisk deployment. This PR adds the feature to  push the controller
and invoker images into this private registry, so that they can be
accessed by all the VMs.


<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

