### PR TITLE
Make project compile with JDK 11

### DIFF
--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerClient.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerClient.scala
@@ -176,7 +176,7 @@ class DockerClient(dockerHost: Option[String] = None,
     val filterArgs = filters.flatMap { case (attr, value) => Seq("--filter", s"$attr=$value") }
     val allArg = if (all) Seq("--all") else Seq.empty[String]
     val cmd = Seq("ps", "--quiet", "--no-trunc") ++ allArg ++ filterArgs
-    runCmd(cmd, config.timeouts.ps).map(_.lines.toSeq.map(ContainerId.apply))
+    runCmd(cmd, config.timeouts.ps).map(_.linesIterator.toSeq.map(ContainerId.apply))
   }
 
   /**

--- a/tests/src/test/scala/common/StreamLogging.scala
+++ b/tests/src/test/scala/common/StreamLogging.scala
@@ -35,5 +35,5 @@ trait StreamLogging {
   lazy val printstream = new PrintStream(stream)
   implicit lazy val logging: Logging = new PrintStreamLogging(printstream)
 
-  def logLines = new String(stream.toByteArray, StandardCharsets.UTF_8).lines.toList
+  def logLines = new String(stream.toByteArray, StandardCharsets.UTF_8).linesIterator.toList
 }

--- a/tests/src/test/scala/common/WskCliOperations.scala
+++ b/tests/src/test/scala/common/WskCliOperations.scala
@@ -709,7 +709,7 @@ class CliNamespaceOperations(override val wsk: RunCliCmd)
    */
   override def whois()(implicit wskprops: WskProps): String = {
     // the invariant that list() returns a conforming result is enforced in WskRestBasicTests
-    val ns = list().stdout.lines.toSeq.last.trim
+    val ns = list().stdout.linesIterator.toSeq.last.trim
     assert(ns != "_") // this is not permitted
     ns
   }

--- a/tests/src/test/scala/org/apache/openwhisk/core/admin/WskAdminTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/admin/WskAdminTests.scala
@@ -133,7 +133,7 @@ class WskAdminTests extends TestHelpers with WskActorSystem with Matchers with B
         // reverse lookup by namespace
         val out = wskadmin.cli(Seq("user", "list", "-p", "2", "-k", commonNamespace)).stdout.trim
         out should include(auth.compact)
-        out.lines should have size 2
+        out.linesIterator should have size 2
       }, 10, Some(1.second))
 
       // block the user
@@ -141,7 +141,7 @@ class WskAdminTests extends TestHelpers with WskActorSystem with Matchers with B
 
       // wait until the user can no longer be found
       org.apache.openwhisk.utils.retry({
-        wskadmin.cli(Seq("user", "list", "-p", "2", "-k", commonNamespace)).stdout.trim.lines should have size 1
+        wskadmin.cli(Seq("user", "list", "-p", "2", "-k", commonNamespace)).stdout.trim.linesIterator should have size 1
       }, 10, Some(1.second))
 
       // unblock the user
@@ -151,7 +151,7 @@ class WskAdminTests extends TestHelpers with WskActorSystem with Matchers with B
       org.apache.openwhisk.utils.retry({
         val out = wskadmin.cli(Seq("user", "list", "-p", "2", "-k", commonNamespace)).stdout.trim
         out should include(auth.compact)
-        out.lines should have size 2
+        out.linesIterator should have size 2
       }, 10, Some(1.second))
     } finally {
       wskadmin.cli(Seq("user", "delete", subject1)).stdout should include("Subject deleted")
@@ -220,7 +220,7 @@ class WskAdminTests extends TestHelpers with WskActorSystem with Matchers with B
           "--concurrentInvocations",
           "3"))
       // check correctly set
-      val lines = wskadmin.cli(Seq("limits", "get", subject)).stdout.lines.toSeq
+      val lines = wskadmin.cli(Seq("limits", "get", subject)).stdout.linesIterator.toSeq
       lines should have size 3
       lines(0) shouldBe "invocationsPerMinute = 1"
       lines(1) shouldBe "firesPerMinute = 2"
@@ -236,7 +236,7 @@ class WskAdminTests extends TestHelpers with WskActorSystem with Matchers with B
       // set limit
       wskadmin.cli(Seq("limits", "set", subject, "--storeActivations", "false"))
       // check correctly set
