### PR TITLE
Package swagger docs as part of standalone jar

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
@@ -263,4 +263,5 @@ object ConfigKeys {
   val featureFlags = "whisk.feature-flags"
 
   val whiskConfig = "whisk.config"
+  val swaggerUi = "whisk.swagger-ui"
 }

--- a/core/controller/src/main/resources/application.conf
+++ b/core/controller/src/main/resources/application.conf
@@ -113,4 +113,8 @@ whisk{
   tracing {
     component = "Controller"
   }
+  swagger-ui {
+    file-system : true
+    dir-path : "/swagger-ui/"
+  }
 }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/RestAPIs.scala
@@ -48,10 +48,13 @@ import scala.util.{Failure, Success, Try}
  */
 protected[controller] class SwaggerDocs(apipath: Uri.Path, doc: String)(implicit actorSystem: ActorSystem)
     extends Directives {
+  case class SwaggerConfig(fileSystem: Boolean, dirPath: String)
 
   /** Swagger end points. */
   protected val swaggeruipath = "docs"
   protected val swaggerdocpath = "api-docs"
+  private val swaggerUIDir = "swagger-ui"
+  private val swaggerConfig = loadConfigOrThrow[SwaggerConfig](ConfigKeys.swaggerUi)
 
   def basepath(url: Uri.Path = apipath): String = {
     (if (url.startsWithSlash) url else Uri.Path./(url)).toString
@@ -62,7 +65,8 @@ protected[controller] class SwaggerDocs(apipath: Uri.Path, doc: String)(implicit
    */
   val swaggerRoutes: Route = {
     pathPrefix(swaggeruipath) {
-      getFromDirectory("/swagger-ui/")
+      if (swaggerConfig.fileSystem) getFromDirectory(swaggerConfig.dirPath)
+      else getFromResourceDirectory(swaggerConfig.dirPath)
     } ~ path(swaggeruipath) {
       redirect(s"$swaggeruipath/index.html?url=$apiDocsUrl", PermanentRedirect)
     } ~ pathPrefix(swaggerdocpath) {

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/RestAPIs.scala
@@ -53,7 +53,6 @@ protected[controller] class SwaggerDocs(apipath: Uri.Path, doc: String)(implicit
   /** Swagger end points. */
   protected val swaggeruipath = "docs"
   protected val swaggerdocpath = "api-docs"
-  private val swaggerUIDir = "swagger-ui"
   private val swaggerConfig = loadConfigOrThrow[SwaggerConfig](ConfigKeys.swaggerUi)
 
   def basepath(url: Uri.Path = apipath): String = {

--- a/core/standalone/build.gradle
+++ b/core/standalone/build.gradle
@@ -30,9 +30,39 @@ repositories {
     mavenCentral()
 }
 
+task copySwagger(type: Copy) {
+    def version = "3.6.0"
+    mkdir("$buildDir/tmp/swagger")
+    def destFile = file("$buildDir/tmp/swagger/swagger-ui.tar")
+    def uiDir = file("$buildDir/tmp/swagger/swagger-ui")
+    if (!destFile.exists()) {
+        ant.get(src: "https://github.com/swagger-api/swagger-ui/archive/v${version}.tar.gz", dest: destFile)
+    }
+    from(tarTree(resources.gzip(destFile))){
+        include("swagger-ui-${version}/dist/**")
+    }
+    into(uiDir)
+    includeEmptyDirs = false
+    project.ext.swaggerUiDir = file("$buildDir/tmp/swagger/swagger-ui/swagger-ui-${version}/dist")
+}
+
+processResources.dependsOn copySwagger
+
 processResources {
     from(new File(project.rootProject.projectDir, "ansible/files/runtimes.json")) {
         into(".")
+    }
+    //Implement the logic present in controller Docker file
+    from(project.swaggerUiDir) {
+        include "index.html"
+        filter {
+            it.replace("http://petstore.swagger.io/v2/swagger.json", "/api/v1/api-docs")
+        }
+        into("swagger-ui")
+    }
+    from(project.swaggerUiDir) {
+        exclude "index.html"
+        into("swagger-ui")
     }
 }
 

--- a/core/standalone/src/main/resources/standalone.conf
+++ b/core/standalone/src/main/resources/standalone.conf
@@ -68,4 +68,8 @@ whisk {
       pull-standard-images: true
     }
   }
+  swagger-ui {
+    file-system : false
+    dir-path : "BOOT-INF/classes/swagger-ui"
+  }
 }


### PR DESCRIPTION
Package the swagger docs as part of standalone jar such that clients can use it as they would for standard OpenWhisk server

## Description
Packages the swagger docs as part of jar. It makes the swagger ui path configurable and adapts it for standalone case where the ui files are served from classpath resource compared to filesystem 

Due to akka/akka-http#2247 the path needs to account for how Spring Boot would package the files

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

