### PR TITLE
Fix a few compilation accidents

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Exec.scala
@@ -227,7 +227,7 @@ protected[core] case class SequenceExecMetaData(components: Vector[FullyQualifie
   override def size = components.map(_.size).reduceOption(_ + _).getOrElse(0.B)
 }
 
-protected[core] object Exec extends ArgNormalizer[Exec] with DefaultJsonProtocol {
+object Exec extends ArgNormalizer[Exec] with DefaultJsonProtocol {
 
   val maxSize: ByteSize = 48.MB
   val sizeLimit = loadConfigOrThrow[ByteSize](ConfigKeys.execSizeLimit)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ExecManifest.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ExecManifest.scala
@@ -343,12 +343,13 @@ protected[core] object ExecManifest {
     private val defaultSplitter = "([a-z0-9]+):default".r
   }
 
-  protected[entity] implicit val imageNameSerdes = jsonFormat3(ImageName.apply)
+  protected[entity] implicit val imageNameSerdes: RootJsonFormat[ImageName] = jsonFormat3(ImageName.apply)
 
-  protected[entity] implicit val stemCellSerdes = {
+  protected[entity] implicit val stemCellSerdes: RootJsonFormat[StemCell] = {
     import org.apache.openwhisk.core.entity.size.serdes
     jsonFormat2(StemCell.apply)
   }
 
-  protected[entity] implicit val runtimeManifestSerdes = jsonFormat8(RuntimeManifest)
+  protected[entity] implicit val runtimeManifestSerdes: RootJsonFormat[RuntimeManifest]  = jsonFormat8(RuntimeManifest)
+
 }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ExecManifest.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ExecManifest.scala
@@ -350,6 +350,6 @@ protected[core] object ExecManifest {
     jsonFormat2(StemCell.apply)
   }
 
-  protected[entity] implicit val runtimeManifestSerdes: RootJsonFormat[RuntimeManifest]  = jsonFormat8(RuntimeManifest)
+  protected[entity] implicit val runtimeManifestSerdes: RootJsonFormat[RuntimeManifest] = jsonFormat8(RuntimeManifest)
 
 }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskActivation.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskActivation.scala
@@ -153,7 +153,7 @@ object WhiskActivation
   val stateField = "state"
   val valueField = "value"
 
-  protected[entity] implicit val instantSerdes = new RootJsonFormat[Instant] {
+  protected[entity] implicit val instantSerdes: RootJsonFormat[Instant] = new RootJsonFormat[Instant] {
     def write(t: Instant) = t.toEpochMilli.toJson
 
     def read(value: JsValue) =

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/ErrorResponse.scala
@@ -253,7 +253,7 @@ object ErrorResponse extends Directives with DefaultJsonProtocol {
     case _         => ErrorResponse(status.defaultMessage, transid)
   }
 
-  implicit val serializer = new RootJsonFormat[ErrorResponse] {
+  implicit val serializer: RootJsonFormat[ErrorResponse] = new RootJsonFormat[ErrorResponse] {
     def write(er: ErrorResponse) = JsObject("error" -> er.error.toJson, "code" -> er.code.meta.id.toJson)
 
     def read(v: JsValue) =


### PR DESCRIPTION
This changes make sure the Scala compiler can compile the code base correctly under all circumstances. There are no functional changes in this PR.

## Description
- Add a few explicit types for implicit values that are used before the definition point. This is known to [work only by accident](https://contributors.scala-lang.org/t/implicits-with-inferred-return-type-lead-to-undefined-behavior/615)
- Changed the visibility of an object that also compiles only due to a [bug in the Scala compiler](https://github.com/scala/bug/issues/11554).

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