-      val lines = wskadmin.cli(Seq("limits", "get", subject)).stdout.lines.toSeq
+      val lines = wskadmin.cli(Seq("limits", "get", subject)).stdout.linesIterator.toSeq
       lines should have size 1
       lines(0) shouldBe "storeActivations = False"
     } finally {
@@ -250,7 +250,7 @@ class WskAdminTests extends TestHelpers with WskActorSystem with Matchers with B
       // set some limits
       wskadmin.cli(Seq("limits", "set", subject, "--allowedKinds", "nodejs:6", "blackbox"))
       // check correctly set
-      val lines = wskadmin.cli(Seq("limits", "get", subject)).stdout.lines.toSeq
+      val lines = wskadmin.cli(Seq("limits", "get", subject)).stdout.linesIterator.toSeq
       lines should have size 1
       lines(0) shouldBe "allowedKinds = [u'nodejs:6', u'blackbox']"
     } finally {

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/WebActionsApiTests.scala
@@ -887,7 +887,7 @@ trait WebActionsApiBaseTests extends ControllerTestCommon with BeforeAndAfterEac
             status should be(NotFound)
             confirmErrorWithTid(responseAs[JsObject], Some(Messages.propertyNotFound))
             // ensure that error message is pretty printed as { error, code }
-            responseAs[String].lines should have size 4
+            responseAs[String].linesIterator should have size 4
           }
         }
       }

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/ReplicatorTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/ReplicatorTests.scala
@@ -100,7 +100,7 @@ class ReplicatorTests
 
     val Seq(created, deletedDoc, deleted) =
       Seq("create backup: ", "deleting backup document: ", "deleting backup: ").map { prefix =>
-        rr.stdout.lines.collect {
+        rr.stdout.linesIterator.collect {
           case line if line.startsWith(prefix) => line.replace(prefix, "")
         }.toList
       }
@@ -129,7 +129,7 @@ class ReplicatorTests
       dbPrefix)
 
     val line = """([\w-]+) -> ([\w-]+) \(([\w-]+)\)""".r.unanchored
-    val replays = rr.stdout.lines.collect {
+    val replays = rr.stdout.linesIterator.collect {
       case line(backup, target, id) => (backup, target, id)
     }.toList
 

--- a/tests/src/test/scala/system/basic/WskRuleTests.scala
+++ b/tests/src/test/scala/system/basic/WskRuleTests.scala
@@ -385,7 +385,7 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
 
   def verifyRuleList(ruleListResult: RunResult, ruleNameEnable: String, ruleName: String) = {
     val ruleList = ruleListResult.stdout
-    val listOutput = ruleList.lines
+    val listOutput = ruleList.linesIterator
     listOutput.find(_.contains(ruleNameEnable)).get should (include(ruleNameEnable) and include("active"))
     listOutput.find(_.contains(ruleName)).get should (include(ruleName) and include("inactive"))
     ruleList should not include "Unknown"


### PR DESCRIPTION
As mentioned in #4181 compilation fails with JDK 11 with errors like

```
> Task :core:invoker:compileScala
Pruning sources from previous analysis, due to incompatible CompileSetup.
/home/rahullfo/IdeaProjects/incubator-openwhisk/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerClient.scala:164: value toSeq is not a member of java.util.stream.Stream[String]
    runCmd(cmd, config.timeouts.ps).map(_.lines.toSeq.map(ContainerId.apply))
                                                ^
/home/rahullfo/IdeaProjects/incubator-openwhisk/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerClient.scala:164: missing argument list for method apply in object ContainerId
Unapplied methods are only converted to functions when a function type is expected.
You can make this conversion explicit by writing `apply _` or `apply(_)` instead of `apply`.
    runCmd(cmd, config.timeouts.ps).map(_.lines.toSeq.map(ContainerId.apply))
```

This is due to the fact that `lines` method is now part of String class. As mentioned in [SO answer](https://stackoverflow.com/a/52815819/1035417) the fix is to use `linesIterator` instead.

With this change now at least the project compiles  successfully with JDK 11 (as well as JDK 8). 

This PR is part of work being done under #4217 to enable JDK 11 support

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#4217)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

