### PR TITLE
Make tests working in case the "provide-api-key" feature is disabled

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -34,6 +34,8 @@ hosts_dir: "{{ inventory_dir | default(env_hosts_dir) }}"
 whisk:
   version:
     date: "{{ansible_date_time.iso8601}}"
+  feature_flags:
+    require_api_key_annotation: "{{ require_api_key_annotation | default(true) }}"
 
 ##
 # configuration parameters related to support runtimes (see org.apache.openwhisk.core.entity.ExecManifest for schema of the manifest).

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -206,6 +206,8 @@
       "CONFIG_whisk_concurrencyLimit_max": "{{ limit_action_concurrency_max | default() }}"
       "CONFIG_whisk_concurrencyLimit_std": "{{ limit_action_concurrency_std | default() }}"
 
+      "CONFIG_whisk_featureFlags_requireApiKeyAnnotation" : "{{ whisk.feature_flags.require_api_key_annotation | default(true) }}"
+
       "CONFIG_whisk_activation_payload_max":
         "{{ limit_activation_payload | default() }}"
 

--- a/ansible/templates/whisk.properties.j2
+++ b/ansible/templates/whisk.properties.j2
@@ -31,7 +31,8 @@ whisk.api.host.name={{ whisk_api_host_name | default(groups['edge'] | first) }}
 whisk.api.localhost.name={{ whisk_api_localhost_name | default(whisk_api_host_name) | default(whisk_api_localhost_name_default) }}
 whisk.api.vanity.subdomain.parts=1
 
-whisk.action.concurrency={{runtimes_enable_concurrency | default(false)}}
+whisk.action.concurrency={{ runtimes_enable_concurrency | default(false) }}
+whisk.feature.requireApiKeyAnnotation={{ whisk.feature_flags.require_api_key_annotation | default(true) }}
 
 runtimes.manifest={{ runtimesManifest | to_json }}
 

