### PR TITLE
Append 'utf-8' charset parameter after 'Content-type' http header value

### DIFF
--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Actions.scala
@@ -23,7 +23,7 @@ import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
 import org.apache.kafka.common.errors.RecordTooLargeException
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.HttpMethod
+import akka.http.scaladsl.model.{ContentType, HttpEntity, HttpMethod, MediaTypes}
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server.RequestContext
 import akka.http.scaladsl.server.RouteResult
@@ -299,7 +299,9 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
 
         respondWithActivationIdHeader(activation.activationId) {
           if (activation.response.isSuccess) {
-            complete(OK, response)
+            complete(
+              OK,
+              HttpEntity(ContentType(MediaTypes.`application/json`.withParams(Map("charset" -> "utf-8"))), response))
           } else if (activation.response.isApplicationError) {
             // actions that result is ApplicationError status are considered a 'success'
             // and will have an 'error' property in the result - the HTTP status is OK


### PR DESCRIPTION
## Description

## Related issue and scope
- [x] I opened an issue to propose and discuss this change (#4433)

## My changes affect the following components
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

