### PR TITLE
Ignore route management artifacts from deployment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,14 @@ intellij-run-config.groovy
 
 # VSCode
 .vscode/
+
+# route management
+core/routemgmt/createApi/apigw-utils.js
+core/routemgmt/createApi/package-lock.json
+core/routemgmt/createApi/utils.js
+core/routemgmt/deleteApi/apigw-utils.js
+core/routemgmt/deleteApi/package-lock.json
+core/routemgmt/deleteApi/utils.js
+core/routemgmt/getApi/apigw-utils.js
+core/routemgmt/getApi/package-lock.json
+core/routemgmt/getApi/utils.js

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/WebActions.scala
@@ -483,7 +483,7 @@ trait WhiskWebActionsApi
               provide(fullyQualifiedActionName(actionName)) { fullActionName =>
                 onComplete(verifyWebAction(fullActionName, onBehalfOf.isDefined)) {
                   case Success((actionOwnerIdentity, action)) =>
-                    var requiredAuthOk =
+                    val requiredAuthOk =
                       requiredWhiskAuthSuccessful(action.annotations, context.headers).getOrElse(true)
                     if (!requiredAuthOk) {
                       logging.debug(

--- a/core/routemgmt/createApi/package.json
+++ b/core/routemgmt/createApi/package.json
@@ -1,6 +1,6 @@
 {
   "main": "createApi.js",
-  "dependencies" : {
+  "dependencies": {
     "lodash": "4.17.11",
     "request": "2.88.0"
   }

--- a/core/routemgmt/deleteApi/package.json
+++ b/core/routemgmt/deleteApi/package.json
@@ -1,6 +1,6 @@
 {
   "main": "deleteApi.js",
-  "dependencies" : {
+  "dependencies": {
     "lodash": "4.17.11",
     "request": "2.88.0"
   }

--- a/core/routemgmt/getApi/package.json
+++ b/core/routemgmt/getApi/package.json
@@ -1,6 +1,6 @@
 {
   "main": "getApi.js",
-  "dependencies" : {
+  "dependencies": {
     "lodash": "4.17.11",
     "request": "2.88.0"
   }

--- a/docs/webactions.md
+++ b/docs/webactions.md
@@ -301,7 +301,7 @@ The result of these changes is that the `name` is bound to `Jane` and may not be
 
 ## Securing web actions
 
-By default, a web action can be invoked by anyone having the web action's invocation URL. Use the `require-whisk-auth` [web action annotation](annotations.md#annotations-specific-to-web-actions) to secure the web action. When the `require-whisk-auth` annotation is set to `true`, the action will authenticate the invocation request's Basic Authorization credentials against the action owner's whisk auth key.  When set to a number or a case-sensitive string, the action's invocation request must include a `X-Require-Whisk-Auth` header having this same value. Secured web actions will return a `Not Authorized` when credential validation fails.
+By default, a web action can be invoked by anyone having the web action's invocation URL. Use the `require-whisk-auth` [web action annotation](annotations.md#annotations-specific-to-web-actions) to secure the web action. When the `require-whisk-auth` annotation is set to `true`, the action will authenticate the invocation request's Basic Authorization credentials to confirm they represent a valid OpenWhisk identity.  When set to a number or a case-sensitive string, the action's invocation request must include a `X-Require-Whisk-Auth` header having this same value. Secured web actions will return a `Not Authorized` when credential validation fails.
 
 Alternatively, use the `--web-secure` flag to automatically set the `require-whisk-auth` annotation.  When set to `true` a random number is generated as the `require-whisk-auth` annotation value. When set to `false` the `require-whisk-auth` annotation is removed.  When set to any other value, that value is used as the `require-whisk-auth` annotation value.
 


### PR DESCRIPTION
The routemgmt packages copies some files around and zips them up. These files then show up in the git status. This patch ignores them.