### PR TITLE
Settle throttle before running the API GW Tests

### DIFF
--- a/tests/src/test/scala/apigw/healthtests/ApiGwEndToEndTests.scala
+++ b/tests/src/test/scala/apigw/healthtests/ApiGwEndToEndTests.scala
@@ -22,21 +22,18 @@ import java.io.File
 import java.io.FileWriter
 
 import scala.concurrent.duration.DurationInt
-
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import org.scalatest.junit.JUnitRunner
-
-import io.restassured.RestAssured
-
 import common.TestHelpers
 import common.TestUtils
 import common.TestUtils._
 import common.WskOperations
 import common.WskProps
 import common.WskTestHelpers
+import io.restassured.RestAssured
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import system.rest.RestUtil

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/BaseApiGwTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/BaseApiGwTests.scala
@@ -89,8 +89,11 @@ abstract class BaseApiGwTests extends TestHelpers with WskTestHelpers with Befor
    * Create a CLI properties file for use by the tests
    */
   override def beforeAll() = {
-    // Check and settle the throttle so that this test have issues with previous tests
-    checkThrottle(maxInvocationsBeforeThrottle = 1, throttlePercent = 100)
+    //Wait a while to settle the throttle so that the status of throttle algorithm implemented in checkThrottle
+    //is consistent with the reality
+    //Without this waiting time API Tests do fail very consistently on faster build machines
+    //In the longer run the APIGW tests should be moved to a separate namespace
+    Thread.sleep(60.seconds.toMillis)
     cliWskPropsFile.deleteOnExit()
     val wskprops = WskProps(token = "SOME TOKEN")
     wskprops.writeFile(cliWskPropsFile)


### PR DESCRIPTION
## Description
The API GW Test are able to drive OW into throttling. Though some code existed to 
throttle down these tests these tests were failing constantly on faster machines
with 429 returned by OW.

The test code controlling the throttle was correct in throttling the test execution in isolation,
but was of course not able to overview invocations for the given namspace that do happen 
before tests were executing.

Since this limitations does naturally exist, this change simplifies down the throttling logic
to enhance code maintainability and introduces a wait period before executing the tests to ensure 
that the API GW test do not run into throttling driven by prior invokes in the same namespace.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

