### PR TITLE
Switch to consistent indexing policy for CosmosDB

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBViewMapper.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBViewMapper.scala
@@ -21,7 +21,6 @@ import java.util.Collections
 
 import com.microsoft.azure.cosmosdb.DataType.{Number, String}
 import com.microsoft.azure.cosmosdb.IndexKind.{Hash, Range}
-import com.microsoft.azure.cosmosdb.IndexingMode.Lazy
 import com.microsoft.azure.cosmosdb.{PartitionKeyDefinition, SqlParameter, SqlParameterCollection, SqlQuerySpec}
 import org.apache.openwhisk.core.database.ActivationHandler.NS_PATH
 import org.apache.openwhisk.core.database.WhisksHandler.ROOT_NS
@@ -193,7 +192,6 @@ private[cosmosdb] object ActivationViewMapper extends SimpleMapper {
 
   override def indexingPolicy: IndexingPolicy =
     IndexingPolicy(
-      mode = Lazy,
       includedPaths = Set(
         IncludedPath(s"/$NS/?", Index(Hash, String, -1)),
         IncludedPath(s"/$computed/$NS_PATH/?", Index(Hash, String, -1)),

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBViewMapper.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBViewMapper.scala
@@ -20,7 +20,7 @@ package org.apache.openwhisk.core.database.cosmosdb
 import java.util.Collections
 
 import com.microsoft.azure.cosmosdb.DataType.{Number, String}
-import com.microsoft.azure.cosmosdb.IndexKind.{Hash, Range}
+import com.microsoft.azure.cosmosdb.IndexKind.Range
 import com.microsoft.azure.cosmosdb.{PartitionKeyDefinition, SqlParameter, SqlParameterCollection, SqlQuerySpec}
 import org.apache.openwhisk.core.database.ActivationHandler.NS_PATH
 import org.apache.openwhisk.core.database.WhisksHandler.ROOT_NS
@@ -136,9 +136,9 @@ private[cosmosdb] object WhisksViewMapper extends SimpleMapper {
   override def indexingPolicy: IndexingPolicy =
     IndexingPolicy(
       includedPaths = Set(
-        IncludedPath(s"/$TYPE/?", Index(Hash, String, -1)),
-        IncludedPath(s"/$NS/?", Index(Hash, String, -1)),
-        IncludedPath(s"/$computed/$ROOT_NS/?", Index(Hash, String, -1)),
+        IncludedPath(s"/$TYPE/?", Index(Range, String, -1)),
+        IncludedPath(s"/$NS/?", Index(Range, String, -1)),
+        IncludedPath(s"/$computed/$ROOT_NS/?", Index(Range, String, -1)),
         IncludedPath(s"/$UPDATED/?", Index(Range, Number, -1))))
 
   override protected def where(ddoc: String,
@@ -193,8 +193,8 @@ private[cosmosdb] object ActivationViewMapper extends SimpleMapper {
   override def indexingPolicy: IndexingPolicy =
     IndexingPolicy(
       includedPaths = Set(
-        IncludedPath(s"/$NS/?", Index(Hash, String, -1)),
-        IncludedPath(s"/$computed/$NS_PATH/?", Index(Hash, String, -1)),
+        IncludedPath(s"/$NS/?", Index(Range, String, -1)),
+        IncludedPath(s"/$computed/$NS_PATH/?", Index(Range, String, -1)),
         IncludedPath(s"/$START/?", Index(Range, Number, -1))))
 
   override protected def where(ddoc: String,
@@ -253,12 +253,12 @@ private[cosmosdb] object SubjectViewMapper extends CosmosDBViewMapper {
     //and keys are bigger
     IndexingPolicy(
       includedPaths = Set(
-        IncludedPath(s"/$UUID/?", Index(Hash, String, -1)),
-        IncludedPath(s"/$NSS/[]/$NAME/?", Index(Hash, String, -1)),
-        IncludedPath(s"/$SUBJECT/?", Index(Hash, String, -1)),
-        IncludedPath(s"/$NSS/[]/$UUID/?", Index(Hash, String, -1)),
-        IncludedPath(s"/$CONCURRENT_INVOCATIONS/?", Index(Hash, Number, -1)),
-        IncludedPath(s"/$INVOCATIONS_PER_MIN/?", Index(Hash, Number, -1))))
+        IncludedPath(s"/$UUID/?", Index(Range, String, -1)),
+        IncludedPath(s"/$NSS/[]/$NAME/?", Index(Range, String, -1)),
+        IncludedPath(s"/$SUBJECT/?", Index(Range, String, -1)),
+        IncludedPath(s"/$NSS/[]/$UUID/?", Index(Range, String, -1)),
+        IncludedPath(s"/$CONCURRENT_INVOCATIONS/?", Index(Range, Number, -1)),
+        IncludedPath(s"/$INVOCATIONS_PER_MIN/?", Index(Range, Number, -1))))
 
   override def prepareQuery(ddoc: String,
                             view: String,

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/IndexingPolicy.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/IndexingPolicy.scala
@@ -38,7 +38,8 @@ import scala.collection.JavaConverters._
  *    needs to be customized
  *
  */
-case class IndexingPolicy(includedPaths: Set[IncludedPath], excludedPaths: Set[ExcludedPath] = Set(ExcludedPath("/"))) {
+case class IndexingPolicy(includedPaths: Set[IncludedPath],
+                          excludedPaths: Set[ExcludedPath] = Set(ExcludedPath("/*"))) {
 
   def asJava(): JIndexingPolicy = {
     val policy = new JIndexingPolicy()

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/IndexingPolicy.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/IndexingPolicy.scala
@@ -59,18 +59,14 @@ object IndexingPolicy {
    * that at least what we expect is present
    */
   def isSame(expected: IndexingPolicy, current: IndexingPolicy): Boolean = {
-    expected.excludedPaths == current.excludedPaths &&
-    matchIncludes(expected.includedPaths, current.includedPaths)
+    epaths(expected.excludedPaths) == epaths(current.excludedPaths) &&
+    ipaths(expected.includedPaths) == ipaths(current.includedPaths)
   }
 
-  private def matchIncludes(expected: Set[IncludedPath], current: Set[IncludedPath]): Boolean = {
-    expected.size == current.size && expected.forall { i =>
-      current.find(_.path == i.path) match {
-        case Some(x) => i.indexes.subsetOf(x.indexes)
-        case None    => false
-      }
-    }
-  }
+  private def ipaths(included: Set[IncludedPath]) = included.map(_.path)
+
+  //CosmosDB seems to add _etag by default in excluded path. So explicitly ignore that in comparison
+  private def epaths(excluded: Set[ExcludedPath]) = excluded.map(_.path).filterNot(_.contains("_etag"))
 }
 
 case class IncludedPath(path: String, indexes: Set[Index]) {

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/IndexingPolicyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/IndexingPolicyTests.scala
@@ -18,8 +18,7 @@
 package org.apache.openwhisk.core.database.cosmosdb
 
 import com.microsoft.azure.cosmosdb.DataType.String
-import com.microsoft.azure.cosmosdb.IndexKind.{Hash, Range}
-import com.microsoft.azure.cosmosdb.IndexingMode
+import com.microsoft.azure.cosmosdb.IndexKind.Range
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{FlatSpec, Matchers}
@@ -30,39 +29,21 @@ class IndexingPolicyTests extends FlatSpec with Matchers {
 
   it should "match same instance" in {
     val policy =
-      IndexingPolicy(mode = IndexingMode.Lazy, includedPaths = Set(IncludedPath("foo", Index(Hash, String, -1))))
+      IndexingPolicy(includedPaths = Set(IncludedPath("foo", Index(Range, String, -1))))
     IndexingPolicy.isSame(policy, policy) shouldBe true
-  }
-
-  it should "match when same path and subset of indexes" in {
-    val policy =
-      IndexingPolicy(
-        mode = IndexingMode.Lazy,
-        includedPaths = Set(IncludedPath("foo", Index(Hash, String, -1)), IncludedPath("bar", Index(Hash, String, -1))))
-
-    val policy2 =
-      IndexingPolicy(
-        mode = IndexingMode.Lazy,
-        includedPaths = Set(
-          IncludedPath("foo", Index(Hash, String, -1)),
-          IncludedPath("bar", Set(Index(Hash, String, -1), Index(Range, String, -1)))))
-
-    IndexingPolicy.isSame(policy, policy2) shouldBe true
-    IndexingPolicy.isSame(policy2, policy) shouldBe false
   }
 
   it should "not match when same path are different" in {
     val policy =
       IndexingPolicy(
-        mode = IndexingMode.Lazy,
-        includedPaths = Set(IncludedPath("foo", Index(Hash, String, -1)), IncludedPath("bar", Index(Hash, String, -1))))
+        includedPaths =
+          Set(IncludedPath("foo", Index(Range, String, -1)), IncludedPath("bar", Index(Range, String, -1))))
 
     val policy2 =
       IndexingPolicy(
-        mode = IndexingMode.Lazy,
         includedPaths = Set(
-          IncludedPath("foo2", Index(Hash, String, -1)),
-          IncludedPath("bar", Set(Index(Hash, String, -1), Index(Range, String, -1)))))
+          IncludedPath("foo2", Index(Range, String, -1)),
+          IncludedPath("bar", Set(Index(Range, String, -1), Index(Range, String, -1)))))
 
     IndexingPolicy.isSame(policy, policy2) shouldBe false
   }
@@ -70,10 +51,9 @@ class IndexingPolicyTests extends FlatSpec with Matchers {
   it should "convert and match java IndexingPolicy" in {
     val policy =
       IndexingPolicy(
-        mode = IndexingMode.Lazy,
         includedPaths = Set(
-          IncludedPath("foo", Index(Hash, String, -1)),
-          IncludedPath("bar", Set(Index(Hash, String, -1), Index(Range, String, -1)))))
+          IncludedPath("foo", Index(Range, String, -1)),
+          IncludedPath("bar", Set(Index(Range, String, -1), Index(Range, String, -1)))))
 
     val jpolicy = policy.asJava()
     val policy2 = IndexingPolicy(jpolicy)


### PR DESCRIPTION
`activations` collection currently uses `lazy` indexing policy. Per MicrosoftDocs/azure-docs#23875 this is deprecated and should be avoided.

> Lazy mode performs updates to the index at a much lower priority level when the engine is not doing any other work. Because of this query performance can be highly unpredictable. It can also result in higher cost queries because the query engine has to do more work because it can't answer the query from the index. For these reasons we recommend against customers using it.

This PR switches to consistent indexing policy. 

### Disable automatic index policy update logic

Further it also removes logic to automatically update the indexing policy if the collection already exists. Instead it would now log a warning log

```
[2019-05-17T14:47:36.102Z] [WARN] Indexing policy for collection [activations] found to be different.
Expected - {"automatic":true,"indexingMode":"Lazy","includedPaths":[{"path":"/namespace/?","indexes":[{"kind":"Hash","dataType":"String","precision":-1}]},{"path":"/_c/nspath/?","indexes":[{"kind":"Hash","dataType":"String","precision":-1}]},{"path":"/start/?","indexes":[{"kind":"Range","dataType":"Number","precision":-1}]}],"excludedPaths":[{"path":"/"}]}
Existing - {"automatic":true,"indexingMode":"Lazy","includedPaths":[{"path":"/namespace/?","indexes":[]},{"path":"/_c/nspath/?","indexes":[]},{"path":"/start/?","indexes":[]}],"excludedPaths":[{"path":"/"},{"path":"/\"_etag\"/?"}]}
```

Any index update would then need to be done manually by the system administrator

### Dropping Hash index

Now the index docs do not mention of `Hash` index and per [this comment](https://github.com/Azure/azure-cosmosdb-java/issues/93#issuecomment-491417946) those are removed.

Also see [obsolete attributes](https://docs.microsoft.com/en-us/azure/cosmos-db/index-policy#obsolete-attributes)

Due to this now Indexing policy does not use them and always sets the index kind to Range. Now index policy comparison check just check if expected paths are there in included and excluded section

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

