### PR TITLE
Handle deleted limits document for get operation the same way as missing limits document

### DIFF
--- a/tools/admin/wskadmin
+++ b/tools/admin/wskadmin
@@ -576,7 +576,7 @@ def getLimitsCmd(args, props):
             print('No limits found, default system limits apply')
         else:
             print('Failed to get limits (%s)' % res.read().strip())
-        return 1
+            return 1
 
 def deleteLimitsCmd(args, props):
     docId = quote_plus(args.namespace + "/limits")

--- a/tools/admin/wskadmin
+++ b/tools/admin/wskadmin
@@ -572,7 +572,7 @@ def getLimitsCmd(args, props):
                 print('%s = %s' % (limit, givenLimit))
     else:
         error = json.loads(res.read())
-        if error['reason'] == 'missing':
+        if error['reason'] == 'missing' or error['reason'] == 'deleted':
             print('No limits found, default system limits apply')
         else:
             print('Failed to get limits (%s)' % res.read().strip())

--- a/tools/admin/wskadmin
+++ b/tools/admin/wskadmin
@@ -574,9 +574,10 @@ def getLimitsCmd(args, props):
         error = json.loads(res.read())
         if error['reason'] == 'missing' or error['reason'] == 'deleted':
             print('No limits found, default system limits apply')
+            return 0
         else:
             print('Failed to get limits (%s)' % res.read().strip())
-            return 1
+        return 1
 
 def deleteLimitsCmd(args, props):
     docId = quote_plus(args.namespace + "/limits")


### PR DESCRIPTION
This PR is a small consistency fix for the `wskadmin` tool. If the `wskadmin` tool is called to get the currently set limits on a given namespace, it should not print out `Failed to get limits ..` if the limits document is deleted on the database but handle it the same way as if the limits document does not exists (`No limits found, default system limits apply`). This is more consistent as the message shown by `wskadmin` should be the same for both cases. 
In addition, both cases (missing and deleted limits document) shouldn't be treated as error in my opinion and hence the `wskadmin` shouldn't return with a non-zero code, but this is open to discussion.

## Description
This code change changes the messages printed by the `wskadmin` tool for deleted namespace limits documents.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [x] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

