### PR TITLE
Always reset WHISK_SERVER property after StandaloneServerTests

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneServerFixture.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneServerFixture.scala
@@ -86,8 +86,8 @@ trait StandaloneServerFixture extends TestSuite with BeforeAndAfterAll with Stre
 
   override def afterAll(): Unit = {
     super.afterAll()
+    System.clearProperty(WHISK_SERVER)
     if (serverStartedForTest) {
-      System.clearProperty(WHISK_SERVER)
       manifestFile.foreach(FileUtils.deleteQuietly)
       serverProcess.destroy()
     }

--- a/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneServerFixture.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneServerFixture.scala
@@ -55,6 +55,8 @@ trait StandaloneServerFixture extends TestSuite with BeforeAndAfterAll with Stre
     "Wsk Action REST should create and invoke a blocking action resulting in an application error response",
     "Wsk Action REST should create an action, and invoke an action that returns an empty JSON object")
 
+  private val whiskServerPreDefined = System.getProperty(WHISK_SERVER) != null
+
   override def beforeAll(): Unit = {
     val serverUrlViaSysProp = Option(System.getProperty(WHISK_SERVER))
     serverUrlViaSysProp match {
@@ -86,7 +88,9 @@ trait StandaloneServerFixture extends TestSuite with BeforeAndAfterAll with Stre
 
   override def afterAll(): Unit = {
     super.afterAll()
-    System.clearProperty(WHISK_SERVER)
+    if (!whiskServerPreDefined) {
+      System.clearProperty(WHISK_SERVER)
+    }
     if (serverStartedForTest) {
       manifestFile.foreach(FileUtils.deleteQuietly)
       serverProcess.destroy()


### PR DESCRIPTION
## Description
In case the StandaloneServerTests are not able to access the standalone jar file in the beforeAll method, all following REST tests are failing still trying to access OW locally over the standalone port.

The reason for this behavior is that the `WHISK_SERVER`property is only reset to the original value 
in case the standalone server got started successfully.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

