### PR TITLE
Changing default Node.js version to 10

### DIFF
--- a/ansible/files/runtimes.json
+++ b/ansible/files/runtimes.json
@@ -3,7 +3,7 @@
         "nodejs": [
             {
                 "kind": "nodejs:6",
-                "default": true,
+                "default": false,
                 "image": {
                     "prefix": "openwhisk",
                     "name": "nodejs6action",
@@ -37,7 +37,7 @@
             },
             {
                 "kind": "nodejs:10",
-                "default": false,
+                "default": true,
                 "image": {
                     "prefix": "openwhisk",
                     "name": "action-nodejs-v10",

--- a/docs/actions-nodejs.md
+++ b/docs/actions-nodejs.md
@@ -459,11 +459,11 @@ wsk action invoke my-action --result --param lines "[\"and now\", \"for somethin
 
 ## Reference
 
-JavaScript actions can be executed in Node.js version 6 or Node.js version 8.
-Currently actions are executed by default in a Node.js version 6 environment.
+JavaScript actions can be executed in Node.js version 6, version 8 or version 10 environment.
+Currently actions are executed by default in a Node.js version 10 environment.
 
 ### Node.js version 6 environment
-The Node.js 6.14.4 environment will be used for an action if the `--kind` flag is explicitly specified with a value of 'nodejs:6' when creating/updating the action.
+The Node.js  version 6.17.0 environment will be used for an action if the `--kind` flag is explicitly specified with a value of 'nodejs:6' when creating/updating the action.
 
 The following packages are available to be used in the Node.js 6 environment:
 
@@ -520,14 +520,14 @@ The following packages are available to be used in the Node.js 6 environment:
 - [yauzl v2.7.0](https://www.npmjs.com/package/yauzl) - Yet another unzip library for node. For zipping.
 
 ### Node.js version 8 environment
-The Node.js version 8.12.0 environment is used if the `--kind` flag is explicitly specified with a value of 'nodejs:8' when creating or updating an Action.
+The Node.js version 8.15.1 environment is used if the `--kind` flag is explicitly specified with a value of 'nodejs:8' when creating or updating an Action.
 
 The following packages are pre-installed in the Node.js version 8 environment:
 
 - [openwhisk v3.18.0](https://www.npmjs.com/package/openwhisk) - JavaScript client library for the OpenWhisk platform. Provides a wrapper around the OpenWhisk APIs.
 
 ### Node.js version 10 environment
-The Node.js version 10.13.0 environment is used if the `--kind` flag is explicitly specified with a value of 'nodejs:10' when creating or updating an Action.
+The Node.js version 10.15.2 environment is used if the `--kind` flag is explicitly specified with a value of 'nodejs:10' when creating or updating an Action.
 
 The following packages are pre-installed in the Node.js version 10 environment:
 


### PR DESCRIPTION
Changing default Node.js version to 10 as discussed on mailing list.
Fixes #4265

Once this is merged, we can merge #4450?

## Description

Update runtimes.json with v10 as the default, rather than v6.

## Related issue and scope
- [x] issue was opened to propose and discuss this change (#4265)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [x] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [x] I updated the documentation where necessary.

