### PR TITLE
Use Instant with milli second precision

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/common/TransactionId.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/TransactionId.scala
@@ -26,6 +26,7 @@ import spray.json._
 import org.apache.openwhisk.core.ConfigKeys
 import pureconfig._
 import org.apache.openwhisk.common.tracing.WhiskTracerProvider
+import org.apache.openwhisk.common.WhiskInstants._
 
 import scala.util.Try
 
@@ -87,7 +88,7 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
 
     //tracing support
     WhiskTracerProvider.tracer.startSpan(marker, this)
-    StartMarker(Instant.now, marker)
+    StartMarker(Instant.now.inMills, marker)
   }
 
   /**
@@ -186,7 +187,7 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
  * @param start the time when the startMarker was set
  * @param startMarker the LogMarkerToken which defines the start event
  */
-case class StartMarker(val start: Instant, startMarker: LogMarkerToken)
+case class StartMarker(start: Instant, startMarker: LogMarkerToken)
 
 /**
  * The transaction metadata encapsulates important properties about a transaction.
@@ -196,7 +197,7 @@ case class StartMarker(val start: Instant, startMarker: LogMarkerToken)
  * @param start the timestamp when the request processing commenced
  * @param extraLogging enables logging, if set to true
  */
-protected case class TransactionMetadata(val id: String, val start: Instant, val extraLogging: Boolean = false)
+protected case class TransactionMetadata(id: String, start: Instant, extraLogging: Boolean = false)
 
 case class MetricConfig(prometheusEnabled: Boolean,
                         kamonEnabled: Boolean,
@@ -226,7 +227,7 @@ object TransactionId {
   val dbBatcher = TransactionId(systemPrefix + "dbBatcher") // Database batcher
 
   def apply(tid: String, extraLogging: Boolean = false): TransactionId = {
-    val now = Instant.now(Clock.systemUTC())
+    val now = Instant.now(Clock.systemUTC()).inMills
     TransactionId(TransactionMetadata(tid, now, extraLogging))
   }
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/WhiskInstants.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/WhiskInstants.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.common
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+/**
+ * JDK 11 Instant uses nano second precision by default. However OpenWhisk usage of Instant in
+ * many cases involves storing the timestamp in database which uses milli second precision.
+ *
+ * To ensure consistency below utilities can be used to truncate the Instant to millis
+ */
+trait WhiskInstants {
+
+  implicit class InstantImplicits(i: Instant) {
+    def inMills = i.truncatedTo(ChronoUnit.MILLIS)
+  }
+
+  def nowInMillis(): Instant = Instant.now.truncatedTo(ChronoUnit.MILLIS)
+
+}
+
+object WhiskInstants extends WhiskInstants

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -192,7 +192,7 @@ dependencies {
     compile 'org.scalamock:scalamock-scalatest-support_2.12:3.6.0'
     compile "com.typesafe.akka:akka-http-testkit_2.12:${gradle.akka_http.version}"
     compile 'com.github.java-json-tools:json-schema-validator:2.2.8'
-    compile "org.mockito:mockito-core:2.15.0"
+    compile "org.mockito:mockito-core:2.27.0"
     compile 'io.opentracing:opentracing-mock:0.31.0'
     compile "org.apache.curator:curator-test:${gradle.curator.version}"
     compile 'com.atlassian.oai:swagger-request-validator-core:1.4.5'

--- a/tests/src/test/scala/org/apache/openwhisk/core/connector/tests/AcknowledgementMessageTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/connector/tests/AcknowledgementMessageTests.scala
@@ -17,13 +17,11 @@
 
 package org.apache.openwhisk.core.connector.tests
 
-import java.time.Instant
-
 import org.junit.runner.RunWith
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.junit.JUnitRunner
 import spray.json._
-import org.apache.openwhisk.common.TransactionId
+import org.apache.openwhisk.common.{TransactionId, WhiskInstants}
 import org.apache.openwhisk.core.connector.{AcknowledegmentMessage, CompletionMessage, ResultMessage}
 import org.apache.openwhisk.core.entity._
 import org.apache.openwhisk.core.entity.size.SizeInt
@@ -35,7 +33,7 @@ import scala.util.Success
  * Unit tests for the AcknowledgementMessageTests object.
  */
 @RunWith(classOf[JUnitRunner])
-class AcknowledgementMessageTests extends FlatSpec with Matchers {
+class AcknowledgementMessageTests extends FlatSpec with Matchers with WhiskInstants {
 
   behavior of "result message"
 
@@ -45,8 +43,8 @@ class AcknowledgementMessageTests extends FlatSpec with Matchers {
     name = EntityName("a"),
     Subject(),
     activationId = ActivationId.generate(),
-    start = Instant.now(),
-    end = Instant.now(),
+    start = nowInMillis(),
+    end = nowInMillis(),
     response = ActivationResponse.success(Some(JsObject("res" -> JsNumber(1)))),
     annotations = Parameters("limits", ActionLimits(TimeLimit(1.second), MemoryLimit(128.MB), LogLimit(1.MB)).toJson),
     duration = Some(123))

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStoreTests.scala
@@ -31,7 +31,7 @@ import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 import spray.json.DefaultJsonProtocol._
 import spray.json._
-import org.apache.openwhisk.common.TransactionId
+import org.apache.openwhisk.common.{TransactionId, WhiskInstants}
 import org.apache.openwhisk.core.entity._
 import org.apache.openwhisk.core.entity.size.SizeInt
 
@@ -46,7 +46,8 @@ class ArtifactWithFileStorageActivationStoreTests()
     with Matchers
     with BeforeAndAfterAll
     with ScalaFutures
-    with StreamLogging {
+    with StreamLogging
+    with WhiskInstants {
 
   implicit val transid: TransactionId = TransactionId.testing
   implicit val notifier: Option[CacheChangeNotification] = None
@@ -134,8 +135,8 @@ class ArtifactWithFileStorageActivationStoreTests()
             name = EntityName("name"),
             subject = subject,
             activationId = ActivationId.generate(),
-            start = Instant.now,
-            end = Instant.now,
+            start = Instant.now.inMills,
+            end = Instant.now.inMills,
             response = response,
             logs = logs,
             duration = Some(101L),
@@ -185,8 +186,8 @@ class ArtifactWithFileStorageActivationStoreTests()
             name = EntityName("name"),
             subject = subject,
             activationId = ActivationId.generate(),
-            start = Instant.now,
-            end = Instant.now,
+            start = Instant.now.inMills,
+            end = Instant.now.inMills,
             response = response,
             logs = logs,
             duration = Some(101L),

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/behavior/ArtifactStoreBehaviorBase.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/behavior/ArtifactStoreBehaviorBase.scala
@@ -24,7 +24,7 @@ import common.{StreamLogging, WskActorSystem}
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FlatSpec, Matchers}
 import spray.json.{JsObject, JsValue}
-import org.apache.openwhisk.common.TransactionId
+import org.apache.openwhisk.common.{TransactionId, WhiskInstants}
 import org.apache.openwhisk.core.database.memory.MemoryAttachmentStore
 import org.apache.openwhisk.core.database.test.DbUtils
 import org.apache.openwhisk.core.database.test.behavior.ArtifactStoreTestUtil.storeAvailable
@@ -44,7 +44,8 @@ trait ArtifactStoreBehaviorBase
     with WskActorSystem
     with IntegrationPatience
     with BeforeAndAfterEach
-    with BeforeAndAfterAll {
+    with BeforeAndAfterAll
+    with WhiskInstants {
 
   //Bring in sync the timeout used by ScalaFutures and DBUtils
   implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = dbOpTimeout)

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/behavior/ArtifactStoreCRUDBehaviors.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/behavior/ArtifactStoreCRUDBehaviors.scala
@@ -150,8 +150,8 @@ trait ArtifactStoreCRUDBehaviors extends ArtifactStoreBehaviorBase {
       EntityName("activation1"),
       Subject(),
       ActivationId.generate(),
-      start = Instant.now,
-      end = Instant.now)
+      start = Instant.now.inMills,
+      end = Instant.now.inMills)
     val activationDoc = put(activationStore, activation)
     val activationFromDb = activationStore.get[WhiskActivation](activationDoc).futureValue
     activationFromDb shouldBe activation

--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/DatastoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/DatastoreTests.scala
@@ -17,8 +17,6 @@
 
 package org.apache.openwhisk.core.entity.test
 
-import java.time.Instant
-
 import scala.concurrent.Await
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterEach
@@ -26,8 +24,8 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
 import akka.stream.ActorMaterializer
-import common.StreamLogging
-import common.WskActorSystem
+import common.{StreamLogging, WskActorSystem}
+import org.apache.openwhisk.common.WhiskInstants
 import org.scalatest.mockito.MockitoSugar
 import org.mockito.Mockito._
 import org.apache.openwhisk.core.database.DocumentConflictException
@@ -45,7 +43,8 @@ class DatastoreTests
     with DbUtils
     with ExecHelpers
     with MockitoSugar
-    with StreamLogging {
+    with StreamLogging
+    with WhiskInstants {
 
   implicit val materializer = ActorMaterializer()
   val namespace = EntityPath("test namespace")
@@ -132,8 +131,8 @@ class DatastoreTests
     implicit val tid = transid()
     implicit val basename = EntityName("create action blackbox")
     val activations = Seq(
-      WhiskActivation(namespace, aname, Subject(), ActivationId.generate(), start = Instant.now, end = Instant.now),
-      WhiskActivation(namespace, aname, Subject(), ActivationId.generate(), start = Instant.now, end = Instant.now))
+      WhiskActivation(namespace, aname, Subject(), ActivationId.generate(), start = nowInMillis(), end = nowInMillis()),
+      WhiskActivation(namespace, aname, Subject(), ActivationId.generate(), start = nowInMillis(), end = nowInMillis()))
     val docs = activations.map { entity =>
       putGetCheck(datastore, entity, WhiskActivation)
     }
@@ -148,8 +147,8 @@ class DatastoreTests
         aname,
         Subject(),
         ActivationId.generate(),
-        start = Instant.now,
-        end = Instant.now,
+        start = nowInMillis(),
+        end = nowInMillis(),
         logs = ActivationLogs(Vector("Prote\u00EDna"))))
     val docs = activations.map { entity =>
       putGetCheck(datastore, entity, WhiskActivation)
@@ -241,15 +240,15 @@ class DatastoreTests
     implicit val tid = transid()
     implicit val basename = EntityName("update activation")
     val activation =
-      WhiskActivation(namespace, aname, Subject(), ActivationId.generate(), start = Instant.now, end = Instant.now)
+      WhiskActivation(namespace, aname, Subject(), ActivationId.generate(), start = nowInMillis(), end = nowInMillis())
     val docinfo = putGetCheck(datastore, activation, WhiskActivation, false)._2.docinfo
     val revActivation = WhiskActivation(
       namespace,
       aname,
       activation.subject,
       activation.activationId,
-      start = Instant.now,
-      end = Instant.now).revision[WhiskActivation](docinfo.rev)
+      start = nowInMillis(),
+      end = nowInMillis()).revision[WhiskActivation](docinfo.rev)
     putGetCheck(datastore, revActivation, WhiskActivation)
   }
 
@@ -288,7 +287,7 @@ class DatastoreTests
     implicit val tid = transid()
     implicit val basename = EntityName("create activation twice")
     val activation =
-      WhiskActivation(namespace, aname, Subject(), ActivationId.generate(), start = Instant.now, end = Instant.now)
+      WhiskActivation(namespace, aname, Subject(), ActivationId.generate(), start = nowInMillis(), end = nowInMillis())
     putGetCheck(datastore, activation, WhiskActivation)
     intercept[DocumentConflictException] {
       putGetCheck(datastore, activation, WhiskActivation)
@@ -336,7 +335,7 @@ class DatastoreTests
     implicit val tid = transid()
     implicit val basename = EntityName("delete activation twice")
     val activation =
-      WhiskActivation(namespace, aname, Subject(), ActivationId.generate(), start = Instant.now, end = Instant.now)
+      WhiskActivation(namespace, aname, Subject(), ActivationId.generate(), start = nowInMillis(), end = nowInMillis())
     val doc = putGetCheck(datastore, activation, WhiskActivation, false)._1
     assert(Await.result(WhiskActivation.del(datastore, doc), dbOpTimeout))
     intercept[NoDocumentException] {


### PR DESCRIPTION
This PR changes `java.lang.Instant` creation to use milli second precision.

## Description

As mentioned in [comment](https://github.com/apache/incubator-openwhisk/issues/4217#issuecomment-496469481) for #4217 with JDK 11 `Instant` is created with microsecond precision. This PR adds extension method to `Instant` to allow creating it with milli second precision

This PR is part of work being done for #4217 to enable JDK 11 support for OpenWhisk

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#4217 )

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

