### PR TITLE
Track Kafka client side metrics via Kamon

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -95,6 +95,10 @@ whisk {
         common {
             security-protocol = PLAINTEXT
             ssl-endpoint-identification-algorithm = "" // restores pre-kafka 2.0.0 default
+
+            //Enable this for reporting Kafka client metrics
+            //metric-reporters = "org.apache.openwhisk.connector.kafka.KamonMetricsReporter"
+
         }
         producer {
             acks = 1
@@ -153,6 +157,17 @@ whisk {
                 retention-bytes = 1073741824
                 retention-ms    = 3600000
             }
+        }
+
+        metrics {
+            // Name of metrics which should be tracked via Kamon
+            names = [
+                // consumer-fetch-manager-metrics
+                "records-lag-max", // The maximum lag in terms of number of records for any partition in this window
+                "records-consumed-total" // The total number of records consumed
+            ]
+
+            report-interval = 10 seconds
         }
     }
     # db related configuration

--- a/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaConsumerConnector.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaConsumerConnector.scala
@@ -142,6 +142,7 @@ class KafkaConsumerConnector(
   /** Creates a new kafka consumer and subscribes to topic list if given. */
   private def createConsumer(topic: String) = {
     val config = Map(
+      ConsumerConfig.CLIENT_ID_CONFIG -> s"consumer-$topic",
       ConsumerConfig.GROUP_ID_CONFIG -> groupid,
       ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG -> kafkahost,
       ConsumerConfig.MAX_POLL_RECORDS_CONFIG -> maxPeek.toString) ++

--- a/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KamonMetricsReporter.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KamonMetricsReporter.scala
@@ -111,7 +111,9 @@ object KamonMetricsReporter {
   }
 
   def kamonName(mn: MetricName): String = {
-    s"${mn.group()}_${mn.name()}"
+    //Drop the `-total` suffix as it results in prometheus metrics ending with total twice
+    val name = if (mn.name().endsWith("-total")) mn.name().dropRight(6) else mn.name()
+    s"${mn.group()}_$name}"
   }
 
   def isCounterMetric(metric: KafkaMetric): Boolean = Try(metric.measurable()) match {

--- a/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KamonMetricsReporter.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KamonMetricsReporter.scala
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.connector.kafka
+
+import java.util
+import java.util.concurrent.{ScheduledFuture, TimeUnit}
+
+import kamon.Kamon
+import kamon.metric.{Counter, Gauge, Metric}
+import org.apache.kafka.common.MetricName
+import org.apache.kafka.common.metrics.stats.Total
+import org.apache.kafka.common.metrics.{KafkaMetric, MetricsReporter}
+import org.apache.openwhisk.core.ConfigKeys
+import pureconfig.loadConfigOrThrow
+
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.duration.FiniteDuration
+import scala.util.{Success, Try}
+
+class KamonMetricsReporter extends MetricsReporter {
+  import KamonMetricsReporter._
+  private val metrics = new TrieMap[MetricName, MetricBridge]()
+  private val metricConfig = loadConfigOrThrow[KafkaMetricConfig](s"${ConfigKeys.kafka}.metrics")
+  @volatile
+  private var updater: Option[ScheduledFuture[_]] = None
+
+  override def init(metrics: util.List[KafkaMetric]): Unit = metrics.forEach(add)
+
+  override def metricChange(metric: KafkaMetric): Unit = {
+    remove(metric)
+    add(metric)
+  }
+
+  override def metricRemoval(metric: KafkaMetric): Unit = remove(metric)
+
+  override def close(): Unit = updater.foreach(_.cancel(false))
+
+  override def configure(configs: util.Map[String, _]): Unit = {
+    val interval = metricConfig.reportInterval.toSeconds
+    val f = Kamon.scheduler().scheduleAtFixedRate(() => updateAll(), interval, interval, TimeUnit.SECONDS)
+    updater = Some(f)
+  }
+
+  private def add(metric: KafkaMetric): Unit = {
+    val mn = metric.metricName()
+    if (metricConfig.names.contains(mn.name())) {
+      val tags = mn.tags()
+      val metricName = kamonName(mn)
+      val bridge = if (isCounterMetric(metric)) {
+        val counter = Kamon.counter(metricName)
+        new CounterBridge(metric, counter, counter.refine(tags))
+      } else {
+        val gauge = Kamon.gauge(metricName)
+        new GaugeBridge(metric, gauge, gauge.refine(tags))
+      }
+      metrics.putIfAbsent(mn, bridge)
+    }
+  }
+
+  private def remove(metric: KafkaMetric) = metrics.remove(metric.metricName()).foreach(_.remove())
+
+  private def updateAll(): Unit = metrics.values.foreach(_.update())
+}
+
+object KamonMetricsReporter {
+
+  case class KafkaMetricConfig(names: Set[String], reportInterval: FiniteDuration)
+
+  abstract class MetricBridge(val kafkaMetric: KafkaMetric, kamonMetric: Metric[_]) {
+    def remove(): Unit = kamonMetric.remove(kafkaMetric.metricName().tags())
+    def update(): Unit
+
+    def metricValue: Long =
+      Try(kafkaMetric.metricValue())
+        .map {
+          case d: java.lang.Double => d.toLong
+          case _                   => 0L
+        }
+        .getOrElse(0L)
+  }
+
+  class GaugeBridge(kafkaMetric: KafkaMetric, kamonMetric: Metric[_], gauge: Gauge)
+      extends MetricBridge(kafkaMetric, kamonMetric) {
+    override def update(): Unit = gauge.set(metricValue)
+  }
+
+  class CounterBridge(kafkaMetric: KafkaMetric, kamonMetric: Metric[_], counter: Counter)
+      extends MetricBridge(kafkaMetric, kamonMetric) {
+    @volatile
+    private var lastValue: Long = 0
+    override def update(): Unit = {
+      val newValue = metricValue
+      counter.increment(newValue - lastValue)
+      lastValue = newValue
+    }
+  }
+
+  def kamonName(mn: MetricName): String = {
+    s"${mn.group()}_${mn.name()}"
+  }
+
+  def isCounterMetric(metric: KafkaMetric): Boolean = Try(metric.measurable()) match {
+    case Success(_: Total) => true
+    case _                 => false
+  }
+}


### PR DESCRIPTION
Tracks Kafka client metrics via Kamon for monitoring

## Description

Currently Kafka metrics are not getting tracked via Kamon. Due to this we do not gain any insight into the Kafka interactions. Out of the box Kafka [tracks quite a few metrics][1] on client side these metrics are exposed via JMX

![image](https://user-images.githubusercontent.com/664531/57769171-deb13d00-772a-11e9-86a5-15f235c253aa.png)

It also support custom [MetricsReporter][2] to listen to such metrics. This PR makes use of same reporter support to publish the metrics to Kamon (based on approach taken in [kamon-metrics-reporter][3])

### Usage

`KamonMetricsReporter` needs to be enabled via config and provided a set of metric names to track.

```
whisk {
  kafka {
    common {
      metric-reporters = "org.apache.openwhisk.connector.kafka.KamonMetricsReporter"
    }
    metrics {
      // Name of metrics which should be tracked via Kamon
      names = [
        // consumer-fetch-manager-metrics
        "records-lag-max", // The maximum lag in terms of number of records for any partition in this window
        "records-consumed-total" // The total number of records consumed
      ]

      report-interval = 10 seconds
    }
  }
}
```

Once enabled those metrics would be pushed to Kamon. For above config following metrics can be seen in Prometheus

```
# TYPE consumer_fetch_manager_metrics_records_consumed_total counter
consumer_fetch_manager_metrics_records_consumed_total{client_id="consumer-completed0"} 2.0
consumer_fetch_manager_metrics_records_consumed_total{client_id="consumer-cacheInvalidation"} 0.0
consumer_fetch_manager_metrics_records_consumed_total{client_id="consumer-health"} 1007.0
```

### Implementation

This PR takes a whitelist approach and does not publishes all metrics by default. As there are more than 300 metrics tracked by Kafka across Producer and Consumer.

For counters Kafka records two types of metrics `total` and `rate`. See [KIP-187][4] for details. So we should ignore metrics ending with `rate` and prefer `total` metrics for Kamon tracking

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [x] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

[1]: https://docs.confluent.io/current/kafka/monitoring.html
[2]: https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/metrics/MetricsReporter.java
[3]: https://github.com/andreas-schroeder/kamon-kafka-reporter
[4]: https://cwiki.apache.org/confluence/display/KAFKA/KIP-187+-+Add+cumulative+count+metric+for+all+Kafka+rate+metrics
