### PR TITLE
Fix js syntax error which made tests fail with the latest nodejs runtime

### DIFF
--- a/tests/dat/actions/hello.js
+++ b/tests/dat/actions/hello.js
@@ -5,7 +5,7 @@
  * Hello, world.
  */
 function main(params) {
-    greeting = 'hello, ' + params.payload + '!'
+    var greeting = 'hello, ' + params.payload + '!'
     console.log(greeting);
     return {payload: greeting}
 }

--- a/tests/dat/actions/loggingTimeout.js
+++ b/tests/dat/actions/loggingTimeout.js
@@ -13,20 +13,20 @@ function getArg(value, defaultValue) {
 // main( { delay: 100, duration: 10000 } );
 function main(args) {
 
-   durationMillis = getArg(args.duration, 120000);
-   delayMillis = getArg(args.delay, 100);
+   var durationMillis = getArg(args.duration, 120000);
+   var delayMillis = getArg(args.delay, 100);
 
-   logLines = 0;
-   startMillis = new Date();
+   var logLines = 0;
+   var startMillis = new Date();
 
-   timeout = setInterval(function() {
+   var timeout = setInterval(function() {
       console.log(`[${ ++logLines }] The quick brown fox jumps over the lazy dog.`);
    }, delayMillis);
 
    return new Promise(function(resolve, reject) {
       setTimeout(function() {
          clearInterval(timeout);
-         message = `hello, I'm back after ${new Date() - startMillis} ms and printed ${logLines} log lines`
+         var message = `hello, I'm back after ${new Date() - startMillis} ms and printed ${logLines} log lines`
          console.log(message)
          resolve({ message: message });
       }, durationMillis);


### PR DESCRIPTION
## Description
This change fixes a java script syntax error that made tests fail with runtime changes
introduced in https://github.com/apache/incubator-openwhisk-runtime-nodejs/pull/133

I used the deprecated `var`syntax version to be in sync with other test actions. 

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

