### PR TITLE
Remove separate wskdeploy executable from ow-utils

### DIFF
--- a/tools/ow-utils/Dockerfile
+++ b/tools/ow-utils/Dockerfile
@@ -35,11 +35,6 @@ RUN wget -q https://github.com/apache/incubator-openwhisk-cli/releases/download/
   tar xzf OpenWhisk_CLI-$WHISK_CLI_VERSION-linux-amd64.tgz -C /usr/local/bin wsk && \
   rm OpenWhisk_CLI-$WHISK_CLI_VERSION-linux-amd64.tgz
 
-# # Install `wskdeploy` cli in /usr/local/bin
-RUN wget -q https://github.com/apache/incubator-openwhisk-wskdeploy/releases/download/$WHISKDEPLOY_CLI_VERSION/openwhisk_wskdeploy-$WHISKDEPLOY_CLI_VERSION-linux-amd64.tgz && \
-  tar xzf openwhisk_wskdeploy-$WHISK_CLI_VERSION-linux-amd64.tgz -C /usr/local/bin wskdeploy && \
-  rm openwhisk_wskdeploy-$WHISK_CLI_VERSION-linux-amd64.tgz
-
 COPY wskutil.py /bin
 COPY wskprop.py /bin
 COPY wskadmin /bin

--- a/tools/ow-utils/README.md
+++ b/tools/ow-utils/README.md
@@ -25,4 +25,4 @@ for OpenWhisk using most of the tools that are used in the project.
 It includes a JDK8, python/ansible, nodejs, and standard packages
 such as bash, git, wget, curl, and docker.
 
-It also includes the `wsk`, `wskdeploy` and `wskadmin` CLIs.
+It also includes the `wsk` and `wskadmin` CLIs.


### PR DESCRIPTION
wskdeploy is now distributed as a subcommand of wsk (wsk project),
so no need to include a wskdeploy executable.
