### PR TITLE
Akka http server responds HEAD request as GET

### DIFF
--- a/core/controller/src/main/resources/application.conf
+++ b/core/controller/src/main/resources/application.conf
@@ -62,6 +62,16 @@ akka.http {
     # This must be greater than the request timeout.
     idle-timeout = 70s
 
+    # Description:
+    # Enables/disables automatic handling of HEAD requests.
+    # If this setting is enabled the server dispatches HEAD requests as GET
+    # requests to the application and automatically strips off all message
+    # bodies from outgoing responses.
+    # Note that, even when this setting is off the server will never send
+    # out message bodies on responses to HEAD requests.
+    # Default value today is on, hence need to explicitly set this to off
+    transparent-head-requests = off
+
     parsing {
       # This indirectly puts a bound on the name of entities
       # 8k matches nginx default

--- a/tests/dat/actions/echo-web-http-head.js
+++ b/tests/dat/actions/echo-web-http-head.js
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function main(params) {
+    return {
+        statusCode: 200,
+        headers: { 'Request-type': params.__ow_method }
+    };
+}

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskWebActionsTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskWebActionsTests.scala
@@ -309,17 +309,14 @@ class WskWebActionsTests extends TestHelpers with WskTestHelpers with RestUtil w
    * Tests web action for HEAD requests
    */
   it should "create a web action making a HEAD request" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "webaction"
-    val file = Some(TestUtils.getTestActionFilename("echo.js"))
+    val name = "webactionHead"
+    val file = Some(TestUtils.getTestActionFilename("echo-web-http-head.js"))
     val host = getServiceURL()
-    val url = s"$host$testRoutePath/$namespace/default/$name.text/__ow_user"
+    val url = s"$host$testRoutePath/$namespace/default/$name"
 
     assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(name, file, web = Some("true"), annotations = Map("require-whisk-auth" -> true.toJson))
+      action.create(name, file, web = Some("true"))
     }
-
-    val unauthorizedResponse = RestAssured.given().config(sslconfig).get(url)
-    unauthorizedResponse.statusCode shouldBe 401
 
     val authorizedResponse = RestAssured
       .given()
@@ -331,6 +328,7 @@ class WskWebActionsTests extends TestHelpers with WskTestHelpers with RestUtil w
 
     authorizedResponse.statusCode shouldBe 200
     authorizedResponse.body.asString() shouldBe ""
+    authorizedResponse.getHeader("Request-type") shouldBe "head"
   }
 
   private val subdomainRegex = Seq.fill(WhiskProperties.getPartsInVanitySubdomain)("[a-zA-Z0-9]+").mkString("-")

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskWebActionsTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskWebActionsTests.scala
@@ -306,7 +306,7 @@ class WskWebActionsTests extends TestHelpers with WskTestHelpers with RestUtil w
   }
 
   /**
-   * Tests web action for HEAD requests.
+   * Tests web action for HEAD requests
    */
   it should "create a web action making a HEAD request" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
     val name = "webaction"
@@ -330,7 +330,7 @@ class WskWebActionsTests extends TestHelpers with WskTestHelpers with RestUtil w
       .head(url)
 
     authorizedResponse.statusCode shouldBe 200
-    authorizedResponse.body shouldBe null
+    authorizedResponse.body.asString() shouldBe ""
   }
 
   private val subdomainRegex = Seq.fill(WhiskProperties.getPartsInVanitySubdomain)("[a-zA-Z0-9]+").mkString("-")


### PR DESCRIPTION
Akka http client by default treats any http HEAD request as GET unless the configuration sets it otherwise. There are use cases where user expects HEAD to be responded as HEAD and without a response body unlike GET.

https://github.com/akka/akka-http/issues/2088 mentions that the default is set to treat a HEAD as a GET request by the Akka client.

## Description
Update the controller configuration to process HEAD and GET requests as they are expected.
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

