### PR TITLE
Change default docker_image_tag to 'nightly'

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -294,7 +294,7 @@ docker:
   #user:
   image:
     prefix: "{{ docker_image_prefix | default('whisk') }}"
-    tag: "{{ docker_image_tag | default('latest') }}"
+    tag: "{{ docker_image_tag | default('nightly') }}"
   version: 1.12.0-0~trusty
   storagedriver: overlay
   port: 4243


### PR DESCRIPTION
Change the deault docker_image_tag to 'nightly', related to #4539 

## Description
Since docker image with 'latest' tag have been cleared and repalced with 'nightly', some other projects like incubator-openwhisk-cli may failed to run travis check because of docker image not found error

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

