### PR TITLE
Fix ansible defaults for docker_image_tag and prefix

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -52,7 +52,8 @@ whisk:
     require_api_key_annotation: "{{ require_api_key_annotation | default(true) }}"
 
 ##
-# configuration parameters related to support runtimes (see org.apache.openwhisk.core.entity.ExecManifest for schema of the manifest).
+# configuration parameters related to support runtimes
+# (see org.apache.openwhisk.core.entity.ExecManifest for schema of the manifest).
 # briefly the parameters are:
 #
 #   runtimes_registry: optional registry (with trailing slack) where to pull docker images from for runtimes and backbox images
@@ -289,12 +290,13 @@ couchdb:
   version: 2.3
 
 docker:
-  # The user to install docker for. Defaults to the ansible user if not set. This will be the user who is able to run
+  # The user to install docker for. Defaults to the ansible user if not set.
+  # This will be the user who is able to run
   # docker commands on a machine setup with prereq_build.yml
   #user:
   image:
-    prefix: "{{ docker_image_prefix | default('whisk') }}"
-    tag: "{{ docker_image_tag | default('latest') }}"
+    prefix: "{{ docker_image_prefix | default('openwhisk') }}"
+    tag: "{{ docker_image_tag | default('nightly') }}"
   version: 1.12.0-0~trusty
   storagedriver: overlay
   port: 4243


### PR DESCRIPTION
Other components apparently were relying on Ansible var. defaults and now failing since we no longer have "latest" tagged images. This was true for the repo. "incubator-openwhisk-client-go" and its Travis testing (Note that I explicitly set "nightly" for the tag var. in that repo. now when invoking ansible).