### PR TITLE
Fix readme typo

### DIFF
--- a/docs/actions-new.md
+++ b/docs/actions-new.md
@@ -59,7 +59,7 @@ Further, you should automate and pass the following test suites:
 ### The runtimes manifest
 
 Actions when created specify the desired runtime for the function via a property called "kind".
-When using the `wsk` CLI, this is specified as `--kind <runtime-kind>`. The value is a typically
+When using the `wsk` CLI, this is specified as `--kind <runtime-kind>`. The value is typically
 a string describing the language (e.g., `nodejs`) followed by a colon and the version for the runtime
 as in `nodejs:8` or `php:7.3`.
 


### PR DESCRIPTION
Remove first 'a': 
"The value is a typically a string describing the language" --> "The value is typically a string describing the language"