### PR TITLE
Limit the minimum to the cpu-share value

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
@@ -24,6 +24,7 @@ import org.apache.openwhisk.core.entity.{ByteSize, ExecManifest, InvokerInstance
 import org.apache.openwhisk.spi.Spi
 
 import scala.concurrent.Future
+import scala.math.max
 
 case class ContainerArgsConfig(network: String,
                                dnsServers: Seq[String] = Seq.empty,
@@ -44,7 +45,8 @@ case class ContainerPoolConfig(userMemory: ByteSize, concurrentPeekFactor: Doubl
    */
   private val totalShare = 1024.0 // This is a pre-defined value coming from docker and not our hard-coded value.
   // Grant more CPU to a container if it allocates more memory.
-  def cpuShare(reservedMemory: ByteSize) = (totalShare / (userMemory.toBytes / reservedMemory.toBytes)).toInt
+  def cpuShare(reservedMemory: ByteSize) =
+    max((totalShare / (userMemory.toBytes / reservedMemory.toBytes)).toInt, 2) // The minimum allowed cpu-shares is 2
 }
 
 case class RuntimesRegistryCredentials(user: String, password: String)


### PR DESCRIPTION
## Description
The minimum value for `--cpu-shares` is 2.

However, if the `userMemory` is too high or the `reservedMemory` is too low, the result of the previous calculation might be 1. And this issue causes the following issues: https://github.com/apache/incubator-openwhisk/issues/4476#issuecomment-491664067

So I set the minimum value to 2.

## Related issue and scope
- [x] I opened an issue to propose and discuss this change (#4476)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

