### PR TITLE
Adapt limit to query db view as per couch db change

### DIFF
--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/NamespaceBlacklist.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/NamespaceBlacklist.scala
@@ -47,6 +47,7 @@ class NamespaceBlacklist(authStore: AuthStore) {
   def isBlacklisted(identity: Identity): Boolean = blacklist.contains(identity.namespace.name.asString)
 
   /** Refreshes the current blacklist from the database. */
+  /** Limit query parameter set to 0 for limitless record query. */
   def refreshBlacklist()(implicit ec: ExecutionContext, tid: TransactionId): Future[Set[String]] = {
     authStore
       .query(
@@ -54,7 +55,7 @@ class NamespaceBlacklist(authStore: AuthStore) {
         startKey = List.empty,
         endKey = List.empty,
         skip = 0,
-        limit = Int.MaxValue,
+        limit = 0,
         includeDocs = false,
         descending = true,
         reduce = false,


### PR DESCRIPTION
Co-authored-by: steffenrost <srost@de.ibm.com>

CouchDB has introduced a limit check for querying the database view, for the query parameter `limit`. In OpenWhisk it was first set to Scala `Int.Max` value. Since this exceeds the allowed range by couchDB, the query calls using the max value have been reported failing with `http Response: 400 Bad Request`. 

For ref: https://github.com/apache/couchdb/commit/1fdfe466223380d1ee7c82e21283e161290aed87#diff-2bd31f00dcfba780c6c65bc69c256854 

## Description
Changed the query parameter `limit` to max allowed by couchDB. 
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

