### PR TITLE
Run Gradle install for Jenkins build to install Standalone jar

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ timeout(time: 12, unit: 'HOURS') {
         def home = sh(returnStdout: true, script: 'echo $HOME').trim()
         def jobName = sh(returnStdout: true, script: 'echo $JOB_NAME').trim()
         def jobSpace = "${home}/jenkins-slave/workspace/${jobName}"
-        
+
         lock("${hostName}") {
             sh "mkdir -p ${jobSpace}"
             dir("${jobSpace}") {
@@ -51,6 +51,8 @@ timeout(time: 12, unit: 'HOURS') {
                                 -e REGISTRY_HTTP_TLS_KEY=/certs/${key} -p ${port}:${port} registry:2"
                         // Build the controller and invoker images.
                         sh "./gradlew distDocker -PdockerRegistry=${domainName}:${port}"
+                        //Install the various modules like standalone
+                        sh "./gradlew install"
                     }
 
                     stage('Deploy Lean') {


### PR DESCRIPTION
Builds and install the various Gradle module as part of Jenkins build

## Description
Standalone server test need access to the standalone jar which needs to be pre built before tests are run. This was done for Travis and not for Jenkins.  With this PR the required jars are also now built as part of Jenkins build

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#4530 )

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