--- a/tests/src/test/resources/application.conf.j2
+++ b/tests/src/test/resources/application.conf.j2
@@ -16,6 +16,9 @@ akka.http.host-connection-pool.client.idle-timeout = 90 s
 akka.jvm-exit-on-fatal-error = off
 
 whisk {
+    feature-flags {
+      require-api-key-annotation = {{ whisk.feature_flags.require_api_key_annotation | default(true) }}
+    }
     # kafka related configuration
     kafka {
         replication-factor = 1

--- a/tests/src/test/scala/common/WhiskProperties.java
+++ b/tests/src/test/scala/common/WhiskProperties.java
@@ -125,8 +125,17 @@ public class WhiskProperties {
         return new File(whiskHome, name);
     }
 
-    public static String getProperty(String string) {
-        return whiskProperties.getProperty(string);
+    public static String getProperty(String name) {
+        return whiskProperties.getProperty(name);
+    }
+
+    public static Boolean getBooleanProperty(String name, Boolean defaultValue) {
+        String value = whiskProperties.getProperty(name);
+        if (value == null) {
+            return defaultValue;
+        }
+
+        return Boolean.parseBoolean(value);
     }
 
     public static String getKafkaHosts() {

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskRestBasicUsageTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskRestBasicUsageTests.scala
@@ -21,7 +21,6 @@ import akka.http.scaladsl.model.StatusCodes.NotFound
 import akka.http.scaladsl.model.StatusCodes.OK
 import akka.http.scaladsl.model.StatusCodes.BadRequest
 import akka.http.scaladsl.model.StatusCodes.Conflict
-
 import java.time.Instant
 import java.time.Clock
 
@@ -55,6 +54,9 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
   val wsk = new WskRestOperations
   val defaultAction: Some[String] = Some(TestUtils.getTestActionFilename("hello.js"))
   val usrAgentHeaderRegEx: String = """\bUser-Agent\b": \[\s+"OpenWhisk\-CLI/1.\d+.*"""
+
+  val requireAPIKeyAnnotation =
+    Option(WhiskProperties.getProperty("whisk.feature.requireApiKeyAnnotation")).map(_.toBoolean).getOrElse(true)
 
   behavior of "Wsk API basic usage"
 
@@ -317,6 +319,7 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
   }
 
   it should "invoke an action receiving context properties excluding api key" in withAssetCleaner(wskprops) {
+    assume(requireAPIKeyAnnotation)
     (wp, assetHelper) =>
       val namespace = wsk.namespace.whois()
       val name = "context"
@@ -430,13 +433,49 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
         action.create(name, Some(TestUtils.getTestActionFilename("echo.js")), web = Some(flag.toLowerCase))
       }
 
-      val action = wsk.action.get(name)
-      action.getFieldJsValue("annotations").convertTo[Set[JsObject]] shouldBe Set(
+      val expectedSet = Set(
         JsObject("key" -> JsString("exec"), "value" -> JsString("nodejs:6")),
-        JsObject("key" -> WhiskAction.provideApiKeyAnnotationName.toJson, "value" -> JsBoolean(false)),
         JsObject("key" -> JsString("web-export"), "value" -> JsBoolean(webEnabled || rawEnabled)),
         JsObject("key" -> JsString("raw-http"), "value" -> JsBoolean(rawEnabled)),
         JsObject("key" -> JsString("final"), "value" -> JsBoolean(webEnabled || rawEnabled)))
+
+      val action = wsk.action.get(name)
+      action.getFieldJsValue("annotations").convertTo[Set[JsObject]] shouldBe (if (requireAPIKeyAnnotation) {
+                                                                                 Set(
+                                                                                   JsObject(
+                                                                                     "key" -> JsString("exec"),
+                                                                                     "value" -> JsString("nodejs:6")),
+                                                                                   JsObject(
+                                                                                     "key" -> WhiskAction.provideApiKeyAnnotationName.toJson,
+                                                                                     "value" -> JsBoolean(false)),
+                                                                                   JsObject(
+                                                                                     "key" -> JsString("web-export"),
+                                                                                     "value" -> JsBoolean(
+                                                                                       webEnabled || rawEnabled)),
+                                                                                   JsObject(
+                                                                                     "key" -> JsString("raw-http"),
+                                                                                     "value" -> JsBoolean(rawEnabled)),
+                                                                                   JsObject(
+                                                                                     "key" -> JsString("final"),
+                                                                                     "value" -> JsBoolean(
+                                                                                       webEnabled || rawEnabled)))
+                                                                               } else {
+                                                                                 Set(
+                                                                                   JsObject(
+                                                                                     "key" -> JsString("exec"),
+                                                                                     "value" -> JsString("nodejs:6")),
+                                                                                   JsObject(
+                                                                                     "key" -> JsString("web-export"),
+                                                                                     "value" -> JsBoolean(
+                                                                                       webEnabled || rawEnabled)),
+                                                                                   JsObject(
+                                                                                     "key" -> JsString("raw-http"),
+                                                                                     "value" -> JsBoolean(rawEnabled)),
+                                                                                   JsObject(
+                                                                                     "key" -> JsString("final"),
+                                                                                     "value" -> JsBoolean(
+                                                                                       webEnabled || rawEnabled)))
+                                                                               })
     }
   }
 
@@ -450,12 +489,38 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
       }
 
       val action = wsk.action.get(name)
-      action.getFieldJsValue("annotations") shouldBe JsArray(
-        JsObject("key" -> JsString("web-export"), "value" -> JsBoolean(true)),
-        JsObject("key" -> JsString("raw-http"), "value" -> JsBoolean(false)),
-        JsObject("key" -> JsString("final"), "value" -> JsBoolean(true)),
-        JsObject("key" -> WhiskAction.provideApiKeyAnnotationName.toJson, "value" -> JsBoolean(false)),
-        JsObject("key" -> JsString("exec"), "value" -> JsString("nodejs:6")))
+      action.getFieldJsValue("annotations") shouldBe (if (requireAPIKeyAnnotation) {
+                                                        JsArray(
+                                                          JsObject(
+                                                            "key" -> JsString("web-export"),
+                                                            "value" -> JsBoolean(true)),
+                                                          JsObject(
+                                                            "key" -> JsString("raw-http"),
+                                                            "value" -> JsBoolean(false)),
+                                                          JsObject(
+                                                            "key" -> JsString("final"),
+                                                            "value" -> JsBoolean(true)),
+                                                          JsObject(
+                                                            "key" -> WhiskAction.provideApiKeyAnnotationName.toJson,
+                                                            "value" -> JsBoolean(false)),
+                                                          JsObject(
+                                                            "key" -> JsString("exec"),
+                                                            "value" -> JsString("nodejs:6")))
+                                                      } else {
+                                                        JsArray(
+                                                          JsObject(
+                                                            "key" -> JsString("web-export"),
+                                                            "value" -> JsBoolean(true)),
+                                                          JsObject(
+                                                            "key" -> JsString("raw-http"),
+                                                            "value" -> JsBoolean(false)),
+                                                          JsObject(
+                                                            "key" -> JsString("final"),
+                                                            "value" -> JsBoolean(true)),
+                                                          JsObject(
+                                                            "key" -> JsString("exec"),
+                                                            "value" -> JsString("nodejs:6")))
+                                                      })
   }
 
   it should "invoke action while not encoding &, <, > characters" in withAssetCleaner(wskprops) { (wp, assetHelper) =>

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskRestBasicUsageTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskRestBasicUsageTests.scala
@@ -455,27 +455,22 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
         action.create(name, file, web = Some("true"), update = true)
       }
 
