### PR TITLE
Track collection usage metrics for CosmosDB

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -209,6 +209,11 @@ whisk {
         # it would be marked deleted by setting `_deleted` property to true and then actual delete
         # happens via TTL.
         # soft-delete-ttl   = 10 h
+
+        # Frequency at which collection resource usage info like collection size, document count etc is recorded
+        # and exposed as metrics. If any reindexing is in progress then its progress would be logged with this frequency
+        record-usage-frequency = 10 m
+
         connection-policy {
             max-pool-size = 1000
             # When the value of this property is true, the SDK will direct write operations to

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CollectionResourceUsage.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CollectionResourceUsage.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.database.cosmosdb
+
+import org.apache.commons.io.FileUtils
+import org.apache.openwhisk.core.entity.ByteSize
+import org.apache.openwhisk.core.entity.SizeUnits.KB
+
+case class CollectionResourceUsage(documentsSize: Option[ByteSize],
+                                   collectionSize: Option[ByteSize],
+                                   documentsCount: Option[Long],
+                                   indexingProgress: Option[Int],
+                                   documentsSizeQuota: Option[ByteSize]) {
+  def indexSize: Option[ByteSize] = {
+    for {
+      ds <- documentsSize
+      cs <- collectionSize
+    } yield cs - ds
+  }
+
+  def asString: String = {
+    List(
+      documentsSize.map(ds => s"documentSize: ${displaySize(ds)}"),
+      indexSize.map(is => s"indexSize: ${displaySize(is)}"),
+      documentsCount.map(dc => s"documentsCount: $dc"),
+      documentsSizeQuota.map(dq => s"collectionSizeQuota: ${displaySize(dq)}")).flatten.mkString(",")
+  }
+
+  private def displaySize(b: ByteSize) = FileUtils.byteCountToDisplaySize(b.toBytes)
+}
+
+object CollectionResourceUsage {
+  val quotaHeader = "x-ms-resource-quota"
+  val usageHeader = "x-ms-resource-usage"
+  val indexHeader = "x-ms-documentdb-collection-index-transformation-progress"
+
+  def apply(responseHeaders: Map[String, String]): Option[CollectionResourceUsage] = {
+    for {
+      quota <- responseHeaders.get(quotaHeader).map(headerValueToMap)
+      usage <- responseHeaders.get(usageHeader).map(headerValueToMap)
+    } yield {
+      CollectionResourceUsage(
+        usage.get("documentsSize").map(_.toLong).map(ByteSize(_, KB)),
+        usage.get("collectionSize").map(_.toLong).map(ByteSize(_, KB)),
+        usage.get("documentsCount").map(_.toLong),
+        responseHeaders.get(indexHeader).map(_.toInt),
+        quota.get("collectionSize").map(_.toLong).map(ByteSize(_, KB)))
+    }
+  }
+
+  private def headerValueToMap(value: String): Map[String, String] = {
+    //storedProcedures=100;triggers=25;functions=25;documentsCount=-1;documentsSize=xxx;collectionSize=xxx
+    val pairs = value.split("=|;").grouped(2)
+    pairs.map { case Array(k, v) => k -> v }.toMap
+  }
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
@@ -325,6 +325,7 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
     val queryMetrics = scala.collection.mutable.Buffer[QueryMetrics]()
     if (transid.meta.extraLogging) {
       options.setPopulateQueryMetrics(true)
+      options.setEmitVerboseTracesInQuery(true)
     }
 
     def collectQueryMetrics(r: FeedResponse[Document]): Unit = {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfig.scala
@@ -39,7 +39,8 @@ case class CosmosDBConfig(endpoint: String,
                           connectionPolicy: ConnectionPolicy,
                           timeToLive: Option[Duration],
                           clusterId: Option[String],
-                          softDeleteTTL: Option[FiniteDuration]) {
+                          softDeleteTTL: Option[FiniteDuration],
+                          recordUsageFrequency: Option[FiniteDuration]) {
 
   def createClient(): AsyncDocumentClient = {
     new AsyncDocumentClient.Builder()

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CollectionResourceUsageTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CollectionResourceUsageTests.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.database.cosmosdb
+
+import org.apache.openwhisk.core.database.cosmosdb.CollectionResourceUsage.{indexHeader, quotaHeader, usageHeader}
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{FlatSpec, Matchers}
+import org.apache.openwhisk.core.entity.size._
+
+@RunWith(classOf[JUnitRunner])
+class CollectionResourceUsageTests extends FlatSpec with Matchers {
+  behavior of "CollectionInfo"
+
+  it should "populate resource usage info" in {
+    val headers = Map(
+      usageHeader ->
+        "storedProcedures=0;triggers=0;functions=0;documentsCount=5058;documentsSize=780;collectionSize=800",
+      quotaHeader -> "storedProcedures=100;triggers=25;functions=25;documentsCount=-1;documentsSize=335544320;collectionSize=1000",
+      indexHeader -> "42")
+
+    val usage = CollectionResourceUsage(headers).get
+    usage shouldBe CollectionResourceUsage(
+      documentsSize = Some(780.KB),
+      collectionSize = Some(800.KB),
+      documentsCount = Some(5058),
+      indexingProgress = Some(42),
+      documentsSizeQuota = Some(1000.KB))
+  }
+}

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStoreTests.scala
@@ -117,6 +117,15 @@ class CosmosDBArtifactStoreTests extends FlatSpec with CosmosDBStoreBehaviorBase
     js.get.fields(CosmosDBConstants.clusterId) shouldBe JsString("foo")
   }
 
+  it should "fetch collection usage info" in {
+    val uopt = activationStore.getResourceUsage().futureValue
+    uopt shouldBe defined
+    val u = uopt.get
+    println(u.asString)
+    u.documentsCount shouldBe defined
+    u.documentsSize shouldBe defined
+  }
+
   behavior of "CosmosDB query debug"
 
   it should "log query metrics in debug flow" in {


### PR DESCRIPTION
This PR enables support for #4489 by collecting and exposing stats related to collections in CosmosDB

## Description

Now a new config option is exposed  which would allow collecting the collection stats at given frequency. By default this is set at 10 min frequency

```
whisk {
  cosmosdb {
    # Frequency at which collection resource usage info like collection size, document count etc is recorded
    # and exposed as metrics. If any reindexing is in progress then its progress would be logged with this frequency
    record-usage-frequency = 10 m
  }
}
```

Once enabled it would do following things

### Expose stats in logs

```
[2019-05-22T15:50:15.945Z] [INFO] [#tid_sid_unknown] [CosmosDBArtifactStore] Collection usage stats for [whisks] are documentSize: 380 KB,indexSize: 11 KB,documentsCount: 42,collectionSizeQuota: 10 GB
[2019-05-22T15:50:23.869Z] [INFO] [#tid_sid_unknown] [CosmosDBArtifactStore] Collection usage stats for [subjects] are documentSize: 162 KB,indexSize: 0 bytes,documentsCount: 3,collectionSizeQuota: 10 GB
[2019-05-22T15:50:34.354Z] [INFO] [#tid_sid_unknown] [CosmosDBArtifactStore] Collection usage stats for [activations] are documentSize: 192 MB,indexSize: 17 MB,documentsCount: 78961,collectionSizeQuota: 10 GB
```

### Expose index progress stats in logs

if any index config change is then it would be recorded in the logs

```
[2019-05-22T15:50:34.354Z] [INFO] [#tid_sid_unknown] [CosmosDBArtifactStore] Indexing for collection [activations] is at 73%
```

### Expose metrics 

Expose gauges for 3 metrics `indexSize`, `documentsSize` and `documentCount`

```
$ curl -sk https://localhost:10001/metrics | grep cosmos
# TYPE counter_cosmosdb_ru_used_total counter
counter_cosmosdb_ru_used_total{action="get",mode="read",collection="whisks"} 0.0
counter_cosmosdb_ru_used_total{action="put",mode="write",collection="whisks"} 0.0
# TYPE gauge_cosmosdb_indexSize_used_bytes gauge
gauge_cosmosdb_indexSize_used_bytes{collection="subjects"} 0.0
gauge_cosmosdb_indexSize_used_bytes{collection="activations"} 1920000.0
gauge_cosmosdb_indexSize_used_bytes{collection="whisks"} 11264.0
# TYPE gauge_cosmosdb_documentCount_used gauge
gauge_cosmosdb_documentCount_used{collection="subjects"} 3.0
gauge_cosmosdb_documentCount_used{collection="whisks"} 42.0
gauge_cosmosdb_documentCount_used{collection="activations"} 78961.0
# TYPE gauge_cosmosdb_documentsSize_used_bytes gauge
gauge_cosmosdb_documentsSize_used_bytes{collection="activations"} 2060000.0
gauge_cosmosdb_documentsSize_used_bytes{collection="whisks"} 389120.0
gauge_cosmosdb_documentsSize_used_bytes{collection="subjects"} 165888.0
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#4489)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

