### PR TITLE
Disable MesosContainerFactory from subscribing after close

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/mesos/MesosContainerFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/mesos/MesosContainerFactory.scala
@@ -103,6 +103,9 @@ class MesosContainerFactory(config: WhiskConfig,
   /** Inits Mesos framework. */
   val mesosClientActor = clientFactory(as, mesosConfig)
 
+  @volatile
+  private var closed: Boolean = false
+
   subscribe()
 
   /** Subscribes Mesos actor to mesos event stream; retry on timeout (which should be unusual). */
@@ -115,7 +118,7 @@ class MesosContainerFactory(config: WhiskConfig,
       .recoverWith {
         case e =>
           logging.error(this, s"subscribe failed... $e}")
-          subscribe()
+          if (closed) Future.successful(()) else subscribe()
       }
   }
 
@@ -187,6 +190,10 @@ class MesosContainerFactory(config: WhiskConfig,
         case t: Throwable =>
           logging.error(this, s"Mesos framework teardown failed : $t}")
       }
+  }
+
+  def close(): Unit = {
+    closed = true
   }
 }
 object MesosContainerFactory {

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/mesos/test/MesosContainerFactoryTest.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/mesos/test/MesosContainerFactoryTest.scala
@@ -57,6 +57,9 @@ import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.core.mesos.MesosConfig
 import org.apache.openwhisk.core.mesos.MesosContainerFactory
 import org.apache.openwhisk.core.mesos.MesosTimeoutConfig
+import org.apache.openwhisk.utils.retry
+
+import scala.collection.JavaConverters._
 
 @RunWith(classOf[JUnitRunner])
 class MesosContainerFactoryTest
@@ -93,12 +96,24 @@ class MesosContainerFactoryTest
       Seq.empty,
       Map("extra1" -> Set("e1", "e2"), "extra2" -> Set("e3", "e4")))
 
+  private var factory: MesosContainerFactory = _
   override def beforeEach() = {
     stream.reset()
   }
 
+  override protected def afterEach(): Unit = {
+    super.afterEach()
+    Option(factory).foreach(_.close())
+  }
+
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
+    retry({
+      val threadNames = Thread.getAllStackTraces.asScala.keySet.map(_.getName)
+      withClue(s"Threads related to  MesosActorSystem found to be active $threadNames") {
+        assert(!threadNames.exists(_.startsWith("MesosActorSystem")))
+      }
+    }, 10, Some(1.second))
     super.afterAll()
   }
 
@@ -111,7 +126,7 @@ class MesosContainerFactoryTest
 
   it should "send Subscribe on init" in {
     val wskConfig = new WhiskConfig(Map.empty)
-    new MesosContainerFactory(
+    factory = new MesosContainerFactory(
       wskConfig,
       system,
       logging,
@@ -138,16 +153,15 @@ class MesosContainerFactoryTest
       2,
       timeouts)
 
-    val factory =
-      new MesosContainerFactory(
-        wskConfig,
-        system,
-        logging,
-        Map("--arg1" -> Set("v1", "v2"), "--arg2" -> Set("v3", "v4"), "other" -> Set("v5", "v6")),
-        containerArgsConfig,
-        mesosConfig = mesosConfig,
-        clientFactory = (_, _) => testActor,
-        taskIdGenerator = testTaskId _)
+    factory = new MesosContainerFactory(
+      wskConfig,
+      system,
+      logging,
+      Map("--arg1" -> Set("v1", "v2"), "--arg2" -> Set("v3", "v4"), "other" -> Set("v5", "v6")),
+      containerArgsConfig,
+      mesosConfig = mesosConfig,
+      clientFactory = (_, _) => testActor,
+      taskIdGenerator = testTaskId _)
 
     expectMsg(Subscribe)
     factory.createContainer(
@@ -182,16 +196,15 @@ class MesosContainerFactoryTest
 
   it should "send DeleteTask on destroy" in {
     val probe = TestProbe()
-    val factory =
-      new MesosContainerFactory(
-        wskConfig,
-        system,
-        logging,
-        Map("--arg1" -> Set("v1", "v2"), "--arg2" -> Set("v3", "v4"), "other" -> Set("v5", "v6")),
-        containerArgsConfig,
-        mesosConfig = mesosConfig,
-        clientFactory = (system, mesosConfig) => probe.testActor,
-        taskIdGenerator = testTaskId _)
+    factory = new MesosContainerFactory(
+      wskConfig,
+      system,
+      logging,
+      Map("--arg1" -> Set("v1", "v2"), "--arg2" -> Set("v3", "v4"), "other" -> Set("v5", "v6")),
+      containerArgsConfig,
+      mesosConfig = mesosConfig,
+      clientFactory = (system, mesosConfig) => probe.testActor,
+      taskIdGenerator = testTaskId _)
 
     probe.expectMsg(Subscribe)
     //emulate successful subscribe
@@ -251,21 +264,20 @@ class MesosContainerFactoryTest
 
   it should "return static message for logs" in {
     val probe = TestProbe()
-    val factory =
-      new MesosContainerFactory(
-        wskConfig,
-        system,
-        logging,
-        Map("--arg1" -> Set("v1", "v2"), "--arg2" -> Set("v3", "v4"), "other" -> Set("v5", "v6")),
-        new ContainerArgsConfig(
-          "bridge",
-          Seq.empty,
-          Seq.empty,
-          Seq.empty,
-          Map("extra1" -> Set("e1", "e2"), "extra2" -> Set("e3", "e4"))),
-        mesosConfig = mesosConfig,
-        clientFactory = (system, mesosConfig) => probe.testActor,
-        taskIdGenerator = testTaskId _)
+    factory = new MesosContainerFactory(
+      wskConfig,
+      system,
+      logging,
+      Map("--arg1" -> Set("v1", "v2"), "--arg2" -> Set("v3", "v4"), "other" -> Set("v5", "v6")),
+      new ContainerArgsConfig(
+        "bridge",
+        Seq.empty,
+        Seq.empty,
+        Seq.empty,
+        Map("extra1" -> Set("e1", "e2"), "extra2" -> Set("e3", "e4"))),
+      mesosConfig = mesosConfig,
+      clientFactory = (system, mesosConfig) => probe.testActor,
+      taskIdGenerator = testTaskId _)
 
     probe.expectMsg(Subscribe)
     //emulate successful subscribe


### PR DESCRIPTION
Fixes #4521 where we observed out of memory during test runs because MesosContainerFactory continues to retry failed subscribe thus filling up the in memory logger

## Description

In #4521 it was observed that `MesosContainerFactory` continues to execute the subscribe task even after test finishes. Ideally upon close of actor system such subscribe efforts should stop automatically. However somehow the threads continue to remain active.

So now we close the factory and disable subscribe upon close after each test run. With this its confirmed there were no stray away threads running and thus no memory leakage should happen due to this

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#4521 )

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

