### PR TITLE
Delete pod when creating timeout

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/KubernetesClientTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/KubernetesClientTests.scala
@@ -212,6 +212,10 @@ object KubernetesClientTests {
       Future.successful(())
     }
 
+    override def rm(podName: String): Future[Unit] = {
+      rms += ContainerId(podName)
+      Future.successful(())
+    }
     def rm(key: String, value: String, ensureUnpause: Boolean = false)(
       implicit transid: TransactionId): Future[Unit] = {
       rmByLabels += ((key, value))

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/KubernetesContainerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/KubernetesContainerTests.scala
@@ -173,7 +173,6 @@ class KubernetesContainerTests
         memory: ByteSize = 256.MB,
         env: Map[String, String] = Map.empty,
         labels: Map[String, String] = Map.empty)(implicit transid: TransactionId): Future[KubernetesContainer] = {
-        runs += ((name, image, env, labels))
         Future.failed(ProcessUnsuccessfulException(ExitStatus(1), "", ""))
       }
     }
@@ -182,8 +181,8 @@ class KubernetesContainerTests
       KubernetesContainer.create(transid = transid, name = "name", image = "image", userProvidedImage = true)
     a[WhiskContainerStartupError] should be thrownBy await(container)
 
-    kubernetes.runs should have size 1
-    kubernetes.rms should have size 0
+    kubernetes.runs should have size 0
+    kubernetes.rms should have size 1
   }
 
   /*


### PR DESCRIPTION
## Description
Pod creating timeout for some reason,such as mount a nonexistent nfs volume,
both k8s and invoker does't delete the 'ContainerCreating' pod.

## Related issue and scope
- [x] I opened an issue to propose and discuss this change (#4418)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

