### PR TITLE
switch stemcells from nodejs:6 to nodejs:10

### DIFF
--- a/ansible/files/runtimes.json
+++ b/ansible/files/runtimes.json
@@ -13,13 +13,7 @@
                 "attached": {
                     "attachmentName": "codefile",
                     "attachmentType": "text/plain"
-                },
-                "stemCells": [
-                    {
-                        "count": 2,
-                        "memory": "256 MB"
-                    }
-                ]
+                }
             },
             {
                 "kind": "nodejs:8",
@@ -47,7 +41,13 @@
                 "attached": {
                     "attachmentName": "codefile",
                     "attachmentType": "text/plain"
-                }
+                },
+                "stemCells": [
+                    {
+                        "count": 2,
+                        "memory": "256 MB"
+                    }
+                ]
             }
         ],
         "python": [


### PR DESCRIPTION
If we are switching the default runtime to nodejs:10,
we should change the default stemcell configuration to match.
