### PR TITLE
Update pureconfig hydra

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,15 +18,18 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://repo.triplequote.com/libs-release/"
+        }
     }
     dependencies {
         classpath "cz.alenkacz:gradle-scalafmt:${gradle.scalafmt.version}"
         classpath 'org.scoverage:gradle-scoverage:2.3.0'
     }
 }
-
 plugins {
     id "com.gradle.build-scan" version "1.14"
+    id "com.triplequote.hydra" version "0.0.2" apply false
 }
 
 buildScan {
@@ -44,7 +47,7 @@ subprojects {
 
     afterEvaluate {
         if (project.plugins.hasPlugin('application')
-                && project.plugins.hasPlugin('scala')) {
+                && (project.plugins.hasPlugin('scala') || project.plugins.hasPlugin('com.triplequote.hydra'))) {
             startScripts {
                 doLast {
                     unixScript.text = configureUnixClasspath(unixScript)
@@ -73,6 +76,21 @@ subprojects {
                 archives sourcesJar
                 archives testSourcesJar
                 archives testClassesJar
+            }
+        }
+
+        if (project.plugins.hasPlugin('com.triplequote.hydra')) {
+            hydra {
+                metricsServiceVersion = "1.1.0"
+                version = "2.1.6"
+                // optional:
+                // workers = 4
+                dashboardServerUrl=new java.net.URL("http://localhost:3333/metrics")
+            }
+            repositories {
+                maven {
+                    url "https://repo.triplequote.com/libs-release/"
+                }
             }
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ subprojects {
         if (project.plugins.hasPlugin('com.triplequote.hydra')) {
             hydra {
                 metricsServiceVersion = "1.1.0"
-                version = "2.1.6"
+                version = "2.1.7"
                 // optional:
                 // workers = 4
                 dashboardServerUrl=new java.net.URL("http://localhost:3333/metrics")

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -32,7 +32,7 @@ repositories {
 dependencies {
     compile "org.scala-lang:scala-library:${gradle.scala.version}"
 
-    compile ('com.github.pureconfig:pureconfig_2.12:0.9.0') {
+    compile ('com.github.pureconfig:pureconfig_2.12:0.11.0') {
         exclude group: 'org.scala-lang', module: 'scala-compiler'
         exclude group: 'org.scala-lang', module: 'scala-reflect'
     }

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-apply plugin: 'scala'
+apply plugin: 'com.triplequote.hydra'
 apply plugin: 'eclipse'
 apply plugin: 'maven'
 apply plugin: 'org.scoverage'

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -116,4 +116,6 @@ configurations {
 
 tasks.withType(ScalaCompile) {
     scalaCompileOptions.additionalParameters = gradle.scala.compileFlags
+    scalaCompileOptions.forkOptions.memoryMaximumSize = '2g'
+    scalaCompileOptions.forkOptions.jvmArgs = ['-Xss64M']
 }

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/TransactionId.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/TransactionId.scala
@@ -25,6 +25,7 @@ import pureconfig.loadConfigOrThrow
 import spray.json._
 import org.apache.openwhisk.core.ConfigKeys
 import pureconfig._
+import pureconfig.generic.auto._
 import org.apache.openwhisk.common.tracing.WhiskTracerProvider
 import org.apache.openwhisk.common.WhiskInstants._
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/UserEvents.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/UserEvents.scala
@@ -18,6 +18,7 @@
 package org.apache.openwhisk.common
 
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.connector.{EventMessage, MessageProducer}
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/tracing/OpenTracingProvider.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/tracing/OpenTracingProvider.scala
@@ -27,6 +27,7 @@ import io.opentracing.propagation.{Format, TextMapExtractAdapter, TextMapInjectA
 import io.opentracing.util.GlobalTracer
 import io.opentracing.{Span, SpanContext, Tracer}
 import pureconfig._
+import pureconfig.generic.auto._
 import org.apache.openwhisk.common.{LogMarkerToken, TransactionId}
 import org.apache.openwhisk.core.ConfigKeys
 import zipkin2.reporter.okhttp3.OkHttpSender

--- a/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaConsumerConnector.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaConsumerConnector.scala
@@ -23,6 +23,7 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.{RetriableException, WakeupException}
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 import org.apache.openwhisk.common.{Logging, LoggingMarkers, MetricEmitter, Scheduler}
 import org.apache.openwhisk.connector.kafka.KafkaConfiguration._
 import org.apache.openwhisk.core.ConfigKeys

--- a/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaMessagingProvider.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaMessagingProvider.scala
@@ -23,6 +23,7 @@ import akka.actor.ActorSystem
 import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
 import org.apache.kafka.common.errors.{RetriableException, TopicExistsException}
 import pureconfig._
+import pureconfig.generic.auto._
 import org.apache.openwhisk.common.{CausedBy, Logging}
 import org.apache.openwhisk.core.{ConfigKeys, WhiskConfig}
 import org.apache.openwhisk.core.connector.{MessageConsumer, MessageProducer, MessagingProvider}

--- a/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaProducerConnector.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaProducerConnector.scala
@@ -23,6 +23,7 @@ import org.apache.kafka.clients.producer._
 import org.apache.kafka.common.errors._
 import org.apache.kafka.common.serialization.StringSerializer
 import pureconfig._
+import pureconfig.generic.auto._
 import org.apache.openwhisk.common.{Counter, Logging, TransactionId}
 import org.apache.openwhisk.connector.kafka.KafkaConfiguration._
 import org.apache.openwhisk.core.ConfigKeys

--- a/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KamonMetricsReporter.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KamonMetricsReporter.scala
@@ -27,6 +27,7 @@ import org.apache.kafka.common.metrics.stats.Total
 import org.apache.kafka.common.metrics.{KafkaMetric, MetricsReporter}
 import org.apache.openwhisk.core.ConfigKeys
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration.FiniteDuration

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/FeatureFlags.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/FeatureFlags.scala
@@ -17,6 +17,7 @@
 
 package org.apache.openwhisk.core
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 
 object FeatureFlags {
   private case class FeatureFlagConfig(requireApiKeyAnnotation: Boolean)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
@@ -24,6 +24,7 @@ import akka.event.Logging.InfoLevel
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import pureconfig._
+import pureconfig.generic.auto._
 import spray.json.DefaultJsonProtocol._
 import spray.json.JsObject
 import org.apache.openwhisk.common.{Logging, LoggingMarkers, TransactionId}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/ElasticSearchLogStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/ElasticSearchLogStore.scala
@@ -34,6 +34,7 @@ import scala.util.Try
 import spray.json._
 
 import pureconfig._
+import pureconfig.generic.auto._
 
 case class ElasticSearchLogFieldConfig(userLogs: String,
                                        message: String,

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/SplunkLogStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/SplunkLogStore.scala
@@ -40,6 +40,7 @@ import akka.stream.scaladsl.Source
 import com.typesafe.sslconfig.akka.AkkaSSLConfig
 
 import pureconfig._
+import pureconfig.generic.auto._
 
 import scala.concurrent.Future
 import scala.concurrent.Promise

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStore.scala
@@ -25,6 +25,7 @@ import org.apache.openwhisk.common.{Logging, TransactionId}
 import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.entity.{DocInfo, _}
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 import spray.json._
 
 import scala.concurrent.Future

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbStoreProvider.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbStoreProvider.scala
@@ -25,6 +25,7 @@ import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.entity.DocumentReader
 import org.apache.openwhisk.core.entity.size._
 import pureconfig._
+import pureconfig.generic.auto._
 
 import scala.reflect.ClassTag
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStoreProvider.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStoreProvider.scala
@@ -29,6 +29,7 @@ import org.apache.openwhisk.core.database._
 import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.core.entity.{DocumentReader, WhiskActivation, WhiskAuth, WhiskEntity}
 import pureconfig._
+import pureconfig.generic.auto._
 import spray.json.RootJsonFormat
 
 import scala.reflect.ClassTag

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfig.scala
@@ -27,6 +27,7 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigUtil.joinPath
 import org.apache.openwhisk.core.ConfigKeys
 import pureconfig._
+import pureconfig.generic.auto._
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/memory/MemoryArtifactStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/memory/MemoryArtifactStore.scala
@@ -23,6 +23,7 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 import spray.json.{DefaultJsonProtocol, DeserializationException, JsObject, JsString, RootJsonFormat}
 import org.apache.openwhisk.common.{Logging, LoggingMarkers, TransactionId}
 import org.apache.openwhisk.core.ConfigKeys

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/s3/S3AttachmentStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/s3/S3AttachmentStore.scala
@@ -43,6 +43,7 @@ import org.apache.openwhisk.core.database.StoreUtils._
 import org.apache.openwhisk.core.database._
 import org.apache.openwhisk.core.entity.DocId
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivationEntityLimit.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivationEntityLimit.scala
@@ -18,6 +18,7 @@
 package org.apache.openwhisk.core.entity
 
 import pureconfig._
+import pureconfig.generic.auto._
 import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.entity.size.SizeLong
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ConcurrencyLimit.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ConcurrencyLimit.scala
@@ -20,6 +20,7 @@ package org.apache.openwhisk.core.entity
 import com.typesafe.config.ConfigFactory
 import org.apache.openwhisk.core.ConfigKeys
 import pureconfig._
+import pureconfig.generic.auto._
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ExecManifest.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ExecManifest.scala
@@ -18,6 +18,7 @@
 package org.apache.openwhisk.core.entity
 
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 
 import scala.util.{Failure, Success, Try}
 import spray.json._

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/LogLimit.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/LogLimit.scala
@@ -18,6 +18,7 @@
 package org.apache.openwhisk.core.entity
 
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 
 import scala.language.postfixOps
 import scala.util.Failure

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/MemoryLimit.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/MemoryLimit.scala
@@ -26,6 +26,7 @@ import spray.json._
 import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.core.ConfigKeys
 import pureconfig._
+import pureconfig.generic.auto._
 
 case class MemoryLimitConfig(min: ByteSize, max: ByteSize, std: ByteSize)
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/TimeLimit.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/TimeLimit.scala
@@ -18,6 +18,7 @@
 package org.apache.openwhisk.core.entity
 
 import pureconfig._
+import pureconfig.generic.auto._
 
 import scala.concurrent.duration._
 import scala.util.Failure

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskActivation.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskActivation.scala
@@ -27,6 +27,7 @@ import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.database.{ArtifactStore, CacheChangeNotification, DocumentFactory, StaleParameter}
 import pureconfig._
+import pureconfig.generic.auto._
 
 /**
  * A WhiskActivation provides an abstraction of the meta-data

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskStore.scala
@@ -38,6 +38,7 @@ import org.apache.openwhisk.core.database.DocumentSerializer
 import org.apache.openwhisk.core.database.StaleParameter
 import org.apache.openwhisk.spi.SpiLoader
 import pureconfig._
+import pureconfig.generic.auto._
 import scala.reflect.classTag
 
 package object types {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/mesos/MesosContainerFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/mesos/MesosContainerFactory.scala
@@ -31,6 +31,7 @@ import com.adobe.api.platform.runtime.mesos.UNLIKE
 import java.time.Instant
 
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/yarn/YARNContainerFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/yarn/YARNContainerFactory.scala
@@ -28,6 +28,7 @@ import org.apache.openwhisk.core.entity.{ByteSize, ExecManifest, InvokerInstance
 import org.apache.openwhisk.core.yarn.YARNComponentActor.CreateContainerAsync
 import org.apache.openwhisk.core.{ConfigKeys, WhiskConfig}
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 import spray.json._
 
 import scala.collection.immutable.HashMap

--- a/core/controller/build.gradle
+++ b/core/controller/build.gradle
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-apply plugin: 'scala'
+apply plugin: 'com.triplequote.hydra'
 apply plugin: 'application'
 apply plugin: 'eclipse'
 apply plugin: 'maven'

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
@@ -26,6 +26,7 @@ import akka.http.scaladsl.server.Route
 import akka.stream.ActorMaterializer
 import kamon.Kamon
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 import org.apache.openwhisk.common.Https.HttpsConfig

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/RestAPIs.scala
@@ -25,6 +25,7 @@ import akka.http.scaladsl.server.directives.AuthenticationDirective
 import akka.http.scaladsl.server.{Directives, Route}
 import akka.stream.ActorMaterializer
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 import org.apache.openwhisk.common.{Logging, TransactionId}

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Triggers.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Triggers.scala
@@ -36,6 +36,7 @@ import akka.stream.ActorMaterializer
 import spray.json.DefaultJsonProtocol._
 import com.typesafe.sslconfig.akka.AkkaSSLConfig
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 import spray.json._
 import org.apache.openwhisk.common.Https.HttpsConfig
 import org.apache.openwhisk.common.{Https, TransactionId}

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/actions/PrimitiveActions.scala
@@ -45,6 +45,7 @@ import scala.language.postfixOps
 import scala.util.{Failure, Success}
 
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 
 protected[actions] trait PrimitiveActions {
   /** The core collections require backend services to be injected in this trait. */

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/Collection.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/Collection.scala
@@ -37,6 +37,7 @@ import org.apache.openwhisk.core.entity.WhiskRule
 import org.apache.openwhisk.core.entity.WhiskTrigger
 import org.apache.openwhisk.core.entity.types.EntityStore
 import pureconfig._
+import pureconfig.generic.auto._
 
 /**
  * A collection encapsulates the name of a collection and implicit rights when subject

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/Entitlement.scala
@@ -203,6 +203,7 @@ protected[core] abstract class EntitlementProvider(
 
   private val kindRestrictor = {
     import pureconfig.loadConfigOrThrow
+    import pureconfig.generic.auto._
     import org.apache.openwhisk.core.ConfigKeys
     case class AllowedKinds(whitelist: Option[Set[String]] = None)
     val allowedKinds = loadConfigOrThrow[AllowedKinds](ConfigKeys.runtimes)

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/CommonLoadBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/CommonLoadBalancer.scala
@@ -26,6 +26,7 @@ import akka.event.Logging.InfoLevel
 import akka.stream.ActorMaterializer
 import org.apache.kafka.clients.producer.RecordMetadata
 import pureconfig._
+import pureconfig.generic.auto._
 import org.apache.openwhisk.common.LoggingMarkers._
 import org.apache.openwhisk.common._
 import org.apache.openwhisk.core.connector._

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/LeanBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/LeanBalancer.scala
@@ -30,6 +30,7 @@ import org.apache.openwhisk.core.{ConfigKeys, WhiskConfig}
 import org.apache.openwhisk.spi.SpiLoader
 import org.apache.openwhisk.utils.ExecutionContextFactory
 import pureconfig._
+import pureconfig.generic.auto._
 import org.apache.openwhisk.core.entity.size._
 
 import scala.concurrent.Future

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
@@ -29,6 +29,7 @@ import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.stream.ActorMaterializer
 import org.apache.kafka.clients.producer.RecordMetadata
 import pureconfig._
+import pureconfig.generic.auto._
 import org.apache.openwhisk.common._
 import org.apache.openwhisk.core.WhiskConfig._
 import org.apache.openwhisk.core.connector._

--- a/core/invoker/build.gradle
+++ b/core/invoker/build.gradle
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-apply plugin: 'scala'
+apply plugin: 'com.triplequote.hydra'
 apply plugin: 'application'
 apply plugin: 'eclipse'
 apply plugin: 'maven'

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
@@ -23,6 +23,7 @@ import akka.actor.{FSM, Props, Stash}
 import akka.event.Logging.InfoLevel
 import akka.pattern.pipe
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 import scala.collection.immutable
 import spray.json.DefaultJsonProtocol._
 import spray.json._

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerClient.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerClient.scala
@@ -33,6 +33,7 @@ import scala.util.Success
 import scala.util.Try
 import akka.event.Logging.{ErrorLevel, InfoLevel}
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 import org.apache.openwhisk.common.{Logging, LoggingMarkers, MetricEmitter, TransactionId}
 import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.containerpool.ContainerId

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerContainerFactory.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerContainerFactory.scala
@@ -34,6 +34,7 @@ import scala.concurrent.duration._
 import java.util.concurrent.TimeoutException
 
 import pureconfig._
+import pureconfig.generic.auto._
 import org.apache.openwhisk.core.ConfigKeys
 
 case class DockerContainerFactoryConfig(useRunc: Boolean)

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/RuncClient.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/RuncClient.scala
@@ -29,6 +29,7 @@ import org.apache.openwhisk.common.LoggingMarkers
 import org.apache.openwhisk.common.Logging
 import org.apache.openwhisk.core.ConfigKeys
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 import akka.event.Logging.{ErrorLevel, InfoLevel}
 import org.apache.openwhisk.core.containerpool.ContainerId
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
@@ -33,6 +33,7 @@ import akka.stream.stage._
 import akka.util.ByteString
 import io.fabric8.kubernetes.api.model._
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 import org.apache.openwhisk.common.Logging
 import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.core.ConfigKeys

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClientWithInvokerAgent.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClientWithInvokerAgent.scala
@@ -25,6 +25,7 @@ import akka.http.scaladsl.model.{HttpRequest, HttpResponse, MessageEntity, Uri}
 import akka.http.scaladsl.marshalling.Marshal
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import org.apache.openwhisk.core.ConfigKeys

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesContainerFactory.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesContainerFactory.scala
@@ -19,6 +19,7 @@ package org.apache.openwhisk.core.containerpool.kubernetes
 
 import akka.actor.ActorSystem
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
@@ -34,6 +34,7 @@ import org.apache.openwhisk.http.{BasicHttpService, BasicRasService}
 import org.apache.openwhisk.spi.{Spi, SpiLoader}
 import org.apache.openwhisk.utils.ExecutionContextFactory
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext}

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -36,6 +36,7 @@ import org.apache.openwhisk.core.{ConfigKeys, WhiskConfig}
 import org.apache.openwhisk.http.Messages
 import org.apache.openwhisk.spi.SpiLoader
 import pureconfig._
+import pureconfig.generic.auto._
 import spray.json._
 
 import scala.concurrent.duration._

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -22,7 +22,7 @@ plugins {
     id 'org.hidetake.swagger.generator' version '2.12.0'
 }
 
-apply plugin: 'scala'
+apply plugin: 'com.triplequote.hydra'
 apply plugin: 'eclipse'
 apply plugin: 'maven'
 apply plugin: 'org.scoverage'

--- a/tests/src/test/scala/common/WskTracingTests.scala
+++ b/tests/src/test/scala/common/WskTracingTests.scala
@@ -23,6 +23,7 @@ import com.github.benmanes.caffeine.cache.Ticker
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 import org.apache.openwhisk.common.{LoggingMarkers, TransactionId}
 import org.apache.openwhisk.common.tracing.{OpenTracer, TracingConfig}
 import org.apache.openwhisk.core.ConfigKeys

--- a/tests/src/test/scala/common/rest/WskRestOperations.scala
+++ b/tests/src/test/scala/common/rest/WskRestOperations.scala
@@ -54,6 +54,7 @@ import org.scalatest.Matchers
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.Span.convertDurationToSpan
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 

--- a/tests/src/test/scala/ha/ShootComponentsTests.scala
+++ b/tests/src/test/scala/ha/ShootComponentsTests.scala
@@ -35,6 +35,7 @@ import akka.stream.ActorMaterializer
 import common._
 import common.rest.{HttpConnection, WskRestOperations}
 import pureconfig._
+import pureconfig.generic.auto._
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import org.apache.openwhisk.core.WhiskConfig

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/docker/test/DockerContainerFactoryTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/docker/test/DockerContainerFactoryTests.scala
@@ -45,6 +45,7 @@ import org.apache.openwhisk.core.containerpool.docker.RuncApi
 import org.apache.openwhisk.core.entity.{ByteSize, ExecManifest, InvokerInstanceId}
 import org.apache.openwhisk.core.entity.size._
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 
 @RunWith(classOf[JUnitRunner])
 class DockerContainerFactoryTests

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerArgsConfigTest.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerArgsConfigTest.scala
@@ -22,6 +22,7 @@ import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import org.scalatest.junit.JUnitRunner
 import pureconfig._
+import pureconfig.generic.auto._
 import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.containerpool.ContainerArgsConfig
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBTestSupport.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBTestSupport.scala
@@ -20,6 +20,7 @@ package org.apache.openwhisk.core.database.cosmosdb
 import com.microsoft.azure.cosmosdb.{Database, SqlParameter, SqlParameterCollection, SqlQuerySpec}
 import org.scalatest.{BeforeAndAfterAll, FlatSpec}
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.database.test.behavior.ArtifactStoreTestUtil.storeAvailable
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/s3/CloudFrontSignerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/s3/CloudFrontSignerTests.scala
@@ -25,6 +25,7 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{FlatSpec, Matchers, OptionValues}
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 
 @RunWith(classOf[JUnitRunner])
 class CloudFrontSignerTests extends FlatSpec with Matchers with OptionValues {

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/AttachmentCompatibilityTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/AttachmentCompatibilityTests.scala
@@ -30,6 +30,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FlatSpec, Matchers}
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 import spray.json._
 import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.core.ConfigKeys

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/CouchDbRestClientTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/CouchDbRestClientTests.scala
@@ -37,6 +37,7 @@ import akka.util.ByteString
 import common.StreamLogging
 import common.WskActorSystem
 import pureconfig._
+import pureconfig.generic.auto._
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import org.apache.openwhisk.core.ConfigKeys

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/DatabaseScriptTestUtils.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/DatabaseScriptTestUtils.scala
@@ -26,6 +26,7 @@ import akka.actor.ActorSystem
 import common.WaitFor
 import common.WhiskProperties
 import pureconfig._
+import pureconfig.generic.auto._
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import org.apache.openwhisk.common.Logging

--- a/tests/src/test/scala/org/apache/openwhisk/core/limits/ConcurrencyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/limits/ConcurrencyTests.scala
@@ -26,6 +26,7 @@ import org.apache.openwhisk.core.entity.size._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import pureconfig.loadConfigOrThrow
+import pureconfig.generic.auto._
 
 import scala.concurrent.Await
 import scala.concurrent.Future

--- a/tools/admin/build.gradle
+++ b/tools/admin/build.gradle
@@ -17,11 +17,11 @@
 
 plugins {
     id 'org.springframework.boot' version '2.0.2.RELEASE'
-    id 'scala'
 }
 
 apply plugin: 'org.scoverage'
 apply plugin: 'maven'
+apply plugin: 'com.triplequote.hydra'
 
 project.archivesBaseName = "openwhisk-admin-tools"
 


### PR DESCRIPTION
Increase the amount of stack space for the Scala compiler.

## Description
- the move to pureconfig put the Scala compiler on the verge of `StackOverflowException`, this fixes it.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