+      val baseAnnotations =
+        Parameters("web-export", JsBoolean(true)) ++
+          Parameters("raw-http", JsBoolean(false)) ++
+          Parameters("final", JsBoolean(true))
+
+      val testAnnotations = if (requireAPIKeyAnnotation) {
+        baseAnnotations ++
+          Parameters(WhiskAction.provideApiKeyAnnotationName, JsBoolean(false)) ++
+          Parameters("exec", "nodejs:6")
+      } else {
+        baseAnnotations ++
+          Parameters("exec", "nodejs:6")
+      }
+
       val action = wsk.action.get(name)
-      action.getFieldJsValue("annotations") shouldBe (if (requireAPIKeyAnnotation) {
-                                                        JsArray(
-                                                          JsObject("key" -> JsString("web-export"), "value" -> JsTrue),
-                                                          JsObject("key" -> JsString("raw-http"), "value" -> JsFalse),
-                                                          JsObject("key" -> JsString("final"), "value" -> JsTrue),
-                                                          JsObject(
-                                                            "key" -> WhiskAction.provideApiKeyAnnotationName.toJson,
-                                                            "value" -> JsFalse),
-                                                          JsObject(
-                                                            "key" -> JsString("exec"),
-                                                            "value" -> JsString("nodejs:6")))
-                                                      } else {
-                                                        JsArray(
-                                                          JsObject("key" -> JsString("web-export"), "value" -> JsTrue),
-                                                          JsObject("key" -> JsString("raw-http"), "value" -> JsFalse),
-                                                          JsObject("key" -> JsString("final"), "value" -> JsTrue),
-                                                          JsObject(
-                                                            "key" -> JsString("exec"),
-                                                            "value" -> JsString("nodejs:6")))
-                                                      })
+      action.getFieldJsValue("annotations") shouldBe testAnnotations.toJsArray
   }
 
   it should "invoke action while not encoding &, <, > characters" in withAssetCleaner(wskprops) { (wp, assetHelper) =>

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ControllerTestCommon.scala
@@ -87,7 +87,7 @@ protected trait ControllerTestCommon
 
   def systemAnnotations(kind: String, create: Boolean = true): Parameters = {
     val base = if (create && FeatureFlags.requireApiKeyAnnotation) {
-      Parameters(WhiskAction.provideApiKeyAnnotationName, JsBoolean(false))
+      Parameters(WhiskAction.provideApiKeyAnnotationName, JsFalse)
     } else {
       Parameters()
     }

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ControllerTestCommon.scala
@@ -30,7 +30,7 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.http.scaladsl.testkit.RouteTestTimeout
 import spray.json._
 import org.apache.openwhisk.common.TransactionId
-import org.apache.openwhisk.core.WhiskConfig
+import org.apache.openwhisk.core.{FeatureFlags, WhiskConfig}
 import org.apache.openwhisk.core.connector.ActivationMessage
 import org.apache.openwhisk.core.containerpool.logging.LogStoreProvider
 import org.apache.openwhisk.core.controller.{CustomHeaders, RestApiCommons, WhiskServices}
@@ -86,7 +86,7 @@ protected trait ControllerTestCommon
   }
 
   def systemAnnotations(kind: String, create: Boolean = true): Parameters = {
-    val base = if (create) {
+    val base = if (create && FeatureFlags.requireApiKeyAnnotation) {
       Parameters(WhiskAction.provideApiKeyAnnotationName, JsBoolean(false))
     } else {
       Parameters()

--- a/tests/src/test/scala/system/basic/WskActionTests.scala
+++ b/tests/src/test/scala/system/basic/WskActionTests.scala
@@ -186,14 +186,13 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
         JsObject("key" -> JsString("origParam2"), "value" -> JsNumber(999)))
       val baseAnnots = Seq(
         JsObject("key" -> JsString("origAnnot1"), "value" -> JsString("origAnnotValue1")),
-        JsObject("key" -> JsString("copiedAnnot2"), "value" -> JsBoolean(false)),
+        JsObject("key" -> JsString("copiedAnnot2"), "value" -> JsFalse),
         JsObject("key" -> JsString("copiedAnnot1"), "value" -> JsString("copiedAnnotValue1")),
-        JsObject("key" -> JsString("origAnnot2"), "value" -> JsBoolean(true)),
+        JsObject("key" -> JsString("origAnnot2"), "value" -> JsTrue),
         JsObject("key" -> JsString("exec"), "value" -> JsString("nodejs:6")),
-        JsObject("key" -> WhiskAction.provideApiKeyAnnotationName.toJson, "value" -> JsBoolean(false)))
+        JsObject("key" -> WhiskAction.provideApiKeyAnnotationName.toJson, "value" -> JsFalse))
       val resAnnots: Seq[JsObject] = if (FeatureFlags.requireApiKeyAnnotation) {
-        baseAnnots ++ Seq(
-          JsObject("key" -> WhiskAction.provideApiKeyAnnotationName.toJson, "value" -> JsBoolean(false)))
+        baseAnnots ++ Seq(JsObject("key" -> WhiskAction.provideApiKeyAnnotationName.toJson, "value" -> JsFalse))
       } else baseAnnots
 
       assetHelper.withCleaner(wsk.action, origName) {
@@ -255,14 +254,11 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
     val child = "wc"
 
     assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      if (FeatureFlags.requireApiKeyAnnotation) {
-        action.create(
-          name,
-          Some(TestUtils.getTestActionFilename("wcbin.js")),
-          annotations = Map(WhiskAction.provideApiKeyAnnotationName -> JsBoolean(true)))
-      } else {
-        action.create(name, Some(TestUtils.getTestActionFilename("wcbin.js")))
-      }
+      val annotations =
+        if (FeatureFlags.requireApiKeyAnnotation) Map(WhiskAction.provideApiKeyAnnotationName -> JsTrue)
+        else Map.empty[String, JsValue]
+      action.create(name, Some(TestUtils.getTestActionFilename("wcbin.js")), annotations = annotations)
+
     }
     assetHelper.withCleaner(wsk.action, child) { (action, _) =>
       action.create(child, Some(TestUtils.getTestActionFilename("wc.js")))

--- a/tests/src/test/scala/system/basic/WskActionTests.scala
+++ b/tests/src/test/scala/system/basic/WskActionTests.scala
@@ -26,6 +26,7 @@ import common._
 import common.rest.WskRestOperations
 import org.apache.openwhisk.core.entity.WhiskAction
 import org.apache.commons.io.FileUtils
+import org.apache.openwhisk.core.FeatureFlags
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
@@ -183,13 +184,17 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
         JsObject("key" -> JsString("copiedParam2"), "value" -> JsNumber(123)),
         JsObject("key" -> JsString("origParam1"), "value" -> JsString("origParamValue1")),
         JsObject("key" -> JsString("origParam2"), "value" -> JsNumber(999)))
-      val resAnnots = Seq(
+      val baseAnnots = Seq(
         JsObject("key" -> JsString("origAnnot1"), "value" -> JsString("origAnnotValue1")),
         JsObject("key" -> JsString("copiedAnnot2"), "value" -> JsBoolean(false)),
         JsObject("key" -> JsString("copiedAnnot1"), "value" -> JsString("copiedAnnotValue1")),
         JsObject("key" -> JsString("origAnnot2"), "value" -> JsBoolean(true)),
         JsObject("key" -> JsString("exec"), "value" -> JsString("nodejs:6")),
         JsObject("key" -> WhiskAction.provideApiKeyAnnotationName.toJson, "value" -> JsBoolean(false)))
+      val resAnnots: Seq[JsObject] = if (FeatureFlags.requireApiKeyAnnotation) {
+        baseAnnots ++ Seq(
+          JsObject("key" -> WhiskAction.provideApiKeyAnnotationName.toJson, "value" -> JsBoolean(false)))
+      } else baseAnnots
 
       assetHelper.withCleaner(wsk.action, origName) {
         val file = Some(TestUtils.getTestActionFilename("echo.js"))
@@ -250,10 +255,14 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
     val child = "wc"
 
     assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(
-        name,
-        Some(TestUtils.getTestActionFilename("wcbin.js")),
-        annotations = Map(WhiskAction.provideApiKeyAnnotationName -> JsBoolean(true)))
+      if (FeatureFlags.requireApiKeyAnnotation) {
+        action.create(
+          name,
+          Some(TestUtils.getTestActionFilename("wcbin.js")),
+          annotations = Map(WhiskAction.provideApiKeyAnnotationName -> JsBoolean(true)))
+      } else {
+        action.create(name, Some(TestUtils.getTestActionFilename("wcbin.js")))
+      }
     }
     assetHelper.withCleaner(wsk.action, child) { (action, _) =>
       action.create(child, Some(TestUtils.getTestActionFilename("wc.js")))

--- a/tests/src/test/scala/system/basic/WskRestBasicTests.scala
+++ b/tests/src/test/scala/system/basic/WskRestBasicTests.scala
@@ -44,8 +44,7 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
 
   val defaultAction: Some[String] = Some(TestUtils.getTestActionFilename("hello.js"))
 
-  val requireApiKeyAnnotation =
-    Option(WhiskProperties.getProperty("whisk.feature.requireApiKeyAnnotation")).map(_.toBoolean).getOrElse(true)
+  val requireAPIKeyAnnotation = WhiskProperties.getBooleanProperty("whisk.feature.requireApiKeyAnnotation", true);
 
   /**
    * Retry operations that need to settle the controller cache
@@ -142,7 +141,7 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
     RestResult.getField(action, "name") shouldBe actionName
     val annoAction = RestResult.getFieldJsValue(action, "annotations")
 
-    annoAction shouldBe (if (requireApiKeyAnnotation) {
+    annoAction shouldBe (if (requireAPIKeyAnnotation) {
                            JsArray(
                              JsObject("key" -> JsString("description"), "value" -> JsString("Action description")),
                              JsObject(
@@ -370,7 +369,7 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
       result.getFieldJsValue("parameters") shouldBe JsArray(
         JsObject("key" -> JsString("payload"), "value" -> JsString("test")))
 
-      result.getFieldJsValue("annotations") shouldBe (if (requireApiKeyAnnotation) {
+      result.getFieldJsValue("annotations") shouldBe (if (requireAPIKeyAnnotation) {
                                                         JsArray(
                                                           JsObject(
                                                             "key" -> WhiskAction.provideApiKeyAnnotationName.toJson,
@@ -483,7 +482,7 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
     result.getField("namespace") shouldBe ns
 
     val annos = result.getFieldJsValue("annotations")
-    annos shouldBe (if (requireApiKeyAnnotation) {
+    annos shouldBe (if (requireAPIKeyAnnotation) {
                       JsArray(
                         JsObject("key" -> JsString("description"), "value" -> JsString("Action description")),
                         JsObject(

--- a/tests/src/test/scala/system/basic/WskRestBasicTests.scala
+++ b/tests/src/test/scala/system/basic/WskRestBasicTests.scala
@@ -44,6 +44,9 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
 
   val defaultAction: Some[String] = Some(TestUtils.getTestActionFilename("hello.js"))
 
+  val requireApiKeyAnnotation =
+    Option(WhiskProperties.getProperty("whisk.feature.requireApiKeyAnnotation")).map(_.toBoolean).getOrElse(true)
+
   /**
    * Retry operations that need to settle the controller cache
    */
@@ -138,15 +141,37 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
     val action = result.getFieldListJsObject("actions")(0)
     RestResult.getField(action, "name") shouldBe actionName
     val annoAction = RestResult.getFieldJsValue(action, "annotations")
-    annoAction shouldBe JsArray(
-      JsObject("key" -> JsString("description"), "value" -> JsString("Action description")),
-      JsObject(
-        "key" -> JsString("parameters"),
-        "value" -> JsArray(
-          JsObject("name" -> JsString("paramName1"), "description" -> JsString("Parameter description 1")),
-          JsObject("name" -> JsString("paramName2"), "description" -> JsString("Parameter description 2")))),
-      JsObject("key" -> WhiskAction.provideApiKeyAnnotationName.toJson, "value" -> JsBoolean(false)),
-      JsObject("key" -> JsString("exec"), "value" -> JsString("nodejs:6")))
+
+    annoAction shouldBe (if (requireApiKeyAnnotation) {
+                           JsArray(
+                             JsObject("key" -> JsString("description"), "value" -> JsString("Action description")),
+                             JsObject(
+                               "key" -> JsString("parameters"),
+                               "value" -> JsArray(
+                                 JsObject(
+                                   "name" -> JsString("paramName1"),
+                                   "description" -> JsString("Parameter description 1")),
+                                 JsObject(
+                                   "name" -> JsString("paramName2"),
+                                   "description" -> JsString("Parameter description 2")))),
+                             JsObject(
+                               "key" -> WhiskAction.provideApiKeyAnnotationName.toJson,
+                               "value" -> JsBoolean(false)),
+                             JsObject("key" -> JsString("exec"), "value" -> JsString("nodejs:6")))
+                         } else {
+                           JsArray(
+                             JsObject("key" -> JsString("description"), "value" -> JsString("Action description")),
+                             JsObject(
+                               "key" -> JsString("parameters"),
+                               "value" -> JsArray(
+                                 JsObject(
+                                   "name" -> JsString("paramName1"),
+                                   "description" -> JsString("Parameter description 1")),
+                                 JsObject(
+                                   "name" -> JsString("paramName2"),
+                                   "description" -> JsString("Parameter description 2")))),
+                             JsObject("key" -> JsString("exec"), "value" -> JsString("nodejs:6")))
+                         })
   }
 
   it should "create a package with a name that contains spaces" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
@@ -344,9 +369,21 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
       RestResult.getField(exec, "code") should not be ""
       result.getFieldJsValue("parameters") shouldBe JsArray(
         JsObject("key" -> JsString("payload"), "value" -> JsString("test")))
-      result.getFieldJsValue("annotations") shouldBe JsArray(
-        JsObject("key" -> WhiskAction.provideApiKeyAnnotationName.toJson, "value" -> JsBoolean(false)),
-        JsObject("key" -> JsString("exec"), "value" -> JsString("nodejs:6")))
+
+      result.getFieldJsValue("annotations") shouldBe (if (requireApiKeyAnnotation) {
+                                                        JsArray(
+                                                          JsObject(
+                                                            "key" -> WhiskAction.provideApiKeyAnnotationName.toJson,
+                                                            "value" -> JsBoolean(false)),
+                                                          JsObject(
+                                                            "key" -> JsString("exec"),
+                                                            "value" -> JsString("nodejs:6")))
+                                                      } else {
+                                                        JsArray(
+                                                          JsObject(
+                                                            "key" -> JsString("exec"),
+                                                            "value" -> JsString("nodejs:6")))
+                                                      })
       result.getFieldJsValue("limits") shouldBe JsObject(
         "timeout" -> JsNumber(60000),
         "memory" -> JsNumber(256),
@@ -444,16 +481,36 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
 
     result.getField("name") shouldBe name
     result.getField("namespace") shouldBe ns
+
     val annos = result.getFieldJsValue("annotations")
-    annos shouldBe JsArray(
-      JsObject("key" -> JsString("description"), "value" -> JsString("Action description")),
-      JsObject(
-        "key" -> JsString("parameters"),
-        "value" -> JsArray(
-          JsObject("name" -> JsString("paramName1"), "description" -> JsString("Parameter description 1")),
-          JsObject("name" -> JsString("paramName2"), "description" -> JsString("Parameter description 2")))),
-      JsObject("key" -> WhiskAction.provideApiKeyAnnotationName.toJson, "value" -> JsBoolean(false)),
-      JsObject("key" -> JsString("exec"), "value" -> JsString("nodejs:6")))
+    annos shouldBe (if (requireApiKeyAnnotation) {
+                      JsArray(
+                        JsObject("key" -> JsString("description"), "value" -> JsString("Action description")),
+                        JsObject(
+                          "key" -> JsString("parameters"),
+                          "value" -> JsArray(
+                            JsObject(
+                              "name" -> JsString("paramName1"),
+                              "description" -> JsString("Parameter description 1")),
+                            JsObject(
+                              "name" -> JsString("paramName2"),
+                              "description" -> JsString("Parameter description 2")))),
+                        JsObject("key" -> WhiskAction.provideApiKeyAnnotationName.toJson, "value" -> JsBoolean(false)),
+                        JsObject("key" -> JsString("exec"), "value" -> JsString("nodejs:6")))
+                    } else {
+                      JsArray(
+                        JsObject("key" -> JsString("description"), "value" -> JsString("Action description")),
+                        JsObject(
+                          "key" -> JsString("parameters"),
+                          "value" -> JsArray(
+                            JsObject(
+                              "name" -> JsString("paramName1"),
+                              "description" -> JsString("Parameter description 1")),
+                            JsObject(
+                              "name" -> JsString("paramName2"),
+                              "description" -> JsString("Parameter description 2")))),
+                        JsObject("key" -> JsString("exec"), "value" -> JsString("nodejs:6")))
+                    })
   }
 
   it should "create an action with a name that contains spaces" in withAssetCleaner(wskprops) { (wp, assetHelper) =>


### PR DESCRIPTION
## Description
This tests make the unit and system tests working in the case the new`provide-api-key`feature is disabled (it is enabled per default). 

Disablement of the feature can now be controlled by an Ansible variable named 
`whisk.feature_flags-require_api_key_annotation`.

A successful run with the feature disabled can be found [here](https://travis-ci.org/apache/incubator-openwhisk/builds/510850362)

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

