### PR TITLE
Fix path.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -208,7 +208,7 @@ Apache License 2.0
 
 This distribution bundles the following components, which are available under an Apache License 2.0 (https://opensource.org/licenses/Apache-2.0).
 Spray Caching 1.3.4 (io.spray:spray-caching_2.11:1.3.4 - http://spray.io/documentation/1.2.4/spray-caching/)
-  ConcurrentMapBackedCache.scala under common/scala/src/main/scala/whisk/core/database contains implementation
+  ConcurrentMapBackedCache.scala under common/scala/src/main/scala/org/apache/openwhisk/core/database/ contains implementation
   from Spray's [[spray.caching.Cache]] and [[spray.caching.SimpleLruCache]] respectively.
   License included at licenses/LICENSE-spray.txt, or https://github.com/spray/spray/blob/master/LICENSE
   Copyright (C) 2011-2015 the spray project <http://spray.io>


### PR DESCRIPTION
The path noted in the LICENSE was incorrect.