### PR TITLE
Improve Robustness of WskRestBasicUsageTests

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskRestBasicUsageTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskRestBasicUsageTests.scala
@@ -434,15 +434,16 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
 
       val action = wsk.action.get(name)
 
-      val baseAnnotations = Parameters("exec", "nodejs:6") ++
-        Parameters("web-export", JsBoolean(webEnabled || rawEnabled)) ++
+      val baseAnnotations = Parameters("web-export", JsBoolean(webEnabled || rawEnabled)) ++
         Parameters("raw-http", JsBoolean(rawEnabled)) ++
-        Parameters("final", JsBoolean(webEnabled || rawEnabled))
+        Parameters("final", JsBoolean(webEnabled || rawEnabled)) ++
+        Parameters("exec", "nodejs:6")
       val testAnnotations = if (requireAPIKeyAnnotation) {
         baseAnnotations ++ Parameters(WhiskAction.provideApiKeyAnnotationName, JsFalse)
       } else baseAnnotations
 
-      action.getFieldJsValue("annotations") shouldBe testAnnotations.toJsArray
+      action.getFieldJsValue("annotations").convertTo[Set[JsObject]] shouldBe testAnnotations.toJsArray
+        .convertTo[Set[JsObject]]
     }
   }
 
@@ -470,7 +471,8 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
       }
 
       val action = wsk.action.get(name)
-      action.getFieldJsValue("annotations") shouldBe testAnnotations.toJsArray
+      action.getFieldJsValue("annotations").convertTo[Set[JsObject]] shouldBe testAnnotations.toJsArray
+        .convertTo[Set[JsObject]]
   }
 
   it should "invoke action while not encoding &, <, > characters" in withAssetCleaner(wskprops) { (wp, assetHelper) =>


### PR DESCRIPTION
## Description
This PR changes the result comparison of two testcases to comparing sets instead of JsArrays. 
This is introduced by seeing unstable results in some environments.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

